### PR TITLE
Import Cogitator Omnissiah app and add Claude Code setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install Node.js dependencies (idempotent; npm reuses cache on warm containers)
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# GEMINI_API_KEY: Required for Gemini AI API calls.
+# AI Studio automatically injects this at runtime from user secrets.
+# Users configure this via the Secrets panel in the AI Studio UI.
+GEMINI_API_KEY="MY_GEMINI_API_KEY"
+
+# APP_URL: The URL where this applet is hosted.
+# AI Studio automatically injects this at runtime with the Cloud Run service URL.
+# Used for self-referential links, OAuth callbacks, and API endpoints.
+APP_URL="MY_APP_URL"
+
+# NOTION_API_KEY: Twój token integracji Notion (Internal Integration Token)
+NOTION_API_KEY=""
+
+# NOTION_DATABASE_ID: ID Twojej bazy danych w Notion
+NOTION_DATABASE_ID="25efda05810e80cb8837f305735e1fbb"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+build/
+dist/
+coverage/
+.DS_Store
+*.log
+.env*
+!.env.example
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+Cogitator Omnissiah — a full-stack app that syncs sci-fi book awards (Hugo, Nebula, Locus) from the "Archiwum Encyklopedii Fantastyki" (MediaWiki API) into a personal Notion database. Hybrid Vite + Express setup: React 19 SPA frontend, Express backend with long-running sync tasks streamed over SSE.
+
+## Commands
+
+```bash
+npm run dev      # Start dev server (tsx server.ts — serves API + Vite frontend)
+npm run build    # vite build + esbuild bundle of server.ts → dist/server.cjs
+npm run lint     # tsc --noEmit (type-check; no separate linter configured)
+npm test         # vitest run (full suite)
+npx vitest run <path>   # Run a single test file
+```
+
+Environment variables (see `.env.example`): `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `GEMINI_API_KEY`. Tests mock all external services and run without them.
+
+## Required reading
+
+- **`COGITATOR_GUIDELINES.md`** — the authoritative architectural guidelines (backend patterns, frontend rules, data-integrity logic, test architecture, design system). Follow it for every change.
+- **`/docs/*.md`** — detailed per-feature algorithm documentation (book sync, duplicate detection, purification, schema validation, stats, Vinted scanner, etc.). Read the relevant doc before touching a service.
+
+## Architecture map
+
+- **Adapters** (repo root): `notion.adapter.ts`, `wiki.adapter.ts` — pure API wrappers, no business logic. External failures degrade gracefully (return empty results + `console.warn`) rather than throw.
+- **Services** (`/services/`): one service per sync concern (`bookSyncService`, `duplicateSyncService`, `publisherSyncService`, `seriesSyncService`, `cyclesSyncService`, `lpSyncService`, `statsService`, `integrityService`, `purificationService`, `schemaValidationService`). Logic-heavy, stateless where possible.
+- **Orchestration**: `SyncManager` in `server.ts` coordinates services, concurrency (`p-limit`), cancellation, and SSE progress events.
+- **Controllers/Routes** (`/controllers/`, `/routes/`): HTTP parsing/response only; delegate to services.
+- **Frontend** (`/src/`): components in `src/components/` (atomic parts in subdirs), all data fetching via custom hooks in `src/hooks/` (`useSync` is the standard SSE pattern — reuse it, don't re-implement).
+- **Parsing**: `wiki.parser.ts` extracts book metadata from MediaWiki wikitext (`{{tabela wydania}}`, `{{Książka}}` templates).
+- **Resilience**: `retry.ts` (`withRetry`) wraps flaky external calls with exponential backoff.
+
+## Tests
+
+Vitest, organized into `__tests__/` subdirectories: `/__tests__/` (adapters, server, infra), `/services/__tests__/`, `/src/__tests__/`, `/src/hooks/__tests__/`. Backend tests use `@vitest-environment node`; frontend tests use JSDOM. Mock external deps with `vi.mock` (Notion SDK, axios). Keep the suite green — run `npm test` and `npm run lint` before committing.
+
+## Conventions
+
+- Tailwind CSS only; glassmorphism theme (`slate-950` background, `cyan-400`/`purple-500` accents); `motion/react` for animations; `lucide-react` icons.
+- UI copy and domain naming use Warhammer 40k "Adeptus Mechanicus" flavor (rituals, Machine Spirit, sanctity) — preserve it.
+- After major architectural changes, update `COGITATOR_GUIDELINES.md` and `README.md` to match the implementation (see guidelines §8).

--- a/COGITATOR_GUIDELINES.md
+++ b/COGITATOR_GUIDELINES.md
@@ -1,0 +1,71 @@
+# COGITATOR OMNISSIAH: ARCHITECTURAL GUIDELINES (v1.3)
+
+## 1. CORE ARCHITECTURE (BACKEND)
+- **Pattern**: Service-Adapter-Manager.
+- **Adapters**: `NotionAdapter`, `WikiAdapter`. Pure API wrappers. No business logic.
+- **Services**: `*SyncService`, `StatsService`, `IntegrityService`, `PurificationService`, `SchemaValidationService`. Logic-heavy, stateless where possible.
+- **Orchestration**: `SyncManager` (in `server.ts`). Manages concurrency, cancellation tokens, and global sync state.
+- **Communication**: SSE (Server-Sent Events) for real-time progress. Use `sendEvent({ type, ... })`.
+- **Concurrency**: Use `p-limit` for external API calls (Notion/Wiki/OPAC).
+- **Error Handling**: Fail-fast for library scans. Detailed logging for timeouts/network errors. Use `withRetry` for flaky external services.
+- **Resilience**: `withRetry` handles transient network errors (socket hang up, timeout, ECONNRESET) with exponential backoff.
+
+## 2. FRONTEND ARCHITECTURE (REACT)
+- **Component Decomposition**: Strict SRP. UI components in `src/components/` (atomic parts in subdirs like `stats/`).
+- **Logic Isolation**: No `useEffect` for data fetching in components. Use Custom Hooks:
+  - `useSync`: Standard for all long-running server operations.
+  - `useStats`: Global dashboard data.
+  - `useLibraryCheck`: Isolated library scanning state.
+  - `useConfig`: Notion schema and connection status.
+  - `useWikiUpdates`: Tracking recent changes in the encyclopedia.
+- **Styling**: Tailwind CSS only. Theme: Glassmorphism, `slate-950` background, `cyan-400` / `purple-500` accents.
+- **Animations**: `motion/react` (Framer Motion). Use for entry/exit and progress bars.
+- **Dynamic UI**: Progress bars and summary cards SHOULD inherit the color of the active ritual (passed via `SyncState.color`) to provide visual feedback and reinforce ritual identity.
+
+## 3. DATA INTEGRITY & SYNC LOGIC
+- **Duplicate Detection**: Multi-signal (Title PL, Title Orig, Author Similarity, Common Words).
+- **Purification Ritual (SRP)**: Deep cleaning (Wiki syntax stripping, native Notion formatting removal) is EXCLUSIVE to `PurificationService`. `BookSyncService` stays with simple whitespace normalization to avoid scope creep.
+- **Wiki Parser Priority**: When extracting from `{{tabela wydania}}`, always pick the highest indexed `informacjaN` that is NOT empty. Fallback to `{{Książka}}` only if no valid `infowydanie` is found.
+- **Notion Schema**: Always check for column existence before writing. Handled by `SchemaValidationService`.
+- **Library Scan**: 30000ms timeout, 500ms delay, 4 retries. Fail-fast on network error. Uses `withRetry`.
+- **Vinted Scan**: 30000ms timeout, 3 retries, 3-5s delay with jitter.
+
+## 4. TEST ARCHITECTURE (VITEST)
+- **Structure**: Tests are organized into `__tests__` subdirectories to maintain `src` cleanliness.
+  - `/__tests__/`: Infrastructure, adapters, and server tests.
+  - `/services/__tests__/`: Business logic and synchronization services.
+  - `/src/__tests__/`: Main UI components.
+  - `/src/hooks/__tests__/`: Custom React hooks.
+- **Mocking**: Use `vi.mock` for external dependencies (Notion SDK, Axios).
+- **Environment**: Use `@vitest-environment node` for backend tests and JSDOM for frontend tests.
+
+## 5. TOKEN OPTIMIZATION (AI INSTRUCTIONS)
+- **Surgical Edits**: Use `edit_file` with precise `TargetContent`. Never replace whole files.
+- **Context Awareness**: Read `package.json` and `server.ts` imports before adding new services.
+- **Conciseness**: Skip apologies and meta-talk. Execute -> Summarize.
+- **Reuse**: Reference `useSync` patterns instead of re-implementing SSE handling.
+
+## 6. DESIGN SYSTEM
+- **Font**: Display (Headings) = Tracking-tighter, uppercase. Body = Sans.
+- **Icons**: `lucide-react`.
+- **Palette**: `cyan-500` (primary), `purple-600` (secondary), `slate-900/20` (glass).
+
+## 7. ALGORITHM DOCUMENTATION
+- **Detailed Instructions**: Detailed machine instructions for each core functionality are located in the `/docs/` directory.
+- **Available Docs**:
+  - `docs/book-sync.md`: Book Synchronization Algorithm.
+  - `docs/publisher-series-sync.md`: Publisher & Series Synchronization.
+  - `docs/duplicate-detection.md`: Duplicate Detection & Management.
+  - `docs/library-check.md`: Library Availability Check (Scraping).
+  - `docs/stats-service.md`: Statistics Generation.
+  - `docs/integrity-service.md`: Data Integrity & Sanctity.
+  - `docs/purification-service.md`: Data Purification.
+  - `docs/schema-validation.md`: Schema Validation & Initialization.
+  - `docs/lp-sync.md`: Lp (Position) Synchronization.
+  - `docs/cycles-sync.md`: Book Cycles Detection.
+  - `docs/vinted-scanner.md`: AI-Powered Market Search.
+
+## 8. DOCUMENTATION & MAINTENANCE
+- **Self-Correction**: After every major architectural change or logic fix (e.g., new service, parser update), the AI Agent MUST review and update `COGITATOR_GUIDELINES.md` and `README.md`.
+- **Version Control**: Increment the version in the header if significant changes are made.
+- **Consistency**: Ensure that `README.md` descriptions match the actual implementation in `services/`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,129 @@
-# CogitatorOmmnissiah
-A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.
+# Adeptus Archivist: Sci-Fi Award Synchronizer
+
+Adeptus Archivist is a specialized tool designed to bridge the gap between sci-fi literature encyclopedias and personal Notion databases. It automates the process of tracking award-winning science fiction novels, ensuring your personal library or reading list is always up-to-date with the latest data from the "Archiwum Encyklopedii Fantastyki".
+
+## Project Goals
+
+- **Automated Data Harvesting**: Extract structured data from MediaWiki-based encyclopedias (specifically Hugo, Nebula, and Locus awards).
+- **Notion Integration**: Seamlessly synchronize harvested data with a Notion database, handling both new entries and updates to existing ones.
+- **Data Enrichment**: Automatically fetch additional details like publishers and series information for each book.
+- **Market Intelligence**: Integrated Vinted scanner to help users find physical copies of award-winning books.
+
+## Architectural Solutions
+
+### 1. Hybrid Full-Stack Architecture
+The application uses a **Vite + Express** hybrid setup. 
+- **Frontend**: A high-performance React SPA styled with Tailwind CSS, featuring a "Cyber-Archivist" aesthetic. It uses Framer Motion for immersive animations and Lucide-React for iconography.
+- **Backend**: An Express.js server that handles long-running synchronization tasks, API proxying, and secure communication with external services (Notion, MediaWiki).
+
+### 2. Service-Oriented Architecture (Refactored)
+To adhere to the **Single Responsibility Principle (SRP)**, the backend has been refactored into a modular structure:
+- **Services (`/services/`)**: Encapsulate core business logic for different synchronization tasks (e.g., `BookSyncService`, `DuplicateSyncService`, `PublisherSyncService`, `SeriesSyncService`, `CyclesSyncService`, `LpSyncService`, `StatsService`, `IntegrityService`, `PurificationService`, `SchemaValidationService`).
+- **Controllers (`/controllers/`)**: Handle HTTP request parsing and response formatting, delegating business logic to services.
+- **Routes (`/routes/`)**: Define API endpoints and map them to appropriate controllers.
+- **SyncManager**: Acts as an orchestrator that coordinates the execution of various synchronization services.
+
+### 3. Adapter Pattern for External Services
+To maintain clean separation of concerns, the project implements dedicated adapters:
+- **NotionAdapter**: Encapsulates the complexity of the Notion SDK, managing database queries, page creation, and property mapping.
+- **WikiAdapter**: Handles HTTP communication with the MediaWiki API, including content fetching and slot-based data retrieval.
+
+### 4. Real-Time Progress Tracking (SSE)
+Synchronization tasks can be time-consuming. The system uses **Server-Sent Events (SSE)** to provide real-time feedback to the frontend. This allows the user to see exactly which book is being processed, the current progress percentage, and estimated time of arrival (ETA).
+
+### 5. Intelligent Data Merging & Normalization
+The sync engine doesn't just overwrite data. It:
+- **Data Normalization**: A dedicated `DataNormalizer` service handles specific exceptions for publishers (e.g., "Zysk i S-ka") and original titles to ensure consistency across different data sources.
+- **Diff Engine**: A specialized `DiffEngine` ensures that multi-select properties in Notion are compared correctly (ignoring order and whitespace) before triggering an update.
+- **Multi-Award Handling**: Correctly merges multiple awards for a single book (e.g., a book winning both Hugo and Nebula).
+- **Smart Updates**: Compares existing Notion data with Wiki data and only performs updates if changes are detected, minimizing API calls.
+
+### 6. AI-Powered Market Search
+The "Vinted Artifact Scanner" leverages the **Gemini 3 Flash** model with Google Search grounding. This allows the app to perform real-time web searches for current listings on Vinted.pl, providing users with direct links to purchase books.
+
+## Tech Stack
+
+- **Frontend**: React 19, Tailwind CSS 4, Motion, Lucide-React.
+- **Backend**: Node.js, Express, Axios.
+- **Integrations**: Notion SDK, MediaWiki API, Google GenAI (Gemini).
+- **Dev Tools**: Vitest, TypeScript, Vite, tsx, esbuild.
+
+## Environment Configuration
+
+The application requires the following environment variables:
+- `NOTION_API_KEY`: Your Notion integration token.
+- `NOTION_DATABASE_ID`: The ID of the target Notion database.
+- `GEMINI_API_KEY`: API key for AI-powered features.
+
+---
+*Developed for the preservation of literary artifacts in the digital age.*
+
+## Test Suite
+
+The project includes a comprehensive test suite covering frontend, backend, and core logic, organized into a clean directory structure.
+
+### 1. Test Directory Structure
+- **`/__tests__/`**: Infrastructure, adapters, and server tests.
+- **`/services/__tests__/`**: Business logic and synchronization services.
+- **`/src/__tests__/`**: Main UI components (e.g., `App.test.tsx`).
+- **`/src/hooks/__tests__/`**: Custom React hooks.
+
+### 2. Frontend Integration Tests (`src/__tests__/App.test.tsx`)
+- **Status Ducha Maszyny**: Verifies the rendering of the "Machine Spirit" status and award links.
+- **Award Selection**: Ensures all award options (Hugo, Nebula, Locus, All) are available in the dropdown.
+- **Synchronization Flow**:
+    - Tests single award synchronization (Hugo, Nebula, Locus).
+    - Tests "All Awards" synchronization flow.
+    - Verifies real-time UI updates during streaming (status messages, progress bar).
+    - **Sync Summary**: Asserts on the final summary, checking counts for added, updated, and skipped items, and verifying the list of added book names.
+- **Tool Navigation**: Checks the visibility of data exploration, cycle marking, and Rytuał Rekonstrukcji Liczb tools.
+- **Schema Editor**:
+    - Verifies rendering of Notion properties and their status (usage percentage).
+    - Tests the ability to delete options from properties (except for the "Autor" property).
+- **Vinted Scanner**: Verifies the UI state during a Vinted artifact search.
+
+### 3. Backend API Tests (`__tests__/server.test.ts`)
+- **Health & Config**: Verifies `/api/health` and `/api/config` endpoints.
+- **Notion Schema**: Tests fetching and updating the Notion database schema via `/api/notion/schema`.
+- **Sync Control**:
+    - Verifies the initiation of the synchronization stream via `/api/sync`.
+    - Tests the synchronization stop mechanism via `/api/sync/stop`.
+
+### 4. Core Logic & Service Tests
+- **Data Extraction (`__tests__/wiki.parser.test.ts`)**: Tests the `WikiParser` logic for extracting publisher and series information from complex MediaWiki wikitext templates.
+- **Service Logic (`services/__tests__/*.test.ts`)**: Comprehensive tests for each synchronization service, ensuring correct data comparison, normalization, and Notion updates.
+- **Hook Logic (`src/hooks/__tests__/*.test.ts`)**: Verifies the behavior of custom React hooks, including SSE handling in `useSync`.
+
+### Running Tests
+To execute the full test suite, run:
+```bash
+npm test
+```
+
+## Synchronization Process
+
+The synchronization process is a multi-stage pipeline designed to ensure data integrity and minimize Notion API usage.
+
+### 1. Data Harvesting
+- **Wiki Fetching**: The `WikiAdapter` fetches raw wikitext from the "Archiwum Encyklopedii Fantastyki" for the selected award page.
+- **Parsing**: The `WikiParser` processes the wikitext, stripping HTML/Wiki markup, normalizing table structures, and extracting book metadata (year, author, titles). It uses a priority system to pick the most relevant edition details from `{{tabela wydania}}`.
+
+### 2. Data Merging & Normalization
+- **Data Normalization**: The `DataNormalizer` service applies specific rules to publishers and titles to handle known variations and ensure data consistency.
+- **Deduplication**: Books appearing multiple times (e.g., winning multiple awards) are merged into a single entry with a combined list of awards.
+- **Duplicate Detection**: The system uses a strict word-matching algorithm on original titles. If two books share at least two significant words (ignoring common stop words and short words) in their original titles, they are flagged as potential duplicates.
+- **Award Logic**: If a book wins Hugo, Nebula, and Locus, it is automatically tagged with the "Wszystkie" (All) award.
+
+### 3. Notion Synchronization
+- **Database Query**: The system queries the existing Notion database to build a map of books already present, using Polish or original titles as keys.
+- **Comparison & Action**:
+    - **New Book**: If not found, a new row is created in Notion with all properties.
+    - **Existing Book**: If found, the system compares existing Notion data with the new data.
+    - **Update**: If differences are detected (e.g., new award, title change), only the specific fields are updated in Notion.
+    - **Skip**: If no changes are detected, the book is skipped to save API quota.
+
+### 4. Real-Time Reporting
+- The backend streams progress updates to the frontend using **Server-Sent Events (SSE)**, reporting:
+    - `status`: Current stage of the pipeline.
+    - `progress`: Percentage completion for long-running tasks.
+    - `complete`: Final summary containing counts of added, updated, and skipped books, along with lists of added/updated titles.

--- a/__tests__/notion.adapter.test.ts
+++ b/__tests__/notion.adapter.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client } from '@notionhq/client';
+
+const mockClient = {
+  databases: {
+    retrieve: vi.fn(),
+    update: vi.fn(),
+    query: vi.fn(),
+  },
+  dataSources: {
+    retrieve: vi.fn(),
+    update: vi.fn(),
+    query: vi.fn(),
+  },
+  pages: {
+    update: vi.fn(),
+    create: vi.fn(),
+  }
+};
+
+vi.mock('@notionhq/client', () => {
+  return {
+    Client: class {
+      constructor() {
+        return mockClient;
+      }
+    }
+  };
+});
+
+import { NotionAdapter } from '../notion.adapter';
+
+describe('NotionAdapter', () => {
+  let adapter: NotionAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new NotionAdapter('test-key', 'test-db-id');
+  });
+
+  describe('init', () => {
+    it('initializes as data source if possible', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValueOnce({ id: 'test-db-id' });
+      
+      await adapter.init();
+      
+      expect(mockClient.dataSources.retrieve).toHaveBeenCalledWith({ data_source_id: 'test-db-id' });
+      expect((adapter as any).isDataSource).toBe(true);
+      expect((adapter as any).actualDataSourceId).toBe('test-db-id');
+    });
+
+    it('falls back to database if data source retrieve fails', async () => {
+      mockClient.dataSources.retrieve.mockRejectedValueOnce(new Error('Not found'));
+      mockClient.databases.retrieve.mockResolvedValueOnce({ id: 'test-db-id', data_sources: [] });
+      
+      await adapter.init();
+      
+      expect(mockClient.databases.retrieve).toHaveBeenCalledWith({ database_id: 'test-db-id' });
+      expect((adapter as any).isDataSource).toBe(false);
+      expect((adapter as any).actualDataSourceId).toBe('test-db-id');
+    });
+
+    it('uses data source from database if available', async () => {
+      mockClient.dataSources.retrieve.mockRejectedValueOnce(new Error('Not found'));
+      mockClient.databases.retrieve.mockResolvedValueOnce({ 
+        id: 'test-db-id', 
+        data_sources: [{ id: 'ds-123' }] 
+      });
+      
+      await adapter.init();
+      
+      expect((adapter as any).isDataSource).toBe(true);
+      expect((adapter as any).actualDataSourceId).toBe('ds-123');
+    });
+  });
+
+  describe('getSchema', () => {
+    it('returns schema from data source', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValueOnce({ id: 'test-db-id' }); // for init
+      mockClient.dataSources.retrieve.mockResolvedValueOnce({ properties: { 'Tytuł': {} } }); // for getSchema
+      
+      const schema = await adapter.getSchema();
+      expect(schema).toEqual({ 'Tytuł': {} });
+    });
+  });
+
+  describe('queryAllBooks', () => {
+    it('queries all books and parses them correctly', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValueOnce({ id: 'test-db-id' }); // for init
+      
+      const mockPage = {
+        id: 'page-1',
+        properties: {
+          'Tytuł polski': { type: 'title', title: [{ plain_text: 'Solaris' }] },
+          'Autor': { type: 'rich_text', rich_text: [{ plain_text: 'Stanisław Lem' }] },
+          'Rok': { type: 'number', number: 1961 },
+          'Nagroda': { type: 'multi_select', multi_select: [{ name: 'Zajdel' }] }
+        }
+      };
+      
+      mockClient.dataSources.query.mockResolvedValueOnce({
+        results: [mockPage],
+        has_more: false
+      });
+
+      const books = await adapter.queryAllBooks();
+      
+      expect(books).toHaveLength(1);
+      expect(books[0]).toEqual(expect.objectContaining({
+        id: 'page-1',
+        plTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        year: '1961',
+        awards: ['Zajdel']
+      }));
+    });
+  });
+
+  describe('updateDatabaseProperty', () => {
+    it('updates a property correctly', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValueOnce({ id: 'test-db-id' }); // for init
+      
+      await adapter.updateDatabaseProperty('test-db-id', 'Wydawnictwo', 'rich_text');
+      
+      expect(mockClient.dataSources.update).toHaveBeenCalledWith({
+        data_source_id: 'test-db-id',
+        properties: {
+          'Wydawnictwo': {
+            rich_text: {}
+          }
+        }
+      });
+    });
+  });
+});

--- a/__tests__/retry.test.ts
+++ b/__tests__/retry.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { withRetry } from '../retry';
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('resolves immediately if function succeeds', async () => {
+    const fn = vi.fn().mockResolvedValue('success');
+    const result = await withRetry(fn);
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 429 rate limit error', async () => {
+    const error429 = new Error('Rate limit');
+    (error429 as any).status = 429;
+    
+    const fn = vi.fn()
+      .mockRejectedValueOnce(error429)
+      .mockResolvedValueOnce('success');
+
+    const promise = withRetry(fn, 3, 100);
+    
+    // Fast-forward timers to skip the delay
+    await vi.runAllTimersAsync();
+    
+    const result = await promise;
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on 5xx server error', async () => {
+    const error500 = new Error('Server error');
+    (error500 as any).status = 500;
+    
+    const fn = vi.fn()
+      .mockRejectedValueOnce(error500)
+      .mockResolvedValueOnce('success');
+
+    const promise = withRetry(fn, 3, 100);
+    await vi.runAllTimersAsync();
+    
+    const result = await promise;
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on 4xx client errors (except 429)', async () => {
+    const error404 = new Error('Not found');
+    (error404 as any).status = 404;
+    
+    const fn = vi.fn().mockRejectedValue(error404);
+
+    await expect(withRetry(fn, 3, 100)).rejects.toThrow('Not found');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after max retries', async () => {
+    const error500 = new Error('Server error');
+    (error500 as any).status = 500;
+    
+    const fn = vi.fn().mockRejectedValue(error500);
+
+    const promise = withRetry(fn, 3, 100);
+    
+    // Attach a catch handler to prevent unhandled rejection warning
+    promise.catch(() => {});
+    
+    // Advance timers enough times to trigger all retries
+    for (let i = 0; i < 3; i++) {
+      await vi.runAllTimersAsync();
+    }
+
+    await expect(promise).rejects.toThrow('Server error');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+
+import { app, closeServer } from '../server';
+
+// Mocking adapters
+vi.mock('../notion.adapter', () => {
+  const NotionAdapter = vi.fn();
+  NotionAdapter.prototype.init = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.getSchema = vi.fn().mockResolvedValue({
+    "Autor": { type: "multi_select", multi_select: { options: [] } }
+  });
+  NotionAdapter.prototype.updateSchema = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.queryAllBooks = vi.fn().mockResolvedValue([]);
+  NotionAdapter.prototype.updatePage = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.addRow = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+  NotionAdapter.prototype.resolveDataSourceId = vi.fn().mockResolvedValue('test-ds-id');
+  NotionAdapter.prototype.retrieveDataSource = vi.fn().mockResolvedValue({ properties: {} });
+  NotionAdapter.prototype.updateDatabaseProperty = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.createColumnIfNeeded = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.updateLp = vi.fn().mockResolvedValue(undefined);
+  return { NotionAdapter };
+});
+
+vi.mock('../wiki.adapter', () => {
+  const WikiAdapter = vi.fn();
+  WikiAdapter.prototype.fetchPageContent = vi.fn().mockResolvedValue('{| class="wikitable"\n|-\n! Rok !! Autor !! Tytuł oryginalny !! Tytuł polski\n|-\n| 1961 || [[Stanisław Lem]] || \'\'Solaris\'\' || Solaris\n|}');
+  WikiAdapter.prototype.fetchPageContentWithSlots = vi.fn().mockResolvedValue('{{Książka|wydawca=Wydawnictwo Literackie|seria=Dzieła}}');
+  return { WikiAdapter };
+});
+
+describe('Backend API Endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NOTION_API_KEY = 'test-key';
+    process.env.NOTION_DATABASE_ID = 'test-db';
+  });
+
+  it('GET /api/health returns ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok', isSyncing: false });
+  });
+
+  it('GET /api/config returns environment status', async () => {
+    const res = await request(app).get('/api/config');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('hasNotionKey', true);
+    expect(res.body).toHaveProperty('hasDatabaseId', true);
+  });
+
+  it('GET /api/notion/schema returns properties', async () => {
+    const res = await request(app).get('/api/notion/schema');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('Autor');
+  });
+
+  it('PATCH /api/notion/schema updates property', async () => {
+    const res = await request(app)
+      .patch('/api/notion/schema')
+      .send({
+        propertyName: 'Autor',
+        propertyType: 'multi_select',
+        newOptions: [{ name: 'Lem' }]
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  it('POST /api/sync starts a sync stream', async () => {
+    const res = await request(app)
+      .post('/api/sync')
+      .send({
+        awardName: 'Nagroda Hugo',
+        pageTitle: 'Hugo nagroda powieść',
+        syncAll: false
+      });
+    
+    expect(res.status).toBe(200);
+    expect(res.header['content-type']).toContain('text/event-stream');
+    // We don't wait for full stream completion in this simple test
+  });
+
+  it('POST /api/sync-duplicates starts a duplicate check stream', async () => {
+    const res = await request(app)
+      .post('/api/sync-duplicates')
+      .send({});
+    
+    expect(res.status).toBe(200);
+    expect(res.header['content-type']).toContain('text/event-stream');
+  });
+
+  it('POST /api/sync-duplicates/stop stops a duplicate check', async () => {
+    const res = await request(app).post('/api/sync-duplicates/stop');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success');
+  });
+
+  afterAll(() => {
+    closeServer();
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  cleanTitle,
+  sanitizeNotionString,
+  sanitizeNotionTag,
+  isValidUrl,
+  stripWikiFormatting,
+  calculateSimilarity,
+  countCommonWords,
+  normalizeAuthor
+} from '../utils';
+
+describe('utils', () => {
+  describe('cleanTitle', () => {
+    it('removes extra spaces', () => {
+      expect(cleanTitle('  Hello   World  ')).toBe('Hello World');
+    });
+    it('returns empty string for falsy values', () => {
+      expect(cleanTitle('')).toBe('');
+      expect(cleanTitle(null as any)).toBe('');
+    });
+  });
+
+  describe('sanitizeNotionString', () => {
+    it('removes control characters and limits length', () => {
+      const longString = 'a'.repeat(2500);
+      const sanitized = sanitizeNotionString(longString, 2000);
+      expect(sanitized.length).toBe(2000);
+      expect(sanitizeNotionString('Hello\x00World')).toBe('HelloWorld');
+    });
+  });
+
+  describe('sanitizeNotionTag', () => {
+    it('removes commas and control characters, limits to 100', () => {
+      expect(sanitizeNotionTag('Sci-Fi, Fantasy')).toBe('Sci-Fi Fantasy');
+      const longTag = 'a'.repeat(150);
+      expect(sanitizeNotionTag(longTag).length).toBe(100);
+    });
+  });
+
+  describe('isValidUrl', () => {
+    it('validates http and https urls', () => {
+      expect(isValidUrl('https://example.com')).toBe(true);
+      expect(isValidUrl('http://example.com')).toBe(true);
+      expect(isValidUrl('ftp://example.com')).toBe(false);
+      expect(isValidUrl('not a url')).toBe(false);
+      expect(isValidUrl(null)).toBe(false);
+    });
+  });
+
+  describe('stripWikiFormatting', () => {
+    it('removes wiki links and italics', () => {
+      expect(stripWikiFormatting("''[[The Lord of the Rings|Władca Pierścieni]]''")).toBe('Władca Pierścieni');
+      expect(stripWikiFormatting("[[Dune]]")).toBe('Dune');
+    });
+  });
+
+  describe('calculateSimilarity', () => {
+    it('calculates string similarity correctly', () => {
+      expect(calculateSimilarity('test', 'test')).toBe(1);
+      expect(calculateSimilarity('test', 'tast')).toBeGreaterThan(0.5);
+      expect(calculateSimilarity('abc', 'xyz')).toBe(0);
+    });
+  });
+
+  describe('countCommonWords', () => {
+    it('counts common significant words', () => {
+      expect(countCommonWords('The Lord of the Rings', 'Lord of Rings')).toBe(2); // 'lord', 'rings'
+      expect(countCommonWords('Harry Potter and the Goblet of Fire', 'Harry Potter')).toBe(2);
+    });
+  });
+
+  describe('normalizeAuthor', () => {
+    it('normalizes author names', () => {
+      expect(normalizeAuthor('Tolkien, J.R.R.')).toBe('jrr tolkien');
+      expect(normalizeAuthor('Stanisław Lem (1921-2006)')).toBe('stanisław lem');
+      expect(normalizeAuthor('George R. R. Martin')).toBe('george r r martin');
+    });
+  });
+});

--- a/__tests__/wiki.adapter.test.ts
+++ b/__tests__/wiki.adapter.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn()
+}));
+
+vi.mock('axios', () => {
+  return {
+    default: {
+      create: vi.fn(() => ({
+        get: mockGet
+      }))
+    }
+  };
+});
+
+import { WikiAdapter } from '../wiki.adapter';
+
+describe('WikiAdapter', () => {
+  let wikiAdapter: WikiAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wikiAdapter = new WikiAdapter();
+  });
+
+  describe('fetchPageContent', () => {
+    it('fetches page content successfully', async () => {
+      const mockResponse = {
+        data: {
+          query: {
+            pages: {
+              '123': {
+                revisions: [{ '*': 'Mocked Wiki Content' }]
+              }
+            }
+          }
+        }
+      };
+      mockGet.mockResolvedValueOnce(mockResponse);
+      
+      const content = await wikiAdapter.fetchPageContent('Test Title');
+      expect(content).toBe('Mocked Wiki Content');
+      expect(mockGet).toHaveBeenCalledWith(
+        'https://encyklopediafantastyki.pl/api.php',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            titles: 'Test Title'
+          })
+        })
+      );
+    });
+
+    it('returns empty string when page is not found', async () => {
+      const mockResponse = {
+        data: {
+          query: {
+            pages: {
+              '-1': { missing: true }
+            }
+          }
+        }
+      };
+      mockGet.mockResolvedValueOnce(mockResponse);
+
+      await expect(wikiAdapter.fetchPageContent('Unknown Title')).resolves.toBe('');
+    });
+  });
+
+  describe('fetchPageContentWithSlots', () => {
+    it('fetches page content from main slot', async () => {
+      const mockResponse = {
+        data: {
+          query: {
+            pages: {
+              '123': {
+                revisions: [{
+                  slots: {
+                    main: { '*': 'Slot Content' }
+                  }
+                }]
+              }
+            }
+          }
+        }
+      };
+      mockGet.mockResolvedValueOnce(mockResponse);
+      
+      const content = await wikiAdapter.fetchPageContentWithSlots('Test Title');
+      expect(content).toBe('Slot Content');
+    });
+  });
+});

--- a/__tests__/wiki.parser.test.ts
+++ b/__tests__/wiki.parser.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { WikiParser } from '../wiki.parser';
+
+describe('WikiParser', () => {
+  describe('cleanWikitext', () => {
+    it('cleans wikitext formatting', () => {
+      expect(WikiParser.cleanWikitext('[[Link|Text]]')).toBe('Text');
+      expect(WikiParser.cleanWikitext('{{sortname|John|Doe}}')).toBe('John Doe');
+      expect(WikiParser.cleanWikitext("''Italic''")).toBe('Italic');
+    });
+  });
+
+  describe('extractPublisherAndSeries', () => {
+    it('extracts publisher and series from wikitext', () => {
+      const wikitext = `
+        {{Książka
+        |autor = Stanisław Lem
+        |tytuł = Solaris
+        |wydawca = Wydawnictwo Literackie
+        |seria = Dzieła
+        }}
+      `;
+      const result = WikiParser.extractPublisherAndSeries(wikitext);
+      expect(result.wydawca).toBe('Wydawnictwo Literackie');
+      expect(result.seria).toBe('Dzieła');
+    });
+
+    it('handles missing series', () => {
+      const wikitext = `
+        {{Książka
+        |wydawca = Iskry
+        }}
+      `;
+      const result = WikiParser.extractPublisherAndSeries(wikitext);
+      expect(result.wydawca).toBe('Iskry');
+      expect(result.seria).toBe('');
+    });
+
+    it('handles missing publisher', () => {
+      const wikitext = `
+        {{Książka
+        |seria = Fantastyka-Przygoda
+        }}
+      `;
+      const result = WikiParser.extractPublisherAndSeries(wikitext);
+      expect(result.wydawca).toBe('');
+      expect(result.seria).toBe('Fantastyka-Przygoda');
+    });
+  });
+
+  describe('extractAuthor', () => {
+    it('extracts author from infobox', () => {
+      const wikitext = `
+        {{Książka
+        |autor = [[Stanisław Lem]]
+        }}
+      `;
+      expect(WikiParser.extractAuthor(wikitext)).toBe('Stanisław Lem');
+    });
+  });
+
+  describe('checkCycle', () => {
+    it('detects cycle from parameters', () => {
+      expect(WikiParser.checkCycle('| cykl = Fundacja')).toBe(true);
+      expect(WikiParser.checkCycle('| seria = Diuna')).toBe(true);
+    });
+
+    it('detects cycle from templates', () => {
+      expect(WikiParser.checkCycle('{{Cykl | nazwa = Wiedźmin}}')).toBe(true);
+    });
+
+    it('returns false when no cycle is present', () => {
+      expect(WikiParser.checkCycle('{{Książka | autor = Lem}}')).toBe(false);
+    });
+  });
+});

--- a/check-console.cjs
+++ b/check-console.cjs
@@ -1,0 +1,13 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+  
+  page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+  page.on('pageerror', error => console.log('PAGE ERROR:', error.message));
+  page.on('requestfailed', request => console.log('REQUEST FAILED:', request.url(), request.failure().errorText));
+
+  await page.goto('http://localhost:3000', { waitUntil: 'networkidle0' });
+  await browser.close();
+})();

--- a/check-console.js
+++ b/check-console.js
@@ -1,0 +1,13 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+  
+  page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+  page.on('pageerror', error => console.log('PAGE ERROR:', error.message));
+  page.on('requestfailed', request => console.log('REQUEST FAILED:', request.url(), request.failure().errorText));
+
+  await page.goto('http://localhost:3000', { waitUntil: 'networkidle0' });
+  await browser.close();
+})();

--- a/components/ParticleBackground.tsx
+++ b/components/ParticleBackground.tsx
@@ -1,0 +1,201 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export const ParticleBackground: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    if (typeof window !== 'undefined') {
+      const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+      setPrefersReducedMotion(mediaQuery.matches);
+      
+      const listener = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+      mediaQuery.addEventListener("change", listener);
+      return () => mediaQuery.removeEventListener("change", listener);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted || prefersReducedMotion) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let animationFrameId: number;
+    let particles: Particle[] = [];
+
+    const mouse = { x: -1000, y: -1000 };
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      initParticles();
+    };
+
+    type Particle = {
+      x: number;
+      y: number;
+      vx: number;
+      vy: number;
+      size: number;
+      update: () => void;
+      draw: () => void;
+    };
+
+    const createParticle = (): Particle => {
+      const p: Particle = {
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        vx: (Math.random() - 0.5) * 0.5,
+        vy: (Math.random() - 0.5) * 0.5,
+        size: Math.random() * 2 + 0.5,
+        update: () => {
+          p.x += p.vx;
+          p.y += p.vy;
+          if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+          if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+        },
+        draw: () => {
+          if (!ctx) return;
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+          ctx.fillStyle = "rgba(139, 92, 246, 0.8)";
+          ctx.fill();
+        }
+      };
+      return p;
+    };
+
+    const initParticles = () => {
+      particles = [];
+      // Adjust particle count based on screen size
+      const numParticles = Math.min(
+        Math.floor((window.innerWidth * window.innerHeight) / 12000),
+        120,
+      );
+      for (let i = 0; i < numParticles; i++) {
+        particles.push(createParticle());
+      }
+    };
+
+    const drawLines = () => {
+      for (let i = 0; i < particles.length; i++) {
+        // Connect particles to each other
+        for (let j = i + 1; j < particles.length; j++) {
+          const dx = particles[i].x - particles[j].x;
+          const dy = particles[i].y - particles[j].y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+
+          if (distance < 120) {
+            ctx.beginPath();
+            ctx.strokeStyle = `rgba(56, 189, 248, ${0.2 - distance / 600})`; // Cyan-ish connections
+            ctx.lineWidth = 0.5;
+            ctx.moveTo(particles[i].x, particles[i].y);
+            ctx.lineTo(particles[j].x, particles[j].y);
+            ctx.stroke();
+          }
+        }
+
+        // Connect particles to mouse
+        const dxMouse = particles[i].x - mouse.x;
+        const dyMouse = particles[i].y - mouse.y;
+        const distanceMouse = Math.sqrt(dxMouse * dxMouse + dyMouse * dyMouse);
+
+        if (distanceMouse < 180) {
+          ctx.beginPath();
+          // Brighter connection to the mouse cursor
+          ctx.strokeStyle = `rgba(139, 92, 246, ${0.6 - distanceMouse / 300})`;
+          ctx.lineWidth = 1;
+          ctx.moveTo(particles[i].x, particles[i].y);
+          ctx.lineTo(mouse.x, mouse.y);
+          ctx.stroke();
+
+          // Slight attraction to mouse
+          if (distanceMouse > 50) {
+            particles[i].x -= dxMouse * 0.005;
+            particles[i].y -= dyMouse * 0.005;
+          }
+        }
+      }
+    };
+
+    const animate = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      particles.forEach((p) => {
+        p.update();
+        p.draw();
+      });
+
+      drawLines();
+
+      animationFrameId = requestAnimationFrame(animate);
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      mouse.x = e.clientX;
+      mouse.y = e.clientY;
+    };
+
+    const handleMouseOut = () => {
+      mouse.x = -1000;
+      mouse.y = -1000;
+    };
+
+    window.addEventListener("resize", resize, { passive: true });
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
+    window.addEventListener("mouseout", handleMouseOut, { passive: true });
+
+    resize();
+    animate();
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseout", handleMouseOut);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [prefersReducedMotion, mounted]);
+
+  if (!mounted) {
+    return (
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 pointer-events-none z-0"
+        style={{
+          background:
+            "radial-gradient(circle at center, #0f172a 0%, #020617 100%)",
+        }}
+      />
+    );
+  }
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 pointer-events-none z-0"
+        style={{
+          background:
+            "radial-gradient(circle at center, #0f172a 0%, #020617 100%)",
+        }}
+      />
+    );
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="fixed inset-0 pointer-events-none z-0"
+      style={{
+        background:
+          "radial-gradient(circle at center, #0f172a 0%, #020617 100%)",
+      }}
+    />
+  );
+};

--- a/components/SanctityDebugger.tsx
+++ b/components/SanctityDebugger.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Bug, ChevronRight, AlertCircle, Database, Globe } from "lucide-react";
+import { IntegrityCheckResult } from "../types";
+
+interface SanctityDebuggerProps {
+  result: IntegrityCheckResult | null;
+}
+
+export const SanctityDebugger: React.FC<SanctityDebuggerProps> = ({ result }) => {
+  const [selectedDiff, setSelectedDiff] = React.useState<string | null>(null);
+
+  if (!result) return null;
+
+  const hasHeresy = !result.lpUniqueness.status || 
+                    !result.yearCountMatch.status || 
+                    !result.originalTitleUniqueness.status || 
+                    !result.polishTitleUniqueness.status || 
+                    !result.awardCountMatch.status || 
+                    !result.cycleCountMatch.status;
+
+  if (!hasHeresy) return null;
+
+  const diffItems = [
+    {
+      id: "years",
+      label: "Rozbieżności Roczników",
+      status: result.yearCountMatch.status,
+      data: result.yearCountMatch.diffs.map(d => ({
+        title: `Rok ${d.year}`,
+        notion: d.notion,
+        wiki: d.wiki,
+        notionOnly: d.notionOnly,
+        wikiOnly: d.wikiOnly,
+        misplaced: d.misplaced
+      }))
+    },
+    {
+      id: "awards",
+      label: "Rozbieżności Nagród",
+      status: result.awardCountMatch.status,
+      data: result.awardCountMatch.diffs.map(d => ({
+        title: d.award,
+        notion: d.notion,
+        wiki: d.wiki,
+        notionOnly: d.notionOnly,
+        wikiOnly: d.wikiOnly,
+        misplaced: undefined
+      }))
+    },
+    {
+      id: "cycles",
+      label: "Rozbieżności Cykli",
+      status: result.cycleCountMatch.status,
+      data: result.cycleCountMatch.status ? [] : [{
+        title: "Cykle",
+        notion: result.cycleCountMatch.notionCount,
+        wiki: result.cycleCountMatch.wikiCount,
+        notionOnly: result.cycleCountMatch.notionOnly,
+        wikiOnly: result.cycleCountMatch.wikiOnly,
+        misplaced: undefined
+      }]
+    }
+  ].filter(item => !item.status);
+
+  return (
+    <div className="bg-slate-900/60 border border-amber-500/20 rounded-2xl p-6 backdrop-blur-md shadow-2xl shadow-amber-900/10">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-2 bg-amber-500/10 rounded-lg border border-amber-500/30">
+          <Bug className="w-5 h-5 text-amber-400" />
+        </div>
+        <div>
+          <h3 className="text-sm font-bold uppercase tracking-[0.3em] text-amber-400">Protokół Debugowania Sanctity</h3>
+          <p className="text-[10px] text-slate-500 font-mono mt-1">ANALIZA ROZBIEŻNOŚCI STRUKTURALNYCH [NOTION vs WIKI]</p>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {diffItems.map((item) => (
+          <div key={item.id} className="space-y-2">
+            <button
+              onClick={() => setSelectedDiff(selectedDiff === item.id ? null : item.id)}
+              className="w-full flex items-center justify-between p-3 bg-slate-950/50 border border-slate-800 rounded-xl hover:border-amber-500/30 transition-all group"
+            >
+              <div className="flex items-center gap-3">
+                <AlertCircle className="w-4 h-4 text-amber-500" />
+                <span className="text-xs font-bold text-slate-300 uppercase tracking-wider">{item.label}</span>
+              </div>
+              <ChevronRight className={`w-4 h-4 text-slate-600 transition-transform ${selectedDiff === item.id ? 'rotate-90' : ''}`} />
+            </button>
+
+            <AnimatePresence>
+              {selectedDiff === item.id && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="overflow-hidden"
+                >
+                  <div className="space-y-3 p-1">
+                    {item.data.map((diff, idx) => (
+                      <div key={idx} className="bg-slate-950 rounded-xl border border-slate-800 overflow-hidden">
+                        <div className="bg-slate-900/50 px-4 py-2 border-b border-slate-800 flex justify-between items-center">
+                          <span className="text-[10px] font-bold text-amber-500/80 uppercase tracking-widest">{diff.title}</span>
+                          <div className="flex gap-4 text-[9px] font-mono">
+                            <span className="text-cyan-400">NOTION: {diff.notion}</span>
+                            <span className="text-purple-400">WIKI: {diff.wiki}</span>
+                          </div>
+                        </div>
+                        
+                        <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-800">
+                          {/* Notion Side */}
+                          <div className="p-3 space-y-2">
+                            <div className="flex items-center gap-2 mb-2">
+                              <Database className="w-3 h-3 text-cyan-500" />
+                              <span className="text-[9px] font-bold text-cyan-500/70 uppercase tracking-tighter">Tylko w Notion</span>
+                            </div>
+                            {diff.notionOnly && diff.notionOnly.length > 0 ? (
+                              <div className="space-y-1">
+                                {diff.notionOnly.map((book, i) => (
+                                  <div key={i} className="text-[9px] text-slate-400 font-mono bg-cyan-500/5 p-1.5 rounded border border-cyan-500/10">
+                                    + {book}
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <div className="text-[9px] text-slate-600 italic p-2">Brak unikalnych rekordów</div>
+                            )}
+                          </div>
+
+                          {/* Wiki Side */}
+                          <div className="p-3 space-y-2">
+                            <div className="flex items-center gap-2 mb-2">
+                              <Globe className="w-3 h-3 text-purple-500" />
+                              <span className="text-[9px] font-bold text-purple-500/70 uppercase tracking-tighter">Tylko na Wiki</span>
+                            </div>
+                            {diff.wikiOnly && diff.wikiOnly.length > 0 ? (
+                              <div className="space-y-1">
+                                {diff.wikiOnly.map((book, i) => (
+                                  <div key={i} className="text-[9px] text-slate-400 font-mono bg-purple-500/5 p-1.5 rounded border border-purple-500/10">
+                                    - {book}
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <div className="text-[9px] text-slate-600 italic p-2">Brak unikalnych rekordów</div>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* Misplaced Section */}
+                        {diff.misplaced && diff.misplaced.length > 0 && (
+                          <div className="p-3 bg-amber-500/5 border-t border-slate-800">
+                            <div className="flex items-center gap-2 mb-2">
+                              <AlertCircle className="w-3 h-3 text-amber-500" />
+                              <span className="text-[9px] font-bold text-amber-500/70 uppercase tracking-tighter">Błędny Rok (Wykryto w innym roczniku)</span>
+                            </div>
+                            <div className="space-y-1">
+                              {diff.misplaced.map((item, i) => (
+                                <div key={i} className="flex justify-between items-center text-[9px] text-slate-400 font-mono bg-amber-500/10 p-1.5 rounded border border-amber-500/20">
+                                  <span>? {item.title}</span>
+                                  <span className="text-amber-500/80">{item.otherYear}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/constants.ts
+++ b/constants.ts
@@ -1,0 +1,6 @@
+export const PREDEFINED_AWARDS = [
+  { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
+  { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
+  { name: "Nagroda Locus", title: "Locus nagroda powieść" },
+  { name: "Wszystkie Nagrody", title: "Wszystkie" },
+];

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -1,0 +1,273 @@
+import { Request, Response } from "express";
+import { syncManager } from "../server";
+import { SyncEvent, SyncParams } from "../src/types";
+
+export const getStats = async (req: Request, res: Response) => {
+  try {
+    const stats = await syncManager.getStats();
+    res.json(stats);
+  } catch (error: any) {
+    console.error("Stats Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania statystyk." });
+  }
+};
+
+export const getWikiLastUpdate = async (req: Request, res: Response) => {
+  try {
+    const { title } = req.query;
+    if (!title) return res.status(400).json({ error: "Missing title parameter" });
+    const lastUpdate = await syncManager.getWikiLastUpdate(title as string);
+    res.json({ lastUpdate });
+  } catch (error: any) {
+    console.error("Wiki Last Update Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania daty aktualizacji." });
+  }
+};
+
+export const getHealth = (req: Request, res: Response) => {
+  res.json({ 
+    status: "ok",
+    isSyncing: syncManager.isSyncing
+  });
+};
+
+export const getConfig = (req: Request, res: Response) => {
+  res.json({
+    hasNotionKey: !!process.env.NOTION_API_KEY,
+    hasDatabaseId: !!process.env.NOTION_DATABASE_ID,
+  });
+};
+
+export const getNotionSchema = async (req: Request, res: Response) => {
+  try {
+    const properties = await syncManager.getNotionSchema();
+    if (!properties || Object.keys(properties).length === 0) {
+      return res.json({ _empty: { type: "Baza danych nie ma żadnych kolumn (właściwości) lub jest całkowicie pusta." } });
+    }
+    res.json(properties);
+  } catch (error: any) {
+    console.error("Notion API Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania schematu." });
+  }
+};
+
+export const updateNotionSchema = async (req: Request, res: Response) => {
+  try {
+    const { propertyName, propertyType, newOptions } = req.body;
+    await syncManager.updateNotionSchema(propertyName, propertyType, newOptions);
+    res.json({ success: true });
+  } catch (error: any) {
+    console.error("Schema Update Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas aktualizacji schematu." });
+  }
+};
+
+export const resetSyncState = (req: Request, res: Response) => {
+  syncManager.resetSyncState();
+  res.json({ success: true, message: "Stan synchronizacji został zresetowany." });
+};
+
+const stopSyncTask = (res: Response, message: string) => {
+  if (syncManager.stopActiveSync()) {
+    res.json({ success: true, message });
+  } else {
+    res.json({ success: false, message: "Brak trwającej synchronizacji." });
+  }
+};
+
+export const stopSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie synchronizacji...");
+};
+
+export const stopPublisherSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie synchronizacji wydawnictw...");
+};
+
+export const stopSeriesSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie synchronizacji serii...");
+};
+
+export const stopCyclesSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie synchronizacji cykli...");
+};
+
+export const stopLpSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie aktualizacji Lp...");
+};
+
+export const stopDuplicatesSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie sprawdzania duplikatów...");
+};
+
+export const stopLibraryCheck = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie skanowania biblioteki...");
+};
+
+export const stopIntegrityCheck = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymano skanowanie integralności.");
+};
+
+const setupSSE = (res: Response) => {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  return (data: SyncEvent) => res.write(`data: ${JSON.stringify(data)}\n\n`);
+};
+
+export const runSync = async (req: Request, res: Response) => {
+  const { awardName, pageTitle, syncAll } = req.body as SyncParams;
+  
+  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+    return res.status(400).json({ error: "Brak kluczy API Notion." });
+  }
+
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runBookSync({ awardName, pageTitle, syncAll }, sendEvent),
+    "Sync Error:"
+  );
+};
+
+const executeSyncTask = async (
+  req: Request,
+  res: Response,
+  task: (sendEvent: (data: SyncEvent) => void) => Promise<void>,
+  errorMessage: string
+) => {
+  if (syncManager.isSyncing) return res.status(400).json({ error: "Inna synchronizacja jest już w toku." });
+  
+  const sendEvent = setupSSE(res);
+  const keepAlive = setInterval(() => res.write(": keepalive\n\n"), 15000);
+  try {
+    await task(sendEvent);
+    clearInterval(keepAlive);
+    res.end();
+  } catch (error: any) {
+    clearInterval(keepAlive);
+    console.error(errorMessage, error);
+    sendEvent({ type: "error", error: error.message || errorMessage });
+    res.end();
+  }
+};
+
+export const runPublisherSync = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runPublisherSync(sendEvent),
+    "Sync Publisher Error:"
+  );
+};
+
+export const runSeriesSync = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runSeriesSync(sendEvent),
+    "Sync Series Error:"
+  );
+};
+
+export const runCyclesSync = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runCyclesSync(sendEvent),
+    "Sync Cycles Error:"
+  );
+};
+
+export const runLpSync = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runLpSync(sendEvent),
+    "Sync Lp Error:"
+  );
+};
+
+export const runDuplicateCheck = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runDuplicateCheck(sendEvent),
+    "Sync Duplicates Error:"
+  );
+};
+
+export const runPurifySync = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runPurifySync(sendEvent),
+    "Sync Purify Error:"
+  );
+};
+
+export const stopPurifySync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymano rytuał puryfikacji.");
+};
+
+export const runSchemaSync = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runSchemaSync(sendEvent),
+    "Sync Schema Error:"
+  );
+};
+
+export const runIntegrityCheck = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.runIntegrityCheck(sendEvent),
+    "Integrity Check Error:"
+  );
+};
+
+export const stopSchemaSync = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymano inicjalizację schematu.");
+};
+
+export const markAsRead = async (req: Request, res: Response) => {
+  try {
+    const { pageId } = req.body;
+    if (!pageId) return res.status(400).json({ error: "Missing pageId parameter" });
+    await syncManager.markAsRead(pageId);
+    res.json({ success: true });
+  } catch (error: any) {
+    console.error("Mark as Read Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas oznaczania jako przeczytane." });
+  }
+};
+
+export const checkVintedAvailability = async (req: Request, res: Response) => {
+  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+    return res.status(400).json({ error: "Brak kluczy API Notion." });
+  }
+
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.checkVintedAvailability(sendEvent),
+    "Vinted Check Error:"
+  );
+};
+
+export const stopVintedCheck = (req: Request, res: Response) => {
+  stopSyncTask(res, "Zatrzymywanie skanowania Vinted...");
+};
+
+export const checkLibraryAvailability = async (req: Request, res: Response) => {
+  const { libraryCode } = req.body;
+  if (!libraryCode) return res.status(400).json({ error: "Missing libraryCode parameter" });
+
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.checkLibraryAvailability(libraryCode, sendEvent),
+    "Library Check Error:"
+  );
+};

--- a/docs/book-sync.md
+++ b/docs/book-sync.md
@@ -1,0 +1,37 @@
+# Book Synchronization Algorithm (BookSyncService)
+
+## 1. Overview
+Synchronizes book data from MediaWiki award tables (Hugo, Nebula, Locus) to a Notion database. It handles extraction, merging, and duplicate detection.
+
+## 2. Extraction Logic (`fetchBooksFromMediaWiki`)
+- **Source**: MediaWiki wikitext of award pages.
+- **Parsing Strategy**:
+  - Splits wikitext into rows using `|-`.
+  - Identifies column mapping (Year, Author, Original Title, Polish Title) by looking for header keywords.
+  - **Year Handling**: Remembers the last encountered year to fill empty year cells in subsequent rows.
+  - **Cell Cleaning**:
+    - Removes table attributes (e.g., `rowspan`, `style`).
+    - Strips wiki links `[[Page|Text]]` -> `Text`.
+    - Extracts links for Polish titles to use as Notion URLs.
+    - Handles special cases like "Nagroda Locus" (skipping YA category if requested).
+- **Normalization**: Original titles and authors are normalized using `dataNormalizer`.
+
+## 3. Comparison & Update Logic (`compareBooks`)
+- **Diff Engine**: Uses `DiffEngine` to perform stable comparisons of multi-select and string properties, ensuring updates are only made when meaningful changes occur.
+- **Polish Title**: Updates if the Wiki title differs from Notion. Preserves existing links if valid.
+- **Original Title**: Fills if empty in Notion.
+- **Author**: Merges authors, ensuring a unique list (max 100). Normalizes names (e.g., "Liu Cixin" -> "Liu Cixin, Ken Liu").
+- **Awards**: Combines existing awards with new ones. Automatically adds "Wszystkie" tag if Hugo, Nebula, and Locus are all present.
+- **Year**: Appends new years to the multi-select list.
+
+## 4. Duplicate Detection (In-Sync)
+- **Primary Key**: `Lower(Title|Author)`.
+- **Fuzzy Matching**:
+  - If no exact match is found, it scans the existing Notion database.
+  - **Criteria**: Same author (similarity > 0.85) AND at least 2 common significant words in the original title.
+  - **Stop Words**: Common Polish/English prepositions/conjunctions are ignored during word counting.
+
+## 5. Implementation Details
+- **Concurrency**: Uses `p-limit` to throttle Notion API calls.
+- **Cancellation**: Checks a cancellation token before every major operation.
+- **Progress Reporting**: Sends SSE events for status, progress, and completion.

--- a/docs/cycles-sync.md
+++ b/docs/cycles-sync.md
@@ -1,0 +1,18 @@
+# Book Cycles Detection Algorithm (CyclesSyncService)
+
+## 1. Overview
+Automatically identifies and marks books that belong to a literary cycle or series in the Notion database.
+
+## 2. Detection Logic (`runCyclesCheck`)
+- **Source**: All records from the Notion database.
+- **Criteria**:
+  - A book is considered part of a cycle if it has a non-empty value in the **"Seria"** column.
+- **Action**:
+  - Sets the **"Część cyklu"** checkbox to `true` if a series is present.
+  - Sets it to `false` if the series column is empty.
+
+## 3. Implementation Details
+- **Comparison**: Only updates the Notion record if the current checkbox value differs from the expected one.
+- **Concurrency**: Uses `p-limit(3)` to throttle Notion API calls.
+- **Progress Reporting**: Sends SSE events for each book being processed.
+- **Output**: Returns a summary of how many books were updated and any errors encountered.

--- a/docs/duplicate-detection.md
+++ b/docs/duplicate-detection.md
@@ -1,0 +1,33 @@
+# Duplicate Detection & Management Algorithm (DuplicateSyncService)
+
+## 1. Overview
+Identifies potential duplicate records in the Notion database based on title and author similarity. It provides a summary of findings for manual or automated resolution.
+
+## 2. Detection Logic (`runDuplicateCheck`)
+- **Source**: All records from the Notion database.
+- **Comparison Strategy**: $O(n^2)$ comparison of all book pairs.
+- **Signals**:
+  - **Exact Match (PL/Orig Title)**: `Lower(TitleA) === Lower(TitleB)`.
+  - **High Similarity (PL/Orig Title)**: `calculateSimilarity(TitleA, TitleB) > 0.9`.
+  - **Common Words + Same Author**:
+    - Same author (similarity > 0.85).
+    - At least 2 common significant words in the original or Polish title.
+  - **Common Words (Orig/PL Title)**: At least 2 common significant words (even if authors differ).
+- **Exclusions**:
+  - Pairs with clearly different authors (similarity < 0.5) are skipped to avoid false positives from common titles.
+  - Records with missing both Polish and original titles are ignored.
+
+## 3. Similarity Algorithm (`calculateSimilarity`)
+- **Method**: Levenshtein distance.
+- **Normalization**: Similarity = (LongerLength - Distance) / LongerLength.
+- **Range**: 0.0 (completely different) to 1.0 (identical).
+
+## 4. Word Counting (`countCommonWords`)
+- **Stop Words**: Ignores common Polish/English prepositions/conjunctions (e.g., "w", "na", "the", "of").
+- **Significant Words**: Only words with length > 2 are considered.
+- **Matching**: Case-insensitive set intersection.
+
+## 5. Implementation Details
+- **Batching**: Processes in batches to avoid blocking the event loop.
+- **Progress Reporting**: Sends SSE events for status, progress, and completion.
+- **Output**: Returns a list of duplicate pairs with the specific detection reason (e.g., "identyczny tytuł PL", "dopasowanie słów + ten sam autor").

--- a/docs/integrity-service.md
+++ b/docs/integrity-service.md
@@ -1,0 +1,30 @@
+# Data Integrity & Sanctity Algorithm (IntegrityService)
+
+## 1. Overview
+Performs a comprehensive cross-reference check between the Notion database and the Archiwum Encyklopedii (Wiki) to ensure data "sanctity" and consistency.
+
+## 2. Verification Logic (`runIntegrityCheck`)
+- **Source**: All records from Notion and all predefined award pages from Wiki (Hugo, Nebula, Locus).
+- **Matching Strategy**:
+  - Uses a "Robust Key": `Lower(NormalizedTitle|NormalizedAuthor)`.
+  - Normalizes titles by removing punctuation and extra spaces.
+  - Normalizes authors using `dataNormalizer`.
+
+## 3. Specific Checks
+- **Lp Uniqueness**:
+  - Scans for duplicate "Lp" values in Notion.
+- **Title Uniqueness (per Author)**:
+  - Scans for duplicate Polish or Original titles for the same author in Notion.
+- **Book Count per Year**:
+  - Compares the number of books per year in Notion vs. Wiki.
+  - **Exclusion**: Ignores "Locus YA" (Powieść dla młodzieży) category as it's not tracked in the main database.
+  - **Misplaced Detection**: Identifies books that exist in both databases but have different years.
+  - **Notion Only / Wiki Only**: Lists books that are missing from one of the databases for a specific year.
+  - **Collisions**: Uses fuzzy matching (similarity > 0.8) to identify potential matches when exact titles differ.
+- **Award Count Match**:
+  - Compares the count of books for each award (Hugo, Nebula, Locus) in Notion vs. Wiki.
+  - Identifies specific books that are missing the award tag in Notion.
+
+## 4. Implementation Details
+- **Robust Matching**: Handles minor title variations (e.g., "The Mule" vs "Mule") by stripping punctuation and normalizing spaces.
+- **Output**: Returns a detailed `IntegrityCheckResult` object with status (boolean) and a list of specific discrepancies for each check.

--- a/docs/library-check.md
+++ b/docs/library-check.md
@@ -1,0 +1,27 @@
+# Library Availability Check Algorithm (server.ts)
+
+## 1. Overview
+Scrapes the OPAC (Online Public Access Catalog) of the Municipal Public Library in Lublin (MBP Lublin) to check the availability of books in specific branches.
+
+## 2. Scraping Logic (`checkLibraryAvailability`)
+- **Source**: `https://opac.mbp.lublin.pl/search/description?q={title}&index=1&scope=full&f2%5B0%5D={libraryCode}`.
+- **Target**: Books in Notion that are NOT marked as "Przeczytane", "Biblioteka", "Biblioteka 9", or "Posiadam".
+- **Parsing Strategy**:
+  - Fetches the HTML content of the search results page.
+  - **Availability Check**:
+    - If the HTML contains "Brak wyników" or "Nie znaleziono", the book is marked as unavailable.
+    - If the HTML contains `class="record"` or "Szczegóły", the book is considered potentially available.
+  - **Title Extraction**:
+    - Uses a regex to extract the title from the OPAC page: `<dt[^>]*>\s*Tytuł:\s*<\/dt>\s*<dd[^>]*>\s*<span[^>]*>(.*?)<\/span>/i`.
+    - This helps verify if the search result actually matches the book being checked.
+
+## 3. Reliability & Performance
+- **Retry Pattern**: Uses `withRetry` (3 attempts, 2000ms delay) to handle network timeouts or temporary OPAC unavailability.
+- **Concurrency**: Uses `p-limit(2)` to limit concurrent requests, preventing the OPAC server from blocking the application's IP.
+- **Throttling**: Adds a 500ms delay between requests to ensure a steady, non-aggressive scraping pace.
+- **Timeout**: Sets a 20000ms (20s) timeout for each request.
+
+## 4. Implementation Details
+- **HTTPS Agent**: Uses `https.Agent` with `rejectUnauthorized: false` to avoid issues with potential SSL certificate misconfigurations on the OPAC server.
+- **Progress Reporting**: Sends SSE events for each book being checked, including the current progress (e.g., "Sprawdzanie: Tytuł (5/100)").
+- **Output**: Returns a list of available books with their extracted titles and authors.

--- a/docs/lp-sync.md
+++ b/docs/lp-sync.md
@@ -1,0 +1,23 @@
+# Lp (Position) Synchronization Algorithm (LpSyncService)
+
+## 1. Overview
+Re-numbers the "Lp" column in the Notion database based on a specific sorting order (Year, then Title).
+
+## 2. Sorting Logic (`runLpSync`)
+- **Source**: All records from the Notion database.
+- **Filter**: Only books with a non-empty Polish title, original title, or author are considered.
+- **Sorting Criteria**:
+  - **Primary**: Year (ascending).
+  - **Secondary**: Polish Title (or Original Title if Polish is missing) (alphabetical).
+- **Year Handling**:
+  - Parses the first year from the multi-select string (e.g., "1990, 1991" -> 1990).
+  - Default year for sorting missing values is 0.
+
+## 3. Re-numbering Logic
+- **Expected Lp**: The book's index in the sorted list + 1.
+- **Update Logic**: Only updates the Notion record if the current "Lp" value differs from the expected one.
+
+## 4. Implementation Details
+- **Concurrency**: Uses `p-limit(3)` to throttle Notion API calls.
+- **Progress Reporting**: Sends SSE events for each book being re-numbered.
+- **Output**: Returns a summary of how many books were re-numbered and any errors encountered.

--- a/docs/publisher-series-sync.md
+++ b/docs/publisher-series-sync.md
@@ -1,0 +1,32 @@
+# Publisher & Series Synchronization Algorithm (PublisherSyncService, SeriesSyncService)
+
+## 1. Overview
+Extracts publisher and series information from individual book pages in the Archiwum Encyklopedii (Wiki) and updates the corresponding Notion records.
+
+## 2. Extraction Logic (`WikiParser.extractPublisherAndSeries`)
+- **Source**: Wikitext of individual book pages.
+- **Priority 1**: `{{tabela wydania}}` (infowydanie).
+  - Scans for `informacjaN` where N is the highest index (e.g., `informacja3` > `informacja1`).
+  - This ensures the *latest* Polish edition's data is used.
+  - Extracts `wydawca` and `seria` from the `{{infowydanie}}` template.
+- **Priority 2 (Fallback)**: `{{Książka}}` template.
+  - Used only if no valid `infowydanie` is found.
+  - Extracts `wydawca` and `seria` fields.
+- **Cleaning**:
+  - Strips wiki links `[[Page|Text]]` -> `Text`.
+  - Removes HTML tags and MediaWiki special syntax.
+
+## 3. Normalization (`dataNormalizer`)
+- **Publisher**: Maps common variants to a canonical name (e.g., "Zysk" -> "Zysk i S-ka", "Prószyński" -> "Prószyński i S-ka").
+- **Series**: Removes parenthetical suffixes (e.g., "Kameleon (seria)" -> "Kameleon") and maps variants (e.g., "Klasyka SF" -> "Klasyka Science Fiction").
+
+## 4. Update Logic
+- **Bulk Fetching**: Uses `WikiAdapter.fetchPagesContentBulk` to fetch multiple pages in a single request (MediaWiki API limit: 50 pages).
+- **Diff Engine**: Uses `DiffEngine.isMultiSelectEqual` to compare current Notion values with extracted ones.
+  - Splits by comma, trims, sorts, and joins for a stable comparison.
+- **Notion Update**: Only updates if a difference is detected.
+
+## 5. Implementation Details
+- **Memory Efficiency**: Processes books in batches to avoid large memory footprints.
+- **Progress Reporting**: Sends SSE events for status, progress, and completion.
+- **Error Handling**: Collects errors per book and reports them in the final summary.

--- a/docs/purification-service.md
+++ b/docs/purification-service.md
@@ -1,0 +1,27 @@
+# Data Purification Algorithm (PurificationService)
+
+## 1. Overview
+Strips Wiki formatting and native Notion rich text formatting from book titles in the Notion database to ensure a clean and consistent data presentation.
+
+## 2. Purification Logic (`runPurification`)
+- **Source**: All records from the Notion database.
+- **Target Fields**: "Tytuł polski" and "Tytuł oryginalny".
+- **Wiki Formatting Removal (`stripWikiFormatting`)**:
+  - Removes wiki italics/bold (`''+`).
+  - Removes wiki links `[[Page|Text]]` -> `Text`.
+  - Normalizes spaces and trims.
+- **Notion Native Formatting Removal**:
+  - Scans the `rich_text` array for any `annotations` (italic, bold, strikethrough, underline, code).
+  - If any formatting is found, it's removed by re-writing the text as a plain string.
+- **Link Preservation**:
+  - If a title has a link (either from a Wiki link or a Notion URL field), it's preserved during the purification process.
+
+## 3. Implementation Details
+- **Sanitization (`sanitizeNotionString`)**:
+  - Removes control characters (e.g., `\x00-\x08`).
+  - Normalizes multiple spaces to a single space.
+  - Trims and limits the length to 2000 characters (Notion API limit).
+- **Update Logic**:
+  - Only updates the Notion record if a difference is detected between the original and the purified title.
+- **Progress Reporting**: Sends SSE events for each book being purified.
+- **Output**: Returns a summary of how many books were cleaned and any errors encountered.

--- a/docs/schema-validation.md
+++ b/docs/schema-validation.md
@@ -1,0 +1,32 @@
+# Schema Validation & Initialization Algorithm (SchemaValidationService)
+
+## 1. Overview
+Ensures the Notion database has the correct structure (columns and types) required for synchronization.
+
+## 2. Validation Logic (`runSchemaValidation`)
+- **Source**: Notion database metadata.
+- **Required Properties**:
+  - `Lp`: `title` (Primary column)
+  - `Autor`: `multi_select`
+  - `Rok`: `multi_select`
+  - `Tytuł polski`: `rich_text`
+  - `Tytuł oryginalny`: `rich_text`
+  - `Wydawnictwo`: `multi_select`
+  - `Seria`: `multi_select`
+  - `Nagroda`: `multi_select`
+  - `Część cyklu`: `checkbox`
+
+## 3. Initialization Steps
+- **Primary Column Renaming**:
+  - If the primary column (type `title`) is NOT named "Lp", it's renamed to "Lp".
+- **Column Creation**:
+  - If a required column is missing, it's created with the correct type.
+- **Type Correction**:
+  - If a column exists but has the wrong type, it's updated to the correct type.
+  - **Note**: This may result in data loss if the types are incompatible (e.g., `text` to `checkbox`).
+
+## 4. Implementation Details
+- **Notion API**: Uses `updateDatabaseProperty` and `renameProperty` to modify the database schema.
+- **Database Resolution**: Uses `resolveDataSourceId` to handle potential database ID variations.
+- **Progress Reporting**: Sends SSE events for each schema modification.
+- **Output**: Returns a summary of which columns were added or updated.

--- a/docs/stats-service.md
+++ b/docs/stats-service.md
@@ -1,0 +1,33 @@
+# Statistics Generation Algorithm (StatsService)
+
+## 1. Overview
+Generates comprehensive statistics for the dashboard by aggregating data from the Notion database.
+
+## 2. Aggregation Logic (`getStats`)
+- **Source**: All records from the Notion database.
+- **Global Filter**: Only books with a non-empty Polish title are considered.
+- **Author Progress**:
+  - Splits authors by comma and trims.
+  - Counts total books per author and how many are marked as "Przeczytane".
+  - Sorts authors by "Read" count and returns the top 15.
+- **Award Books Progress**:
+  - Counts total books and how many are marked as "Przeczytane".
+- **Owned but Unread**:
+  - Filters books marked as "Posiadam" but NOT "Przeczytane".
+  - Sorts by year (earliest first).
+- **Award Coverage Progress**:
+  - Counts how many books have each specific award tag (e.g., Hugo, Nebula, Locus).
+- **"All" Awards Progress**:
+  - Specifically tracks books with the "Wszystkie" tag (Hugo + Nebula + Locus).
+- **Yearly Progress**:
+  - Groups books by year and counts "Read" vs. "Total".
+  - Sorts by year (chronological).
+- **Library Stats**:
+  - Specifically tracks books marked as "Biblioteka" (Felin) and "Biblioteka 9" (Bronowice).
+
+## 3. Implementation Details
+- **Sorting**:
+  - Year sorting handles multi-year strings (e.g., "1990, 1991") by taking the first year.
+  - Default year for sorting missing values is "9999".
+- **Memory Efficiency**: Aggregates data in-memory after a single Notion query.
+- **Output**: Returns a structured JSON object with all statistics ready for the dashboard.

--- a/docs/vinted-scanner.md
+++ b/docs/vinted-scanner.md
@@ -1,0 +1,22 @@
+# AI-Powered Market Search (Vinted Scanner)
+
+## 1. Overview
+Leverages the Gemini 3 Flash model with Google Search grounding to find physical copies of books on Vinted.pl.
+
+## 2. Search Logic
+- **Input**: Book title and author from the Notion database.
+- **AI Model**: `gemini-3-flash-preview`.
+- **Grounding**: Uses `google_search_retrieval` to perform real-time web searches.
+- **Prompting**:
+  - Instructs the AI to find active listings on `vinted.pl` for the specific book.
+  - Requires the AI to return direct links to the listings.
+
+## 3. Frontend Integration
+- **Trigger**: User clicks the "Vinted" icon next to a book in the library check or search results.
+- **Display**: Shows the AI-generated response (links and descriptions) in a modal or dedicated section.
+- **Status**: Displays a "Searching..." state while the AI processes the request.
+
+## 4. Implementation Details
+- **API**: Uses the `@google/genai` SDK.
+- **Security**: Requires a valid `GEMINI_API_KEY` in the environment.
+- **Reliability**: Relies on the AI's ability to parse search results and identify relevant listings.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Google AI Studio App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "Cogitator Omnissiah",
+  "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
+  "requestFramePermissions": []
+}

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -1,0 +1,382 @@
+import { Client } from "@notionhq/client";
+import { withRetry } from "./retry";
+import { sanitizeNotionString, sanitizeNotionTag } from "./utils";
+import { NotionPage, NotionProperty, NotionPageProperties, NotionBook } from "./src/types";
+
+export class NotionAdapter {
+  private notion: Client;
+  private actualDataSourceId: string | null = null;
+  private isDataSource: boolean = true;
+
+  constructor(apiKey: string, private databaseId: string) {
+    this.notion = new Client({ auth: apiKey });
+  }
+
+  async init(): Promise<void> {
+    if (this.actualDataSourceId) return; // Already initialized
+
+    try {
+      // Try as data_source first
+      await (this.notion as any).dataSources.retrieve({ data_source_id: this.databaseId });
+      this.actualDataSourceId = this.databaseId;
+      this.isDataSource = true;
+    } catch (e: any) {
+      // Fallback to database
+      try {
+        const database = await this.notion.databases.retrieve({ database_id: this.databaseId }) as any;
+        if (database.data_sources && database.data_sources.length > 0) {
+          this.actualDataSourceId = database.data_sources[0].id;
+          this.isDataSource = true;
+        } else {
+          // It's a regular database
+          this.actualDataSourceId = this.databaseId;
+          this.isDataSource = false;
+        }
+      } catch (dbError: any) {
+        throw new Error(`Nie można znaleźć bazy danych ani źródła danych o ID: ${this.databaseId}. Upewnij się, że integracja ma dostęp.`);
+      }
+    }
+  }
+
+  async getSchema(): Promise<any> {
+    await this.init();
+    if (this.isDataSource) {
+      const dataSource = await withRetry(() => (this.notion as any).dataSources.retrieve({
+        data_source_id: this.actualDataSourceId!,
+      }));
+      return (dataSource as any).properties;
+    } else {
+      const database = await withRetry(() => this.notion.databases.retrieve({
+        database_id: this.actualDataSourceId!,
+      }));
+      return (database as any).properties;
+    }
+  }
+
+  async updateSchema(propertyName: string, propertyType: string, newOptions: any): Promise<void> {
+    await this.init();
+    const propertiesPayload: any = {
+      [propertyName]: {
+        [propertyType]: {
+          options: newOptions
+        }
+      }
+    };
+
+    if (this.isDataSource) {
+      await withRetry(() => (this.notion as any).dataSources.update({
+        data_source_id: this.actualDataSourceId!,
+        properties: propertiesPayload
+      }));
+    } else {
+      await withRetry(() => this.notion.databases.update({
+        database_id: this.actualDataSourceId!,
+        properties: propertiesPayload
+      } as any));
+    }
+  }
+
+  async createColumnIfNeeded(columnName: string, type: string = "rich_text"): Promise<void> {
+    await this.init();
+    const schema = await this.getSchema();
+    if (!schema[columnName]) {
+      if (this.isDataSource) {
+        await withRetry(() => (this.notion as any).dataSources.update({
+          data_source_id: this.actualDataSourceId!,
+          properties: {
+            [columnName]: { [type]: {} }
+          }
+        }));
+      } else {
+        await withRetry(() => this.notion.databases.update({
+          database_id: this.actualDataSourceId!,
+          properties: {
+            [columnName]: { [type]: {} }
+          }
+        } as any));
+      }
+    }
+  }
+
+  private getProp(props: NotionPageProperties, name: string): NotionProperty | undefined {
+    if (props[name]) return props[name];
+    const lowerName = name.toLowerCase();
+    for (const key in props) {
+      if (key.toLowerCase() === lowerName) return props[key];
+    }
+    return undefined;
+  }
+
+  private getPlainText(prop?: NotionProperty): string {
+    if (!prop) return "";
+    const type = prop.type;
+    if (type === "title") return prop.title?.map((t) => t.plain_text).join("") || "";
+    if (type === "rich_text") return prop.rich_text?.map((t) => t.plain_text).join("") || "";
+    if (type === "number") return prop.number !== undefined && prop.number !== null ? prop.number.toString() : "";
+    if (type === "select") return prop.select?.name || "";
+    if (type === "multi_select") return prop.multi_select?.map((x) => x.name).join(", ") || "";
+    if (type === "checkbox") return prop.checkbox?.toString() || "";
+    if (type === "url") return prop.url || "";
+    return "";
+  }
+
+  private parseNotionPageToBook(page: NotionPage): NotionBook {
+    const props = page.properties;
+    
+    const plTitle = this.getPlainText(this.getProp(props, "Tytuł polski"));
+    const origTitle = this.getPlainText(this.getProp(props, "Tytuł oryginalny"));
+    const author = this.getPlainText(this.getProp(props, "Autor"));
+    
+    const plTitleProp = this.getProp(props, "Tytuł polski");
+    const origTitleProp = this.getProp(props, "Tytuł oryginalny");
+    const plTitleRichText = plTitleProp?.type === "title" ? plTitleProp.title : plTitleProp?.rich_text || [];
+    const origTitleRichText = origTitleProp?.type === "title" ? origTitleProp.title : origTitleProp?.rich_text || [];
+
+    const yearProp = this.getProp(props, "Rok");
+    let year: string | undefined = undefined;
+    if (yearProp) {
+      if (yearProp.type === "multi_select") {
+        year = yearProp.multi_select?.map((x) => x.name).join(", ");
+      } else if (yearProp.type === "number") {
+        year = yearProp.number !== undefined && yearProp.number !== null ? yearProp.number.toString() : undefined;
+      } else {
+        year = this.getPlainText(yearProp).trim() || undefined;
+      }
+    }
+
+    const currentWydawnictwo = this.getPlainText(this.getProp(props, "Wydawnictwo"));
+    const currentSeria = this.getPlainText(this.getProp(props, "Seria"));
+    const currentCzesccyklu = this.getProp(props, "Część cyklu")?.checkbox || false;
+    const lp = this.getPlainText(this.getProp(props, "Lp"));
+
+    const nagrodaProp = this.getProp(props, "Nagroda");
+    const awards = nagrodaProp?.type === "multi_select"
+      ? nagrodaProp.multi_select?.map((x) => x.name) || []
+      : (nagrodaProp?.type === "select" && nagrodaProp.select?.name ? [nagrodaProp.select.name] : []);
+
+    const zrodloProp = this.getProp(props, "Źródło");
+    const zrodlo = zrodloProp?.type === "multi_select" 
+      ? zrodloProp.multi_select?.map((x) => x.name) || []
+      : (zrodloProp?.type === "select" && zrodloProp.select?.name ? [zrodloProp.select.name] : []);
+
+    return { 
+      id: page.id, 
+      plTitle, 
+      origTitle, 
+      author, 
+      year, 
+      currentWydawnictwo, 
+      currentSeria, 
+      currentCzesccyklu, 
+      lp, 
+      awards, 
+      zrodlo,
+      plTitleRichText, 
+      origTitleRichText 
+    };
+  }
+
+  async queryAllBooks(onProgress?: (count: number) => void, checkCancellation?: () => boolean): Promise<NotionBook[]> {
+    await this.init();
+    const allBooks: NotionBook[] = [];
+    let hasMore = true;
+    let nextCursor: string | undefined = undefined;
+
+    while (hasMore) {
+      if (checkCancellation && checkCancellation()) break;
+      
+      let response;
+      if (this.isDataSource) {
+        response = await withRetry(() => (this.notion as any).dataSources.query({
+          data_source_id: this.actualDataSourceId!,
+          start_cursor: nextCursor,
+        }));
+      } else {
+        response = await withRetry(() => (this.notion.databases as any).query({
+          database_id: this.actualDataSourceId!,
+          start_cursor: nextCursor,
+        }));
+      }
+
+      for (const page of response.results) {
+        allBooks.push(this.parseNotionPageToBook(page as NotionPage));
+      }
+
+      hasMore = response.has_more;
+      nextCursor = response.next_cursor ?? undefined;
+      if (onProgress) onProgress(allBooks.length);
+    }
+
+    return allBooks;
+  }
+
+  async getBooksForStats(onProgress?: (count: number) => void): Promise<NotionBook[]> {
+    await this.init();
+    const allBooks: NotionBook[] = [];
+    let hasMore = true;
+    let nextCursor: string | undefined = undefined;
+
+    while (hasMore) {
+      let response;
+      if (this.isDataSource) {
+        response = await withRetry(() => (this.notion as any).dataSources.query({
+          data_source_id: this.actualDataSourceId!,
+          start_cursor: nextCursor,
+        }));
+      } else {
+        response = await withRetry(() => (this.notion.databases as any).query({
+          database_id: this.actualDataSourceId!,
+          start_cursor: nextCursor,
+        }));
+      }
+
+      for (const page of response.results) {
+        allBooks.push(this.parseNotionPageToBook(page as NotionPage));
+      }
+
+      hasMore = response.has_more;
+      nextCursor = response.next_cursor ?? undefined;
+      if (onProgress) onProgress(allBooks.length);
+    }
+
+    return allBooks;
+  }
+
+  buildPropertyValue(value: string, type: string): any {
+    if (!value) return null;
+    if (type === "select") {
+      return { select: { name: sanitizeNotionTag(value) } };
+    } else if (type === "multi_select") {
+      const tags = Array.from(new Set(
+        value.split(',')
+          .map(t => sanitizeNotionTag(t))
+          .filter(t => t.length > 0)
+      )).map(name => ({ name }));
+      return { multi_select: tags };
+    } else if (type === "title") {
+      return { title: [{ text: { content: sanitizeNotionString(value) } }] };
+    } else {
+      return { rich_text: [{ text: { content: sanitizeNotionString(value) } }] };
+    }
+  }
+
+  async updateBookPublisher(pageId: string, wydawnictwo: string, wydawnictwoPropType: string = "rich_text"): Promise<void> {
+    const wydawnictwoPayload = this.buildPropertyValue(wydawnictwo, wydawnictwoPropType);
+
+    await withRetry(() => this.notion.pages.update({
+      page_id: pageId,
+      properties: {
+        "Wydawnictwo": wydawnictwoPayload
+      }
+    }));
+  }
+
+  async updateLp(pageId: string, lp: string): Promise<void> {
+    await withRetry(() => this.notion.pages.update({
+      page_id: pageId,
+      properties: {
+        "Lp": { title: [{ text: { content: lp } }] }
+      }
+    }));
+  }
+
+  async addTagToMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
+    await this.init();
+    
+    // 1. Get current tags
+    const page = await withRetry(() => this.notion.pages.retrieve({ page_id: pageId })) as any;
+    const prop = page.properties[propertyName];
+    
+    if (!prop || prop.type !== "multi_select") {
+      throw new Error(`Property ${propertyName} is not a multi_select`);
+    }
+    
+    const currentTags = prop.multi_select.map((t: any) => ({ name: t.name }));
+    
+    // 2. Check if tag already exists
+    if (currentTags.some((t: any) => t.name === tag)) {
+      return; // Already has the tag
+    }
+    
+    // 3. Add new tag
+    currentTags.push({ name: tag });
+    
+    // 4. Update page
+    await withRetry(() => this.notion.pages.update({
+      page_id: pageId,
+      properties: {
+        [propertyName]: { multi_select: currentTags }
+      }
+    }));
+  }
+
+  async resolveDataSourceId(databaseId: string): Promise<string> {
+    await this.init();
+    return this.actualDataSourceId!;
+  }
+
+  async retrieveDataSource(dataSourceId: string): Promise<any> {
+    await this.init();
+    if (this.isDataSource) {
+      return await withRetry(() => (this.notion as any).dataSources.retrieve({ data_source_id: dataSourceId }));
+    } else {
+      return await withRetry(() => this.notion.databases.retrieve({ database_id: dataSourceId }));
+    }
+  }
+
+  async updateDatabaseProperty(databaseId: string, propertyName: string, propertyType: string): Promise<void> {
+    await this.init();
+    const propertiesPayload = {
+      [propertyName]: { [propertyType]: {} }
+    };
+    if (this.isDataSource) {
+      await withRetry(() => (this.notion as any).dataSources.update({
+        data_source_id: databaseId,
+        properties: propertiesPayload
+      }));
+    } else {
+      await withRetry(() => this.notion.databases.update({
+        database_id: databaseId,
+        properties: propertiesPayload
+      } as any));
+    }
+  }
+
+  async renameProperty(databaseId: string, oldName: string, newName: string): Promise<void> {
+    await this.init();
+    const propertiesPayload = {
+      [oldName]: { name: newName }
+    };
+    if (this.isDataSource) {
+      await withRetry(() => (this.notion as any).dataSources.update({
+        data_source_id: databaseId,
+        properties: propertiesPayload
+      }));
+    } else {
+      await withRetry(() => this.notion.databases.update({
+        database_id: databaseId,
+        properties: propertiesPayload
+      } as any));
+    }
+  }
+
+  async updatePage(pageId: string, properties: any): Promise<void> {
+    await withRetry(() => this.notion.pages.update({
+      page_id: pageId,
+      properties
+    }));
+  }
+
+  async addRow(properties: any): Promise<any> {
+    await this.init();
+    const parent = this.isDataSource
+      ? { type: "data_source_id", data_source_id: this.actualDataSourceId! }
+      : { type: "database_id", database_id: this.actualDataSourceId! };
+
+    const response = await withRetry(() => this.notion.pages.create({
+      parent: parent,
+      properties
+    } as any));
+    return response;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5794 @@
+{
+  "name": "react-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "react-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@google/genai": "^1.29.0",
+        "@notionhq/client": "^5.15.0",
+        "@tailwindcss/vite": "^4.1.14",
+        "@vitejs/plugin-react": "^5.0.4",
+        "axios": "^1.14.0",
+        "dotenv": "^17.2.3",
+        "esbuild": "^0.27.4",
+        "express": "^4.21.2",
+        "lucide-react": "^0.546.0",
+        "motion": "^12.38.0",
+        "p-limit": "^7.3.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "vite": "^6.2.0"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/express": "^4.17.21",
+        "@types/node": "^22.14.0",
+        "@types/supertest": "^7.2.0",
+        "autoprefixer": "^10.4.21",
+        "jsdom": "^29.0.1",
+        "supertest": "^7.2.2",
+        "tailwindcss": "^4.1.14",
+        "tsx": "^4.21.0",
+        "typescript": "~5.8.2",
+        "vite": "^6.2.0",
+        "vitest": "^4.1.2"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
+      "integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.47.0.tgz",
+      "integrity": "sha512-0VV7AaXm5rQu3oRHNZNEubRAOL2lv5u+YA72eWnDwcOx3B1jFRbvtgL4drRHlocRHOnludvr3xmbQGbR+/RQAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.15.0.tgz",
+      "integrity": "sha512-boQ+zMmTu/HRfPajynYjlXkytkmn0rUgD0FJrbMaz6n1WC6HPxe2Lgn/Ay/VEA2j2dMzB1Hpnhtrtkz4Q1I/rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001782",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.546.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.546.0.tgz",
+      "integrity": "sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "react-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx server.ts",
+    "start": "node dist/server.cjs",
+    "build": "vite build && esbuild server.ts --bundle --platform=node --target=node18 --outfile=dist/server.cjs --format=cjs",
+    "preview": "vite preview",
+    "clean": "rm -rf dist",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@google/genai": "^1.29.0",
+    "@notionhq/client": "^5.15.0",
+    "@tailwindcss/vite": "^4.1.14",
+    "@vitejs/plugin-react": "^5.0.4",
+    "axios": "^1.14.0",
+    "dotenv": "^17.2.3",
+    "esbuild": "^0.27.4",
+    "express": "^4.21.2",
+    "lucide-react": "^0.546.0",
+    "motion": "^12.38.0",
+    "p-limit": "^7.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vite": "^6.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.14.0",
+    "@types/supertest": "^7.2.0",
+    "autoprefixer": "^10.4.21",
+    "jsdom": "^29.0.1",
+    "supertest": "^7.2.2",
+    "tailwindcss": "^4.1.14",
+    "tsx": "^4.21.0",
+    "typescript": "~5.8.2",
+    "vite": "^6.2.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/retry.ts
+++ b/retry.ts
@@ -1,0 +1,40 @@
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delayMs = 1000,
+  backoffFactor = 2
+): Promise<T> {
+  let attempt = 0;
+  while (attempt < retries) {
+    try {
+      return await fn();
+    } catch (error: any) {
+      attempt++;
+      if (attempt >= retries) {
+        throw error;
+      }
+      
+      // Check if it's a rate limit error (429) or server error (5xx)
+      const isRateLimit = error?.status === 429 || error?.response?.status === 429;
+      const isServerError = error?.status >= 500 || error?.response?.status >= 500;
+      
+      const transientCodes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED', 'EPIPE', 'ENOTFOUND', 'EAI_AGAIN', 'ERR_HTTP2_GOAWAY_SESSION', 'ERR_STREAM_WRITE_AFTER_END'];
+      const isTransientNetworkError = transientCodes.includes(error.code) || 
+                                     (error.message && (
+                                       error.message.toLowerCase().includes('socket hang up') ||
+                                       error.message.toLowerCase().includes('connreset') ||
+                                       error.message.toLowerCase().includes('timeout')
+                                     ));
+      
+      if (!isRateLimit && !isServerError && !isTransientNetworkError) {
+        // Don't retry client errors (4xx) other than 429
+        throw error;
+      }
+
+      const waitTime = delayMs * Math.pow(backoffFactor, attempt - 1);
+      console.warn(`[Retry] Attempt ${attempt} failed. Retrying in ${waitTime}ms... (${error.message})`);
+      await new Promise(resolve => setTimeout(resolve, waitTime));
+    }
+  }
+  throw new Error("Unreachable");
+}

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -1,0 +1,37 @@
+import express from "express";
+import * as syncController from "../controllers/syncController";
+
+const router = express.Router();
+
+router.get("/stats", syncController.getStats);
+router.get("/wiki/last-update", syncController.getWikiLastUpdate);
+router.get("/health", syncController.getHealth);
+router.get("/config", syncController.getConfig);
+router.get("/notion/schema", syncController.getNotionSchema);
+router.patch("/notion/schema", syncController.updateNotionSchema);
+router.post("/sync/reset", syncController.resetSyncState);
+router.post("/sync/stop", syncController.stopSync);
+router.post("/sync-schema/stop", syncController.stopSchemaSync);
+router.post("/sync-purify/stop", syncController.stopPurifySync);
+router.post("/sync-publisher/stop", syncController.stopPublisherSync);
+router.post("/sync-series/stop", syncController.stopSeriesSync);
+router.post("/sync-cycles/stop", syncController.stopCyclesSync);
+router.post("/sync-lp/stop", syncController.stopLpSync);
+router.post("/sync-duplicates/stop", syncController.stopDuplicatesSync);
+router.post("/sync-integrity/stop", syncController.stopIntegrityCheck);
+router.post("/library-check/stop", syncController.stopLibraryCheck);
+router.post("/sync", syncController.runSync);
+router.post("/sync-schema", syncController.runSchemaSync);
+router.post("/sync-purify", syncController.runPurifySync);
+router.post("/sync-publisher", syncController.runPublisherSync);
+router.post("/sync-series", syncController.runSeriesSync);
+router.post("/sync-cycles", syncController.runCyclesSync);
+router.post("/sync-lp", syncController.runLpSync);
+router.post("/sync-duplicates", syncController.runDuplicateCheck);
+router.post("/sync-integrity", syncController.runIntegrityCheck);
+router.post("/mark-as-read", syncController.markAsRead);
+router.post("/vinted-check", syncController.checkVintedAvailability);
+router.post("/vinted-check/stop", syncController.stopVintedCheck);
+router.post("/library-check", syncController.checkLibraryAvailability);
+
+export default router;

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,627 @@
+import express from "express";
+import { createServer as createViteServer } from "vite";
+import path from "path";
+import { NotionAdapter } from "./notion.adapter";
+import { WikiAdapter } from "./wiki.adapter";
+import { WikiParser } from "./wiki.parser";
+import { cleanTitle, calculateSimilarity, normalizeAuthor } from "./utils";
+import dotenv from "dotenv";
+import pLimit from "p-limit";
+import axios from "axios";
+import https from "https";
+import { BookSyncService } from "./services/bookSyncService";
+import { DuplicateSyncService } from "./services/duplicateSyncService";
+import { PublisherSyncService } from "./services/publisherSyncService";
+import { SeriesSyncService } from "./services/seriesSyncService";
+import { CyclesSyncService } from "./services/cyclesSyncService";
+import { LpSyncService } from "./services/lpSyncService";
+import { StatsService } from "./services/statsService";
+import { PurificationService } from "./services/purificationService";
+import { SchemaValidationService } from "./services/schemaValidationService";
+import { IntegrityService } from "./services/integrityService";
+import { withRetry } from "./retry";
+import syncRoutes from "./routes/syncRoutes";
+
+dotenv.config();
+
+const USER_AGENTS = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.0.0',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.1 Safari/605.1.15'
+];
+
+const getRandomUserAgent = () => USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
+
+const notionAdapter = new NotionAdapter(process.env.NOTION_API_KEY!, process.env.NOTION_DATABASE_ID!);
+const wikiAdapter = new WikiAdapter();
+const duplicateSyncService = new DuplicateSyncService(notionAdapter, wikiAdapter);
+const bookSyncService = new BookSyncService(notionAdapter, wikiAdapter);
+const publisherSyncService = new PublisherSyncService(notionAdapter, wikiAdapter);
+const seriesSyncService = new SeriesSyncService(notionAdapter, wikiAdapter);
+const cyclesSyncService = new CyclesSyncService(notionAdapter, wikiAdapter);
+const lpSyncService = new LpSyncService(notionAdapter);
+const statsService = new StatsService(notionAdapter);
+const purificationService = new PurificationService(notionAdapter);
+const schemaValidationService = new SchemaValidationService(notionAdapter);
+const integrityService = new IntegrityService(notionAdapter, wikiAdapter);
+
+class SyncManager {
+  public activeTask: string | null = null;
+  public cancelRequested = false;
+
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  get isSyncing() {
+    return this.activeTask !== null;
+  }
+
+  async getStats() {
+    return await statsService.getStats();
+  }
+
+  async getNotionSchema() {
+    return await this.notion.getSchema();
+  }
+
+  async updateNotionSchema(propertyName: string, propertyType: string, newOptions: any) {
+    return await this.notion.updateSchema(propertyName, propertyType, newOptions);
+  }
+
+  private async executeTask(taskName: string, taskFn: () => Promise<void>) {
+    if (this.isSyncing) throw new Error(`Inna synchronizacja (${this.activeTask}) jest już w toku.`);
+    this.activeTask = taskName;
+    this.cancelRequested = false;
+    try {
+      await taskFn();
+    } finally {
+      this.activeTask = null;
+      this.cancelRequested = false;
+    }
+  }
+
+  async runBookSync(params: { awardName?: string; pageTitle?: string; syncAll?: boolean }, sendEvent: (data: any) => void) {
+    await this.executeTask('book', () => bookSyncService.runBookSync(params, sendEvent, () => this.cancelRequested));
+  }
+
+  async runPurifySync(sendEvent: (data: any) => void) {
+    await this.executeTask('purify', () => purificationService.runPurification(sendEvent, () => this.cancelRequested));
+  }
+
+  async runSchemaSync(sendEvent: (data: any) => void) {
+    await this.executeTask('schema', () => schemaValidationService.runSchemaValidation(sendEvent, () => this.cancelRequested));
+  }
+
+  async runPublisherSync(sendEvent: (data: any) => void) {
+    await this.executeTask('publisher', () => publisherSyncService.runPublisherSync(sendEvent, () => this.cancelRequested));
+  }
+
+  async runSeriesSync(sendEvent: (data: any) => void) {
+    await this.executeTask('series', () => seriesSyncService.runSeriesSync(sendEvent, () => this.cancelRequested));
+  }
+
+  async runDuplicateCheck(sendEvent: (data: any) => void) {
+    await this.executeTask('duplicates', () => duplicateSyncService.runDuplicateCheck(sendEvent, () => this.cancelRequested));
+  }
+
+  async runLpSync(sendEvent: (data: any) => void) {
+    await this.executeTask('lp', () => lpSyncService.runLpSync(sendEvent, () => this.cancelRequested));
+  }
+
+  async runCyclesSync(sendEvent: (data: any) => void) {
+    await this.executeTask('cycles', () => cyclesSyncService.runCyclesSync(sendEvent, () => this.cancelRequested));
+  }
+
+  async runIntegrityCheck(sendEvent: (data: any) => void) {
+    await this.executeTask('integrity', () => integrityService.runIntegrityCheck(sendEvent, () => this.cancelRequested));
+  }
+
+  async getWikiLastUpdate(pageTitle: string) {
+    return await this.wiki.fetchLastRevisionDate(pageTitle);
+  }
+
+  async markAsRead(pageId: string) {
+    return await this.notion.addTagToMultiSelect(pageId, "Źródło", "Przeczytane");
+  }
+
+  async checkLibraryAvailability(libraryCode: string, sendEvent: (data: any) => void) {
+    await this.executeTask('library', async () => {
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      const allBooks = await this.notion.getBooksForStats();
+      
+      // Filter books that are NOT (Przeczytane, Biblioteka, Biblioteka 9, Posiadam)
+      const candidates = allBooks.filter(b => {
+        const zrodlo = b.zrodlo || [];
+        const excluded = ["Przeczytane", "Biblioteka", "Biblioteka 9", "Posiadam"];
+        return !zrodlo.some(z => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
+      });
+
+      sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia...` });
+      
+      const results: any[] = [];
+      const limit = pLimit(2); // Limit concurrent requests to avoid blocking
+      
+      const httpsAgent = new https.Agent({ 
+        rejectUnauthorized: false,
+        keepAlive: true,
+        keepAliveMsecs: 1000,
+        timeout: 45000,
+        maxSockets: 5
+      });
+
+      for (let i = 0; i < candidates.length; i++) {
+        if (this.cancelRequested) {
+          sendEvent({ type: "status", message: "Skanowanie przerwane przez użytkownika." });
+          break;
+        }
+        const book = candidates[i];
+        const title = book.plTitle;
+        const fullName = `${title} ${book.author || ""}`.trim();
+        
+        sendEvent({ 
+          type: "progress", 
+          message: `Sprawdzanie: ${fullName} (${i + 1}/${candidates.length})`,
+          current: i + 1,
+          total: candidates.length
+        });
+
+        const url = `https://opac.mbp.lublin.pl/search/description?q=${encodeURIComponent(title)}&index=1&scope=full&f2%5B0%5D=${libraryCode}`;
+        
+        const headers = {
+          'User-Agent': getRandomUserAgent(),
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+          'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+          'Cache-Control': 'no-cache',
+          'Pragma': 'no-cache',
+          'Connection': 'keep-alive'
+        };
+        
+        try {
+          const response = await withRetry(async () => {
+            return await axios.get(url, {
+              httpsAgent,
+              headers,
+              timeout: 30000
+            });
+          }, 4, 3000);
+
+          const html = response.data;
+          
+          // Simple check for results: if it doesn't contain "Brak wyników" or "Nie znaleziono"
+          // and contains something that looks like a record (e.g., "record-item" or "Szczegóły")
+          const noResults = html.includes("Brak wyników") || html.includes("Nie znaleziono");
+          const hasResults = !noResults && (html.includes("class=\"record\"") || html.includes("Szczegóły"));
+
+          if (hasResults) {
+            let extractedTitle = null;
+            let extractedAuthor = null;
+
+            const titleRegex = /<dt[^>]*>\s*Tytuł:\s*<\/dt>\s*<dd[^>]*>\s*<span[^>]*>(.*?)<\/span>/i;
+            const match = html.match(titleRegex);
+            if (match) {
+              extractedTitle = match[1].replace(/<[^>]+>/g, '').trim();
+            }
+
+            const authorRegex = /<dt[^>]*>\s*Autor:\s*<\/dt>\s*<dd[^>]*>\s*<span[^>]*>(.*?)<\/span>/i;
+            const authorMatch = html.match(authorRegex);
+            if (authorMatch) {
+              extractedAuthor = authorMatch[1].replace(/<[^>]+>/g, '').trim();
+            }
+
+            let isMatch = false;
+            
+            // Title match
+            const normNotionTitle = cleanTitle(book.plTitle || "").toLowerCase();
+            const normOpacTitle = cleanTitle(extractedTitle || "").toLowerCase();
+            const titleSimilarity = calculateSimilarity(normNotionTitle, normOpacTitle);
+            const titleMatch = titleSimilarity > 0.8 || normOpacTitle.includes(normNotionTitle) || normNotionTitle.includes(normOpacTitle) || !extractedTitle;
+
+            // Author match
+            const normNotionAuthor = normalizeAuthor(book.author || "");
+            const normOpacAuthor = normalizeAuthor(extractedAuthor || "");
+            
+            let authorMatchBool = false;
+            if (!normNotionAuthor) {
+                authorMatchBool = true;
+            } else if (normOpacAuthor) {
+                const authorSimilarity = calculateSimilarity(normNotionAuthor, normOpacAuthor);
+                authorMatchBool = authorSimilarity > 0.7 || normOpacAuthor.includes(normNotionAuthor) || normNotionAuthor.includes(normOpacAuthor);
+            } else {
+                const authorParts = normNotionAuthor.split(' ').filter((p: string) => p.length > 2);
+                const allPartsFound = authorParts.length > 0 && authorParts.every((part: string) => html.toLowerCase().includes(part));
+                authorMatchBool = allPartsFound;
+            }
+
+            if (titleMatch && authorMatchBool) {
+              const matchResult = {
+                id: book.id,
+                title: book.plTitle,
+                author: book.author,
+                year: book.year,
+                extractedTitle: extractedTitle,
+                extractedAuthor: extractedAuthor
+              };
+              results.push(matchResult);
+              sendEvent({ type: "match", result: matchResult });
+            }
+          }
+        } catch (err: any) {
+          console.warn(`Error checking ${title}: ${err.message || "Nieznany błąd"}`);
+          // Don't throw, just continue with the next book
+          // We can optionally send a status update about the error
+          sendEvent({ 
+            type: "status", 
+            message: `⚠️ Błąd sprawdzania "${title}": ${err.message || "Timeout/Błąd sieci"}. Kontynuuję...` 
+          });
+        }
+
+        // Add a small delay between requests
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+
+      sendEvent({ type: "complete", result: { success: true, results, message: `Zakończono sprawdzanie. Znaleziono ${results.length} książek.` } });
+    });
+  }
+
+  async checkVintedAvailability(sendEvent: (data: any) => void) {
+    await this.executeTask('vinted', async () => {
+      try {
+        sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+        const allBooks = await this.notion.getBooksForStats();
+        
+        // Filter books:
+        // - Have Polish title
+        // - Exclude from source: Posiadam, Przeczytane, Audioteka, Biblioteka, Biblioteka 9
+        const candidates = allBooks.filter(b => {
+          const zrodlo = b.zrodlo || [];
+          const excluded = ["Posiadam", "Przeczytane", "Audioteka", "Biblioteka", "Biblioteka 9"];
+          return !zrodlo.some(z => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
+        });
+
+        sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia na Vinted...` });
+        
+        const results: any[] = [];
+      const httpsAgent = new https.Agent({ 
+        rejectUnauthorized: false,
+        keepAlive: true,
+        keepAliveMsecs: 1000,
+        timeout: 45000,
+        maxSockets: 5
+      });
+
+      for (let i = 0; i < candidates.length; i++) {
+        if (this.cancelRequested) {
+          sendEvent({ type: "status", message: "Skanowanie Vinted przerwane przez użytkownika." });
+          break;
+        }
+        const book = candidates[i];
+        const title = book.plTitle;
+        const searchText = `${title} ${book.author || ""}`.trim();
+        
+        const headers = {
+          'User-Agent': getRandomUserAgent(),
+          'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+          'Referer': 'https://www.vinted.pl/',
+          'Upgrade-Insecure-Requests': '1',
+          'Sec-Fetch-Dest': 'document',
+          'Sec-Fetch-Mode': 'navigate',
+          'Sec-Fetch-Site': 'none',
+          'Sec-Fetch-User': '?1',
+          'Accept-Encoding': 'gzip, deflate, br',
+          'Connection': 'keep-alive',
+          'Cache-Control': 'max-age=0',
+        };
+
+        sendEvent({ 
+          type: "progress", 
+          message: `Sprawdzanie Vinted: ${searchText} (${i + 1}/${candidates.length})`,
+          current: i + 1,
+          total: candidates.length
+        });
+
+        // Vinted Search URL
+        const url = `https://www.vinted.pl/catalog?catalog[]=2319&language_book_ids[]=6440&page=1&order=price_low_to_high&price_from=2&currency=PLN&search_text=${encodeURIComponent(searchText)}`;
+        
+        // Initial search attempt event
+        sendEvent({
+          type: "search_attempt",
+          result: {
+            id: book.id,
+            title: book.plTitle,
+            author: book.author,
+            url,
+            status: "pending",
+            itemCount: 0
+          }
+        });
+
+        try {
+          const response = await withRetry(async () => {
+            return await axios.get(url, {
+              httpsAgent,
+              headers,
+              timeout: 30000
+            });
+          }, 3, 4000);
+
+          const html = response.data;
+          console.log(`Vinted response for ${title}: ${html.length} chars`);
+          
+          // Debug logging for empty results
+          if (html.includes("cloudflare") || html.includes("captcha") || html.includes("robot")) {
+            console.warn(`Vinted blocked request for ${title} (Bot detection detected)`);
+            sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0 }
+            });
+          }
+
+          if (html.includes("Brak wyników") || html.includes("Nie znaleźliśmy żadnych przedmiotów")) {
+            // If "Title Author" failed, maybe try just "Title" in a real app, 
+            // but for now let's just log it.
+            console.log(`No results found on Vinted for: ${searchText}`);
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
+            });
+            continue;
+          }
+          
+          const items: any[] = [];
+          
+          // Vinted often stores data in a script tag with data-component-name="Catalog"
+          // or similar. We'll try to find the JSON blob more reliably.
+          let rawItems: any[] = [];
+          
+          // Try to find JSON in script tag content or data-props attribute
+          const catalogMatch = html.match(/data-component-name="Catalog"[^>]*data-props="([^"]+)"/s) || 
+                               html.match(/data-component-name="Catalog"[^>]*>\s*({.*?})\s*<\/script>/s);
+          
+          if (catalogMatch) {
+            try {
+              // HTML attributes use &quot; instead of "
+              let jsonStr = catalogMatch[1];
+              if (jsonStr.includes('&quot;')) {
+                jsonStr = jsonStr.replace(/&quot;/g, '"')
+                                 .replace(/&amp;/g, '&')
+                                 .replace(/&lt;/g, '<')
+                                 .replace(/&gt;/g, '>')
+                                 .replace(/&#39;/g, "'");
+              }
+              const catalogData = JSON.parse(jsonStr);
+              rawItems = catalogData.items?.list || 
+                         catalogData.items || 
+                         catalogData.catalog?.results?.items || 
+                         catalogData.catalog?.items ||
+                         [];
+              console.log(`Found ${rawItems.length} raw items in JSON for ${title}`);
+            } catch (e) {
+              console.warn("Failed to parse Vinted Catalog JSON");
+            }
+          }
+
+          // Fallback to the old "items" regex if the above failed
+          if (rawItems.length === 0) {
+            const jsonMatch = html.match(/"items":\s*(\[.*?\])/);
+            if (jsonMatch) {
+              try {
+                // Try to find the matching closing bracket for the array
+                let bracketCount = 0;
+                let endIndex = -1;
+                const str = jsonMatch[1];
+                for (let i = 0; i < str.length; i++) {
+                  if (str[i] === '[') bracketCount++;
+                  else if (str[i] === ']') {
+                    bracketCount--;
+                    if (bracketCount === 0) {
+                      endIndex = i + 1;
+                      break;
+                    }
+                  }
+                }
+                const jsonStr = endIndex !== -1 ? str.substring(0, endIndex) : str;
+                rawItems = JSON.parse(jsonStr);
+              } catch (e) {
+                // If it fails, it might be because the regex was too simple
+              }
+            }
+          }
+
+          if (Array.isArray(rawItems)) {
+            for (const item of rawItems) {
+              if (items.length >= 5) break;
+              
+              const itemTitle = (item.title || "").toLowerCase();
+              const searchTitle = title.toLowerCase();
+              const searchAuthor = (book.author || "").toLowerCase();
+              
+              // More flexible relevance check:
+              // 1. Item title contains the book title
+              // 2. OR Book title contains the item title
+              // 3. OR Item title contains the author's name
+              const hasTitle = itemTitle.includes(searchTitle) || searchTitle.includes(itemTitle);
+              const hasAuthor = searchAuthor && itemTitle.includes(searchAuthor);
+              
+              if (hasTitle || hasAuthor) {
+                items.push({
+                  id: item.id,
+                  title: item.title || itemTitle,
+                  price: item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || item.price || "??",
+                  currency: item.price?.currency_code || item.currency || "PLN",
+                  url: item.url ? (item.url.startsWith('http') ? item.url : `https://www.vinted.pl${item.url}`) : `https://www.vinted.pl/items/${item.id}`
+                });
+              }
+            }
+          }
+
+          // Fallback to regex if JSON parsing failed or found no items
+          if (items.length === 0) {
+            // Look for item blocks
+            const itemBlocks = html.split('class="feed-grid__item"');
+            if (itemBlocks.length > 1) {
+              for (let j = 1; j < itemBlocks.length && items.length < 5; j++) {
+                const block = itemBlocks[j];
+                const urlMatch = block.match(/href="(\/items\/[^"]+)"/);
+                const titleMatch = block.match(/title="([^"]+)"/);
+                const priceMatch = block.match(/aria-label="([^"]*?(\d+[.,]\d+)\s*([A-Z]{3}|zł))"/i) || 
+                                   block.match(/>(\d+[.,]\d+)\s*([A-Z]{3}|zł)</i);
+
+                if (urlMatch && titleMatch) {
+                  const itemTitle = titleMatch[1];
+                  if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
+                    items.push({
+                      title: itemTitle,
+                      url: `https://www.vinted.pl${urlMatch[1]}`,
+                      price: priceMatch ? priceMatch[1] : "Sprawdź",
+                      currency: priceMatch ? (priceMatch[3] || priceMatch[2]) : "PLN"
+                    });
+                  }
+                }
+              }
+            }
+          }
+
+          // Last resort: simple global regex
+          if (items.length === 0) {
+            const itemRegex = /href="(\/items\/[^"]+)"[^>]*title="([^"]+)"/g;
+            let match;
+            while ((match = itemRegex.exec(html)) !== null && items.length < 5) {
+              const itemUrl = `https://www.vinted.pl${match[1]}`;
+              const itemTitle = match[2];
+              
+              if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
+                items.push({
+                  title: itemTitle,
+                  url: itemUrl,
+                  price: "Sprawdź",
+                  currency: "PLN"
+                });
+              }
+            }
+          }
+
+          if (items.length > 0) {
+            const matchResult = {
+              id: book.id,
+              title: book.plTitle,
+              author: book.author,
+              searchUrl: url,
+              vintedItems: items
+            };
+            results.push(matchResult);
+            sendEvent({ type: "match", result: matchResult });
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length }
+            });
+          } else {
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
+            });
+          }
+        } catch (err: any) {
+          console.warn(`Error checking Vinted for ${title}: ${err.message || "Nieznany błąd"}`);
+          sendEvent({
+            type: "search_attempt",
+            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0 }
+          });
+          if (err.response?.status === 429) {
+            sendEvent({ 
+              type: "status", 
+              message: `🛑 Vinted zablokował zapytania (429). Odczekaj chwilę...` 
+            });
+            // Wait longer if blocked
+            await new Promise(resolve => setTimeout(resolve, 5000));
+          } else if (err.response?.status === 403) {
+            sendEvent({ 
+              type: "status", 
+              message: `🛡️ Vinted zablokował dostęp (403 - Cloudflare). Próbuję dalej...` 
+            });
+          } else {
+            sendEvent({ 
+              type: "status", 
+              message: `⚠️ Błąd Vinted dla "${title}": ${err.message || "Timeout"}. Kontynuuję...` 
+            });
+          }
+        }
+
+        // Delay to avoid being blocked (with jitter)
+        const jitter = Math.floor(Math.random() * 2000);
+        await new Promise(resolve => setTimeout(resolve, 3000 + jitter));
+      }
+
+      sendEvent({ type: "complete", result: { success: true, results, message: `Zakończono skanowanie Vinted. Znaleziono oferty dla ${results.length} książek.` } });
+      } catch (error: any) {
+        console.error("Vinted Initialization Error:", error);
+        sendEvent({ type: "error", error: `Błąd inicjalizacji Vinted: ${error.message}` });
+      }
+    });
+  }
+
+  stopActiveSync() {
+    if (this.activeTask) {
+      this.cancelRequested = true;
+      return true;
+    }
+    return false;
+  }
+
+  resetSyncState() {
+    this.activeTask = null;
+    this.cancelRequested = false;
+  }
+}
+
+export const syncManager = new SyncManager(notionAdapter, wikiAdapter);
+
+export const app = express();
+app.use(express.json());
+app.use("/api", syncRoutes);
+
+const PORT = 3000;
+let server: any;
+
+export async function startServer() {
+  // Vite middleware for development
+  if (process.env.NODE_ENV !== "production" && !process.env.VITEST) {
+    const vite = await createViteServer({
+      server: { middlewareMode: true },
+      appType: "spa",
+    });
+    app.use(vite.middlewares);
+  } else if (process.env.NODE_ENV === "production") {
+    const distPath = path.join(process.cwd(), "dist");
+    app.use(express.static(distPath));
+    app.get("*", (req, res) => {
+      res.sendFile(path.join(distPath, "index.html"));
+    });
+  }
+
+  server = app.listen(PORT, "0.0.0.0", () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught Exception thrown:', err);
+});
+
+if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
+  startServer();
+}
+
+export const closeServer = () => {
+  if (server) {
+    server.close();
+  }
+};

--- a/services/__tests__/bookSyncService.test.ts
+++ b/services/__tests__/bookSyncService.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BookSyncService } from '../bookSyncService';
+import { NotionAdapter } from '../../notion.adapter';
+import { WikiAdapter } from '../../wiki.adapter';
+import { Book, NotionBook } from '../../src/types';
+
+describe('BookSyncService', () => {
+  let service: BookSyncService;
+  let mockNotion: any;
+  let mockWiki: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      init: vi.fn(),
+      queryAllBooks: vi.fn(),
+      updatePage: vi.fn(),
+      addRow: vi.fn(),
+    };
+
+    mockWiki = {
+      fetchPageContent: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new BookSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+  });
+
+  describe('fetchBooksFromMediaWiki', () => {
+    it('parses wiki table and returns books', async () => {
+      const wikitext = `
+{| class="wikitable"
+|-
+! Rok 
+! Autor 
+! Tytuł oryginalny 
+! Tytuł polski
+|- style="background: #ccffcc"
+| [[1961]] || [[Stanisław Lem]] || ''Solaris'' || Solaris
+|}`;
+      mockWiki.fetchPageContent.mockResolvedValue(wikitext);
+
+      const books = await service.fetchBooksFromMediaWiki('Test Page', 'Nagroda Test', mockSendEvent);
+
+      expect(books).toHaveLength(1);
+      expect(books[0]).toEqual(expect.objectContaining({
+        year: '1961',
+        author: 'Stanisław Lem',
+        originalTitle: 'Solaris',
+        polishTitle: 'Solaris',
+        award: 'Nagroda Test'
+      }));
+    });
+  });
+
+  describe('compareBooks', () => {
+    it('returns updates when titles differ', () => {
+      const existing: NotionBook = {
+        id: '1',
+        plTitle: 'Stary',
+        origTitle: '', // Empty to trigger update
+        author: 'Lem',
+        year: '2000',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      };
+      const newBook: Book = {
+        polishTitle: 'Nowy',
+        originalTitle: 'New',
+        author: 'Lem',
+        year: '2000',
+        award: 'Test',
+        polishTitleLink: null
+      };
+
+      const updates = service.compareBooks(existing, newBook);
+
+      expect(updates).toHaveProperty('Tytuł polski');
+      expect(updates).toHaveProperty('Tytuł oryginalny');
+    });
+
+    it('returns empty object when books are identical', () => {
+      const existing: NotionBook = {
+        id: '1',
+        plTitle: 'Solaris',
+        origTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        year: '1961',
+        awards: ['Nagroda Test'],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      };
+      const newBook: Book = {
+        polishTitle: 'Solaris',
+        originalTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        year: '1961',
+        award: 'Nagroda Test',
+        awards: ['Nagroda Test'],
+        polishTitleLink: null
+      };
+
+      const updates = service.compareBooks(existing, newBook);
+
+      expect(updates).toEqual({});
+    });
+  });
+
+  describe('runBookSync', () => {
+    it('syncs books correctly', async () => {
+      mockWiki.fetchPageContent.mockResolvedValue(`
+{| class="wikitable"
+|-
+! Rok 
+! Autor 
+! Tytuł oryginalny 
+! Tytuł polski
+|-
+| [[1961]] || [[Stanisław Lem]] || ''Solaris'' || Solaris
+|}`);
+      
+      mockNotion.queryAllBooks.mockResolvedValue([]);
+
+      await service.runBookSync({ pageTitle: 'Test', awardName: 'Nagroda Test' }, mockSendEvent, () => false);
+
+      expect(mockNotion.addRow).toHaveBeenCalledTimes(1);
+      expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
+    });
+
+    it('handles cancellation', async () => {
+      mockWiki.fetchPageContent.mockResolvedValue('Some content');
+      await service.runBookSync({ pageTitle: 'Test', awardName: 'Nagroda Test' }, mockSendEvent, () => true);
+
+      expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', error: 'Synchronizacja przerwana przez użytkownika.' }));
+      expect(mockNotion.addRow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/__tests__/cyclesSyncService.test.ts
+++ b/services/__tests__/cyclesSyncService.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CyclesSyncService } from '../cyclesSyncService';
+import { NotionAdapter } from '../../notion.adapter';
+import { WikiAdapter } from '../../wiki.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('CyclesSyncService', () => {
+  let service: CyclesSyncService;
+  let mockNotion: any;
+  let mockWiki: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      resolveDataSourceId: vi.fn().mockResolvedValue('test-id'),
+      createColumnIfNeeded: vi.fn(),
+      queryAllBooks: vi.fn(),
+      updatePage: vi.fn(),
+    };
+
+    mockWiki = {
+      fetchPagesContentBulk: vi.fn(),
+      searchPage: vi.fn(),
+      fetchPageContent: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new CyclesSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+  });
+
+  it('updates cycle checkbox when it differs', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: 'page-1',
+        plTitle: 'Solaris',
+        origTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        year: '1961',
+        currentCzesccyklu: false,
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({
+      'solaris': '{{Książka infobox\n|autor = Stanisław Lem\n|cykl = Opowieści o pilocie Pirxie\n}}'
+    });
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('page-1', {
+      'Część cyklu': { checkbox: true }
+    });
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
+  });
+});

--- a/services/__tests__/dataNormalizer.test.ts
+++ b/services/__tests__/dataNormalizer.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeData } from '../dataNormalizer';
+
+describe('dataNormalizer', () => {
+  it('normalizes publishers', () => {
+    expect(normalizeData('Zysk', 'publisher')).toBe('Zysk i S-ka');
+    expect(normalizeData('Prószyński', 'publisher')).toBe('Prószyński i S-ka');
+    expect(normalizeData('Unknown', 'publisher')).toBe('Unknown');
+  });
+
+  it('normalizes authors', () => {
+    expect(normalizeData('Liu Cixin', 'author')).toBe('Liu Cixin, Ken Liu');
+    expect(normalizeData('Cixin Liu', 'author')).toBe('Liu Cixin, Ken Liu');
+    expect(normalizeData('Ann Leckie', 'author')).toBe('Ann Leckie');
+    expect(normalizeData('Anne Leckie', 'author')).toBe('Ann Leckie');
+  });
+
+  it('normalizes series', () => {
+    expect(normalizeData('Kameleon (seria)', 'series')).toBe('Kameleon');
+    expect(normalizeData('Klasyka SF', 'series')).toBe('Klasyka Science Fiction');
+  });
+
+  it('is case insensitive', () => {
+    expect(normalizeData('zysk', 'publisher')).toBe('Zysk i S-ka');
+    expect(normalizeData('liu cixin', 'author')).toBe('Liu Cixin, Ken Liu');
+  });
+});

--- a/services/__tests__/diffEngine.test.ts
+++ b/services/__tests__/diffEngine.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { DiffEngine } from '../diffEngine';
+
+describe('DiffEngine', () => {
+  it('compares multi-select strings correctly', () => {
+    expect(DiffEngine.isMultiSelectEqual('Zysk, MAG', 'MAG, Zysk')).toBe(true);
+    expect(DiffEngine.isMultiSelectEqual('Zysk, MAG', 'MAG, Zysk, Rebis')).toBe(false);
+    expect(DiffEngine.isMultiSelectEqual('  Zysk  ', 'Zysk')).toBe(true);
+    expect(DiffEngine.isMultiSelectEqual('', null as any)).toBe(true);
+  });
+
+  it('compares strings correctly', () => {
+    expect(DiffEngine.isStringEqual(' Solaris ', 'Solaris')).toBe(true);
+    expect(DiffEngine.isStringEqual('Solaris', 'Cyberiada')).toBe(false);
+  });
+});

--- a/services/__tests__/duplicateSyncService.test.ts
+++ b/services/__tests__/duplicateSyncService.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DuplicateSyncService } from '../duplicateSyncService';
+import { NotionAdapter } from '../../notion.adapter';
+import { WikiAdapter } from '../../wiki.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('DuplicateSyncService', () => {
+  let service: DuplicateSyncService;
+  let mockNotion: any;
+  let mockWiki: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      init: vi.fn(),
+      queryAllBooks: vi.fn(),
+    };
+
+    mockWiki = {};
+
+    mockSendEvent = vi.fn();
+
+    service = new DuplicateSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+  });
+
+  it('detects duplicates with identical titles', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: '1',
+        plTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        origTitle: 'Solaris',
+        year: '1961',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      },
+      {
+        id: '2',
+        plTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        origTitle: 'Solaris',
+        year: '1961',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '2',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+
+    await service.runDuplicateCheck(mockSendEvent, () => false);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'complete',
+      result: expect.objectContaining({
+        duplicates: expect.arrayContaining([
+          expect.objectContaining({ reason: 'identyczny tytuł PL' })
+        ])
+      })
+    }));
+  });
+
+  it('detects duplicates with common words and same author', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: '1',
+        plTitle: 'The Left Hand of Darkness',
+        author: 'Ursula K. Le Guin',
+        origTitle: 'The Left Hand of Darkness',
+        year: '1969',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      },
+      {
+        id: '2',
+        plTitle: 'Lewa ręka ciemności',
+        author: 'Ursula K. Le Guin',
+        origTitle: 'Left Hand of Darkness',
+        year: '1969',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '2',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+
+    await service.runDuplicateCheck(mockSendEvent, () => false);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'complete',
+      result: expect.objectContaining({
+        duplicates: expect.arrayContaining([
+          expect.objectContaining({ reason: 'dopasowanie słów + ten sam autor' })
+        ])
+      })
+    }));
+  });
+});

--- a/services/__tests__/integrityService.test.ts
+++ b/services/__tests__/integrityService.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IntegrityService } from '../integrityService';
+import { NotionAdapter } from '../../notion.adapter';
+import { WikiAdapter } from '../../wiki.adapter';
+import { NotionBook, Book } from '../../src/types';
+
+describe('IntegrityService', () => {
+  let service: IntegrityService;
+  let mockNotion: any;
+  let mockWiki: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      init: vi.fn(),
+      queryAllBooks: vi.fn(),
+    };
+
+    mockWiki = {
+      fetchPageContent: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new IntegrityService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+  });
+
+  it('detects duplicate Lp values', async () => {
+    const mockBooks: NotionBook[] = [
+      { id: '1', lp: '1', plTitle: 'Book 1', author: 'Author', origTitle: '', year: '2000', awards: ['Nagroda Hugo'], zrodlo: [], currentWydawnictwo: '', currentSeria: '', currentCzesccyklu: false, plTitleRichText: [], origTitleRichText: [] },
+      { id: '2', lp: '1', plTitle: 'Book 2', author: 'Author', origTitle: '', year: '2000', awards: ['Nagroda Hugo'], zrodlo: [], currentWydawnictwo: '', currentSeria: '', currentCzesccyklu: false, plTitleRichText: [], origTitleRichText: [] }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+    mockWiki.fetchPageContent.mockResolvedValue(''); // No wiki books for simplicity
+
+    await service.runIntegrityCheck(mockSendEvent, () => false);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'complete',
+      result: expect.objectContaining({
+        lpUniqueness: expect.objectContaining({ status: false, duplicates: expect.arrayContaining([expect.stringContaining('Lp 1')]) })
+      })
+    }));
+  });
+
+  it('detects year mismatch between Notion and Wiki', async () => {
+    const mockNotionBooks: NotionBook[] = [
+      { id: '1', lp: '1', plTitle: 'Solaris', author: 'Stanisław Lem', origTitle: 'Solaris', year: '1961', awards: ['Nagroda Hugo'], zrodlo: [], currentWydawnictwo: '', currentSeria: '', currentCzesccyklu: false, plTitleRichText: [], origTitleRichText: [] }
+    ];
+
+    const wikiContent = `
+{| class="wikitable"
+|-
+! Rok !! Autor !! Tytuł oryginalny !! Tytuł polski
+|-
+| [[1962]] || [[Stanisław Lem]] || ''Solaris'' || Solaris
+|}`;
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockNotionBooks);
+    mockWiki.fetchPageContent.mockResolvedValue(wikiContent);
+
+    await service.runIntegrityCheck(mockSendEvent, () => false);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'complete',
+      result: expect.objectContaining({
+        yearCountMatch: expect.objectContaining({ status: false })
+      })
+    }));
+  });
+});

--- a/services/__tests__/lpSyncService.test.ts
+++ b/services/__tests__/lpSyncService.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LpSyncService } from '../lpSyncService';
+import { NotionAdapter } from '../../notion.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('LpSyncService', () => {
+  let service: LpSyncService;
+  let mockNotion: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      queryAllBooks: vi.fn(),
+      updateLp: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new LpSyncService(mockNotion as unknown as NotionAdapter);
+  });
+
+  it('sorts books by year and title and updates Lp', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: 'page-2',
+        plTitle: 'B',
+        author: 'Author',
+        origTitle: 'B',
+        year: '2000',
+        lp: '1',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        plTitleRichText: [],
+        origTitleRichText: []
+      },
+      {
+        id: 'page-1',
+        plTitle: 'A',
+        author: 'Author',
+        origTitle: 'A',
+        year: '1990',
+        lp: '2',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+
+    await service.runLpSync(mockSendEvent, () => false);
+
+    // After sort: page-1 (1990) should be Lp 1, page-2 (2000) should be Lp 2
+    expect(mockNotion.updateLp).toHaveBeenCalledWith('page-1', '1');
+    expect(mockNotion.updateLp).toHaveBeenCalledWith('page-2', '2');
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
+  });
+});

--- a/services/__tests__/publisherSyncService.test.ts
+++ b/services/__tests__/publisherSyncService.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublisherSyncService } from '../publisherSyncService';
+import { NotionAdapter } from '../../notion.adapter';
+import { WikiAdapter } from '../../wiki.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('PublisherSyncService', () => {
+  let service: PublisherSyncService;
+  let mockNotion: any;
+  let mockWiki: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      queryAllBooks: vi.fn(),
+      updatePage: vi.fn(),
+      buildPropertyValue: vi.fn((val, type) => ({ [type]: val })),
+    };
+
+    mockWiki = {
+      fetchPagesContentBulk: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new PublisherSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+  });
+
+  it('updates publisher when it differs', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: 'page-1',
+        plTitle: 'Solaris',
+        origTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        year: '1961',
+        currentWydawnictwo: 'Stare Wydawnictwo',
+        awards: [],
+        zrodlo: [],
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({
+      'solaris': '{{Książka infobox\n|wydawca = Nowe Wydawnictwo\n}}'
+    });
+
+    await service.runPublisherSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('page-1', {
+      'Wydawnictwo': expect.anything()
+    });
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
+  });
+
+  it('handles cancellation', async () => {
+    mockNotion.queryAllBooks.mockResolvedValue([]);
+    
+    await service.runPublisherSync(mockSendEvent, () => true);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'status', message: 'Przerwano Rytuał Wydania.' }));
+    expect(mockNotion.updatePage).not.toHaveBeenCalled();
+  });
+});

--- a/services/__tests__/purificationService.test.ts
+++ b/services/__tests__/purificationService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PurificationService } from '../purificationService';
+import { NotionAdapter } from '../../notion.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('PurificationService', () => {
+  let service: PurificationService;
+  let mockNotion: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      init: vi.fn(),
+      queryAllBooks: vi.fn(),
+      updatePage: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new PurificationService(mockNotion as unknown as NotionAdapter);
+  });
+
+  it('removes wiki formatting from titles', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: 'page-1',
+        plTitle: "[[Solaris]]",
+        origTitle: "''Solaris''",
+        author: 'Stanisław Lem',
+        year: '1961',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+
+    await service.runPurification(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('page-1', {
+      'Tytuł polski': expect.objectContaining({ rich_text: [expect.objectContaining({ text: { content: 'Solaris' } })] }),
+      'Tytuł oryginalny': expect.objectContaining({ rich_text: [expect.objectContaining({ text: { content: 'Solaris' } })] })
+    });
+  });
+});

--- a/services/__tests__/schemaValidationService.test.ts
+++ b/services/__tests__/schemaValidationService.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SchemaValidationService } from '../schemaValidationService';
+import { NotionAdapter } from '../../notion.adapter';
+
+describe('SchemaValidationService', () => {
+  let service: SchemaValidationService;
+  let mockNotion: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    process.env.NOTION_DATABASE_ID = 'test-db-id';
+    mockNotion = {
+      init: vi.fn(),
+      resolveDataSourceId: vi.fn().mockResolvedValue('actual-id'),
+      retrieveDataSource: vi.fn(),
+      renameProperty: vi.fn(),
+      updateDatabaseProperty: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new SchemaValidationService(mockNotion as unknown as NotionAdapter);
+  });
+
+  it('renames title column if it is not Lp', async () => {
+    mockNotion.retrieveDataSource.mockResolvedValueOnce({
+      properties: {
+        'Name': { name: 'Name', type: 'title' }
+      }
+    }).mockResolvedValueOnce({
+      properties: {
+        'Lp': { name: 'Lp', type: 'title' }
+      }
+    });
+
+    await service.runSchemaValidation(mockSendEvent, () => false);
+
+    expect(mockNotion.renameProperty).toHaveBeenCalledWith('actual-id', 'Name', 'Lp');
+  });
+
+  it('creates missing properties', async () => {
+    mockNotion.retrieveDataSource.mockResolvedValue({
+      properties: {
+        'Lp': { name: 'Lp', type: 'title' }
+        // Missing others
+      }
+    });
+
+    await service.runSchemaValidation(mockSendEvent, () => false);
+
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Autor', 'multi_select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Tytuł polski', 'rich_text');
+  });
+});

--- a/services/__tests__/seriesSyncService.test.ts
+++ b/services/__tests__/seriesSyncService.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SeriesSyncService } from '../seriesSyncService';
+import { NotionAdapter } from '../../notion.adapter';
+import { WikiAdapter } from '../../wiki.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('SeriesSyncService', () => {
+  let service: SeriesSyncService;
+  let mockNotion: any;
+  let mockWiki: any;
+  let mockSendEvent: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      queryAllBooks: vi.fn(),
+      updatePage: vi.fn(),
+      buildPropertyValue: vi.fn((val, type) => ({ [type]: val })),
+    };
+
+    mockWiki = {
+      fetchPagesContentBulk: vi.fn(),
+    };
+
+    mockSendEvent = vi.fn();
+
+    service = new SeriesSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+  });
+
+  it('updates series when it differs', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: 'page-1',
+        plTitle: 'Solaris',
+        origTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        year: '1961',
+        currentSeria: 'Stara Seria',
+        awards: [],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({
+      'solaris': '{{Książka infobox\n|seria = Nowa Seria\n}}'
+    });
+
+    await service.runSeriesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('page-1', {
+      'Seria': expect.anything()
+    });
+    expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
+  });
+});

--- a/services/__tests__/statsService.test.ts
+++ b/services/__tests__/statsService.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StatsService } from '../statsService';
+import { NotionAdapter } from '../../notion.adapter';
+import { NotionBook } from '../../src/types';
+
+describe('StatsService', () => {
+  let service: StatsService;
+  let mockNotion: any;
+
+  beforeEach(() => {
+    mockNotion = {
+      getBooksForStats: vi.fn(),
+    };
+
+    service = new StatsService(mockNotion as unknown as NotionAdapter);
+  });
+
+  it('calculates stats correctly', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: '1',
+        plTitle: 'Solaris',
+        author: 'Stanisław Lem',
+        origTitle: 'Solaris',
+        year: '1961',
+        zrodlo: ['Przeczytane', 'Posiadam'],
+        awards: ['Nagroda Hugo'],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      },
+      {
+        id: '2',
+        plTitle: 'Cyberiada',
+        author: 'Stanisław Lem',
+        origTitle: 'Cyberiada',
+        year: '1965',
+        zrodlo: ['Posiadam'],
+        awards: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '2',
+        plTitleRichText: [],
+        origTitleRichText: []
+      }
+    ];
+
+    mockNotion.getBooksForStats.mockResolvedValue(mockBooks);
+
+    const stats = await service.getStats();
+
+    expect(stats.awardBooksStats).toEqual({ read: 1, total: 2 });
+    expect(stats.authorStats).toContainEqual(expect.objectContaining({
+      name: 'Stanisław Lem',
+      read: 1,
+      total: 2
+    }));
+    expect(stats.ownedUnread).toHaveLength(1);
+    expect(stats.ownedUnread[0].title).toBe('Cyberiada');
+  });
+});

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -1,0 +1,398 @@
+import pLimit from "p-limit";
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { calculateSimilarity, countCommonWords, cleanTitle, sanitizeNotionString, sanitizeNotionTag, isValidUrl } from "../utils";
+import { Book, NotionBook, SyncEvent, SyncParams } from "../src/types";
+import { normalizeData } from "./dataNormalizer";
+
+export class BookSyncService {
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  async fetchBooksFromMediaWiki(pageTitle: string, awardName: string, sendEvent: (data: SyncEvent) => void): Promise<Book[]> {
+    sendEvent({ type: "status", message: `Inicjacja ekstrakcji danych z Archiwum Encyklopedii: ${awardName}...` });
+    const wikitext = await this.wiki.fetchPageContent(pageTitle);
+    
+    sendEvent({ type: "status", message: `Dekodowanie tablic wyników: ${awardName}...` });
+    const books: Book[] = [];
+    
+    let processedWikitext = wikitext;
+    if (awardName === "Nagroda Locus") {
+      processedWikitext = processedWikitext.replace(/={2,}\s*Zwycięzcy w kategorii Powieść dla młodzieży\s*={2,}[^]*?(?=\n==|$)/i, '');
+    }
+
+    let cleanedWiki = processedWikitext
+      .replace(/\{\{sortname\|([^|}]+)\|([^|}]+)(?:\|[^}]+)?\}\}/gi, '$1 $2')
+      .replace(/<br\s*\/?>/gi, ' ')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\|\}[\s\S]*?\{\|[^\n]*\n/g, '\n|-\n');
+
+    const rows = cleanedWiki.split(/\|-/);
+    let lastYear = "";
+    let colMap = { rok: 0, autor: 1, tytulOryginalny: 2, tytulPolski: 3, expectedLength: 4 };
+
+    const parseCell = (cell: string, extractLink = false, extractItalics = false) => {
+      if (!cell) return extractLink ? { text: "", link: null } : "";
+      let text = cell.trim();
+      let link = null;
+      
+      if (extractLink) {
+        const linkMatch = text.match(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/);
+        if (linkMatch) {
+          const pageName = linkMatch[1].trim().replace(/ /g, '_');
+          link = `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent(pageName)}`;
+        }
+      }
+      
+      if (extractItalics && !text.toLowerCase().includes("(aka")) {
+        const italicsMatch = text.match(/''(.+?)''/);
+        if (italicsMatch) text = italicsMatch[1];
+      }
+      
+      text = text.replace(/\[\[[^\]|]+\|([^\]]+)\]\]/g, '$1')
+                 .replace(/\[\[([^\]]+)\]\]/g, '$1')
+                 .replace(/''+/g, '')
+                 .trim();
+                 
+      return extractLink ? { text, link } : text;
+    };
+
+    for (let i = 0; i < rows.length; i++) {
+      let trimmedRow = rows[i].trim();
+      const endTableIndex = trimmedRow.indexOf('|}');
+      if (endTableIndex !== -1) trimmedRow = trimmedRow.substring(0, endTableIndex).trim();
+      if (!trimmedRow || trimmedRow.startsWith('}')) continue;
+
+      const isWinner = trimmedRow.toLowerCase().includes('background') || trimmedRow.toLowerCase().includes('bgcolor');
+      const baseName = awardName.replace('Nagroda ', '').replace('Nominacja ', '');
+      const currentAward = isWinner ? `Nagroda ${baseName}` : `Nominacja ${baseName}`;
+
+      let rowContent = trimmedRow;
+      if (!rowContent.startsWith('|') && !rowContent.startsWith('!')) rowContent = rowContent.replace(/^.*?\n/, '');
+      rowContent = '\n' + rowContent;
+      
+      const cellsRaw = rowContent.split(/\n\||\n!|\|\|/);
+      const cells = cellsRaw.map(c => {
+        const pipeIndex = c.indexOf('|');
+        if (pipeIndex !== -1 && c.substring(0, pipeIndex).includes('=')) return c.substring(pipeIndex + 1).trim();
+        return c.trim().replace(/^!/, '').replace(/^\|/, '').trim();
+      });
+
+      if (cells.length > 0 && cells[0] === '') cells.shift();
+      while (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+      
+      if (cells.some(c => c.toLowerCase().includes('autor'))) {
+        colMap.rok = cells.findIndex(c => c.toLowerCase().includes('rok'));
+        colMap.autor = cells.findIndex(c => c.toLowerCase().includes('autor'));
+        colMap.tytulOryginalny = cells.findIndex(c => c.toLowerCase().includes('oryginalny'));
+        colMap.tytulPolski = cells.findIndex(c => c.toLowerCase().includes('polski'));
+        colMap.expectedLength = cells.length;
+        continue;
+      }
+
+      if (cells.length === 1) {
+        if (books.length > 0) {
+          let extraAuthor = parseCell(cells[0]) as string;
+          extraAuthor = extraAuthor.replace(/\s*\(remis\)/gi, '').trim();
+          books[books.length - 1].author += ", " + extraAuthor;
+        }
+        continue;
+      }
+
+      if (cells.length < 2) continue;
+
+      let year = "", author = "", originalTitle = "", polishTitle = "", polishTitleLink = null;
+      let isFullRow = false;
+      if (colMap.rok !== -1) {
+         const possibleYearCell = cells[colMap.rok];
+         if (possibleYearCell) {
+             const yearMatch = possibleYearCell.match(/^['\[]*(\d{4})/);
+             if (yearMatch && !possibleYearCell.includes('{{sortname')) isFullRow = true;
+         }
+      } else {
+         isFullRow = cells.length >= colMap.expectedLength;
+      }
+
+      const omittedColumns = isFullRow ? 0 : Math.max(1, colMap.autor);
+      
+      if (isFullRow) {
+        const yearMatch = cells[colMap.rok]?.match(/^['\[]*(\d{4})/);
+        year = yearMatch ? yearMatch[1] : cells[colMap.rok];
+        lastYear = year;
+        author = parseCell(cells[colMap.autor] || "") as string;
+        originalTitle = parseCell(cells[colMap.tytulOryginalny] || "", false, true) as string;
+        const plParsed = parseCell(cells[colMap.tytulPolski] || "", true, true) as {text: string, link: string | null};
+        polishTitle = plParsed.text;
+        polishTitleLink = plParsed.link;
+      } else {
+        year = lastYear;
+        author = parseCell(cells[0] || "") as string;
+        originalTitle = parseCell(cells[colMap.tytulOryginalny - omittedColumns] || "", false, true) as string;
+        const plParsed = parseCell(cells[colMap.tytulPolski - omittedColumns] || "", true, true) as {text: string, link: string | null};
+        polishTitle = plParsed.text;
+        polishTitleLink = plParsed.link;
+      }
+
+      author = author.replace(/\s*\(remis\)/gi, '').trim();
+      if (author || polishTitle || originalTitle) {
+        books.push({ 
+          year, 
+          author, 
+          polishTitle: cleanTitle(polishTitle), 
+          originalTitle: normalizeData(cleanTitle(originalTitle), 'title'), 
+          polishTitleLink, award: currentAward 
+        });
+      }
+    }
+    return books;
+  }
+
+  compareBooks(existingBook: NotionBook, book: Book): any {
+    const updates: any = {};
+    
+    const cleanExistingPl = sanitizeNotionString(existingBook.plTitle);
+    const cleanExistingOrig = sanitizeNotionString(existingBook.origTitle);
+    const cleanNewPl = sanitizeNotionString(book.polishTitle);
+    const cleanNewOrig = sanitizeNotionString(book.originalTitle);
+
+    // Update Polish title if it differs from the wiki
+    if (cleanNewPl && cleanExistingPl !== cleanNewPl) {
+      const link = book.polishTitleLink;
+      updates["Tytuł polski"] = { rich_text: [{ text: { content: cleanNewPl, ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
+    } else if (cleanExistingPl && existingBook.plTitle !== cleanExistingPl) {
+      const link = book.polishTitleLink;
+      updates["Tytuł polski"] = { rich_text: [{ text: { content: cleanExistingPl, ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
+    }
+
+    if (cleanNewOrig && (!cleanExistingOrig || cleanExistingOrig === "")) {
+      updates["Tytuł oryginalny"] = { rich_text: [{ text: { content: cleanNewOrig } }] };
+    } else if (cleanExistingOrig && existingBook.origTitle !== cleanExistingOrig) {
+      updates["Tytuł oryginalny"] = { rich_text: [{ text: { content: cleanExistingOrig } }] };
+    }
+
+    // Update Author if it differs
+    const newAuthors = Array.from(new Set(
+      normalizeData(book.author || "", 'author').split(',')
+        .map((a: string) => sanitizeNotionTag(a))
+        .filter(Boolean)
+    ));
+    const existingAuthors = (existingBook.author || "").split(',')
+      .map((a: string) => sanitizeNotionTag(a))
+      .filter(Boolean);
+    
+    const authorsChanged = newAuthors.length !== existingAuthors.length || 
+                           newAuthors.some(a => !existingAuthors.includes(a)) ||
+                           existingAuthors.some(a => !newAuthors.includes(a));
+
+    if (authorsChanged && newAuthors.length > 0) {
+      updates["Autor"] = { multi_select: newAuthors.slice(0, 100).map(name => ({ name })) };
+    }
+    
+    const newAwards = (book.awards || []).map(sanitizeNotionTag).filter(Boolean);
+    const existingAwards = (existingBook.awards || []).map(sanitizeNotionTag).filter(Boolean);
+    
+    const combinedAwardsSet = new Set([...existingAwards]);
+    let awardsUpdated = false;
+
+    for (const aw of newAwards) {
+      if (!combinedAwardsSet.has(aw)) {
+        combinedAwardsSet.add(aw);
+        awardsUpdated = true;
+      }
+    }
+    
+    const hasHugo = combinedAwardsSet.has("Nagroda Hugo");
+    const hasNebula = combinedAwardsSet.has("Nagroda Nebula");
+    const hasLocus = combinedAwardsSet.has("Nagroda Locus");
+    if (hasHugo && hasNebula && hasLocus && !combinedAwardsSet.has("Wszystkie")) {
+      combinedAwardsSet.add("Wszystkie");
+      awardsUpdated = true;
+    }
+    
+    if (awardsUpdated) {
+      updates["Nagroda"] = { multi_select: Array.from(combinedAwardsSet).map(name => ({ name })) };
+    }
+
+    // Update Year if it differs
+    const newYear = (book.year || "").trim();
+    const existingYears = (existingBook.year || "").split(',')
+      .map((y: string) => y.trim())
+      .filter(Boolean);
+    
+    if (newYear && !existingYears.includes(newYear)) {
+      const updatedYears = Array.from(new Set([...existingYears, newYear]))
+        .sort()
+        .map(name => ({ name }));
+      updates["Rok"] = { multi_select: updatedYears };
+    }
+
+    return updates;
+  }
+
+  private countCommonWords(title1: string, title2: string): number {
+    const words1 = new Set(title1.toLowerCase().split(/\s+/).filter(w => w.length > 0));
+    const words2 = new Set(title2.toLowerCase().split(/\s+/).filter(w => w.length > 0));
+    let common = 0;
+    for (const w1 of words1) {
+      if (words2.has(w1)) common++;
+    }
+    return common;
+  }
+
+  async runBookSync(params: SyncParams, sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
+      await this.notion.init();
+      let allBooksToSync: Book[] = [];
+      if (params.syncAll) {
+        const PREDEFINED_AWARDS = [
+          { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
+          { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
+          { name: "Nagroda Locus", title: "Locus nagroda powieść" }
+        ];
+        for (const aw of PREDEFINED_AWARDS) {
+          if (checkCancellation()) break;
+          const books = await this.fetchBooksFromMediaWiki(aw.title, aw.name, sendEvent);
+          allBooksToSync = allBooksToSync.concat(books);
+        }
+      } else if (params.pageTitle && params.awardName) {
+        allBooksToSync = await this.fetchBooksFromMediaWiki(params.pageTitle, params.awardName, sendEvent);
+      }
+      if (checkCancellation()) {
+        sendEvent({ type: "error", error: "Synchronizacja przerwana przez użytkownika." });
+        return;
+      }
+      const mergedBooksMap = new Map<string, Book>();
+      for (const book of allBooksToSync) {
+        const normalizedAuthor = normalizeData(book.author || "", 'author');
+        const key = `${book.polishTitle || book.originalTitle}|${normalizedAuthor}`.trim().toLowerCase();
+        if (!key) continue;
+        if (mergedBooksMap.has(key)) {
+          const existing = mergedBooksMap.get(key)!;
+          if (!existing.awards?.includes(book.award)) existing.awards?.push(book.award);
+        } else {
+          book.awards = [book.award];
+          book.author = normalizedAuthor; // Store normalized author
+          mergedBooksMap.set(key, book);
+        }
+      }
+      const booksToSync = Array.from(mergedBooksMap.values());
+      sendEvent({ type: "status", message: "Skanowanie bazy danych Notion..." });
+      const existingBooks = await this.notion.queryAllBooks(
+        (count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }),
+        checkCancellation
+      );
+
+      const existingBooksMap = new Map<string, NotionBook>();
+      for (const book of existingBooks) {
+        const normalizedAuthor = normalizeData(cleanTitle(book.author || ""), 'author');
+        const cleanedPl = normalizeData(cleanTitle(book.plTitle || ""), 'title');
+        const cleanedOrig = normalizeData(cleanTitle(book.origTitle || ""), 'title');
+        
+        if (cleanedPl) {
+          const key = `${cleanedPl}|${normalizedAuthor}`.toLowerCase();
+          existingBooksMap.set(key, book);
+        }
+        if (cleanedOrig) {
+          const key = `${cleanedOrig}|${normalizedAuthor}`.toLowerCase();
+          existingBooksMap.set(key, book);
+        }
+      }
+      let synced = 0, updated = 0;
+      const syncSummary = { added: [] as string[], updated: [] as string[], skipped: [] as string[], duplicates: [] as string[] };
+      const errors: any[] = [];
+      
+      const limit = pLimit(3);
+      let processedCount = 0;
+
+      const syncTasks = booksToSync.map((book) => limit(async () => {
+        if (checkCancellation()) return;
+        
+        processedCount++;
+        if (processedCount % 5 === 0 || processedCount === booksToSync.length) {
+          sendEvent({ type: "progress", message: "Zapisywanie danych do bazy Notion...", current: processedCount, total: booksToSync.length });
+        }
+        
+        try {
+          const searchKeyPL = `${cleanTitle(book.polishTitle || "")}|${book.author}`.toLowerCase();
+          const searchKeyOrig = `${cleanTitle(book.originalTitle || "")}|${book.author}`.toLowerCase();
+          let existingBook = existingBooksMap.get(searchKeyPL) || existingBooksMap.get(searchKeyOrig);
+          const bookDisplayName = `${book.polishTitle || book.originalTitle} - ${book.author} (${book.year})`;
+          
+          let isDuplicateFound = false;
+          if (!existingBook) {
+            // Check for potential duplicates
+            for (const [titleWithAuthor, bookData] of existingBooksMap.entries()) {
+              let isDuplicate = false;
+              
+              // Check if authors are similar
+              const authorA = (book.author || "").toLowerCase().trim();
+              const authorB = (bookData.author || "").toLowerCase().trim();
+              const sameAuthor = authorA && authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > 0.85);
+
+              // Strict rule: at least 2 common significant words in original title AND same author
+              if (sameAuthor && book.originalTitle && bookData.origTitle && countCommonWords(book.originalTitle, bookData.origTitle) >= 2) {
+                isDuplicate = true;
+              }
+
+              if (isDuplicate) {
+                syncSummary.duplicates.push(`${bookDisplayName} (duplikat: ${bookData.origTitle || titleWithAuthor} - dopasowanie słów + autor)`);
+                isDuplicateFound = true;
+                break;
+              }
+            }
+          }
+
+          if (isDuplicateFound) return;
+
+          if (existingBook) {
+            const updates = this.compareBooks(existingBook, book);
+            if (Object.keys(updates).length > 0) {
+              await this.notion.updatePage(existingBook.id, updates);
+              updated++;
+              const updatedFields = Object.keys(updates).join(', ');
+              syncSummary.updated.push(`${bookDisplayName} (Zaktualizowano: ${updatedFields})`);
+            } else {
+              syncSummary.skipped.push(bookDisplayName);
+            }
+          } else {
+            const properties: any = {
+              "Lp": { title: [{ text: { content: sanitizeNotionString(book.polishTitle || book.originalTitle || "Nowy") } }] },
+              "Tytuł polski": { rich_text: [{ text: { content: sanitizeNotionString(book.polishTitle || ""), ...(isValidUrl(book.polishTitleLink) ? { link: { url: book.polishTitleLink } } : {}) } }] },
+              "Tytuł oryginalny": { rich_text: [{ text: { content: sanitizeNotionString(book.originalTitle || "") } }] },
+            };
+            if (book.year) {
+              properties["Rok"] = { multi_select: [{ name: book.year.toString() }] };
+            }
+            if (book.author) {
+              const authors = Array.from(new Set(
+                book.author.split(',')
+                  .map((a: string) => sanitizeNotionTag(a))
+                  .filter(Boolean)
+              ));
+              properties["Autor"] = { multi_select: authors.slice(0, 100).map(name => ({ name })) };
+            }
+            if (book.awards && book.awards.length > 0) {
+              const awardsSet = new Set(book.awards.map(sanitizeNotionTag).filter(Boolean));
+              const hasHugo = awardsSet.has("Nagroda Hugo");
+              const hasNebula = awardsSet.has("Nagroda Nebula");
+              const hasLocus = awardsSet.has("Nagroda Locus");
+              if (hasHugo && hasNebula && hasLocus && !awardsSet.has("Wszystkie")) awardsSet.add("Wszystkie");
+              properties["Nagroda"] = { multi_select: Array.from(awardsSet).map(name => ({ name })) };
+            }
+            await this.notion.addRow(properties);
+            synced++;
+            syncSummary.added.push(bookDisplayName);
+          }
+        } catch (err: any) {
+          errors.push({ book: book.polishTitle, error: err.message });
+        }
+      }));
+
+      await Promise.all(syncTasks);
+
+      sendEvent({ type: "complete", result: { synced, updated, summary: syncSummary, errors: errors.map(e => `${e.book}: ${e.error}`) } });
+    } catch (error: any) {
+      sendEvent({ type: "error", error: error.message });
+    }
+  }
+}

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -1,0 +1,142 @@
+import pLimit from "p-limit";
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { WikiParser } from "../wiki.parser";
+import { calculateSimilarity } from "../utils";
+import { NotionBook, SyncEvent } from "../src/types";
+import { normalizeData } from "./dataNormalizer";
+
+export class CyclesSyncService {
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  async runCyclesSync(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      const databaseId = process.env.NOTION_DATABASE_ID;
+      const actualDataSourceId = await this.notion.resolveDataSourceId(databaseId!);
+      sendEvent({ type: "status", message: "Sprawdzanie struktury bazy Notion..." });
+      await this.notion.createColumnIfNeeded("Część cyklu", "checkbox");
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      const allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      
+      if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano synchronizację cykli." }); return; }
+
+      // Zbieranie unikalnych tytułów do pobrania (zarówno polskie jak i oryginalne)
+      const titlesToFetch = Array.from(new Set([
+        ...allBooks.map(b => b.plTitle).filter(Boolean),
+        ...allBooks.map(b => b.origTitle).filter(Boolean)
+      ])) as string[];
+      
+      sendEvent({ type: "status", message: `Pobieranie treści ${titlesToFetch.length} stron z Encyklopedii (Bulk API)...` });
+      const wikiContents = await this.wiki.fetchPagesContentBulk(titlesToFetch);
+
+      let processedCount = 0, updatedCount = 0;
+      const syncSummary = { added: [] as string[], updated: [] as string[] };
+      const errors: any[] = [];
+      const limit = pLimit(3);
+      
+      const isAuthorMatch = (wikiAuthor: string, notionAuthor: string) => {
+        if (!wikiAuthor || !notionAuthor) return true;
+        const normWiki = normalizeData(wikiAuthor, 'author').toLowerCase().trim();
+        const normNotion = normalizeData(notionAuthor, 'author').toLowerCase().trim();
+        
+        if (normWiki.includes(normNotion) || normNotion.includes(normWiki)) return true;
+        return calculateSimilarity(normWiki, normNotion) > 0.6;
+      };
+
+      const checkCycleInWikitext = (wikitext: string): boolean => {
+        if (!wikitext) return false;
+        // Extended cycle detection: |cykl=, |cykle=, {{Cykl}}, {{cykl}}
+        // Exclude |seria= to avoid false positives
+        const hasCycleParam = /\|\s*cykl(e)?\s*=\s*[^\s|}]/i.test(wikitext);
+        const hasCycleTemplate = /\{\{(C|c)ykl\s*\|/i.test(wikitext);
+        return hasCycleParam || hasCycleTemplate;
+      };
+
+      const syncTasks = allBooks.map((book) => limit(async () => {
+        if (checkCancellation()) return;
+        
+        processedCount++;
+        if (processedCount % 10 === 0 || processedCount === allBooks.length) {
+          sendEvent({ type: "progress", message: "Analiza i aktualizacja cykli (In-Memory Diff)...", current: processedCount, total: allBooks.length });
+        }
+        
+        const plTitle = book.plTitle;
+        const origTitle = book.origTitle;
+        const notionAuthor = book.author || "";
+        
+        if (!plTitle && !origTitle) return;
+        
+        try {
+          let wikitext = "";
+          let foundSource = "";
+
+          // 1. Try Bulk Fetch results (Polish title first, then Original)
+          wikitext = (plTitle ? wikiContents[plTitle.toLowerCase()] : null) || 
+                     (origTitle ? wikiContents[origTitle.toLowerCase()] : null);
+
+          if (wikitext) {
+            const wikiAuthor = WikiParser.extractAuthor(wikitext);
+            if (!isAuthorMatch(wikiAuthor, notionAuthor)) {
+              wikitext = "";
+            } else {
+              foundSource = "Bulk Fetch";
+            }
+          }
+
+          // 2. Multi-Search (Polish title + Author)
+          if (!wikitext && plTitle && notionAuthor) {
+            const searchedTitles = await this.wiki.searchPage(`${plTitle} ${notionAuthor}`, 3);
+            for (const title of searchedTitles) {
+              const content = await this.wiki.fetchPageContent(title);
+              const wikiAuthor = WikiParser.extractAuthor(content);
+              if (isAuthorMatch(wikiAuthor, notionAuthor)) {
+                wikitext = content;
+                foundSource = `Search (PL): ${title}`;
+                break;
+              }
+            }
+          }
+
+          // 3. Multi-Search (Original title + Author)
+          if (!wikitext && origTitle && notionAuthor) {
+            const searchedTitles = await this.wiki.searchPage(`${origTitle} ${notionAuthor}`, 3);
+            for (const title of searchedTitles) {
+              const content = await this.wiki.fetchPageContent(title);
+              const wikiAuthor = WikiParser.extractAuthor(content);
+              if (isAuthorMatch(wikiAuthor, notionAuthor)) {
+                wikitext = content;
+                foundSource = `Search (Orig): ${title}`;
+                break;
+              }
+            }
+          }
+
+          // 4. Direct Fetch Fallback (Exact title from Notion)
+          if (!wikitext && plTitle) {
+            try {
+              const content = await this.wiki.fetchPageContent(plTitle);
+              const wikiAuthor = WikiParser.extractAuthor(content);
+              if (isAuthorMatch(wikiAuthor, notionAuthor)) {
+                wikitext = content;
+                foundSource = `Direct Fetch: ${plTitle}`;
+              }
+            } catch (e) {}
+          }
+
+          if (!wikitext) return;
+
+          const hasCycle = checkCycleInWikitext(wikitext);
+          if (hasCycle !== book.currentCzesccyklu) {
+            await this.notion.updatePage(book.id, { "Część cyklu": { checkbox: hasCycle } });
+            updatedCount++;
+            syncSummary.updated.push(`${plTitle || origTitle} (Zaktualizowano: Część cyklu via ${foundSource})`);
+          }
+        } catch (err: any) { errors.push({ book: plTitle || origTitle, error: err.message }); }
+      }));
+
+      await Promise.all(syncTasks);
+
+      sendEvent({ type: "complete", result: { success: !checkCancellation(), found: allBooks.length, updated: updatedCount, summary: syncSummary, errors: errors.length > 0 ? errors : undefined } });
+    } catch (error: any) { sendEvent({ type: "error", error: error.message }); }
+  }
+}

--- a/services/dataNormalizer.ts
+++ b/services/dataNormalizer.ts
@@ -1,0 +1,70 @@
+export type NormalizationContext = 'publisher' | 'title' | 'series' | 'author';
+
+const MAPPINGS: Record<NormalizationContext, Record<string, string>> = {
+  publisher: {
+    "Zysk": "Zysk i S-ka",
+    "Zysk i S-ka": "Zysk i S-ka",
+    "Zysk i Ska": "Zysk i S-ka",
+    "Zysk i Spółka": "Zysk i S-ka",
+    "Prószyński": "Prószyński i S-ka",
+    "Prószyński i S-ka": "Prószyński i S-ka",
+    "Prószyński  i S-ka": "Prószyński i S-ka",
+    "Prószyński i Spółka": "Prószyński i S-ka",
+  },
+  title: {
+    "The Computer Connection": "The Computer Connection (aka The Indian Giver)",
+    "The Computer Connection (aka The Indian Giver)": "The Computer Connection (aka The Indian Giver)",
+    "The Strange Case of the Alchemist's Daughter": "The Strange Case of the Alchemist's Daughter",
+    "The Strange Case of the Alchemist’s Daughter": "The Strange Case of the Alchemist's Daughter",
+    "Mule": "Mule (Foundation and Empire)",
+    "We Are All Completely Beside Ourselves": "We Are All Completely Beside Ourselves",
+  },
+  series: {
+    "Kameleon (Zysk i Spółka)": "Kameleon",
+    "Kameleon (seria)": "Kameleon",
+    "Klasyka SF": "Klasyka Science Fiction",
+    "Nowa Fantastyka (seria)": "Nowa Fantastyka",
+    "Fantastyka (seria)": "Nowa Fantastyka",
+    "Fantastyka Przygoda": "Fantastyka",
+    "Fantastyka Beta": "Fantastyka",
+  },
+  author: {
+    "Liu Cixin": "Liu Cixin, Ken Liu",
+    "Cixin Liu": "Liu Cixin, Ken Liu",
+    "Liu Cixin, Ken Liu, Ken Liu (tłumacz)": "Liu Cixin, Ken Liu",
+    "Liu Cixin, Ken Liu (tłumacz)": "Liu Cixin, Ken Liu",
+    "Ann Leckie": "Ann Leckie",
+    "Anne Leckie": "Ann Leckie",
+    "Edmond Hamilton (jako Brett Sterling)": "Edmond Hamilton, Brett Sterling",
+    "Edward E. Smith": "E. E. Doc Smith",
+    "E. E. Doc Smith": "E. E. Doc Smith",
+    "E. E. Smith": "E. E. Doc Smith",
+    "A. E. van Vogt": "A. E. Van Vogt",
+    "A. E. Van Vogt": "A. E. Van Vogt",
+  }
+};
+
+/**
+ * Normalizuje dane na podstawie zdefiniowanych mapowań wyjątków.
+ * Jeśli wartość nie znajduje się w mapowaniu, zwraca wartość oryginalną.
+ */
+export function normalizeData(value: string, context: NormalizationContext): string {
+    if (!value) return value;
+    const trimmed = value.trim();
+    const lowerTrimmed = trimmed.toLowerCase();
+    
+    const contextMapping = MAPPINGS[context];
+    if (contextMapping) {
+        // First try exact match
+        if (contextMapping[trimmed]) return contextMapping[trimmed];
+        
+        // Then try case-insensitive match
+        for (const key in contextMapping) {
+            if (key.toLowerCase() === lowerTrimmed) {
+                return contextMapping[key];
+            }
+        }
+    }
+    
+    return value;
+}

--- a/services/diffEngine.ts
+++ b/services/diffEngine.ts
@@ -1,0 +1,24 @@
+export class DiffEngine {
+  /**
+   * Porównuje dwie wartości typu multi_select (np. "Zysk, MAG" i "MAG, Zysk").
+   * Rozdziela po przecinku, usuwa białe znaki, sortuje i porównuje.
+   */
+  static isMultiSelectEqual(val1: string, val2: string): boolean {
+    const normalize = (s: string) => 
+      (s || "")
+        .split(',')
+        .map(t => t.trim())
+        .filter(t => t.length > 0)
+        .sort()
+        .join(',');
+        
+    return normalize(val1) === normalize(val2);
+  }
+
+  /**
+   * Standardowe porównanie stringów z pominięciem spacji brzegowych.
+   */
+  static isStringEqual(val1: string, val2: string): boolean {
+    return (val1 || "").trim() === (val2 || "").trim();
+  }
+}

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -1,0 +1,99 @@
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { NotionBook, SyncEvent } from "../src/types";
+import { countCommonWords, calculateSimilarity } from "../utils";
+
+export class DuplicateSyncService {
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  async runDuplicateCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    console.log("DuplicateSyncService runDuplicateCheck started");
+    try {
+      sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
+      await this.notion.init();
+      console.log("Notion initialized");
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      const allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      console.log(`Fetched ${allBooks.length} books`);
+      
+      const duplicates: { bookA: string; bookB: string; reason: string }[] = [];
+      for (let i = 0; i < allBooks.length; i++) {
+        if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano sprawdzanie duplikatów." }); break; }
+        
+        for (let j = i + 1; j < allBooks.length; j++) {
+          const bookA = allBooks[i];
+          const bookB = allBooks[j];
+          
+          const titleA = (bookA.plTitle || "").toLowerCase().trim();
+          const titleB = (bookB.plTitle || "").toLowerCase().trim();
+          const origA = (bookA.origTitle || "").toLowerCase().trim();
+          const origB = (bookB.origTitle || "").toLowerCase().trim();
+          const authorA = (bookA.author || "").toLowerCase().trim();
+          const authorB = (bookB.author || "").toLowerCase().trim();
+          
+          if ((!titleA && !origA) || (!titleB && !origB)) continue;
+          
+          let isDuplicate = false;
+          let reason = "";
+          
+          const sameAuthor = authorA && authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > 0.85);
+          const differentAuthor = authorA && authorB && !sameAuthor && calculateSimilarity(authorA, authorB) < 0.5; // Clearly different
+
+          if (differentAuthor) continue; 
+          
+          // 1. Exact match for Polish title
+          if (titleA && titleB && titleA === titleB) {
+            isDuplicate = true;
+            reason = "identyczny tytuł PL";
+          } 
+          // 2. Exact match for Original title
+          else if (origA && origB && origA === origB) {
+            isDuplicate = true;
+            reason = "identyczny tytuł oryg.";
+          }
+          // 3. High similarity for Polish title
+          else if (titleA && titleB && calculateSimilarity(titleA, titleB) > 0.9) {
+            isDuplicate = true;
+            reason = "wysokie podobieństwo PL";
+          }
+          // 4. High similarity for Original title
+          else if (origA && origB && calculateSimilarity(origA, origB) > 0.9) {
+            isDuplicate = true;
+            reason = "wysokie podobieństwo oryg.";
+          }
+          // 5. Common words (at least 2) + same author
+          else if (sameAuthor && ((origA && origB && countCommonWords(origA, origB) >= 2) || (titleA && titleB && countCommonWords(titleA, titleB) >= 2))) {
+            isDuplicate = true;
+            reason = "dopasowanie słów + ten sam autor";
+          }
+          // 6. Common words (at least 2) for Original title
+          else if (origA && origB && countCommonWords(origA, origB) >= 2) {
+            isDuplicate = true;
+            reason = "dopasowanie słów oryg.";
+          }
+          // 7. Common words (at least 2) for Polish title
+          else if (titleA && titleB && countCommonWords(titleA, titleB) >= 2) {
+            isDuplicate = true;
+            reason = "dopasowanie słów PL";
+          }
+          
+          if (isDuplicate) {
+            const displayA = `${bookA.plTitle || bookA.origTitle || "Unknown"}${bookA.author ? ` - ${bookA.author}` : ""}`;
+            const displayB = `${bookB.plTitle || bookB.origTitle || "Unknown"}${bookB.author ? ` - ${bookB.author}` : ""}`;
+            duplicates.push({ 
+              bookA: displayA,
+              bookB: displayB,
+              reason
+            });
+          }
+        }
+        
+        if (i % 10 === 0 || i === allBooks.length - 1) {
+          sendEvent({ type: "progress", message: "Sprawdzanie duplikatów...", current: i, total: allBooks.length });
+        }
+      }
+      
+      sendEvent({ type: "complete", result: { success: true, duplicates } });
+    } catch (error: any) { sendEvent({ type: "error", error: error.message }); }
+  }
+}

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -1,0 +1,368 @@
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { BookSyncService } from "./bookSyncService";
+import { SyncEvent, NotionBook, Book } from "../src/types";
+import { normalizeData } from "./dataNormalizer";
+
+export interface IntegrityCheckResult {
+  lpUniqueness: { status: boolean; duplicates: string[] };
+  yearCountMatch: { 
+    status: boolean; 
+    diffs: { 
+      year: string; 
+      notion: number; 
+      wiki: number;
+      notionOnly?: string[];
+      wikiOnly?: string[];
+      misplaced?: { title: string, otherYear: string }[];
+      collisions?: { title: string, matches: string[] }[];
+    }[] 
+  };
+  originalTitleUniqueness: { status: boolean; duplicates: string[] };
+  polishTitleUniqueness: { status: boolean; duplicates: string[] };
+  awardCountMatch: { 
+    status: boolean; 
+    diffs: { 
+      award: string; 
+      notion: number; 
+      wiki: number;
+      notionOnly?: string[];
+      wikiOnly?: string[];
+    }[] 
+  };
+}
+
+export class IntegrityService {
+  private bookSyncService: BookSyncService;
+
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {
+    this.bookSyncService = new BookSyncService(notion, wiki);
+  }
+
+  async runIntegrityCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Inicjalizacja Skanera Sanctity..." });
+      await this.notion.init();
+
+      // 1. Fetch Notion Data
+      sendEvent({ type: "status", message: "Pobieranie wszystkich danych z Notion..." });
+      const notionBooks = await this.notion.queryAllBooks(
+        (count) => sendEvent({ type: "status", message: `Pobrano ${count} rekordów z Notion...` }),
+        checkCancellation
+      );
+
+      if (checkCancellation()) return;
+
+      // 2. Fetch Wiki Data (Predefined Awards)
+      sendEvent({ type: "status", message: "Pobieranie danych z Archiwum Encyklopedii (Nagrody)..." });
+      const PREDEFINED_AWARDS = [
+        { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
+        { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
+        { name: "Nagroda Locus", title: "Locus nagroda powieść" }
+      ];
+
+      let allWikiBooks: Book[] = [];
+      for (const aw of PREDEFINED_AWARDS) {
+        if (checkCancellation()) break;
+        const books = await this.bookSyncService.fetchBooksFromMediaWiki(aw.title, aw.name, sendEvent);
+        allWikiBooks = allWikiBooks.concat(books);
+      }
+
+      if (checkCancellation()) return;
+
+      sendEvent({ type: "status", message: "Analiza integralności danych (Rytuał Weryfikacji)..." });
+
+      const getRobustKey = (author: string, title: string) => {
+        // Try normalizing the whole author string first (for cases like "Liu Cixin, Ken Liu (tłumacz)")
+        const normalizedAuthor = normalizeData(author || "", 'author');
+        
+        // Split, clean and sort authors for robust matching
+        const authors = normalizedAuthor.split(',').map(a => 
+          a.toLowerCase()
+            .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
+            .replace(/\s{2,}/g, " ")
+            .trim()
+        ).filter(Boolean).sort();
+        
+        const normAuthor = authors.join(",");
+
+        const normTitle = normalizeData(title || "", 'title')
+          .toLowerCase()
+          .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
+          .replace(/\s{2,}/g, " ")
+          .trim();
+        return `${normTitle}|${normAuthor}`;
+      };
+
+      // --- PERFORM CHECKS ---
+
+      // A. Lp Uniqueness
+      const lpMap = new Map<string, number>();
+      notionBooks.forEach(b => {
+        if (b.lp) lpMap.set(b.lp, (lpMap.get(b.lp) || 0) + 1);
+      });
+      const lpDuplicates = Array.from(lpMap.entries())
+        .filter(([_, count]) => count > 1)
+        .map(([lp, count]) => `Lp ${lp}: powtórzony ${count} razy`);
+
+      // B. Original Title Uniqueness (per author)
+      const origTitleMap = new Map<string, number>();
+      notionBooks.forEach(b => {
+        const key = getRobustKey(b.author || "", b.origTitle || "");
+        if (b.origTitle) origTitleMap.set(key, (origTitleMap.get(key) || 0) + 1);
+      });
+      const origDuplicates = Array.from(origTitleMap.entries())
+        .filter(([_, count]) => count > 1)
+        .map(([key, count]) => `"${key.split('|')[0]}" (${key.split('|')[1]}): powtórzony ${count} razy`);
+
+      // C. Polish Title Uniqueness (per author)
+      const plTitleMap = new Map<string, number>();
+      notionBooks.forEach(b => {
+        const key = getRobustKey(b.author || "", b.plTitle || "");
+        if (b.plTitle) plTitleMap.set(key, (plTitleMap.get(key) || 0) + 1);
+      });
+      const plDuplicates = Array.from(plTitleMap.entries())
+        .filter(([_, count]) => count > 1)
+        .map(([key, count]) => `"${key.split('|')[0]}" (${key.split('|')[1]}): powtórzony ${count} razy`);
+
+      // D. Book Count per Year
+      const IGNORED_LOCUS_TAGS = ["Powieść dla młodzieży", "Locus - Powieść dla młodzieży", "Locus YA"];
+      
+      const notionYearMap = new Map<string, number>();
+      const mergedNotionBooksMap = new Map<string, { years: Set<string>, display: string, keys: string[] }>();
+      const notionKeyToPrimaryKey = new Map<string, string>();
+
+      notionBooks.forEach(b => {
+        // Filter out books that don't have any of our tracked awards (Hugo, Nebula, Locus)
+        // but also respect the Locus YA exclusion
+        const hasTrackedAward = b.awards?.some(aw => {
+          const lowerAw = aw.toLowerCase();
+          if (lowerAw.includes("locus") && IGNORED_LOCUS_TAGS.some(tag => lowerAw.includes(tag.toLowerCase()))) return false;
+          return ["hugo", "nebula", "locus"].some(kw => lowerAw.includes(kw));
+        });
+        if (!hasTrackedAward) return;
+
+        const keys = [
+          getRobustKey(b.author || "", b.origTitle || ""),
+          getRobustKey(b.author || "", b.plTitle || "")
+        ].filter(Boolean);
+        
+        if (keys.length === 0) return;
+
+        // Try to find if any of these keys already exist in the map (to merge duplicates in Notion)
+        let primaryKey = keys.find(k => notionKeyToPrimaryKey.has(k));
+        if (primaryKey) {
+          primaryKey = notionKeyToPrimaryKey.get(primaryKey)!;
+        } else {
+          primaryKey = keys[0];
+          mergedNotionBooksMap.set(primaryKey, { 
+            years: new Set(), 
+            display: `"${b.origTitle || b.plTitle}" (${b.author})`,
+            keys: keys
+          });
+        }
+        
+        const data = mergedNotionBooksMap.get(primaryKey)!;
+        if (b.year) {
+          const years = b.year.split(',').map(y => y.trim()).filter(Boolean);
+          years.forEach(y => data.years.add(y));
+        }
+        
+        keys.forEach(k => notionKeyToPrimaryKey.set(k, primaryKey!));
+      });
+
+      mergedNotionBooksMap.forEach((data) => {
+        data.years.forEach(y => {
+          notionYearMap.set(y, (notionYearMap.get(y) || 0) + 1);
+        });
+      });
+
+      const wikiYearMap = new Map<string, number>();
+      const mergedWikiBooksMap = new Map<string, { years: Set<string>, display: string, keys: string[] }>();
+      const wikiKeyToPrimaryKey = new Map<string, string>();
+
+      allWikiBooks.forEach(b => {
+        const keys = [
+          getRobustKey(b.author || "", b.originalTitle || ""),
+          getRobustKey(b.author || "", b.polishTitle || "")
+        ].filter(Boolean);
+        
+        if (keys.length === 0) return;
+
+        let primaryKey = keys.find(k => wikiKeyToPrimaryKey.has(k));
+        if (primaryKey) {
+          primaryKey = wikiKeyToPrimaryKey.get(primaryKey)!;
+        } else {
+          primaryKey = keys[0];
+          mergedWikiBooksMap.set(primaryKey, { 
+            years: new Set(), 
+            display: `"${b.originalTitle || b.polishTitle}" (${b.author})`,
+            keys: keys
+          });
+        }
+        
+        const data = mergedWikiBooksMap.get(primaryKey)!;
+        data.years.add(b.year.toString());
+        keys.forEach(k => wikiKeyToPrimaryKey.set(k, primaryKey!));
+      });
+
+      mergedWikiBooksMap.forEach((data) => {
+        data.years.forEach(y => {
+          if (y) wikiYearMap.set(y, (wikiYearMap.get(y) || 0) + 1);
+        });
+      });
+
+      const allYears = Array.from(new Set([...notionYearMap.keys(), ...wikiYearMap.keys()])).sort();
+      const yearDiffs = allYears.map(y => {
+        const notionCount = notionYearMap.get(y) || 0;
+        const wikiCount = wikiYearMap.get(y) || 0;
+        
+        if (notionCount === wikiCount) return null;
+
+        const notionBooksInYear = Array.from(mergedNotionBooksMap.values())
+          .filter(data => data.years.has(y));
+          
+        const wikiBooksInYear = Array.from(mergedWikiBooksMap.values())
+          .filter(data => data.years.has(y));
+
+        // Track matches to find collisions
+        const notionToWikiMatches = new Map<string, string[]>();
+        const wikiToNotionMatches = new Map<string, string[]>();
+
+        wikiBooksInYear.forEach(wb => {
+          const matches = notionBooksInYear.filter(nb => nb.keys.some(k => wb.keys.includes(k)));
+          matches.forEach(nb => {
+            const key = nb.display;
+            if (!notionToWikiMatches.has(key)) notionToWikiMatches.set(key, []);
+            notionToWikiMatches.get(key)!.push(wb.display);
+          });
+        });
+
+        notionBooksInYear.forEach(nb => {
+          const matches = wikiBooksInYear.filter(wb => wb.keys.some(k => nb.keys.includes(k)));
+          matches.forEach(wb => {
+            const key = wb.display;
+            if (!wikiToNotionMatches.has(key)) wikiToNotionMatches.set(key, []);
+            wikiToNotionMatches.get(key)!.push(nb.display);
+          });
+        });
+
+        // 1. Notion Only (in this year) - No matches in wikiBooksInYear
+        const notionOnlyInYear = notionBooksInYear.filter(nb => !notionToWikiMatches.has(nb.display));
+
+        // 2. Wiki Only (in this year) - No matches in notionBooksInYear
+        const wikiOnlyInYear = wikiBooksInYear.filter(wb => !wikiToNotionMatches.has(wb.display));
+
+        // 3. Collisions
+        const collisions: { title: string, matches: string[] }[] = [];
+        
+        // Many Wiki -> One Notion
+        notionToWikiMatches.forEach((matches, notionTitle) => {
+          if (matches.length > 1) {
+            collisions.push({ title: `Notion: ${notionTitle}`, matches: matches.map(m => `Wiki: ${m}`) });
+          }
+        });
+
+        // Many Notion -> One Wiki
+        wikiToNotionMatches.forEach((matches, wikiTitle) => {
+          if (matches.length > 1) {
+            collisions.push({ title: `Wiki: ${wikiTitle}`, matches: matches.map(m => `Notion: ${m}`) });
+          }
+        });
+
+        // 4. Misplaced (exists in other database but in a different year)
+        const misplaced: { title: string, otherYear: string }[] = [];
+        const notionOnlyFinal: string[] = [];
+        const wikiOnlyFinal: string[] = [];
+
+        notionOnlyInYear.forEach(nb => {
+          const wikiMatch = Array.from(mergedWikiBooksMap.values()).find(wb => 
+            wb.keys.some(k => nb.keys.includes(k))
+          );
+          if (wikiMatch) {
+            misplaced.push({ 
+              title: nb.display, 
+              otherYear: `Wiki mówi: ${Array.from(wikiMatch.years).join(", ")}` 
+            });
+          } else {
+            notionOnlyFinal.push(nb.display);
+          }
+        });
+
+        wikiOnlyInYear.forEach(wb => {
+          const notionMatch = Array.from(mergedNotionBooksMap.values()).find(nb => 
+            nb.keys.some(k => wb.keys.includes(k))
+          );
+          if (notionMatch) {
+            misplaced.push({ 
+              title: wb.display, 
+              otherYear: `Notion mówi: ${Array.from(notionMatch.years).join(", ")}` 
+            });
+          } else {
+            wikiOnlyFinal.push(wb.display);
+          }
+        });
+
+        return {
+          year: y,
+          notion: notionCount,
+          wiki: wikiCount,
+          notionOnly: notionOnlyFinal.length > 0 ? notionOnlyFinal : undefined,
+          wikiOnly: wikiOnlyFinal.length > 0 ? wikiOnlyFinal : undefined,
+          misplaced: misplaced.length > 0 ? misplaced : undefined,
+          collisions: collisions.length > 0 ? collisions : undefined
+        };
+      }).filter((d): d is NonNullable<typeof d> => d !== null);
+
+      // E. Award Count Match
+      const notionAwardMap = new Map<string, { count: number, books: string[] }>();
+      notionBooks.forEach(b => {
+        (b.awards || []).forEach(aw => {
+          if (aw !== "Wszystkie") {
+            if (!notionAwardMap.has(aw)) notionAwardMap.set(aw, { count: 0, books: [] });
+            const data = notionAwardMap.get(aw)!;
+            data.count++;
+            data.books.push(`"${b.origTitle || b.plTitle}" (${b.author})`);
+          }
+        });
+      });
+
+      const wikiAwardMap = new Map<string, { count: number, books: string[] }>();
+      allWikiBooks.forEach(b => {
+        if (!wikiAwardMap.has(b.award)) wikiAwardMap.set(b.award, { count: 0, books: [] });
+        const data = wikiAwardMap.get(b.award)!;
+        data.count++;
+        data.books.push(`"${b.originalTitle || b.polishTitle}" (${b.author})`);
+      });
+
+      const awardDiffs = Array.from(new Set([...notionAwardMap.keys(), ...wikiAwardMap.keys()])).map(aw => {
+        const notionData = notionAwardMap.get(aw);
+        const wikiData = wikiAwardMap.get(aw);
+        const notionCount = notionData?.count || 0;
+        const wikiCount = wikiData?.count || 0;
+
+        if (notionCount === wikiCount) return null;
+
+        return {
+          award: aw,
+          notion: notionCount,
+          wiki: wikiCount,
+          notionOnly: notionData?.books.filter(nb => !wikiData?.books.includes(nb)),
+          wikiOnly: wikiData?.books.filter(wb => !notionData?.books.includes(wb))
+        };
+      }).filter((d): d is NonNullable<typeof d> => d !== null);
+
+      const result: IntegrityCheckResult = {
+        lpUniqueness: { status: lpDuplicates.length === 0, duplicates: lpDuplicates },
+        yearCountMatch: { status: yearDiffs.length === 0, diffs: yearDiffs },
+        originalTitleUniqueness: { status: origDuplicates.length === 0, duplicates: origDuplicates },
+        polishTitleUniqueness: { status: plDuplicates.length === 0, duplicates: plDuplicates },
+        awardCountMatch: { status: awardDiffs.length === 0, diffs: awardDiffs }
+      };
+
+      sendEvent({ type: "complete", result });
+    } catch (error: any) {
+      sendEvent({ type: "error", error: error.message });
+    }
+  }
+}

--- a/services/lpSyncService.ts
+++ b/services/lpSyncService.ts
@@ -1,0 +1,45 @@
+import { NotionAdapter } from "../notion.adapter";
+import pLimit from "p-limit";
+import { NotionBook, SyncEvent } from "../src/types";
+
+export class LpSyncService {
+  constructor(private notion: NotionAdapter) {}
+
+  async runLpSync(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      let allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      
+      // Filter out empty books (ghost rows) to avoid assigning Lp to them
+      allBooks = allBooks.filter(b => b.plTitle || b.origTitle || b.author);
+
+      if (checkCancellation()) { sendEvent({ type: "error", error: "Przerwano aktualizację Lp." }); return; }
+      sendEvent({ type: "status", message: "Sortowanie i aktualizacja kolumny Lp..." });
+      allBooks.sort((a, b) => {
+        const yearA = parseInt(a.year || "0") || 0, yearB = parseInt(b.year || "0") || 0;
+        if (yearA !== yearB) return yearA - yearB;
+        return (a.plTitle || a.origTitle || "").localeCompare(b.plTitle || b.origTitle || "");
+      });
+      let updatedCount = 0, processedCount = 0;
+      const syncSummary = { added: [] as string[], updated: [] as string[] };
+      const limit = pLimit(3);
+      const updateTasks = allBooks.map((book, i) => limit(async () => {
+        if (checkCancellation()) return;
+        const expectedLp = (i + 1).toString();
+        if ((book as any).lp !== expectedLp) {
+          try {
+            await this.notion.updateLp(book.id, expectedLp);
+            updatedCount++;
+            syncSummary.updated.push(`${book.plTitle || book.origTitle} (Zaktualizowano: Lp -> ${expectedLp})`);
+          } catch (err: any) { console.error(`Błąd Lp dla ${book.plTitle}:`, err.message); }
+        }
+        processedCount++;
+        if (processedCount % 10 === 0 || processedCount === allBooks.length) {
+          sendEvent({ type: "progress", message: "Aktualizacja numeracji (Lp)...", current: processedCount, total: allBooks.length });
+        }
+      }));
+      await Promise.all(updateTasks);
+      sendEvent({ type: "complete", result: { success: !checkCancellation(), found: allBooks.length, updated: updatedCount, summary: syncSummary } });
+    } catch (error: any) { sendEvent({ type: "error", error: error.message }); }
+  }
+}

--- a/services/publisherSyncService.ts
+++ b/services/publisherSyncService.ts
@@ -1,0 +1,75 @@
+import pLimit from "p-limit";
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { WikiParser } from "../wiki.parser";
+import { NotionBook, SyncEvent } from "../src/types";
+import { normalizeData } from "./dataNormalizer";
+import { DiffEngine } from "./diffEngine";
+
+export class PublisherSyncService {
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  async runPublisherSync(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      const allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      
+      if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano Rytuał Wydania." }); return; }
+
+      const titlesToFetch = Array.from(new Set(allBooks.map(b => b.plTitle || b.origTitle).filter(Boolean))) as string[];
+      
+      sendEvent({ type: "status", message: `Pobieranie treści ${titlesToFetch.length} stron z Encyklopedii (Bulk API)...` });
+      const wikiContents = await this.wiki.fetchPagesContentBulk(titlesToFetch);
+
+      let processedCount = 0, updatedCount = 0;
+      const syncSummary = { added: [] as string[], updated: [] as string[] };
+      const errors: any[] = [];
+      
+      const wydawnictwoPropType = "multi_select";
+      const limit = pLimit(3);
+
+      const syncTasks = allBooks.map((book) => limit(async () => {
+        if (checkCancellation()) return;
+        
+        processedCount++;
+        if (processedCount % 10 === 0 || processedCount === allBooks.length) {
+          sendEvent({ type: "progress", message: "Analiza i aktualizacja wydawnictw (In-Memory Diff)...", current: processedCount, total: allBooks.length });
+        }
+        
+        const titleToSearch = book.plTitle || book.origTitle;
+        if (!titleToSearch) return;
+        
+        try {
+          const wikitext = wikiContents[titleToSearch.toLowerCase()];
+          if (!wikitext) return;
+
+          const extracted = WikiParser.extractPublisherAndSeries(wikitext);
+          let wydawca = extracted.wydawca;
+          
+          wydawca = normalizeData(wydawca, 'publisher');
+          
+          const updates: any = {};
+          const currentWyd = (book.currentWydawnictwo || "").trim();
+          
+          if (wydawca && !DiffEngine.isMultiSelectEqual(wydawca, currentWyd)) {
+            updates["Wydawnictwo"] = this.notion.buildPropertyValue(wydawca, wydawnictwoPropType);
+          }
+          
+          if (Object.keys(updates).length > 0) {
+            await this.notion.updatePage(book.id, updates);
+            updatedCount++;
+            syncSummary.updated.push(`${titleToSearch} (Wydawnictwo: ${wydawca})`);
+          }
+        } catch (err: any) {
+          errors.push({ book: titleToSearch, error: err.message });
+        }
+      }));
+
+      await Promise.all(syncTasks);
+
+      sendEvent({ type: "complete", result: { found: allBooks.length, synced: 0, updated: updatedCount, summary: syncSummary, errors: errors.map(e => `${e.book}: ${e.error}`) } });
+    } catch (error: any) {
+      sendEvent({ type: "error", error: error.message });
+    }
+  }
+}

--- a/services/purificationService.ts
+++ b/services/purificationService.ts
@@ -1,0 +1,101 @@
+import pLimit from "p-limit";
+import { NotionAdapter } from "../notion.adapter";
+import { SyncEvent } from "../src/types";
+import { stripWikiFormatting, sanitizeNotionString, isValidUrl } from "../utils";
+
+export class PurificationService {
+  constructor(private notion: NotionAdapter) {}
+
+  async runPurification(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
+      await this.notion.init();
+
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      const existingBooks = await this.notion.queryAllBooks(
+        (count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }),
+        checkCancellation
+      );
+
+      if (checkCancellation()) {
+        sendEvent({ type: "status", message: "Przerwano rytuał puryfikacji." });
+        return;
+      }
+
+      sendEvent({ type: "status", message: "Oczyszczanie danych w istniejących rekordach Notion..." });
+      let cleanedCount = 0;
+      let processedCount = 0;
+      const syncSummary = { updated: [] as string[], skipped: [] as string[] };
+      const errors: any[] = [];
+      const limit = pLimit(3);
+
+      const syncTasks = existingBooks.map((eb) => limit(async () => {
+        if (checkCancellation()) return;
+        
+        processedCount++;
+        if (processedCount % 10 === 0 || processedCount === existingBooks.length) {
+          sendEvent({ type: "progress", message: "Oczyszczanie danych...", current: processedCount, total: existingBooks.length });
+        }
+
+        try {
+          const cleanPl = stripWikiFormatting(eb.plTitle || "");
+          const cleanOrig = stripWikiFormatting(eb.origTitle || "");
+
+          // Check if Notion has native formatting (italics, bold, etc.)
+          const hasNativeFormatting = (richText: any[]) => {
+            return richText?.some(part => 
+              part.annotations && (
+                part.annotations.italic || 
+                part.annotations.bold || 
+                part.annotations.strikethrough || 
+                part.annotations.underline || 
+                part.annotations.code
+              )
+            );
+          };
+
+          const updates: any = {};
+          const needsPlUpdate = (eb.plTitle && eb.plTitle !== cleanPl) || hasNativeFormatting(eb.plTitleRichText || []);
+          const needsOrigUpdate = (eb.origTitle && eb.origTitle !== cleanOrig) || hasNativeFormatting(eb.origTitleRichText || []);
+
+          if (needsPlUpdate) {
+            const link = eb.plTitleRichText?.[0]?.text?.link?.url || eb.plTitleRichText?.[0]?.href;
+            const sanitizedPl = sanitizeNotionString(cleanPl);
+            updates["Tytuł polski"] = { rich_text: [{ text: { content: sanitizedPl, ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
+          }
+          if (needsOrigUpdate) {
+            const link = eb.origTitleRichText?.[0]?.text?.link?.url || eb.origTitleRichText?.[0]?.href;
+            const sanitizedOrig = sanitizeNotionString(cleanOrig);
+            updates["Tytuł oryginalny"] = { rich_text: [{ text: { content: sanitizedOrig, ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
+          }
+
+          if (Object.keys(updates).length > 0) {
+            await this.notion.updatePage(eb.id, updates);
+            cleanedCount++;
+            const title = eb.plTitle || eb.origTitle || "Nieznany tytuł";
+            syncSummary.updated.push(`${title} (Oczyszczono formatowanie)`);
+          } else {
+            syncSummary.skipped.push(eb.plTitle || eb.origTitle || "Nieznany tytuł");
+          }
+        } catch (err: any) {
+          errors.push({ book: eb.plTitle || eb.origTitle, error: err.message });
+        }
+      }));
+
+      await Promise.all(syncTasks);
+
+      sendEvent({
+        type: "complete",
+        result: {
+          found: existingBooks.length,
+          synced: 0,
+          updated: cleanedCount,
+          summary: syncSummary,
+          errors: errors.map(e => `${e.book}: ${e.error}`)
+        }
+      });
+    } catch (error: any) {
+      sendEvent({ type: "error", error: error.message });
+    }
+  }
+}

--- a/services/schemaValidationService.ts
+++ b/services/schemaValidationService.ts
@@ -1,0 +1,84 @@
+import { NotionAdapter } from "../notion.adapter";
+import { SyncEvent } from "../src/types";
+
+export class SchemaValidationService {
+  constructor(private notion: NotionAdapter) {}
+
+  async runSchemaValidation(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
+      await this.notion.init();
+
+      const databaseId = process.env.NOTION_DATABASE_ID;
+      if (!databaseId) throw new Error("Brak NOTION_DATABASE_ID w zmiennych środowiskowych.");
+      
+      const actualDataSourceId = await this.notion.resolveDataSourceId(databaseId);
+
+      sendEvent({ type: "status", message: "Pobieranie schematu bazy..." });
+      const db = await this.notion.retrieveDataSource(actualDataSourceId) as any;
+
+      if (checkCancellation()) {
+        sendEvent({ type: "status", message: "Przerwano inicjalizację schematu." });
+        return;
+      }
+
+      const requiredProps = [
+        { name: "Lp", type: "title" },
+        { name: "Autor", type: "multi_select" },
+        { name: "Rok", type: "multi_select" },
+        { name: "Tytuł polski", type: "rich_text" },
+        { name: "Tytuł oryginalny", type: "rich_text" },
+        { name: "Wydawnictwo", type: "multi_select" },
+        { name: "Seria", type: "multi_select" },
+        { name: "Nagroda", type: "multi_select" },
+        { name: "Część cyklu", type: "checkbox" }
+      ];
+
+      // 1. Handle primary (title) column renaming if necessary
+      const titleProp = Object.values(db.properties).find((p: any) => p.type === "title") as any;
+      if (titleProp && titleProp.name !== "Lp") {
+        sendEvent({ type: "status", message: `Zmiana nazwy głównej kolumny z ${titleProp.name} na Lp...` });
+        await this.notion.renameProperty(actualDataSourceId, titleProp.name, "Lp");
+        // Refresh db properties after rename
+        const updatedDb = await this.notion.retrieveDataSource(actualDataSourceId) as any;
+        db.properties = updatedDb.properties;
+      }
+
+      let addedCount = 0;
+      const summary = { added: [] as string[] };
+
+      for (const prop of requiredProps) {
+        if (checkCancellation()) break;
+        
+        // Skip title as it's already handled by renaming
+        if (prop.type === "title") continue;
+
+        const existingProp = db.properties[prop.name];
+        if (!existingProp) {
+          sendEvent({ type: "status", message: `Tworzenie brakującej kolumny: ${prop.name}...` });
+          await this.notion.updateDatabaseProperty(actualDataSourceId, prop.name, prop.type);
+          addedCount++;
+          summary.added.push(prop.name);
+        } else if (existingProp.type !== prop.type) {
+          sendEvent({ type: "status", message: `Aktualizacja typu kolumny ${prop.name} z ${existingProp.type} na ${prop.type}...` });
+          await this.notion.updateDatabaseProperty(actualDataSourceId, prop.name, prop.type);
+          addedCount++;
+          summary.added.push(`${prop.name} (zmiana typu)`);
+        }
+      }
+
+      sendEvent({
+        type: "complete",
+        result: {
+          found: requiredProps.length,
+          synced: addedCount,
+          updated: 0,
+          summary: { added: summary.added },
+          errors: []
+        }
+      });
+    } catch (error: any) {
+      sendEvent({ type: "error", error: error.message });
+    }
+  }
+}

--- a/services/seriesSyncService.ts
+++ b/services/seriesSyncService.ts
@@ -1,0 +1,75 @@
+import pLimit from "p-limit";
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { WikiParser } from "../wiki.parser";
+import { NotionBook, SyncEvent } from "../src/types";
+import { normalizeData } from "./dataNormalizer";
+import { DiffEngine } from "./diffEngine";
+
+export class SeriesSyncService {
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  async runSeriesSync(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
+    try {
+      sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
+      const allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      
+      if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano Rytuał Seryjny." }); return; }
+
+      const titlesToFetch = Array.from(new Set(allBooks.map(b => b.plTitle || b.origTitle).filter(Boolean))) as string[];
+      
+      sendEvent({ type: "status", message: `Pobieranie treści ${titlesToFetch.length} stron z Encyklopedii (Bulk API)...` });
+      const wikiContents = await this.wiki.fetchPagesContentBulk(titlesToFetch);
+
+      let processedCount = 0, updatedCount = 0;
+      const syncSummary = { added: [] as string[], updated: [] as string[] };
+      const errors: any[] = [];
+      
+      const seriaPropType = "multi_select";
+      const limit = pLimit(3);
+
+      const syncTasks = allBooks.map((book) => limit(async () => {
+        if (checkCancellation()) return;
+        
+        processedCount++;
+        if (processedCount % 10 === 0 || processedCount === allBooks.length) {
+          sendEvent({ type: "progress", message: "Analiza i aktualizacja serii (In-Memory Diff)...", current: processedCount, total: allBooks.length });
+        }
+        
+        const titleToSearch = book.plTitle || book.origTitle;
+        if (!titleToSearch) return;
+        
+        try {
+          const wikitext = wikiContents[titleToSearch.toLowerCase()];
+          if (!wikitext) return;
+
+          const extracted = WikiParser.extractPublisherAndSeries(wikitext);
+          let seria = extracted.seria;
+          
+          seria = normalizeData(seria, 'series');
+          
+          const updates: any = {};
+          const currentSer = (book.currentSeria || "").trim();
+          
+          if (seria && !DiffEngine.isMultiSelectEqual(seria, currentSer)) {
+            updates["Seria"] = this.notion.buildPropertyValue(seria, seriaPropType);
+          }
+          
+          if (Object.keys(updates).length > 0) {
+            await this.notion.updatePage(book.id, updates);
+            updatedCount++;
+            syncSummary.updated.push(`${titleToSearch} (Seria: ${seria})`);
+          }
+        } catch (err: any) {
+          errors.push({ book: titleToSearch, error: err.message });
+        }
+      }));
+
+      await Promise.all(syncTasks);
+
+      sendEvent({ type: "complete", result: { found: allBooks.length, synced: 0, updated: updatedCount, summary: syncSummary, errors: errors.map(e => `${e.book}: ${e.error}`) } });
+    } catch (error: any) {
+      sendEvent({ type: "error", error: error.message });
+    }
+  }
+}

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -1,0 +1,133 @@
+import { NotionAdapter } from "../notion.adapter";
+
+export class StatsService {
+  constructor(private notion: NotionAdapter) {}
+
+  async getStats() {
+    let books = await this.notion.getBooksForStats();
+    
+    // Global filter: only books with a non-empty Polish title
+    books = books.filter(b => b.plTitle && b.plTitle.trim() !== "");
+    
+    // 1. Author progress
+    const authorStats: Record<string, { read: number; total: number; books: any[] }> = {};
+    books.forEach(book => {
+      if (!book.author) return;
+      const authors = book.author.split(',').map((a: string) => a.trim());
+      authors.forEach(author => {
+        if (!authorStats[author]) authorStats[author] = { read: 0, total: 0, books: [] };
+        authorStats[author].total++;
+        const isRead = (book.zrodlo || []).includes("Przeczytane");
+        if (isRead) {
+          authorStats[author].read++;
+        }
+        authorStats[author].books.push({
+          id: book.id,
+          title: book.plTitle || book.origTitle,
+          year: book.year,
+          read: isRead
+        });
+      });
+    });
+
+    // Sort books for each author by year
+    Object.values(authorStats).forEach(stat => {
+      stat.books.sort((a, b) => {
+        const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
+        const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
+        return yearA - yearB;
+      });
+    });
+
+    // 2. Award books progress
+    const awardBooksRead = books.filter(b => (b.zrodlo || []).includes("Przeczytane")).length;
+    const awardBooksStats = { read: awardBooksRead, total: books.length };
+
+    // 3. Owned but unread
+    const ownedUnread = books
+      .filter(b => (b.zrodlo || []).includes("Posiadam") && !(b.zrodlo || []).includes("Przeczytane"))
+      .map(b => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year }));
+
+    // 4. Award coverage progress
+    const awardCoverage: Record<string, { count: number; total: number }> = {};
+    books.forEach(book => {
+      (book.awards || []).forEach(nagroda => {
+        if (!awardCoverage[nagroda]) awardCoverage[nagroda] = { count: 0, total: books.length };
+        awardCoverage[nagroda].count++;
+      });
+    });
+
+    // 5. "All" awards progress (Przeczytane for books with "Wszystkie" tag)
+    const allAwardsBooks = books.filter(b => (b.awards || []).includes("Wszystkie"));
+    const allAwardsRead = allAwardsBooks.filter(b => (b.zrodlo || []).includes("Przeczytane")).length;
+    const allAwardsStats = { read: allAwardsRead, total: allAwardsBooks.length };
+
+    // 6. Yearly progress
+    const yearlyStats: Record<string, { read: number; total: number; books: any[] }> = {};
+    books.forEach(book => {
+      if (!book.year) return;
+      const years = book.year.toString().split(',').map(y => y.trim()).filter(Boolean);
+      years.forEach(year => {
+        if (!yearlyStats[year]) yearlyStats[year] = { read: 0, total: 0, books: [] };
+        yearlyStats[year].total++;
+        const isRead = (book.zrodlo || []).includes("Przeczytane");
+        if (isRead) {
+          yearlyStats[year].read++;
+        }
+        yearlyStats[year].books.push({
+          id: book.id,
+          title: book.plTitle || book.origTitle,
+          author: book.author,
+          read: isRead
+        });
+      });
+    });
+
+    return {
+      authorStats: Object.entries(authorStats)
+        .map(([name, stats]) => ({ name, ...stats }))
+        .sort((a, b) => b.read - a.read)
+        .slice(0, 15), // Top 15 authors
+      awardBooksStats,
+      ownedUnread: ownedUnread
+        .sort((a, b) => {
+          const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
+          const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
+          return yearA - yearB;
+        }),
+      awardCoverage: Object.entries(awardCoverage)
+        .map(([name, stats]) => ({ name, ...stats }))
+        .sort((a, b) => b.count - a.count),
+      allAwardsStats,
+      yearlyStats: Object.entries(yearlyStats)
+        .map(([year, stats]) => ({ year, ...stats }))
+        .sort((a, b) => parseInt(a.year) - parseInt(b.year)),
+      libraryStats: [
+        {
+          id: "Biblioteka",
+          name: "Biblioteka Felin",
+          books: books
+            .filter(b => (b.zrodlo || []).includes("Biblioteka"))
+            .map(b => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year, read: (b.zrodlo || []).includes("Przeczytane") }))
+            .sort((a, b) => {
+              const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
+              const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
+              return yearA - yearB;
+            })
+        },
+        {
+          id: "Biblioteka 9",
+          name: "Biblioteka Bronowice",
+          books: books
+            .filter(b => (b.zrodlo || []).includes("Biblioteka 9"))
+            .map(b => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year, read: (b.zrodlo || []).includes("Przeczytane") }))
+            .sort((a, b) => {
+              const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
+              const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
+              return yearA - yearB;
+            })
+        }
+      ]
+    };
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,407 @@
+import React, { useEffect, useState } from "react";
+import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart } from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
+import { StatsSection } from "./components/StatsSection";
+import { VintedSection } from "./components/VintedSection";
+import { StatusSection } from "./components/StatusSection";
+import { SyncAwards } from "./components/SyncAwards";
+import { OtherToolsCard } from "./components/OtherToolsCard";
+import { ProgressAndResults } from "./components/ProgressAndResults";
+import { SyncSummaryResult } from "./components/SyncSummaryResult";
+import { SchemaSection } from "./components/SchemaSection";
+import { SanctityDebugger } from "./components/SanctityDebugger";
+import { ParticleBackground } from "./components/ParticleBackground";
+import { PREDEFINED_AWARDS } from "./constants";
+import { useSync } from "./hooks/useSync";
+import { useConfig } from "./hooks/useConfig";
+import { formatETA } from "./utils/time";
+import { IntegrityCheckResult } from "./types";
+
+export default function App() {
+  const { configStatus, schema, schemaLoading, schemaError, fetchSchema } = useConfig();
+  const [activeTab, setActiveTab] = useState<'stats' | 'config' | 'vinted'>('stats');
+  const [showScrollTop, setShowScrollTop] = useState(false);
+  const [fullSyncResults, setFullSyncResults] = useState<any[] | null>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 300);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const sync = useSync("/api/sync", "/api/sync/stop", {
+    awardName: PREDEFINED_AWARDS[0].name,
+    pageTitle: PREDEFINED_AWARDS[0].title,
+    color: "cyan"
+  });
+  const publisherSync = useSync("/api/sync-publisher", "/api/sync-publisher/stop", { color: "rose" });
+  const seriesSync = useSync("/api/sync-series", "/api/sync-series/stop", { color: "indigo" });
+  const cyclesSync = useSync("/api/sync-cycles", "/api/sync-cycles/stop", { color: "blue" });
+  const lpSync = useSync("/api/sync-lp", "/api/sync-lp/stop", { color: "purple" });
+  const integritySync = useSync("/api/sync-integrity", "/api/sync-integrity/stop", { color: "cyan" });
+  const duplicatesSync = useSync("/api/sync-duplicates", "/api/sync-duplicates/stop", { color: "orange" });
+  const purifySync = useSync("/api/sync-purify", "/api/sync-purify/stop", { color: "amber" });
+  const schemaSync = useSync("/api/sync-schema", "/api/sync-schema/stop", { color: "emerald" });
+
+  const handleAwardChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedName = e.target.value;
+    const predefined = PREDEFINED_AWARDS.find(a => a.name === selectedName);
+    
+    sync.setState(prev => ({
+      ...prev,
+      awardName: selectedName,
+      pageTitle: predefined ? predefined.title : (selectedName === "Wszystkie Nagrody" ? "" : prev.pageTitle)
+    }));
+  };
+
+  const syncs = [sync, publisherSync, seriesSync, cyclesSync, lpSync, duplicatesSync, purifySync, schemaSync, integritySync];
+  const anyError = syncs.find(s => s.state.error);
+
+  const clearOthers = (currentSync: any) => {
+    syncs.forEach(s => {
+      if (s !== currentSync) {
+        s.reset();
+      }
+    });
+  };
+
+  const handleSyncAction = async (syncService: any, params: any = {}, statusMessage: string | null = null) => {
+    setFullSyncResults(null);
+    clearOthers(syncService);
+    return await syncService.startSync(params, undefined, statusMessage);
+  };
+
+  const handleSyncSchema = () => handleSyncAction(schemaSync);
+  const handleSyncPurify = () => handleSyncAction(purifySync);
+  const handleSyncPublisher = () => handleSyncAction(publisherSync);
+  const handleSyncSeries = () => handleSyncAction(seriesSync);
+  const handleCyclesSync = () => handleSyncAction(cyclesSync);
+  const handleSyncLp = () => handleSyncAction(lpSync);
+
+  const handleSync = () => {
+    const isSyncAll = sync.state.awardName === "Wszystkie Nagrody";
+    handleSyncAction(sync, {
+      awardName: sync.state.awardName,
+      pageTitle: sync.state.pageTitle,
+      syncAll: isSyncAll
+    });
+  };
+
+  const handleFullSync = async () => {
+    setFullSyncResults(null);
+    const results: any[] = [];
+    
+    // 1. Schema Initiation
+    clearOthers(schemaSync);
+    const res1 = await schemaSync.startSync({}, undefined, "Krok 1/7: Rytuał Inicjacji Schematu...");
+    if (!res1) return;
+    results.push({ name: "Schemat", result: res1, color: "emerald" });
+
+    // 2. Purification
+    clearOthers(purifySync);
+    const res2 = await purifySync.startSync({}, undefined, "Krok 2/7: Rytuał Puryfikacji...");
+    if (!res2) return;
+    results.push({ name: "Puryfikacja", result: res2, color: "amber" });
+
+    // 3. Sync Awards (Wszystkie)
+    clearOthers(sync);
+    const res3 = await sync.startSync({
+      awardName: "Wszystkie Nagrody",
+      syncAll: true
+    }, undefined, "Krok 3/7: Synchronizacja Nagród...");
+    if (!res3) return;
+    results.push({ name: "Nagrody", result: res3, color: "cyan" });
+
+    // 4. Cycles Marking
+    clearOthers(cyclesSync);
+    const res4 = await cyclesSync.startSync({}, undefined, "Krok 4/7: Rytuał Oznaczania Cykli...");
+    if (!res4) return;
+    results.push({ name: "Cykle", result: res4, color: "blue" });
+
+    // 5. Publisher Sync
+    clearOthers(publisherSync);
+    const res5 = await publisherSync.startSync({}, undefined, "Krok 5/7: Rytuał Wydania...");
+    if (!res5) return;
+    results.push({ name: "Wydawcy", result: res5, color: "rose" });
+
+    // 6. Series Sync
+    clearOthers(seriesSync);
+    const res6 = await seriesSync.startSync({}, undefined, "Krok 6/7: Rytuał Seryjny...");
+    if (!res6) return;
+    results.push({ name: "Serie", result: res6, color: "indigo" });
+
+    // 7. Numbers Reconstruction (Lp)
+    clearOthers(lpSync);
+    const res7 = await lpSync.startSync({}, undefined, "Krok 7/7: Rytuał Rekonstrukcji Liczb...");
+    if (res7) {
+      results.push({ name: "Lubimy Czytać", result: res7, color: "purple" });
+    }
+
+    setFullSyncResults(results);
+  };
+  
+  const handleResetSync = async () => {
+    try {
+      await fetch("/api/sync/reset", { method: "POST" });
+      syncs.forEach(s => s.reset());
+    } catch (err) {
+      console.error("Reset Error:", err);
+    }
+  };
+
+  const handleSyncDuplicates = () => {
+    clearOthers(duplicatesSync);
+    duplicatesSync.startSync({}, (result) => {
+      const duplicatesFormatted = result.duplicates.map((d: any) => 
+        `${d.bookA} <-> ${d.bookB} (${d.reason})`
+      );
+      return { 
+        ...result,
+        summary: { duplicates: duplicatesFormatted }
+      };
+    }, null);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-200 font-sans selection:bg-cyan-500/30 selection:text-white relative overflow-hidden">
+      <ParticleBackground />
+      
+      <div className="relative z-10 max-w-5xl mx-auto px-6 py-16 space-y-12">
+        {/* Header */}
+        <motion.header 
+          initial={{ opacity: 0, y: -30 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex flex-col md:flex-row items-center gap-8 text-center md:text-left"
+        >
+          <motion.div 
+            whileHover={{ scale: 1.05, rotate: 5 }}
+            className="p-5 bg-slate-900/80 rounded-2xl border border-cyan-500/30 shadow-2xl shadow-cyan-500/20 backdrop-blur-xl"
+          >
+            <Database className="w-12 h-12 text-cyan-400" />
+          </motion.div>
+          <div className="flex-1">
+            <h1 className="text-4xl md:text-5xl font-bold tracking-tighter font-display mb-2">
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]">
+                COGITATOR OMNISSIAH
+              </span>
+            </h1>
+            <p className="text-slate-400 text-lg font-medium tracking-wide uppercase flex items-center justify-center md:justify-start gap-2">
+              <Terminal className="w-4 h-4 text-purple-500" />
+              Protokół Synchronizacji Danych Archiwalnych
+            </p>
+          </div>
+        </motion.header>
+
+        {/* Tab Navigation */}
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-8">
+          <button
+            onClick={() => setActiveTab('stats')}
+            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+              activeTab === 'stats' 
+                ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]' 
+                : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
+            }`}
+          >
+            <Database className="w-5 h-5" />
+            Statystyki Archiwum
+          </button>
+          <button
+            onClick={() => setActiveTab('config')}
+            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+              activeTab === 'config' 
+                ? 'bg-purple-500/20 border-purple-500/50 text-purple-400 shadow-[0_0_20px_rgba(168,85,247,0.2)]' 
+                : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
+            }`}
+          >
+            <Cog className={`w-5 h-5 ${syncs.some(s => s.state.loading) ? 'animate-spin text-purple-400' : ''}`} />
+            Liturgie Synchronizacji
+          </button>
+          <button
+            onClick={() => setActiveTab('vinted')}
+            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+              activeTab === 'vinted' 
+                ? 'bg-rose-500/20 border-rose-500/50 text-rose-400 shadow-[0_0_20px_rgba(244,63,94,0.2)]' 
+                : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
+            }`}
+          >
+            <ShoppingCart className="w-5 h-5" />
+            Skaner Vinted
+          </button>
+        </div>
+
+        {/* Global Error Display */}
+        <AnimatePresence>
+          {anyError && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              className="glass-card p-6 border-red-500/30 bg-red-500/5 rounded-3xl space-y-4"
+            >
+              <div className="flex items-start gap-4">
+                <div className="p-3 bg-red-500/20 rounded-2xl text-red-400">
+                  <AlertTriangle className="w-6 h-6" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-bold text-red-200 uppercase tracking-widest mb-1">Błąd Synchronizacji</h3>
+                  <p className="text-red-400/80 text-sm font-medium">{anyError.state.error}</p>
+                </div>
+                <button 
+                  onClick={() => anyError.reset()}
+                  className="p-2 hover:bg-red-500/10 rounded-xl text-red-400 transition-colors"
+                >
+                  <XCircle className="w-5 h-5" />
+                </button>
+              </div>
+              
+              {anyError.state.error?.includes("Inna synchronizacja") && (
+                <div className="pt-2">
+                  <button 
+                    onClick={handleResetSync}
+                    className="flex items-center gap-2 px-6 py-2 bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 rounded-xl text-red-200 text-xs font-bold uppercase tracking-widest transition-all"
+                  >
+                    <RefreshCw className="w-4 h-4" />
+                    Wymuś Reset Stanu
+                  </button>
+                  <p className="text-[10px] text-red-500/60 mt-2 italic">Użyj tej opcji, jeśli jesteś pewien, że żadna inna synchronizacja nie jest aktualnie uruchomiona.</p>
+                </div>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Main Content Area */}
+        <AnimatePresence mode="wait">
+          {activeTab === 'stats' ? (
+            <motion.div
+              key="stats"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <StatsSection />
+            </motion.div>
+          ) : activeTab === 'config' ? (
+            <motion.div
+              key="config"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+              className="space-y-12"
+            >
+              <div className="flex items-center gap-6 mb-12">
+                <div className="h-px flex-1 bg-gradient-to-r from-transparent via-purple-500/20 to-transparent"></div>
+                <div className="flex items-center gap-4">
+                  <Cog className="w-6 h-6 text-purple-400" />
+                  <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-purple-100/90 whitespace-nowrap">
+                    Liturgie Synchronizacji
+                  </h2>
+                </div>
+                <div className="h-px flex-1 bg-gradient-to-r from-transparent via-purple-500/20 to-transparent"></div>
+              </div>
+
+              {/* Status Section */}
+              <StatusSection configStatus={configStatus} />
+              
+              {/* Main Actions Grid */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                {/* Sync Awards Card */}
+                <SyncAwards 
+                  sync={sync}
+                  integritySync={integritySync}
+                  handleAwardChange={handleAwardChange}
+                  handleSync={handleSync}
+                  handleFullSync={handleFullSync}
+                  isAnySyncLoading={syncs.some(s => s.state.loading)}
+                />
+
+                {/* Other Tools Card */}
+                <OtherToolsCard 
+                  schemaSync={schemaSync}
+                  purifySync={purifySync}
+                  publisherSync={publisherSync}
+                  seriesSync={seriesSync}
+                  cyclesSync={cyclesSync}
+                  duplicatesSync={duplicatesSync}
+                  lpSync={lpSync}
+                  handleSyncSchema={handleSyncSchema}
+                  handleSyncPurify={handleSyncPurify}
+                  handleSyncPublisher={handleSyncPublisher}
+                  handleSyncSeries={handleSyncSeries}
+                  handleCyclesSync={handleCyclesSync}
+                  handleSyncDuplicates={handleSyncDuplicates}
+                  handleSyncLp={handleSyncLp}
+                  handleResetSync={handleResetSync}
+                  isAnySyncLoading={syncs.some(s => s.state.loading)}
+                />
+              </div>
+
+              {/* Progress and Results */}
+              <AnimatePresence>
+                <ProgressAndResults 
+                  syncs={syncs}
+                  formatETA={formatETA}
+                />
+              </AnimatePresence>
+
+              {/* Sync Summary Result */}
+              <AnimatePresence>
+                <SyncSummaryResult 
+                  syncs={syncs}
+                  fullSyncResults={fullSyncResults}
+                />
+              </AnimatePresence>
+
+              {/* Sanctity Debugger */}
+              <SanctityDebugger 
+                result={integritySync.state.result as IntegrityCheckResult | null} 
+              />
+
+              {/* Schema Section */}
+              <SchemaSection 
+                schema={schema}
+                schemaLoading={schemaLoading}
+                schemaError={schemaError}
+                configStatus={configStatus}
+                fetchSchema={fetchSchema}
+              />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="vinted"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <VintedSection />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScrollTop && (
+          <motion.button
+            initial={{ opacity: 0, y: 20, scale: 0.8 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.8 }}
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.9 }}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="fixed bottom-8 right-8 p-4 bg-cyan-500/20 hover:bg-cyan-500/30 border border-cyan-500/50 text-cyan-400 rounded-full shadow-[0_0_15px_rgba(34,211,238,0.3)] backdrop-blur-md z-50 transition-colors"
+            title="Powrót na górę"
+            aria-label="Powrót na górę"
+          >
+            <ArrowUp className="w-6 h-6" />
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,435 @@
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import App from '../App';
+import React from 'react';
+
+// Mocking SSE and fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('App Main Flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Default config response
+    mockFetch.mockImplementation((url, options) => {
+      if (url === '/api/config') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hasNotionKey: true, hasDatabaseId: true }),
+        });
+      }
+      if (url.startsWith('/api/stats')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            authorStats: [{ name: "Lem", read: 1, total: 2, books: [] }],
+            awardBooksStats: { read: 5, total: 10 },
+            ownedUnread: [],
+            awardCoverage: [{ name: "Hugo", count: 1, total: 2 }],
+            allAwardsStats: { read: 1, total: 2 },
+            yearlyStats: [],
+            libraryStats: []
+          }),
+        });
+      }
+      if (url === '/api/notion/schema') {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({
+            "Autor": { type: "multi_select", multi_select: { options: [{ name: "Lem" }, { name: "Dukaj" }] } },
+            "Status": { type: "select", select: { options: [{ name: "Do przeczytania" }] } },
+            "Nagrody": { type: "multi_select", multi_select: { options: [{ name: "Hugo" }] } }
+          })),
+          status: 200
+        });
+      }
+      if (url === '/api/sync' && options?.method === 'POST') {
+        const stream = new ReadableStream({
+          start(controller) {
+            (global as any).setLastStreamController(controller);
+          }
+        });
+        return Promise.resolve({
+          ok: true,
+          body: stream
+        });
+      }
+    if (url === '/api/sync-duplicates' && options?.method === 'POST') {
+        const stream = new ReadableStream({
+          start(controller) {
+            (global as any).setLastStreamController(controller);
+          }
+        });
+        return Promise.resolve({
+          ok: true,
+          body: stream
+        });
+      }
+      if (url === '/api/vinted-check' && options?.method === 'POST') {
+        const stream = new ReadableStream({
+          start(controller) {
+            (global as any).setLastStreamController(controller);
+          }
+        });
+        return Promise.resolve({
+          ok: true,
+          body: stream
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  it('renders Status Ducha Maszyny and award links', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Status Ducha Maszyny/i)).toBeInTheDocument();
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+      expect(screen.getByText(/Baza Zlokalizowana/i)).toBeInTheDocument();
+    });
+
+    // Check award links
+    expect(screen.getByText('Hugo')).toHaveAttribute('href', expect.stringContaining('Hugo_nagroda_powie%C5%9B%C4%87'));
+    expect(screen.getByText('Locus')).toHaveAttribute('href', expect.stringContaining('Locus_nagroda_powie%C5%9B%C4%87'));
+    expect(screen.getByText('Nebula')).toHaveAttribute('href', expect.stringContaining('Nebula_nagroda_najlepsza_powie%C5%9B%C4%87'));
+  });
+
+  it('shows all award options in the dropdown', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+    });
+
+    const select = screen.getByLabelText(/Wybierz Nagrodę do Synchronizacji/i) as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    
+    const options = Array.from(select.options).map(o => o.value);
+    expect(options).toContain('Nagroda Hugo');
+    expect(options).toContain('Nagroda Nebula');
+    expect(options).toContain('Nagroda Locus');
+    expect(options).toContain('Wszystkie Nagrody');
+  });
+
+  it('handles single award sync flow (UI state)', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+    });
+
+    const syncButton = screen.getByText(/Inicjuj Synchronizację/i);
+    fireEvent.click(syncButton);
+    
+    // Should show loading state (mocking SSE is complex, so we check if it starts)
+    expect(mockFetch).toHaveBeenCalledWith('/api/sync', expect.any(Object));
+  });
+
+  it('handles "Wszystkie Nagrody" sync flow', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+    });
+
+    const select = screen.getByLabelText(/Wybierz Nagrodę do Synchronizacji/i);
+    fireEvent.change(select, { target: { value: 'Wszystkie Nagrody' } });
+    
+    const syncButton = screen.getByText(/Inicjuj Synchronizację/i);
+    fireEvent.click(syncButton);
+    
+    expect(mockFetch).toHaveBeenCalledWith('/api/sync', expect.objectContaining({
+      body: JSON.stringify({
+        awardName: "Wszystkie Nagrody",
+        pageTitle: "Wszystkie",
+        syncAll: true
+      })
+    }));
+  });
+
+  it('displays synchronization summary with added items', async () => {
+    (global as any).resetLastStreamController();
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    const select = screen.getByLabelText(/Wybierz Nagrodę do Synchronizacji/i) as HTMLSelectElement;
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'Nagroda Hugo' } });
+    });
+    expect(select.value).toBe('Nagroda Hugo');
+
+    const syncButton = screen.getByText(/Inicjuj Synchronizację/i);
+    expect(syncButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+
+    // Wait for stream controller to be created
+    await waitFor(() => {
+      expect((global as any).getLastStreamController()).toBeTruthy();
+    });
+
+    // Simulate streaming events
+    await act(async () => {
+      (global as any).pushStreamEvent('status', { message: 'Inicjowanie...' });
+    });
+
+    await act(async () => {
+      (global as any).pushStreamEvent('progress', { 
+        message: 'Synchronizacja w toku...',
+        current: 50,
+        total: 100
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Synchronizacja w toku.../i)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      (global as any).pushStreamEvent('complete', {
+        result: {
+          updated: 2,
+          summary: {
+            added: ['Solaris', 'Cyberiada', 'Book 3', 'Book 4', 'Book 5'],
+            updated: ['Updated 1', 'Updated 2'],
+            skipped: ['Skipped 1']
+          }
+        }
+      });
+    });
+
+    // Check for completion summary
+    await waitFor(() => {
+      expect(screen.getByText(/Zapisy Archiwisty Adeptus/i)).toBeInTheDocument();
+      expect(screen.getByText(/Dodano/i)).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText(/Zaktualizowano/i)).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText(/Pominięto/i)).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText(/Nowe Zapisy \(5\)/i)).toBeInTheDocument();
+      expect(screen.getByText('Solaris')).toBeInTheDocument();
+      expect(screen.getByText('Cyberiada')).toBeInTheDocument();
+    });
+  });
+
+  it('renders other tools: Rytuał Wydania, Rytuał Oznaczania Cykli, Rytuał Rekonstrukcji Liczb', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Rytuał Wydania/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rytuał Oznaczania Cykli/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rytuał Rekonstrukcji Liczb/i)).toBeInTheDocument();
+  });
+
+  it('renders Schema Editor with correct properties and status', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i)).toBeInTheDocument();
+    });
+
+    const expandButton = screen.getByRole('button', { name: '' }); // We need to find the chevron button. It's better to find by test id or aria-label, but let's find the section first.
+    // Actually, let's just find the button inside the SchemaSection.
+    // The button has no aria-label. Let's add one or find it by some other means.
+    // Wait, let's just find the button that is inside the section with text "Katalog Bazy (Schemat Archiwalny)".
+    
+    // Instead of adding aria-label, let's just find the button by its icon or class, or just add aria-label to the button in SchemaSection.tsx.
+    // Let's just click the button that is next to the heading.
+    const schemaHeading = screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i);
+    const expandBtn = schemaHeading.parentElement?.nextElementSibling as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(expandBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Konfiguracja Systemowa Kolumn/i)).toBeInTheDocument();
+    });
+
+    // Check properties
+    expect(screen.getByText('Autor')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Nagrody')).toBeInTheDocument();
+
+    // Check status display (records count) for multiselect
+    // "Nagrody" has 1 option, so it should show "1 / 100"
+    const statusElements = screen.getAllByText('1 / 100');
+    expect(statusElements.length).toBeGreaterThan(0);
+    
+    // "Autor" should NOT have the status display (as per requirement)
+    // In our mock, Autor has 2 options.
+    expect(screen.queryByText('2 / 100')).not.toBeInTheDocument();
+  });
+
+  it('allows deleting options from Schema Editor except for Autor', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i)).toBeInTheDocument();
+    });
+
+    const schemaHeading = screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i);
+    const expandBtn = schemaHeading.parentElement?.nextElementSibling as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(expandBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Nagrody')).toBeInTheDocument();
+    });
+
+    // Find delete button for "Hugo" in "Nagrody"
+    // It's an X icon inside a button with title "Usuń opcję"
+    const nagrodyHeading = screen.getByText('Nagrody');
+    const nagrodySection = nagrodyHeading.closest('.group') as HTMLElement;
+    expect(nagrodySection).toBeInTheDocument();
+    
+    const deleteButtons = within(nagrodySection).queryAllByTitle('Usuń opcję');
+    expect(deleteButtons.length).toBeGreaterThan(0);
+
+    // Check "Autor" section
+    const autorHeading = screen.getByText('Autor');
+    const autorSection = autorHeading.closest('.group') as HTMLElement;
+    expect(autorSection).toBeInTheDocument();
+    
+    const autorDeleteButtons = within(autorSection).queryAllByTitle('Usuń opcję');
+    expect(autorDeleteButtons.length).toBe(0);
+  });
+
+  it('handles Vinted search flow (UI state)', async () => {
+    render(<App />);
+    
+    const vintedTabButton = screen.getByRole('button', { name: /Skaner Vinted/i });
+    await act(async () => {
+      fireEvent.click(vintedTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Katalog Beletrystyka/i)).toBeInTheDocument();
+    });
+    
+    const searchButton = screen.getByText(/Uruchom Skaner Vinted/i);
+    
+    await act(async () => {
+      fireEvent.click(searchButton);
+    });
+    
+    // Use waitFor because state update might not be immediate
+    await waitFor(() => {
+      expect(screen.getByText(/Zatrzymaj Skanowanie/i)).toBeInTheDocument();
+    });
+  });
+
+  it('handles duplicate sync flow (UI state)', async () => {
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+    });
+
+    const syncButton = screen.getByText(/Rytuał Wykrycia Duplikacji/i);
+    fireEvent.click(syncButton);
+    
+    // Should show loading state
+    expect(mockFetch).toHaveBeenCalledWith('/api/sync-duplicates', expect.any(Object));
+  });
+
+  it('displays duplicate sync summary', async () => {
+    (global as any).resetLastStreamController();
+    render(<App />);
+    
+    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    await act(async () => {
+      fireEvent.click(configTabButton);
+    });
+    
+    const syncButton = screen.getByText(/Rytuał Wykrycia Duplikacji/i);
+    expect(syncButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+
+    // Wait for stream controller to be created
+    await waitFor(() => {
+      expect((global as any).getLastStreamController()).toBeTruthy();
+    });
+
+    // Simulate streaming events
+    await act(async () => {
+      (global as any).pushStreamEvent('status', { message: 'Inicjowanie...' });
+    });
+
+    await act(async () => {
+      (global as any).pushStreamEvent('complete', {
+        result: {
+          duplicates: [
+            { bookA: 'Solaris', bookB: 'Solaris (aka)' },
+            { bookA: 'Cyberiada', bookB: 'Cyberiada (aka)' }
+          ]
+        }
+      });
+    });
+
+    // Check for completion summary
+    await waitFor(() => {
+      expect(screen.getByText(/Zapisy Archiwisty Adeptus/i)).toBeInTheDocument();
+      expect(screen.getByText(/Solaris <-> Solaris \(aka\)/)).toBeInTheDocument();
+      expect(screen.getByText(/Cyberiada <-> Cyberiada \(aka\)/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/IntegrityCheckCard.tsx
+++ b/src/components/IntegrityCheckCard.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { ShieldAlert, CheckCircle, AlertTriangle, Loader2, Activity, ChevronDown, ChevronUp } from "lucide-react";
+import { useSync } from "../hooks/useSync";
+import { IntegrityCheckResult } from "../types";
+
+interface IntegrityCheckCardProps {
+  integritySync: ReturnType<typeof useSync>;
+  isAnySyncLoading: boolean;
+}
+
+export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
+  integritySync,
+  isAnySyncLoading
+}) => {
+  const [expanded, setExpanded] = React.useState<string | null>(null);
+  const state = integritySync.state;
+  const result = state.result as IntegrityCheckResult | null;
+
+  const toggleExpand = (key: string) => {
+    setExpanded(expanded === key ? null : key);
+  };
+
+  const renderStatus = (status: boolean) => {
+    return status ? (
+      <div className="flex items-center gap-2 text-emerald-400 font-bold text-[9px] uppercase tracking-widest bg-emerald-500/10 px-1.5 py-0.5 rounded border border-emerald-500/20">
+        <CheckCircle className="w-2.5 h-2.5" />
+        [ ZATWIERDZONO ]
+      </div>
+    ) : (
+      <div className="flex items-center gap-2 text-rose-400 font-bold text-[9px] uppercase tracking-widest bg-rose-500/10 px-1.5 py-0.5 rounded border border-rose-500/20 animate-pulse">
+        <AlertTriangle className="w-2.5 h-2.5" />
+        [ HEREZJA ]
+      </div>
+    );
+  };
+
+  const renderDetailList = (items: string[]) => (
+    <div className="mt-2 p-2 bg-slate-950/90 rounded-xl border border-slate-800 font-mono text-[9px] text-slate-400 max-h-32 overflow-y-auto space-y-1 custom-scrollbar">
+      {items.length > 0 ? (
+        items.map((item, i) => <div key={i} className="border-l border-slate-700 pl-2 py-0.5">{item}</div>)
+      ) : (
+        <div className="text-slate-600 italic">Brak szczegółów.</div>
+      )}
+    </div>
+  );
+
+  const checks = [
+    { id: "lp", label: "Unikalność Lp", status: result?.lpUniqueness.status ?? true, details: result?.lpUniqueness.duplicates || [] },
+    { id: "origTitle", label: "Tytuły Oryginalne", status: result?.originalTitleUniqueness.status ?? true, details: result?.originalTitleUniqueness.duplicates || [] },
+    { id: "plTitle", label: "Tytuły Polskie", status: result?.polishTitleUniqueness.status ?? true, details: result?.polishTitleUniqueness.duplicates || [] },
+    { 
+      id: "years", 
+      label: "Roczniki (Notion/Wiki)", 
+      status: result?.yearCountMatch.status ?? true, 
+      details: result?.yearCountMatch.diffs.flatMap(d => {
+        const lines = [`Rok ${d.year}: Notion(${d.notion}) vs Wiki(${d.wiki})`];
+        if (d.notionOnly && d.notionOnly.length > 0) {
+          lines.push(`  [TYLKO NOTION]:`);
+          d.notionOnly.forEach(b => lines.push(`    • ${b}`));
+        }
+        if (d.wikiOnly && d.wikiOnly.length > 0) {
+          lines.push(`  [TYLKO WIKI]:`);
+          d.wikiOnly.forEach(b => lines.push(`    • ${b}`));
+        }
+        return lines;
+      }) || [] 
+    },
+    { id: "awards", label: "Nagrody (Notion/Wiki)", status: result?.awardCountMatch.status ?? true, details: result?.awardCountMatch.diffs.map(d => `${d.award}: Notion(${d.notion}) vs Wiki(${d.wiki})`) || [] }
+  ];
+
+  return (
+    <div className="bg-slate-900/40 border border-white/5 rounded-2xl p-4 mt-6 backdrop-blur-sm">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <ShieldAlert className={`w-4 h-4 text-cyan-400 ${state.loading ? 'animate-pulse' : ''}`} />
+          <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">Skaner Sanctity</h3>
+        </div>
+        
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={() => integritySync.startSync({}, undefined, "Inicjowanie Skanera Sanctity...")}
+          disabled={isAnySyncLoading}
+          className={`p-2 rounded-full border transition-all ${
+            state.loading 
+              ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_15px_rgba(34,211,238,0.4)] animate-pulse' 
+              : 'bg-slate-800/50 border-slate-700 text-slate-500 hover:text-cyan-400 hover:border-cyan-500/30'
+          }`}
+          title="Inicjuj Skanowanie Sanctity"
+        >
+          {state.loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Activity className="w-4 h-4" />}
+        </motion.button>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {checks.map((check) => (
+          <div key={check.id} className="relative">
+            <div 
+              onClick={() => toggleExpand(check.id)}
+              className={`flex flex-col p-2 rounded-xl border transition-all cursor-pointer ${
+                result ? (check.status ? 'bg-emerald-500/5 border-emerald-500/10' : 'bg-rose-500/5 border-rose-500/20 animate-pulse') : 'bg-slate-950/30 border-slate-800/50'
+              } hover:border-slate-600`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[9px] font-bold text-slate-400 uppercase tracking-wider truncate">{check.label}</span>
+                {check.details.length > 0 && (
+                  <div className="text-slate-600">
+                    {expanded === check.id ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+                  </div>
+                )}
+              </div>
+              {result && (
+                <div className="mt-1">
+                  {renderStatus(check.status)}
+                </div>
+              )}
+            </div>
+            
+            <AnimatePresence>
+              {expanded === check.id && check.details.length > 0 && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="overflow-hidden absolute z-20 left-0 right-0 top-full mt-1"
+                >
+                  {renderDetailList(check.details)}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
+      </div>
+
+      {state.error && (
+        <div className="mt-3 p-2 bg-rose-500/10 border border-rose-500/20 rounded-xl text-rose-400 text-[9px] font-medium flex items-center gap-2">
+          <AlertTriangle className="w-3 h-3 shrink-0" />
+          <span className="truncate">{state.error}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/OtherToolsCard.tsx
+++ b/src/components/OtherToolsCard.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { Settings, Search, RefreshCw, AlertTriangle, Sparkles, Database, BookOpen, Layers } from "lucide-react";
+import { motion } from "motion/react";
+import { useSync } from "../hooks/useSync";
+
+interface OtherToolsCardProps {
+  schemaSync: ReturnType<typeof useSync>;
+  purifySync: ReturnType<typeof useSync>;
+  publisherSync: ReturnType<typeof useSync>;
+  seriesSync: ReturnType<typeof useSync>;
+  cyclesSync: ReturnType<typeof useSync>;
+  duplicatesSync: ReturnType<typeof useSync>;
+  lpSync: ReturnType<typeof useSync>;
+  handleSyncSchema: () => void;
+  handleSyncPurify: () => void;
+  handleSyncPublisher: () => void;
+  handleSyncSeries: () => void;
+  handleCyclesSync: () => void;
+  handleSyncDuplicates: () => void;
+  handleSyncLp: () => void;
+  handleResetSync?: () => void;
+  isAnySyncLoading: boolean;
+}
+
+export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
+  schemaSync,
+  purifySync,
+  publisherSync,
+  seriesSync,
+  cyclesSync,
+  duplicatesSync,
+  lpSync,
+  handleSyncSchema,
+  handleSyncPurify,
+  handleSyncPublisher,
+  handleSyncSeries,
+  handleCyclesSync,
+  handleSyncDuplicates,
+  handleSyncLp,
+  handleResetSync,
+  isAnySyncLoading
+}) => {
+  const schemaSyncState = schemaSync.state;
+  const purifySyncState = purifySync.state;
+  const publisherSyncState = publisherSync.state;
+  const seriesSyncState = seriesSync.state;
+  const cyclesSyncState = cyclesSync.state;
+  const duplicatesSyncState = duplicatesSync.state;
+  const lpSyncState = lpSync.state;
+  return (
+    <motion.div 
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay: 0.5 }}
+      className="glass-card p-8 rounded-3xl flex flex-col h-full"
+    >
+      <h2 className="text-xl font-bold font-display flex items-center gap-3 mb-6 uppercase tracking-widest text-cyan-400">
+        <Settings className="w-5 h-5" />
+        Narzędzia Serwomechanizmów Adeptus
+      </h2>
+      
+      <div className="grid grid-cols-1 gap-4 flex-1">
+        {/* 1. Rytuał Inicjacji Schematu */}
+        <button 
+          onClick={handleSyncSchema} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-emerald-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-emerald-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 bg-slate-900 rounded-xl group-hover:bg-emerald-500/20 transition-colors">
+            <Database className={`w-5 h-5 text-emerald-400 ${schemaSyncState.loading ? 'animate-pulse' : ''}`} />
+          </div>
+          <div className="text-left">
+            <h3 className="font-bold text-slate-200 group-hover:text-emerald-400 transition-colors">Rytuał Inicjacji Schematu</h3>
+            <p className="text-xs text-slate-500 mt-1 uppercase font-bold tracking-tighter">Weryfikacja i kreacja brakujących kolumn w bazie Notion</p>
+          </div>
+        </button>
+
+        {/* 2. Rytuał Puryfikacji */}
+        <button 
+          onClick={handleSyncPurify} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-amber-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-amber-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 bg-slate-900 rounded-xl group-hover:bg-amber-500/20 transition-colors">
+            <Sparkles className={`w-5 h-5 text-amber-400 ${purifySyncState.loading ? 'animate-pulse' : ''}`} />
+          </div>
+          <div className="text-left">
+            <h3 className="font-bold text-slate-200 group-hover:text-amber-400 transition-colors">Rytuał Puryfikacji</h3>
+            <p className="text-xs text-slate-500 mt-1 uppercase font-bold tracking-tighter">Oczyszczanie tytułów z nadmiarowych znaków i formatowania</p>
+          </div>
+        </button>
+
+        {/* 3. Rytuał Rekonstrukcji Liczb */}
+        <button 
+          onClick={handleSyncLp} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-purple-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-purple-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 rounded-xl bg-purple-500/10 text-purple-400 group-hover:scale-110 transition-transform">
+            <RefreshCw className={`w-5 h-5 ${lpSyncState.loading ? 'animate-spin' : ''}`} />
+          </div>
+          <div className="text-left">
+            <div className="font-bold text-slate-200 group-hover:text-purple-400 transition-colors">Rytuał Rekonstrukcji Liczb</div>
+            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Rekalkulacja i naprawa numeracji porządkowej rekordów</div>
+          </div>
+        </button>
+
+        {/* 4. Rytuał Oznaczania Cykli */}
+        <button 
+          onClick={handleCyclesSync} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-blue-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-blue-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 rounded-xl bg-blue-500/10 text-blue-400 group-hover:scale-110 transition-transform">
+            <RefreshCw className={`w-5 h-5 ${cyclesSyncState.loading ? 'animate-spin' : ''}`} />
+          </div>
+          <div className="text-left">
+            <div className="font-bold text-slate-200 group-hover:text-blue-400 transition-colors">Rytuał Oznaczania Cykli</div>
+            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Automatyczne przypisywanie książek do cykli wydawniczych</div>
+          </div>
+        </button>
+
+        {/* 5. Rytuał Wydania */}
+        <button 
+          onClick={handleSyncPublisher} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-rose-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-rose-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 rounded-xl bg-rose-500/10 text-rose-400 group-hover:scale-110 transition-transform">
+            <BookOpen className={`w-5 h-5 ${publisherSyncState.loading ? 'animate-pulse' : ''}`} />
+          </div>
+          <div className="text-left">
+            <div className="font-bold text-slate-200 group-hover:text-rose-400 transition-colors">Rytuał Wydania</div>
+            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Eksploracja i aktualizacja danych o wydawcach z Encyklopedii</div>
+          </div>
+        </button>
+
+        {/* 6. Rytuał Seryjny */}
+        <button 
+          onClick={handleSyncSeries} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-indigo-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-indigo-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 rounded-xl bg-indigo-500/10 text-indigo-400 group-hover:scale-110 transition-transform">
+            <Layers className={`w-5 h-5 ${seriesSyncState.loading ? 'animate-pulse' : ''}`} />
+          </div>
+          <div className="text-left">
+            <div className="font-bold text-slate-200 group-hover:text-indigo-400 transition-colors">Rytuał Seryjny</div>
+            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Eksploracja i aktualizacja danych o seriach wydawniczych</div>
+          </div>
+        </button>
+
+        {/* 7. Rytuał Wykrycia Duplikacji */}
+        <button 
+          onClick={handleSyncDuplicates} 
+          disabled={isAnySyncLoading}
+          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-orange-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-orange-500/10 group disabled:opacity-50 disabled:hover:scale-100"
+        >
+          <div className="p-3 rounded-xl bg-orange-500/10 text-orange-400 group-hover:scale-110 transition-transform">
+            <Search className={`w-5 h-5 ${duplicatesSyncState.loading ? 'animate-pulse' : ''}`} />
+          </div>
+          <div className="text-left">
+            <div className="font-bold text-slate-200 group-hover:text-orange-400 transition-colors">Rytuał Wykrycia Duplikacji</div>
+            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Identyfikacja i oznaczanie potencjalnych duplikatów w bazie</div>
+          </div>
+        </button>
+      </div>
+
+      {handleResetSync && (
+        <div className="mt-8 pt-6 border-t border-slate-800/50">
+          <button 
+            onClick={handleResetSync}
+            className="w-full flex items-center justify-center gap-2 p-3 bg-red-950/20 border border-red-900/30 rounded-xl text-red-400 hover:bg-red-900/30 hover:border-red-500/50 transition-all text-xs font-bold uppercase tracking-widest"
+          >
+            <AlertTriangle className="w-4 h-4" />
+            Resetuj Stan Synchronizacji
+          </button>
+          <p className="text-[10px] text-slate-600 mt-2 text-center italic">Użyj tylko jeśli proces utknął w martwym punkcie.</p>
+        </div>
+      )}
+    </motion.div>
+  );
+};

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useRef } from "react";
+
+export const ParticleBackground: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const prefersReducedMotion = typeof window !== 'undefined' && window.matchMedia(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
+
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let animationFrameId: number;
+    let particles: Particle[] = [];
+
+    const mouse = { x: -1000, y: -1000 };
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      initParticles();
+    };
+
+    type Particle = {
+      x: number;
+      y: number;
+      vx: number;
+      vy: number;
+      size: number;
+      update: () => void;
+      draw: () => void;
+    };
+
+    const createParticle = (): Particle => {
+      const p: Particle = {
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        vx: (Math.random() - 0.5) * 0.5,
+        vy: (Math.random() - 0.5) * 0.5,
+        size: Math.random() * 2 + 0.5,
+        update: () => {
+          p.x += p.vx;
+          p.y += p.vy;
+          if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+          if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+        },
+        draw: () => {
+          if (!ctx) return;
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+          ctx.fillStyle = "rgba(139, 92, 246, 0.8)";
+          ctx.fill();
+        }
+      };
+      return p;
+    };
+
+    const initParticles = () => {
+      particles = [];
+      // Adjust particle count based on screen size
+      const numParticles = Math.min(
+        Math.floor((window.innerWidth * window.innerHeight) / 12000),
+        120,
+      );
+      for (let i = 0; i < numParticles; i++) {
+        particles.push(createParticle());
+      }
+    };
+
+    const drawLines = () => {
+      for (let i = 0; i < particles.length; i++) {
+        // Connect particles to each other
+        for (let j = i + 1; j < particles.length; j++) {
+          const dx = particles[i].x - particles[j].x;
+          const dy = particles[i].y - particles[j].y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+
+          if (distance < 120) {
+            ctx.beginPath();
+            ctx.strokeStyle = `rgba(56, 189, 248, ${0.2 - distance / 600})`; // Cyan-ish connections
+            ctx.lineWidth = 0.5;
+            ctx.moveTo(particles[i].x, particles[i].y);
+            ctx.lineTo(particles[j].x, particles[j].y);
+            ctx.stroke();
+          }
+        }
+
+        // Connect particles to mouse
+        const dxMouse = particles[i].x - mouse.x;
+        const dyMouse = particles[i].y - mouse.y;
+        const distanceMouse = Math.sqrt(dxMouse * dxMouse + dyMouse * dyMouse);
+
+        if (distanceMouse < 180) {
+          ctx.beginPath();
+          // Brighter connection to the mouse cursor
+          ctx.strokeStyle = `rgba(139, 92, 246, ${0.6 - distanceMouse / 300})`;
+          ctx.lineWidth = 1;
+          ctx.moveTo(particles[i].x, particles[i].y);
+          ctx.lineTo(mouse.x, mouse.y);
+          ctx.stroke();
+
+          // Slight attraction to mouse
+          if (distanceMouse > 50) {
+            particles[i].x -= dxMouse * 0.005;
+            particles[i].y -= dyMouse * 0.005;
+          }
+        }
+      }
+    };
+
+    const animate = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      particles.forEach((p) => {
+        p.update();
+        p.draw();
+      });
+
+      drawLines();
+
+      animationFrameId = requestAnimationFrame(animate);
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      mouse.x = e.clientX;
+      mouse.y = e.clientY;
+    };
+
+    const handleMouseOut = () => {
+      mouse.x = -1000;
+      mouse.y = -1000;
+    };
+
+    window.addEventListener("resize", resize, { passive: true });
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
+    window.addEventListener("mouseout", handleMouseOut, { passive: true });
+
+    resize();
+    animate();
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseout", handleMouseOut);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [prefersReducedMotion]);
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 pointer-events-none z-0"
+        style={{
+          background:
+            "radial-gradient(circle at center, #0f172a 0%, #020617 100%)",
+        }}
+      />
+    );
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="fixed inset-0 pointer-events-none z-0"
+      style={{
+        background:
+          "radial-gradient(circle at center, #0f172a 0%, #020617 100%)",
+      }}
+    />
+  );
+};

--- a/src/components/ProgressAndResults.tsx
+++ b/src/components/ProgressAndResults.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { motion } from "motion/react";
+import { useSync } from "../hooks/useSync";
+
+interface ProgressAndResultsProps {
+  syncs: ReturnType<typeof useSync>[];
+  formatETA: (current: number, total: number, startTime: number | null) => string | null;
+}
+
+export const ProgressAndResults: React.FC<ProgressAndResultsProps> = ({
+  syncs,
+  formatETA
+}) => {
+  const activeSync = syncs.find(s => s.state.loading);
+
+  if (!activeSync) return null;
+
+  const state = activeSync.state;
+  const color = state.color || "cyan";
+  const progress = state.progress || { current: 0, total: 1 };
+  const percent = Math.round((progress.current / progress.total) * 100);
+
+  // Map color names to Tailwind classes
+  const colorMap: Record<string, { text: string, border: string, bg: string, shadow: string }> = {
+    cyan: { text: "text-cyan-400", border: "border-cyan-500/20", bg: "bg-cyan-500", shadow: "shadow-[0_0_15px_rgba(34,211,238,0.4)]" },
+    rose: { text: "text-rose-400", border: "border-rose-500/20", bg: "bg-rose-500", shadow: "shadow-[0_0_15px_rgba(244,63,94,0.4)]" },
+    indigo: { text: "text-indigo-400", border: "border-indigo-500/20", bg: "bg-indigo-500", shadow: "shadow-[0_0_15px_rgba(99,102,241,0.4)]" },
+    blue: { text: "text-blue-400", border: "border-blue-500/20", bg: "bg-blue-500", shadow: "shadow-[0_0_15px_rgba(59,130,246,0.4)]" },
+    purple: { text: "text-purple-400", border: "border-purple-500/20", bg: "bg-purple-500", shadow: "shadow-[0_0_15px_rgba(168,85,247,0.4)]" },
+    orange: { text: "text-orange-400", border: "border-orange-500/20", bg: "bg-orange-500", shadow: "shadow-[0_0_15px_rgba(249,115,22,0.4)]" },
+    amber: { text: "text-amber-400", border: "border-amber-500/20", bg: "bg-amber-500", shadow: "shadow-[0_0_15px_rgba(245,158,11,0.4)]" },
+    emerald: { text: "text-emerald-400", border: "border-emerald-500/20", bg: "bg-emerald-500", shadow: "shadow-[0_0_15px_rgba(16,185,129,0.4)]" },
+  };
+
+  const theme = colorMap[color] || colorMap.cyan;
+
+  return (
+    <motion.div 
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className={`glass-card p-8 rounded-3xl ${theme.border}`}
+    >
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex flex-col">
+          <h3 className={`text-lg font-bold font-display ${theme.text} uppercase tracking-widest mb-1`}>
+            {state.statusMessage || "Rytuał w toku..."}
+          </h3>
+          <div className="text-xs text-slate-500 font-bold uppercase tracking-tighter">
+            {formatETA(progress.current, progress.total, state.startTime)}
+          </div>
+        </div>
+        <div className="text-2xl font-bold font-display text-slate-200">
+          {percent}%
+        </div>
+      </div>
+      
+      <div className="w-full bg-slate-950 rounded-full h-4 overflow-hidden border border-slate-800 p-1">
+        <motion.div 
+          className={`${theme.bg} h-full rounded-full ${theme.shadow}`}
+          initial={{ width: 0 }}
+          animate={{ width: `${Math.max(2, percent)}%` }}
+          transition={{ type: "spring", bounce: 0, duration: 0.5 }}
+        />
+      </div>
+
+      <div className="mt-6 flex justify-end">
+        <button 
+          onClick={activeSync.stopSync}
+          className="px-6 py-2 bg-red-950/40 hover:bg-red-900/60 text-red-400 rounded-xl text-xs font-bold uppercase tracking-widest border border-red-900/30 transition-all"
+        >
+          Anihilacja Procesu
+        </button>
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/SanctityDebugger.tsx
+++ b/src/components/SanctityDebugger.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Bug, ChevronRight, AlertCircle, Database, Globe } from "lucide-react";
+import { IntegrityCheckResult } from "../types";
+
+interface SanctityDebuggerProps {
+  result: IntegrityCheckResult | null;
+}
+
+export const SanctityDebugger: React.FC<SanctityDebuggerProps> = ({ result }) => {
+  const [selectedDiff, setSelectedDiff] = React.useState<string | null>(null);
+
+  if (!result) return null;
+
+  const hasHeresy = !result.lpUniqueness.status || 
+                    !result.yearCountMatch.status || 
+                    !result.originalTitleUniqueness.status || 
+                    !result.polishTitleUniqueness.status || 
+                    !result.awardCountMatch.status;
+
+  if (!hasHeresy) return null;
+
+  const diffItems = [
+    {
+      id: "years",
+      label: "Rozbieżności Roczników",
+      status: result.yearCountMatch.status,
+      data: result.yearCountMatch.diffs.map(d => ({
+        title: `Rok ${d.year}`,
+        notion: d.notion,
+        wiki: d.wiki,
+        notionOnly: d.notionOnly,
+        wikiOnly: d.wikiOnly,
+        misplaced: d.misplaced,
+        collisions: d.collisions
+      }))
+    },
+    {
+      id: "awards",
+      label: "Rozbieżności Nagród",
+      status: result.awardCountMatch.status,
+      data: result.awardCountMatch.diffs.map(d => ({
+        title: d.award,
+        notion: d.notion,
+        wiki: d.wiki,
+        notionOnly: d.notionOnly,
+        wikiOnly: d.wikiOnly
+      }))
+    }
+  ].filter(item => !item.status);
+
+  return (
+    <div className="bg-slate-900/60 border border-amber-500/20 rounded-2xl p-6 backdrop-blur-md shadow-2xl shadow-amber-900/10">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-2 bg-amber-500/10 rounded-lg border border-amber-500/30">
+          <Bug className="w-5 h-5 text-amber-400" />
+        </div>
+        <div>
+          <h3 className="text-sm font-bold uppercase tracking-[0.3em] text-amber-400">Protokół Debugowania Sanctity</h3>
+          <p className="text-[10px] text-slate-500 font-mono mt-1">ANALIZA ROZBIEŻNOŚCI STRUKTURALNYCH [NOTION vs WIKI]</p>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {diffItems.map((item) => (
+          <div key={item.id} className="space-y-2">
+            <button
+              onClick={() => setSelectedDiff(selectedDiff === item.id ? null : item.id)}
+              className="w-full flex items-center justify-between p-3 bg-slate-950/50 border border-slate-800 rounded-xl hover:border-amber-500/30 transition-all group"
+            >
+              <div className="flex items-center gap-3">
+                <AlertCircle className="w-4 h-4 text-amber-500" />
+                <span className="text-xs font-bold text-slate-300 uppercase tracking-wider">{item.label}</span>
+              </div>
+              <ChevronRight className={`w-4 h-4 text-slate-600 transition-transform ${selectedDiff === item.id ? 'rotate-90' : ''}`} />
+            </button>
+
+            <AnimatePresence>
+              {selectedDiff === item.id && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="overflow-hidden"
+                >
+                  <div className="space-y-3 p-1">
+                    {item.data.map((diff, idx) => (
+                      <div key={idx} className="bg-slate-950 rounded-xl border border-slate-800 overflow-hidden">
+                        <div className="bg-slate-900/50 px-4 py-2 border-b border-slate-800 flex justify-between items-center">
+                          <span className="text-[10px] font-bold text-amber-500/80 uppercase tracking-widest">{diff.title}</span>
+                          <div className="flex gap-4 text-[9px] font-mono">
+                            <span className="text-cyan-400">NOTION: {diff.notion}</span>
+                            <span className="text-purple-400">WIKI: {diff.wiki}</span>
+                          </div>
+                        </div>
+                        
+                        <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-800">
+                          {/* Notion Side */}
+                          <div className="p-3 space-y-2">
+                            <div className="flex items-center gap-2 mb-2">
+                              <Database className="w-3 h-3 text-cyan-500" />
+                              <span className="text-[9px] font-bold text-cyan-500/70 uppercase tracking-tighter">Tylko w Notion</span>
+                            </div>
+                            {diff.notionOnly && diff.notionOnly.length > 0 ? (
+                              <div className="space-y-1">
+                                {diff.notionOnly.map((book, i) => (
+                                  <div key={i} className="text-[9px] text-slate-400 font-mono bg-cyan-500/5 p-1.5 rounded border border-cyan-500/10">
+                                    + {book}
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <div className="text-[9px] text-slate-600 italic p-2">Brak unikalnych rekordów</div>
+                            )}
+                          </div>
+
+                          {/* Wiki Side */}
+                          <div className="p-3 space-y-2">
+                            <div className="flex items-center gap-2 mb-2">
+                              <Globe className="w-3 h-3 text-purple-500" />
+                              <span className="text-[9px] font-bold text-purple-500/70 uppercase tracking-tighter">Tylko na Wiki</span>
+                            </div>
+                            {diff.wikiOnly && diff.wikiOnly.length > 0 ? (
+                              <div className="space-y-1">
+                                {diff.wikiOnly.map((book, i) => (
+                                  <div key={i} className="text-[9px] text-slate-400 font-mono bg-purple-500/5 p-1.5 rounded border border-purple-500/10">
+                                    - {book}
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <div className="text-[9px] text-slate-600 italic p-2">Brak unikalnych rekordów</div>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* Misplaced Section */}
+                        {diff.misplaced && diff.misplaced.length > 0 && (
+                          <div className="p-3 bg-amber-500/5 border-t border-slate-800">
+                            <div className="flex items-center gap-2 mb-2">
+                              <AlertCircle className="w-3 h-3 text-amber-500" />
+                              <span className="text-[9px] font-bold text-amber-500/70 uppercase tracking-tighter">Błędny Rok (Wykryto w innym roczniku)</span>
+                            </div>
+                            <div className="space-y-1">
+                              {diff.misplaced.map((item, i) => (
+                                <div key={i} className="flex justify-between items-center text-[9px] text-slate-400 font-mono bg-amber-500/10 p-1.5 rounded border border-amber-500/20">
+                                  <span>? {item.title}</span>
+                                  <span className="text-amber-500/80">{item.otherYear}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Collisions Section */}
+                        {diff.collisions && diff.collisions.length > 0 && (
+                          <div className="p-3 bg-red-500/5 border-t border-slate-800">
+                            <div className="flex items-center gap-2 mb-2">
+                              <AlertCircle className="w-3 h-3 text-red-500" />
+                              <span className="text-[9px] font-bold text-red-500/70 uppercase tracking-tighter">Kolizje (Wiele rekordów Wiki vs Jeden Notion)</span>
+                            </div>
+                            <div className="space-y-2">
+                              {diff.collisions.map((item, i) => (
+                                <div key={i} className="text-[9px] text-slate-400 font-mono bg-red-500/10 p-2 rounded border border-red-500/20">
+                                  <div className="font-bold text-red-400 mb-1">{item.title}</div>
+                                  <div className="pl-2 border-l border-red-500/30 space-y-1">
+                                    {item.matches.map((m, j) => (
+                                      <div key={j} className="text-slate-500">{m}</div>
+                                    ))}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -1,0 +1,293 @@
+import React, { useState } from 'react';
+import { Plus, Loader2, X, AlertCircle, Settings } from 'lucide-react';
+import { motion, AnimatePresence } from "motion/react";
+
+interface SchemaEditorProps {
+  schema: any;
+  onSchemaUpdated: () => void;
+}
+
+export function SchemaEditor({ schema, onSchemaUpdated }: SchemaEditorProps) {
+  const [updatingProperty, setUpdatingProperty] = useState<string | null>(null);
+  const [newOptionNames, setNewOptionNames] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<{ propertyName: string, propertyType: string, optionName: string } | null>(null);
+
+  const NOTION_OPTION_LIMIT = 100;
+
+  const handleAddOption = async (propertyName: string, propertyType: string) => {
+    const newOptionName = newOptionNames[propertyName]?.trim();
+    if (!newOptionName) return;
+
+    setError(null);
+    setUpdatingProperty(propertyName);
+    try {
+      const existingOptions = schema[propertyName][propertyType]?.options || [];
+      
+      if (existingOptions.some((opt: any) => opt.name.toLowerCase() === newOptionName.toLowerCase())) {
+        throw new Error("Taka opcja już istnieje.");
+      }
+
+      const newOptions = [...existingOptions, { name: newOptionName }];
+
+      const res = await fetch("/api/notion/schema", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          propertyName,
+          propertyType,
+          newOptions
+        })
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Błąd aktualizacji schematu");
+      }
+
+      setNewOptionNames(prev => ({ ...prev, [propertyName]: "" }));
+      onSchemaUpdated();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setUpdatingProperty(null);
+    }
+  };
+
+  const handleDeleteOption = async () => {
+    if (!confirmDelete) return;
+    const { propertyName, propertyType, optionName } = confirmDelete;
+
+    setError(null);
+    setUpdatingProperty(propertyName);
+    setConfirmDelete(null);
+    try {
+      const existingOptions = schema[propertyName][propertyType]?.options || [];
+      const newOptions = existingOptions.filter((opt: any) => opt.name !== optionName);
+
+      const res = await fetch("/api/notion/schema", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          propertyName,
+          propertyType,
+          newOptions
+        })
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Błąd aktualizacji schematu");
+      }
+
+      onSchemaUpdated();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setUpdatingProperty(null);
+    }
+  };
+
+  return (
+    <div className="mt-4 space-y-6">
+      <AnimatePresence>
+        {error && (
+          <motion.div 
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            className="p-3 bg-rose-950/30 text-rose-400 rounded-lg text-xs border border-rose-900/50 flex items-center gap-2"
+          >
+            <AlertCircle className="w-4 h-4" />
+            {error}
+            <button onClick={() => setError(null)} className="ml-auto hover:text-rose-200">
+              <X className="w-4 h-4" />
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {confirmDelete && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <motion.div 
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setConfirmDelete(null)}
+              className="absolute inset-0 bg-slate-950/80 backdrop-blur-md"
+            />
+            <motion.div 
+              initial={{ opacity: 0, scale: 0.9, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.9, y: 20 }}
+              className="relative w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl shadow-[0_0_50px_rgba(0,0,0,0.8)] overflow-hidden"
+            >
+              <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-cyan-500 to-transparent opacity-50" />
+              
+              <div className="p-8">
+                <div className="flex items-center gap-4 mb-6">
+                  <div className="p-3 bg-rose-500/10 rounded-full border border-rose-500/20">
+                    <AlertCircle className="w-8 h-8 text-rose-400" />
+                  </div>
+                  <div>
+                    <h3 className="text-xl font-display font-bold text-slate-100 uppercase tracking-wider">Potwierdź usunięcie</h3>
+                    <p className="text-sm text-slate-500 font-medium">Operacja nieodwracalna</p>
+                  </div>
+                </div>
+
+                <p className="text-lg text-slate-300 mb-8 font-medium leading-relaxed">
+                  Czy na pewno chcesz usunąć opcję <span className="text-cyan-400 font-bold underline decoration-cyan-400/30 underline-offset-4">"{confirmDelete.optionName}"</span> z bazy danych?
+                </p>
+
+                <div className="flex gap-4">
+                  <button 
+                    onClick={() => setConfirmDelete(null)}
+                    className="flex-1 px-6 py-3 text-sm font-bold text-slate-300 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl transition-all active:scale-95"
+                  >
+                    Anuluj
+                  </button>
+                  <button 
+                    onClick={handleDeleteOption}
+                    className="flex-1 px-6 py-3 text-sm font-bold bg-gradient-to-br from-rose-600 to-rose-900 hover:from-rose-500 hover:to-rose-800 text-white rounded-xl shadow-lg shadow-rose-500/20 transition-all active:scale-95 border border-rose-500/30"
+                  >
+                    Usuń na zawsze
+                  </button>
+                </div>
+              </div>
+              
+              <button 
+                onClick={() => setConfirmDelete(null)}
+                className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-200 transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+
+      <h3 className="text-sm font-display font-bold mb-6 text-slate-500 uppercase tracking-[0.2em] flex items-center gap-3">
+        <div className="w-8 h-[1px] bg-gradient-to-r from-cyan-500 to-transparent" />
+        <Settings className="w-4 h-4 text-cyan-400/80" />
+        Konfiguracja Systemowa Kolumn
+      </h3>
+      <div className="space-y-5">
+        {Object.entries(schema).sort((a, b) => a[0].localeCompare(b[0])).map(([key, value]: [string, any], index) => {
+          const isSelectType = value.type === 'multi_select' || value.type === 'select';
+          const options = isSelectType ? [...(value[value.type]?.options || [])].sort((a, b) => a.name.localeCompare(b.name)) : [];
+          const isOverLimit = options.length >= NOTION_OPTION_LIMIT;
+
+          return (
+            <motion.div 
+              initial={{ opacity: 0, y: 10 }} 
+              animate={{ opacity: 1, y: 0 }} 
+              transition={{ delay: index * 0.05 }}
+              key={key} 
+              className="bg-slate-900/20 border border-white/5 rounded-3xl p-6 backdrop-blur-md hover:border-cyan-500/20 transition-all duration-500 group relative overflow-hidden"
+            >
+              <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-br from-cyan-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
+              
+              <div className="flex items-center justify-between mb-5 relative z-10">
+                <div className="flex flex-col gap-1">
+                  <span className="font-display font-bold text-xl text-slate-200 tracking-tight group-hover:text-cyan-400 transition-colors duration-300">{key}</span>
+                  {isSelectType && key !== 'Autor' && (
+                    <div className="flex items-center gap-2">
+                      <div className="h-1 w-24 bg-slate-800 rounded-full overflow-hidden">
+                        <div 
+                          className={`h-full transition-all duration-1000 ${isOverLimit ? 'bg-rose-500' : 'bg-cyan-500'}`}
+                          style={{ width: `${Math.min(100, (options.length / NOTION_OPTION_LIMIT) * 100)}%` }}
+                        />
+                      </div>
+                      <span className={`text-[9px] font-display font-bold uppercase tracking-widest ${isOverLimit ? 'text-rose-400' : 'text-slate-500'}`}>
+                        {options.length} / {NOTION_OPTION_LIMIT}
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-col items-end gap-1">
+                  <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 rounded-full text-[9px] font-display border border-cyan-500/20 uppercase tracking-[0.15em] font-black shadow-[0_0_15px_rgba(6,182,212,0.1)]">
+                    {value.type}
+                  </span>
+                </div>
+              </div>
+              
+              {isSelectType && (
+                <div className="mt-6 pt-6 border-t border-white/5 relative z-10">
+                  {isOverLimit && key !== 'Autor' && (
+                    <div className="mb-6 p-4 bg-rose-500/5 border border-rose-500/10 rounded-2xl flex items-start gap-3">
+                      <AlertCircle className="w-5 h-5 text-rose-500 mt-0.5 shrink-0" />
+                      <div className="text-[11px] text-rose-300/80 font-display font-medium leading-relaxed">
+                        <span className="font-bold block mb-1 uppercase tracking-wider text-rose-400">Krytyczny Limit API</span>
+                        Wykryto {options.length} wpisów. Notion blokuje edycję powyżej {NOTION_OPTION_LIMIT}. 
+                        Zalecana konwersja na <span className="text-cyan-400 font-bold">Plain Text</span> w panelu sterowania Notion.
+                      </div>
+                    </div>
+                  )}
+                  
+                  <div className="flex items-center justify-between mb-4">
+                    <p className="text-[10px] text-slate-500 uppercase tracking-[0.2em] font-bold">Zasoby Opcji</p>
+                    {options.length === 0 && (
+                      <span className="text-[10px] text-slate-600 italic font-display">Baza pusta</span>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2 mb-6">
+                    {options.map((opt: any) => (
+                      <motion.span 
+                        layout
+                        key={opt.id || opt.name} 
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-slate-950/40 border border-white/5 text-slate-400 rounded-2xl text-xs font-display font-medium group/opt hover:border-cyan-500/40 hover:text-cyan-300 transition-all duration-300 shadow-sm"
+                      >
+                        {opt.name}
+                        {key !== 'Autor' && (
+                          <button
+                            onClick={() => setConfirmDelete({ propertyName: key, propertyType: value.type, optionName: opt.name })}
+                            disabled={updatingProperty === key}
+                            className="text-slate-600 hover:text-rose-500 disabled:opacity-50 transition-colors p-0.5 rounded-md hover:bg-rose-500/10"
+                            title="Usuń opcję"
+                          >
+                            <X className="w-3 h-3" />
+                          </button>
+                        )}
+                      </motion.span>
+                    ))}
+                  </div>
+                  
+                  <div className="flex items-center gap-3">
+                    <div className="relative flex-1 group/input">
+                      <input
+                        type="text"
+                        placeholder="Wprowadź nową desygnację..."
+                        className="w-full pl-4 pr-4 py-3 text-xs bg-slate-950/60 border border-white/5 text-slate-300 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-700 transition-all duration-300 font-display font-medium"
+                        value={newOptionNames[key] || ""}
+                        onChange={(e) => setNewOptionNames(prev => ({ ...prev, [key]: e.target.value }))}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            handleAddOption(key, value.type);
+                          }
+                        }}
+                      />
+                    </div>
+                    <button
+                      onClick={() => handleAddOption(key, value.type)}
+                      disabled={!newOptionNames[key]?.trim() || updatingProperty === key || isOverLimit}
+                      className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-cyan-600 to-cyan-500 text-white rounded-2xl text-xs font-display font-bold hover:from-cyan-500 hover:to-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-300 active:scale-95 shadow-lg shadow-cyan-500/20 uppercase tracking-widest"
+                    >
+                      {updatingProperty === key ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <Plus className="w-4 h-4" />
+                      )}
+                      Inicjuj
+                    </button>
+                  </div>
+                </div>
+              )}
+            </motion.div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SchemaSection.tsx
+++ b/src/components/SchemaSection.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Database, RefreshCw, ChevronDown, ChevronUp } from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
+import { SchemaEditor } from "./SchemaEditor";
+
+interface SchemaSectionProps {
+  schema: any;
+  schemaLoading: boolean;
+  schemaError: string | null;
+  configStatus: {
+    hasNotionKey: boolean;
+    hasDatabaseId: boolean;
+  };
+  fetchSchema: () => void;
+}
+
+export const SchemaSection: React.FC<SchemaSectionProps> = ({
+  schema,
+  schemaLoading,
+  schemaError,
+  configStatus,
+  fetchSchema
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  return (
+    <motion.section 
+      initial={{ opacity: 0, y: 20 }} 
+      animate={{ opacity: 1, y: 0 }} 
+      transition={{ delay: 0.7 }}
+      className="glass-card p-8 rounded-3xl"
+    >
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Database className="w-5 h-5 text-cyan-400" />
+          <h2 className="text-xl font-bold font-display uppercase tracking-widest text-cyan-400">
+            Katalog Bazy (Schemat Archiwalny)
+          </h2>
+        </div>
+        <button 
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="p-2 hover:bg-slate-900 rounded-xl text-slate-500 hover:text-cyan-400 transition-all border border-slate-800"
+        >
+          {isExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
+        </button>
+      </div>
+
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="overflow-hidden"
+          >
+            <p className="text-slate-400 text-sm mb-6">Edytuj strukturę danych w świętym rejestrze Notion.</p>
+            
+            <button 
+              onClick={fetchSchema}
+              disabled={!configStatus.hasNotionKey || !configStatus.hasDatabaseId || schemaLoading}
+              className="flex items-center gap-2 px-6 py-3 bg-slate-900 hover:bg-slate-800 text-slate-200 border border-slate-800 rounded-2xl font-bold transition-all hover:-translate-y-1 shadow-xl mb-8 disabled:opacity-50"
+            >
+              <RefreshCw className={`w-5 h-5 ${schemaLoading ? 'animate-spin' : ''}`} />
+              {schemaLoading ? "Przeszukiwanie Archiwów..." : "Odśwież Katalog z Bazy Notion"}
+            </button>
+
+            {schemaError && (
+              <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-4 bg-red-500/10 border border-red-500/20 rounded-2xl text-red-400 text-sm mb-6">
+                {schemaError}
+              </motion.div>
+            )}
+
+            {schema && (
+              <SchemaEditor schema={schema} onSchemaUpdated={fetchSchema} />
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.section>
+  );
+};

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,0 +1,300 @@
+import React, { useState } from "react";
+import { motion } from "motion/react";
+import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search, CheckCircle2, Loader2 } from "lucide-react";
+import { useStats } from "../hooks/useStats";
+import { useLibraryCheck } from "../hooks/useLibraryCheck";
+import { ProgressBar } from "./stats/ProgressBar";
+import { YearlyProgressItem } from "./stats/YearlyProgressItem";
+import { LibraryProgressItem } from "./stats/LibraryProgressItem";
+import { AuthorProgressItem } from "./stats/AuthorProgressItem";
+import { IdentifiedLibraryItem } from "./stats/IdentifiedLibraryItem";
+import { LIBRARY_BRANCHES } from "../constants";
+
+export const StatsSection: React.FC = () => {
+  const { stats, loading, error, fetchStats } = useStats();
+  const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
+  const [markingId, setMarkingId] = useState<string | null>(null);
+
+  const handleMarkAsRead = async (pageId: string) => {
+    if (markingId) return;
+    setMarkingId(pageId);
+    try {
+      const res = await fetch("/api/mark-as-read", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pageId })
+      });
+      if (!res.ok) throw new Error("Błąd podczas oznaczania jako przeczytane");
+      await fetchStats();
+    } catch (err: any) {
+      console.error(err.message);
+      alert(`Błąd: ${err.message}`);
+    } finally {
+      setMarkingId(null);
+    }
+  };
+
+  if (loading && !stats) {
+    return (
+      <div className="flex flex-col items-center justify-center p-12 space-y-4">
+        <motion.div 
+          animate={{ rotate: 360 }}
+          transition={{ repeat: Infinity, duration: 2, ease: "linear" }}
+          className="text-cyan-500"
+        >
+          <BarChart3 className="w-12 h-12" />
+        </motion.div>
+        <p className="text-cyan-400 font-display uppercase tracking-widest animate-pulse">Analiza Logów Archiwalnych...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 glass-card border-red-500/30 text-center">
+        <p className="text-red-400 font-bold mb-4">Błąd Odczytu Danych: {error}</p>
+        <button 
+          onClick={fetchStats}
+          className="px-6 py-2 bg-red-900/40 hover:bg-red-800/60 text-red-200 rounded-xl border border-red-700/30 transition-all"
+        >
+          Ponów Próbę Odczytu
+        </button>
+      </div>
+    );
+  }
+
+  if (!stats) return null;
+
+  return (
+    <div className="space-y-12">
+      <div className="flex items-center gap-6 mb-12">
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
+        <div className="flex items-center gap-4">
+          <BarChart3 className="w-6 h-6 text-cyan-400" />
+          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-cyan-100/90 whitespace-nowrap">
+            Analiza Zasobów Wiedzy
+          </h2>
+        </div>
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
+        
+        <button 
+          onClick={fetchStats}
+          disabled={loading}
+          className="p-2 hover:bg-slate-900 rounded-lg text-slate-500 hover:text-cyan-400 transition-colors disabled:opacity-50"
+          title="Odśwież Dane"
+          aria-label="Odśwież Dane Statystyczne"
+        >
+          <motion.div 
+            animate={loading ? { rotate: 360 } : {}} 
+            transition={loading ? { repeat: Infinity, duration: 1, ease: "linear" } : {}}
+            whileTap={!loading ? { scale: 0.9 } : {}}
+          >
+            <RefreshCw className={`w-5 h-5 ${loading ? 'text-cyan-400' : ''}`} />
+          </motion.div>
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        {/* Author Progress */}
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6"
+        >
+          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-cyan-500 flex items-center gap-2 mb-4">
+            <User className="w-4 h-4" />
+            Indeks Autorów
+          </h3>
+          <div className="space-y-4 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
+            {stats.authorStats.map((author, idx) => (
+              <AuthorProgressItem key={idx} author={author} />
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Award Progress */}
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6"
+        >
+          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-purple-500 flex items-center gap-2 mb-4">
+            <Award className="w-4 h-4" />
+            Progres Archiwum Nagród
+          </h3>
+          <div className="space-y-6">
+            <ProgressBar 
+              current={stats.awardBooksStats.read}
+              total={stats.awardBooksStats.total}
+              label="Polskie wydania z listy nagród"
+              icon={Book}
+              color="purple"
+            />
+            <ProgressBar 
+              current={stats.allAwardsStats.read}
+              total={stats.allAwardsStats.total}
+              label="Książki mające Wszystkie Nagrody"
+              icon={Award}
+              color="emerald"
+            />
+            
+            <div className="pt-4 space-y-3">
+              <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2">Pokrycie Poszczególnych Nagród</p>
+              <div className="grid grid-cols-2 gap-3">
+                {stats.awardCoverage.map((award, idx) => (
+                  <div key={idx} className="bg-slate-950/50 border border-slate-800 p-2 rounded-xl">
+                    <div className="text-xs font-bold text-slate-400 uppercase truncate">{award.name}</div>
+                    <div className="text-lg font-bold font-display text-purple-400">
+                      {Math.round((award.count / award.total) * 100)}%
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Yearly Progress */}
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6"
+        >
+          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-orange-500 flex items-center gap-2 mb-4">
+            <Calendar className="w-4 h-4" />
+            Chronologia Przeczytanych
+          </h3>
+          <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
+            {stats.yearlyStats.map((year, idx) => (
+              <YearlyProgressItem key={idx} year={year} />
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Owned but Unread */}
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.25 }}
+          className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6"
+        >
+          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-emerald-500 flex items-center gap-2 mb-4">
+            <Package className="w-4 h-4" />
+            Zasoby Oczekujące (Posiadane)
+          </h3>
+          <div className="space-y-3 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
+            {stats.ownedUnread.length === 0 ? (
+              <p className="text-slate-400 text-sm italic text-center py-8">Wszystkie posiadane zasoby zostały przyswojone.</p>
+            ) : (
+              stats.ownedUnread.map((book, idx) => (
+                <div key={idx} className="flex items-start gap-3 p-3 bg-slate-950/30 rounded-xl border border-slate-800/50 group/book">
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="text-sm font-bold text-slate-200 leading-tight">{book.title}</div>
+                      {book.year && <div className="text-xs font-mono text-slate-400">{book.year}</div>}
+                    </div>
+                    <div className="text-xs text-slate-400 uppercase font-bold tracking-tighter">{book.author}</div>
+                  </div>
+                  
+                  <button
+                    onClick={() => handleMarkAsRead(book.id)}
+                    disabled={markingId !== null}
+                    className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
+                      markingId === book.id 
+                        ? 'bg-emerald-500/20 border-emerald-500/50 text-emerald-400' 
+                        : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-emerald-400 hover:border-emerald-500/30'
+                    }`}
+                    title="Oznacz jako przeczytane"
+                  >
+                    {markingId === book.id ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <CheckCircle2 className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </motion.div>
+
+        {/* Library Progress */}
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3 }}
+          className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6"
+        >
+          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-500 flex items-center gap-2 mb-4">
+            <Library className="w-4 h-4" />
+            Książki dostępne w bibliotekach
+          </h3>
+          <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
+            {stats.libraryStats.map((library, idx) => (
+              <LibraryProgressItem 
+                key={idx} 
+                library={library} 
+                onMarkAsRead={handleMarkAsRead}
+                markingId={markingId}
+              />
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Identified in Libraries */}
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.35 }}
+          className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-400 flex items-center gap-2">
+              <Search className="w-4 h-4" />
+              Zidentyfikowane w bibliotekach
+            </h3>
+            
+            <button
+              onClick={() => checkAllLibraries(LIBRARY_BRANCHES)}
+              disabled={checkingLibrary !== null}
+              className="px-4 py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-xl border border-blue-500/30 text-xs font-bold uppercase tracking-widest transition-all disabled:opacity-50 flex items-center gap-2"
+            >
+              {checkingLibrary ? (
+                <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 1, ease: "linear" }}>
+                  <RefreshCw className="w-3 h-3" />
+                </motion.div>
+              ) : (
+                <Search className="w-3 h-3" />
+              )}
+              Skanuj Wszystkie
+            </button>
+          </div>
+          
+          {libraryError && (
+            <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-xs text-red-400 font-bold mb-4">
+              Błąd skanowania: {libraryError}
+            </div>
+          )}
+
+          <div className="space-y-6 max-h-[500px] overflow-y-auto pr-2 custom-scrollbar">
+            {LIBRARY_BRANCHES.map((library) => (
+              <IdentifiedLibraryItem 
+                key={library.id}
+                library={library}
+                books={identifiedBooks[library.id] || []}
+                onCheck={() => checkLibrary(library.id, library.code)}
+                onStop={stopLibraryCheck}
+                onMarkAsRead={handleMarkAsRead}
+                markingId={markingId}
+                isChecking={checkingLibrary === library.id}
+                progress={checkingLibrary === library.id ? checkProgress : null}
+              />
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/StatusSection.tsx
+++ b/src/components/StatusSection.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Zap, Loader2, ExternalLink, History } from "lucide-react";
+import { motion } from "motion/react";
+import { useWikiUpdates, WikiLink } from "../hooks/useWikiUpdates";
+
+interface StatusSectionProps {
+  configStatus: {
+    loading: boolean;
+    hasNotionKey: boolean;
+    hasDatabaseId: boolean;
+    isSyncing?: boolean;
+  };
+}
+
+const WIKI_LINKS: WikiLink[] = [
+  { name: "Hugo", url: "https://encyklopediafantastyki.pl/index.php?title=Hugo_nagroda_powie%C5%9B%C4%87", title: "Hugo nagroda powieść" },
+  { name: "Locus", url: "https://encyklopediafantastyki.pl/index.php?title=Locus_nagroda_powie%C5%9B%C4%87", title: "Locus nagroda powieść" },
+  { name: "Nebula", url: "https://encyklopediafantastyki.pl/index.php?title=Nebula_nagroda_najlepsza_powie%C5%9B%C4%87", title: "Nebula nagroda najlepsza powieść" }
+];
+
+export const StatusSection: React.FC<StatusSectionProps> = ({ configStatus }) => {
+  const wikiUpdates = useWikiUpdates(WIKI_LINKS, !configStatus.loading);
+
+  return (
+    <motion.section 
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.1 }}
+      className="glass-card p-8 rounded-3xl relative overflow-hidden group"
+    >
+      <h2 className="text-xl font-bold font-display flex items-center gap-3 mb-8 uppercase tracking-widest text-cyan-400">
+        <Zap className="w-5 h-5" />
+        Status Ducha Maszyny
+      </h2>
+      
+      {configStatus.loading ? (
+        <div className="flex items-center gap-4 text-slate-400 animate-pulse">
+          <Loader2 className="w-6 h-6 animate-spin" />
+          <span className="font-medium">Inicjalizacja Duchów Maszyny...</span>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {[
+              { label: "NOTION_API_KEY", status: configStatus.hasNotionKey, ok: "Pieczęć Przyłożona", err: "Brak Autoryzacji" },
+              { label: "NOTION_DATABASE_ID", status: configStatus.hasDatabaseId, ok: "Baza Zlokalizowana", err: "Baza Nieznana" },
+              { label: "STATUS PROCESÓW", status: !configStatus.isSyncing, ok: "Gotowość do Pracy", err: "Synchronizacja w Toku" }
+            ].map((item, idx) => (
+              <motion.div 
+                key={item.label}
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.2 + idx * 0.1 }}
+                className="flex items-center gap-4 p-4 rounded-2xl bg-slate-950/50 border border-slate-800/50"
+              >
+                <div className={`w-3 h-3 rounded-full shadow-[0_0_10px_rgba(0,0,0,0.5)] ${item.status ? 'bg-cyan-500 shadow-cyan-500/50' : 'bg-red-600 shadow-red-600/50'}`} />
+                <div>
+                  <div className="text-xs font-bold text-slate-500 uppercase tracking-tighter mb-1">{item.label}</div>
+                  <div className={`text-sm font-bold ${item.status ? 'text-slate-200' : 'text-red-400'}`}>
+                    {item.status ? item.ok : item.err}
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+
+          <div className="pt-4 border-t border-slate-800/50">
+            <div className="text-[10px] font-bold text-slate-500 uppercase tracking-[0.2em] mb-4 ml-1">Sektory Archiwum Encyklopedii</div>
+            <div className="flex flex-wrap gap-4">
+              {WIKI_LINKS.map((link, idx) => (
+                <motion.div
+                  key={link.name}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.4 + idx * 0.1 }}
+                  className="flex flex-col gap-1"
+                >
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-900/50 border border-slate-800 hover:border-cyan-500/50 hover:bg-cyan-500/5 text-slate-400 hover:text-cyan-400 transition-all text-xs font-bold uppercase tracking-widest group"
+                  >
+                    <ExternalLink className="w-3 h-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                    {link.name}
+                  </a>
+                  {wikiUpdates[link.name] && (
+                    <div className="flex items-center gap-1.5 px-2 text-[9px] text-slate-500 font-mono uppercase tracking-tight">
+                      <History className="w-2.5 h-2.5 text-purple-500/70" />
+                      <span>Ostatnia Edycja: {wikiUpdates[link.name]}</span>
+                    </div>
+                  )}
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </motion.section>
+  );
+};

--- a/src/components/SyncAwards.tsx
+++ b/src/components/SyncAwards.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { BookOpen, Loader2, RefreshCw } from "lucide-react";
+import { motion } from "motion/react";
+import { useSync } from "../hooks/useSync";
+import { PREDEFINED_AWARDS } from "../constants";
+import { IntegrityCheckCard } from "./IntegrityCheckCard";
+
+interface SyncAwardsProps {
+  sync: ReturnType<typeof useSync>;
+  integritySync: ReturnType<typeof useSync>;
+  handleAwardChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleSync: () => void;
+  handleFullSync: () => void;
+  isAnySyncLoading: boolean;
+}
+
+export const SyncAwards: React.FC<SyncAwardsProps> = ({ 
+  sync, 
+  integritySync,
+  handleAwardChange, 
+  handleSync, 
+  handleFullSync,
+  isAnySyncLoading
+}) => {
+  const syncState = sync.state;
+  const setSyncState = sync.setState;
+  return (
+    <motion.div 
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay: 0.4 }}
+      className="glass-card p-8 rounded-3xl flex flex-col h-full"
+    >
+      <h2 className="text-xl font-bold font-display flex items-center gap-3 mb-6 uppercase tracking-widest text-purple-400">
+        <BookOpen className="w-5 h-5" />
+        Rytuał Synchronizacji Nagród
+      </h2>
+      
+      <div className="space-y-6 flex-1">
+        <div className="space-y-2">
+          <label htmlFor="award-select" className="text-xs font-bold text-slate-500 uppercase tracking-widest ml-1">Wybierz Nagrodę do Synchronizacji</label>
+          <select 
+            id="award-select"
+            value={syncState.awardName || ""} 
+            onChange={handleAwardChange}
+            disabled={syncState.loading}
+            className="w-full bg-slate-950 border border-slate-800 rounded-2xl px-4 py-3 text-slate-200 focus:ring-2 focus:ring-cyan-500/50 focus:border-cyan-500/50 outline-none transition-all disabled:opacity-50 font-medium"
+          >
+            {PREDEFINED_AWARDS.map(a => (
+              <option key={a.name} value={a.name}>{a.name}</option>
+            ))}
+            <option value="Inna">Inna (wpisz poniżej)</option>
+          </select>
+        </div>
+
+        {syncState.awardName !== "Wszystkie Nagrody" && (
+          <div className="space-y-2">
+            <label className="text-xs font-bold text-slate-500 uppercase tracking-widest ml-1">Tytuł Strony w Archiwum Encyklopedii</label>
+            <input 
+              type="text" 
+              value={syncState.pageTitle || ""} 
+              onChange={(e) => setSyncState(prev => ({ ...prev, pageTitle: e.target.value }))}
+              disabled={syncState.loading}
+              placeholder="np. Hugo nagroda powieść"
+              className="w-full bg-slate-950 border border-slate-800 rounded-2xl px-4 py-3 text-slate-200 focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50 outline-none transition-all disabled:opacity-50 font-medium"
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 pt-4">
+          <button 
+            onClick={() => handleSync()} 
+            disabled={isAnySyncLoading || (syncState.awardName !== "Wszystkie Nagrody" && !syncState.pageTitle)}
+            className="w-full flex items-center justify-center gap-2 px-6 py-3.5 bg-gradient-to-r from-cyan-600 to-blue-700 hover:from-cyan-500 hover:to-blue-600 text-white rounded-2xl font-bold shadow-xl shadow-cyan-500/20 hover:-translate-y-1 transition-all active:scale-95 disabled:opacity-50 disabled:hover:translate-y-0"
+          >
+            {syncState.loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <RefreshCw className="w-5 h-5" />}
+            Inicjuj Synchronizację
+          </button>
+
+          <button 
+            onClick={() => handleFullSync()} 
+            disabled={isAnySyncLoading}
+            className="w-full flex flex-col items-center justify-center gap-1 px-6 py-4 bg-slate-900/50 border border-purple-500/30 hover:border-purple-400/60 text-purple-400 rounded-2xl font-bold shadow-xl shadow-purple-500/10 hover:-translate-y-1 transition-all active:scale-95 disabled:opacity-50 disabled:hover:translate-y-0"
+          >
+            <div className="flex items-center gap-2">
+              <RefreshCw className={`w-4 h-4 ${isAnySyncLoading ? 'animate-spin' : ''}`} />
+              Rytuał Pełnej Synchronizacji
+            </div>
+            <span className="text-[10px] text-slate-500 uppercase tracking-widest font-medium">Sekwencja 1-7 (Schemat → Puryfikacja → Nagrody → Cykle → Wydania → Serie → Liczby)</span>
+          </button>
+        </div>
+
+        <IntegrityCheckCard 
+          integritySync={integritySync}
+          isAnySyncLoading={isAnySyncLoading}
+        />
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/SyncSummaryResult.tsx
+++ b/src/components/SyncSummaryResult.tsx
@@ -1,0 +1,248 @@
+import React, { useState } from "react";
+import { XCircle, CheckCircle2, RefreshCw, AlertCircle, Copy, Check } from "lucide-react";
+import { motion } from "motion/react";
+import { useSync } from "../hooks/useSync";
+
+interface SyncSummaryResultProps {
+  syncs: ReturnType<typeof useSync>[];
+  fullSyncResults?: any[] | null;
+}
+
+export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
+  syncs,
+  fullSyncResults
+}) => {
+  const [copied, setCopied] = useState(false);
+  
+  const activeSync = syncs.find(s => s.state.result && s.endpoint !== "/api/sync-integrity");
+  
+  if (!activeSync && !fullSyncResults) return null;
+
+  // If we have full sync results, we show the aggregated view
+  if (fullSyncResults && fullSyncResults.length > 0) {
+    const totalAdded = fullSyncResults.reduce((acc, curr) => acc + (curr.result?.summary?.added?.length || 0), 0);
+    const totalUpdated = fullSyncResults.reduce((acc, curr) => acc + (curr.result?.updated || 0), 0);
+    const totalSkipped = fullSyncResults.reduce((acc, curr) => acc + (curr.result?.summary?.skipped?.length || 0), 0);
+    const allDuplicates = fullSyncResults.flatMap(curr => curr.result?.summary?.duplicates || []);
+
+    const handleCloseFull = () => {
+      // In App.tsx we should probably have a way to clear this, 
+      // but for now we can just reset all syncs which is what handleClose does
+      syncs.forEach(s => s.setState(prev => ({ ...prev, result: null })));
+      // Note: fullSyncResults is managed by App.tsx, so we might need a prop to clear it
+    };
+
+    return (
+      <motion.div 
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="glass-card p-8 rounded-3xl border-cyan-500/30 bg-cyan-500/5"
+      >
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h3 className="text-xl font-bold font-display text-cyan-400 uppercase tracking-widest">Podsumowanie Wielkiego Rytuału</h3>
+            <p className="text-[10px] text-slate-500 uppercase font-bold tracking-widest mt-1">Pełna Synchronizacja Archiwów Zakończona</p>
+          </div>
+          <button 
+            onClick={() => window.location.reload()} // Simplest way to clear everything for now or just wait for next sync
+            className="text-slate-500 hover:text-slate-200 transition-colors"
+            title="Zamknij podsumowanie"
+          >
+            <XCircle className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+          {[
+            { label: "Suma Dodanych", count: totalAdded, color: "text-emerald-400", bg: "bg-emerald-500/10" },
+            { label: "Suma Zaktualizowanych", count: totalUpdated, color: "text-cyan-400", bg: "bg-cyan-500/10" },
+            { label: "Suma Pominiętych", count: totalSkipped, color: "text-slate-400", bg: "bg-slate-500/10" },
+            { label: "Wszystkie Duplikaty", count: allDuplicates.length, color: "text-amber-400", bg: "bg-amber-500/10" }
+          ].map((stat, i) => (
+            <div key={i} className={`p-4 rounded-2xl ${stat.bg} border border-white/5`}>
+              <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1">{stat.label}</div>
+              <div className={`text-2xl font-bold font-display ${stat.color}`}>{stat.count}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-4">
+          <h4 className="text-xs font-bold text-slate-400 uppercase tracking-[0.3em] mb-4">Szczegóły Poszczególnych Kroków</h4>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {fullSyncResults.map((res, i) => (
+              <div key={i} className="p-3 rounded-xl bg-slate-900/40 border border-slate-800/50 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className={`w-2 h-2 rounded-full bg-${res.color}-500 shadow-[0_0_8px_rgba(var(--${res.color}-500-rgb),0.5)]`} />
+                  <span className="text-xs font-bold text-slate-300 uppercase tracking-wider">{res.name}</span>
+                </div>
+                <div className="text-[10px] font-mono text-slate-500">
+                  +{res.result?.summary?.added?.length || 0} / ~{res.result?.updated || 0}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {allDuplicates.length > 0 && (
+          <div className="mt-10 bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h4 className="text-sm font-bold text-amber-400 uppercase tracking-widest flex items-center gap-2">
+                <AlertCircle className="w-4 h-4" /> Zbiorcza Lista Duplikatów ({allDuplicates.length})
+              </h4>
+              <button 
+                onClick={() => {
+                  navigator.clipboard.writeText(allDuplicates.join("\n")).then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  });
+                }}
+                className="p-2 hover:bg-amber-500/10 rounded-lg text-amber-400/60 hover:text-amber-400 transition-all"
+              >
+                {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+              </button>
+            </div>
+            <div className="max-h-48 overflow-y-auto pr-2 custom-scrollbar space-y-1">
+              {allDuplicates.map((item: string, i: number) => (
+                <div key={i} className="text-[10px] text-slate-400 font-medium border-l border-amber-500/30 pl-2 py-0.5">
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </motion.div>
+    );
+  }
+
+  const activeResult = activeSync.state.result;
+  const color = activeSync.state.color || "cyan";
+  const summary = activeResult?.summary;
+
+  // Map color names to Tailwind classes
+  const colorMap: Record<string, { text: string, border: string, bg: string }> = {
+    cyan: { text: "text-cyan-400", border: "border-cyan-500/20", bg: "bg-cyan-500/10" },
+    rose: { text: "text-rose-400", border: "border-rose-500/20", bg: "bg-rose-500/10" },
+    indigo: { text: "text-indigo-400", border: "border-indigo-500/20", bg: "bg-indigo-500/10" },
+    blue: { text: "text-blue-400", border: "border-blue-500/20", bg: "bg-blue-500/10" },
+    purple: { text: "text-purple-400", border: "border-purple-500/20", bg: "bg-purple-500/10" },
+    orange: { text: "text-orange-400", border: "border-orange-500/20", bg: "bg-orange-500/10" },
+    amber: { text: "text-amber-400", border: "border-amber-500/20", bg: "bg-amber-500/10" },
+    emerald: { text: "text-emerald-400", border: "border-emerald-500/20", bg: "bg-emerald-500/10" },
+  };
+
+  const theme = colorMap[color] || colorMap.cyan;
+
+  const handleClose = () => {
+    syncs.forEach(s => s.setState(prev => ({ ...prev, result: null })));
+  };
+
+  const handleCopyDuplicates = () => {
+    if (!summary?.duplicates) return;
+    const text = summary.duplicates.join("\n");
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <motion.div 
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={`glass-card p-8 rounded-3xl ${theme.border}`}
+    >
+      <div className="flex items-center justify-between mb-8">
+        <h3 className={`text-xl font-bold font-display ${theme.text} uppercase tracking-widest`}>Zapisy Archiwisty Adeptus</h3>
+        <button 
+          onClick={handleClose} 
+          className="text-slate-500 hover:text-slate-200 transition-colors"
+        >
+          <XCircle className="w-6 h-6" />
+        </button>
+      </div>
+
+      <div className="space-y-6">
+        {summary ? (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            {[
+              { label: "Dodano", count: summary.added?.length || 0, color: "text-emerald-400", bg: "bg-emerald-500/10" },
+              { label: "Zaktualizowano", count: (summary.updated?.length || 0) + (activeResult.updated || 0) - (summary.updated?.length || 0), color: theme.text, bg: theme.bg },
+              { label: "Pominięto", count: summary.skipped?.length || 0, color: "text-slate-400", bg: "bg-slate-500/10" },
+              { label: "Duplikaty", count: summary.duplicates?.length || 0, color: "text-amber-400", bg: "bg-amber-500/10" }
+            ].map((stat, i) => (
+              <div key={i} className={`p-4 rounded-2xl ${stat.bg} border border-white/5`}>
+                <div className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-1">{stat.label}</div>
+                <div className={`text-3xl font-bold font-display ${stat.color}`}>{stat.count}</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className={`p-6 ${theme.bg} border ${theme.border} rounded-2xl text-center mb-8`}>
+            <div className={`${theme.text} font-bold uppercase tracking-widest mb-2`}>Rytuał Zakończony Pomyślnie</div>
+            <div className="text-slate-400 text-sm">
+              Przetworzono {activeResult.found || 0} woluminów. 
+              Zaktualizowano {activeResult.updated || 0} wpisów.
+            </div>
+          </div>
+        )}
+
+        {summary && (summary.added?.length > 0 || summary.updated?.length > 0 || summary.duplicates?.length > 0) && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {summary.added?.length > 0 && (
+              <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
+                <h4 className="text-sm font-bold text-emerald-400 uppercase tracking-widest mb-4 flex items-center gap-2">
+                  <CheckCircle2 className="w-4 h-4" /> Nowe Zapisy ({summary.added.length})
+                </h4>
+                <div className="max-h-64 overflow-y-auto pr-2 custom-scrollbar space-y-2">
+                  {summary.added.map((item: string, i: number) => (
+                    <div key={i} className="text-xs text-slate-300 font-medium border-l-2 border-emerald-500/30 pl-3 py-1 bg-emerald-500/5 rounded-r-lg">
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {summary.updated?.length > 0 && (
+              <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
+                <h4 className="text-sm font-bold text-cyan-400 uppercase tracking-widest mb-4 flex items-center gap-2">
+                  <RefreshCw className="w-4 h-4" /> Zaktualizowane ({summary.updated.length})
+                </h4>
+                <div className="max-h-64 overflow-y-auto pr-2 custom-scrollbar space-y-2">
+                  {summary.updated.map((item: string, i: number) => (
+                    <div key={i} className="text-xs text-slate-300 font-medium border-l-2 border-cyan-500/30 pl-3 py-1 bg-cyan-500/5 rounded-r-lg">
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {summary.duplicates?.length > 0 && (
+              <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h4 className="text-sm font-bold text-amber-400 uppercase tracking-widest flex items-center gap-2">
+                    <AlertCircle className="w-4 h-4" /> Potencjalne Duplikaty ({summary.duplicates.length})
+                  </h4>
+                  <button 
+                    onClick={handleCopyDuplicates}
+                    className="p-2 hover:bg-amber-500/10 rounded-lg text-amber-400/60 hover:text-amber-400 transition-all"
+                    title="Kopiuj listę duplikatów"
+                    aria-label="Kopiuj listę duplikatów"
+                  >
+                    {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                  </button>
+                </div>
+                <div className="max-h-64 overflow-y-auto pr-2 custom-scrollbar space-y-2">
+                  {summary.duplicates.map((item: string, i: number) => (
+                    <div key={i} className="text-xs text-slate-300 font-medium border-l-2 border-amber-500/30 pl-3 py-1 bg-amber-500/5 rounded-r-lg">
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/VintedSection.tsx
+++ b/src/components/VintedSection.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { motion } from "motion/react";
+import { ShoppingCart } from "lucide-react";
+import { VintedCheckItem } from "./stats/VintedCheckItem";
+import { useVintedCheck } from "../hooks/useVintedCheck";
+
+export const VintedSection: React.FC = () => {
+  const { vintedResults, searchAttempts, isChecking, checkProgress, vintedError, runVintedCheck, stopVintedCheck } = useVintedCheck();
+
+  return (
+    <div className="space-y-12">
+      <div className="flex items-center gap-6 mb-12">
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-rose-500/20 to-transparent"></div>
+        <div className="flex items-center gap-4">
+          <ShoppingCart className="w-6 h-6 text-rose-400" />
+          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-rose-100/90 whitespace-nowrap">
+            Skaner Vinted
+          </h2>
+        </div>
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-rose-500/20 to-transparent"></div>
+      </div>
+
+      <motion.div 
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="glass-card p-8 rounded-3xl border-rose-500/10"
+      >
+        {vintedError && (
+          <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-2xl text-sm text-red-400 font-bold mb-6">
+            Błąd Vinted: {vintedError}
+          </div>
+        )}
+
+        <VintedCheckItem 
+          results={vintedResults}
+          searchAttempts={searchAttempts}
+          onCheck={runVintedCheck}
+          onStop={stopVintedCheck}
+          isChecking={isChecking}
+          progress={checkProgress}
+        />
+      </motion.div>
+    </div>
+  );
+};

--- a/src/components/stats/AuthorProgressItem.tsx
+++ b/src/components/stats/AuthorProgressItem.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { motion } from "motion/react";
+import { User, ChevronDown, ChevronUp, CheckCircle2, Circle } from "lucide-react";
+
+export const AuthorProgressItem: React.FC<{ author: any }> = ({ author }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const percent = author.total > 0 ? Math.round((author.read / author.total) * 100) : 0;
+  const color = author.read === author.total ? "emerald" : "cyan";
+  const colorClass = color === "emerald" ? "from-emerald-500 to-teal-600" : "from-cyan-500 to-blue-600";
+  const shadowClass = color === "emerald" ? "shadow-emerald-500/20" : "shadow-cyan-500/20";
+
+  return (
+    <div className="space-y-2">
+      <div 
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-1 rounded-lg transition-colors group"
+      >
+        <div className="flex items-center gap-2 text-slate-400 group-hover:text-cyan-400 transition-colors">
+          <User className="w-3 h-3" />
+          <span>{author.name}</span>
+          {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </div>
+        <div className="text-slate-200">{author.read} / {author.total} ({percent}%)</div>
+      </div>
+      <div className="h-2 bg-slate-950 rounded-full overflow-hidden border border-slate-800 p-0.5">
+        <motion.div 
+          initial={{ width: 0 }}
+          animate={{ width: `${percent}%` }}
+          className={`h-full rounded-full bg-gradient-to-r ${colorClass} shadow-lg ${shadowClass}`}
+        />
+      </div>
+      {isExpanded && (
+        <motion.div 
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          className="pl-4 pt-2 space-y-2 overflow-hidden"
+        >
+          {author.books.map((book: any, idx: number) => (
+            <div key={idx} className="flex items-start gap-2 text-xs leading-tight group/book">
+              {book.read ? (
+                <CheckCircle2 className="w-4 h-4 text-emerald-500 flex-shrink-0 mt-0.5" />
+              ) : (
+                <Circle className="w-4 h-4 text-slate-600 flex-shrink-0 mt-0.5" />
+              )}
+              <div className="flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <div className={book.read ? "text-slate-200 font-bold" : "text-slate-400 font-bold"}>{book.title}</div>
+                  {book.year && <div className="text-[10px] font-mono text-slate-500">{book.year}</div>}
+                </div>
+              </div>
+            </div>
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+};

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Search, ChevronDown, ChevronUp, Loader2, CheckCircle2 } from "lucide-react";
+import { formatETA } from "../../utils/time";
+
+interface IdentifiedLibraryItemProps {
+  library: { id: string; name: string; code: string }; 
+  books: any[]; 
+  onCheck: () => void;
+  onStop: () => void;
+  onMarkAsRead: (pageId: string) => void;
+  markingId: string | null;
+  isChecking: boolean;
+  progress: any;
+}
+
+export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({ 
+  library, 
+  books, 
+  onCheck, 
+  onStop, 
+  onMarkAsRead,
+  markingId,
+  isChecking, 
+  progress 
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(true);
+
+  const sortedBooks = React.useMemo(() => {
+    return [...books].sort((a, b) => {
+      const aExact = a.extractedTitle && a.extractedTitle.toLowerCase() === a.title.toLowerCase();
+      const bExact = b.extractedTitle && b.extractedTitle.toLowerCase() === b.title.toLowerCase();
+      
+      if (aExact && !bExact) return -1;
+      if (!aExact && bExact) return 1;
+      return 0;
+    });
+  }, [books]);
+
+  return (
+    <div className="space-y-4">
+      <div 
+        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter p-2 rounded-xl border border-slate-800/50 bg-slate-900/20"
+      >
+        <div 
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex items-center gap-2 text-slate-400 cursor-pointer hover:text-blue-400 transition-colors flex-1"
+        >
+          <Search className="w-4 h-4" />
+          <span className="text-sm">{library.name}</span>
+          {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+        </div>
+        
+        <div className="flex items-center gap-3">
+          {books.length > 0 && (
+            <div className="text-slate-200 bg-blue-500/10 px-2 py-0.5 rounded-full border border-blue-500/20">
+              {books.length}
+            </div>
+          )}
+          <button
+            onClick={(e) => { 
+              e.stopPropagation(); 
+              if (isChecking) onStop();
+              else onCheck(); 
+            }}
+            className={`flex items-center gap-1 px-3 py-1 rounded-lg transition-all text-xs font-bold text-white ${
+              isChecking 
+                ? "bg-red-600 hover:bg-red-500" 
+                : "bg-blue-600 hover:bg-blue-500"
+            }`}
+          >
+            {isChecking ? (
+              <>
+                <Loader2 className="w-3 h-3 animate-spin" />
+                <span>Zatrzymaj</span>
+              </>
+            ) : (
+              <>
+                <Search className="w-3 h-3" />
+                <span>Skanuj dostępność</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {isChecking && progress && (
+        <div className="px-2 space-y-1">
+          <div className="flex justify-between text-xs text-slate-400 uppercase font-bold">
+            <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+              <span className="break-words">{progress.message}</span>
+              {progress.startTime && (
+                <span className="text-[10px] text-slate-500 lowercase font-medium">
+                  {formatETA(progress.current, progress.total, progress.startTime)}
+                </span>
+              )}
+            </div>
+            {progress.total > 0 && <span>{progress.current} / {progress.total}</span>}
+          </div>
+          {progress.total > 0 && (
+            <div className="h-1 bg-slate-900 rounded-full overflow-hidden">
+              <motion.div 
+                initial={{ width: 0 }}
+                animate={{ width: `${(progress.current / progress.total) * 100}%` }}
+                className="h-full bg-blue-500"
+              />
+            </div>
+          )}
+        </div>
+      )}
+      
+      {isExpanded && books.length > 0 && (
+        <motion.div 
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          className="space-y-3 overflow-hidden"
+        >
+          {sortedBooks.map((book: any, idx: number) => {
+            const isExactMatch = book.extractedTitle && book.extractedTitle.toLowerCase() === book.title.toLowerCase();
+            return (
+            <div key={idx} className={`flex items-start gap-3 p-3 rounded-xl border transition-colors group/book ${
+              isExactMatch 
+                ? "bg-green-500/5 border-green-500/30 hover:border-green-500/50" 
+                : "bg-slate-950/30 border-slate-800/50 hover:border-blue-500/30"
+            }`}>
+              <div className="flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <div className={`text-sm font-bold leading-tight ${isExactMatch ? "text-green-400" : "text-slate-200"}`}>
+                    {book.title}
+                  </div>
+                  {book.year && <div className="text-xs font-mono text-slate-400">{book.year}</div>}
+                </div>
+                <div className="text-xs text-slate-400 uppercase font-bold tracking-tighter">{book.author}</div>
+                {(book.extractedTitle && !isExactMatch) || (book.extractedAuthor && book.extractedAuthor !== book.author) ? (
+                  <div className="mt-2 text-xs text-orange-400/80 bg-orange-500/10 p-1.5 rounded border border-orange-500/20">
+                    <span className="font-bold">Znaleziono jako:</span> {book.extractedTitle || book.title}
+                    {book.extractedAuthor && ` - ${book.extractedAuthor}`}
+                  </div>
+                ) : null}
+              </div>
+
+              <button
+                onClick={() => onMarkAsRead(book.id)}
+                disabled={markingId !== null}
+                className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
+                  markingId === book.id 
+                    ? 'bg-emerald-500/20 border-emerald-500/50 text-emerald-400' 
+                    : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-emerald-400 hover:border-emerald-500/30'
+                }`}
+                title="Oznacz jako przeczytane"
+              >
+                {markingId === book.id ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="w-4 h-4" />
+                )}
+              </button>
+            </div>
+          )})}
+        </motion.div>
+      )}
+      
+      {isExpanded && books.length === 0 && !isChecking && (
+        <p className="text-xs text-slate-500 italic text-center py-4">Brak zidentyfikowanych pozycji. Uruchom skanowanie.</p>
+      )}
+    </div>
+  );
+};

--- a/src/components/stats/LibraryProgressItem.tsx
+++ b/src/components/stats/LibraryProgressItem.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Library, ChevronDown, ChevronUp, CheckCircle2, Loader2 } from "lucide-react";
+
+interface LibraryProgressItemProps {
+  library: any;
+  onMarkAsRead: (pageId: string) => void;
+  markingId: string | null;
+}
+
+export const LibraryProgressItem: React.FC<LibraryProgressItemProps> = ({ library, onMarkAsRead, markingId }) => {
+  const [isExpanded, setIsExpanded] = React.useState(true);
+
+  return (
+    <div className="space-y-4">
+      <div 
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-2 rounded-xl transition-colors group border border-transparent hover:border-blue-500/20"
+      >
+        <div className="flex items-center gap-2 text-slate-400 group-hover:text-blue-400 transition-colors">
+          <Library className="w-4 h-4" />
+          <span className="text-sm">{library.name}</span>
+          {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+        </div>
+        <div className="text-slate-200 bg-blue-500/10 px-2 py-0.5 rounded-full border border-blue-500/20">
+          {library.books.length}
+        </div>
+      </div>
+      
+      {isExpanded && (
+        <motion.div 
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          className="space-y-3 overflow-hidden"
+        >
+          {library.books.map((book: any, idx: number) => (
+            <div key={idx} className="flex items-start gap-3 p-3 bg-slate-950/30 rounded-xl border border-slate-800/50 group/book hover:border-blue-500/30 transition-colors">
+              <div className="flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-sm font-bold leading-tight text-slate-200">
+                    {book.title}
+                  </div>
+                  {book.year && <div className="text-xs font-mono text-slate-400">{book.year}</div>}
+                </div>
+                <div className="text-xs text-slate-400 uppercase font-bold tracking-tighter">{book.author}</div>
+              </div>
+
+              {!book.read && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMarkAsRead(book.id);
+                  }}
+                  disabled={markingId !== null}
+                  className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
+                    markingId === book.id 
+                      ? 'bg-emerald-500/20 border-emerald-500/50 text-emerald-400' 
+                      : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-emerald-400 hover:border-emerald-500/30'
+                  }`}
+                  title="Oznacz jako przeczytane"
+                >
+                  {markingId === book.id ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="w-4 h-4" />
+                  )}
+                </button>
+              )}
+              {book.read && (
+                <div className="p-2 text-emerald-500/50" title="Przeczytane">
+                  <CheckCircle2 className="w-4 h-4" />
+                </div>
+              )}
+            </div>
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+};

--- a/src/components/stats/ProgressBar.tsx
+++ b/src/components/stats/ProgressBar.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { motion } from "motion/react";
+
+interface ProgressBarProps {
+  current: number;
+  total: number;
+  label: string;
+  icon: any;
+  color?: string;
+}
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({ current, total, label, icon: Icon, color = "cyan" }) => {
+  const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+  const colorClass = color === "cyan" ? "from-cyan-500 to-blue-600" : 
+                     color === "purple" ? "from-purple-500 to-indigo-600" :
+                     color === "orange" ? "from-orange-500 to-red-600" : "from-emerald-500 to-teal-600";
+  const shadowClass = color === "cyan" ? "shadow-cyan-500/20" : 
+                      color === "purple" ? "shadow-purple-500/20" :
+                      color === "orange" ? "shadow-orange-500/20" : "shadow-emerald-500/20";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter">
+        <div className="flex items-center gap-2 text-slate-400">
+          <Icon className="w-3 h-3" />
+          <span>{label}</span>
+        </div>
+        <div className="text-slate-200">{current} / {total} ({percent}%)</div>
+      </div>
+      <div className="h-2 bg-slate-950 rounded-full overflow-hidden border border-slate-800 p-0.5">
+        <motion.div 
+          initial={{ width: 0 }}
+          animate={{ width: `${percent}%` }}
+          className={`h-full rounded-full bg-gradient-to-r ${colorClass} shadow-lg ${shadowClass}`}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -1,0 +1,201 @@
+import React from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle } from "lucide-react";
+import { formatETA } from "../../utils/time";
+import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
+
+interface VintedCheckItemProps {
+  results: VintedResult[];
+  searchAttempts: VintedSearchAttempt[];
+  onCheck: () => void;
+  onStop: () => void;
+  isChecking: boolean;
+  progress: any;
+}
+
+export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
+  const [showLogs, setShowLogs] = React.useState(false);
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <h3 className="text-lg font-bold text-slate-200 uppercase tracking-widest">Katalog Beletrystyka</h3>
+          <p className="text-xs text-slate-500 font-medium">Skanowanie ofert Vinted (język polski, od 2 PLN)</p>
+        </div>
+        
+        <div className="flex items-center gap-3">
+          {searchAttempts.length > 0 && (
+            <button
+              onClick={() => setShowLogs(!showLogs)}
+              className={`p-3 rounded-2xl transition-all border ${
+                showLogs 
+                  ? "bg-amber-500/20 border-amber-500/50 text-amber-400" 
+                  : "bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300"
+              }`}
+              title="Pokaż logi skanowania"
+            >
+              <Bug className="w-5 h-5" />
+            </button>
+          )}
+
+          <button
+            onClick={() => { 
+              if (isChecking) onStop();
+              else onCheck(); 
+            }}
+            className={`flex items-center gap-3 px-6 py-3 rounded-2xl transition-all text-sm font-bold text-white shadow-xl ${
+              isChecking 
+                ? "bg-red-600 hover:bg-red-500 shadow-red-500/20" 
+                : "bg-cyan-600 hover:bg-cyan-500 shadow-cyan-500/20"
+            }`}
+          >
+            {isChecking ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>Zatrzymaj Skanowanie</span>
+              </>
+            ) : (
+              <>
+                <Search className="w-4 h-4" />
+                <span>Uruchom Skaner Vinted</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {isChecking && progress && (
+        <div className="px-2 space-y-1">
+          <div className="flex justify-between text-xs text-slate-400 uppercase font-bold">
+            <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+              <span className="break-words">{progress.message}</span>
+              {progress.startTime && (
+                <span className="text-[10px] text-slate-500 lowercase font-medium">
+                  {formatETA(progress.current, progress.total, progress.startTime)}
+                </span>
+              )}
+            </div>
+            {progress.total > 0 && <span>{progress.current} / {progress.total}</span>}
+          </div>
+          {progress.total > 0 && (
+            <div className="h-1 bg-slate-900 rounded-full overflow-hidden">
+              <motion.div 
+                initial={{ width: 0 }}
+                animate={{ width: `${(progress.current / progress.total) * 100}%` }}
+                className="h-full bg-cyan-500"
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      <AnimatePresence>
+        {showLogs && searchAttempts.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="overflow-hidden"
+          >
+            <div className="p-6 rounded-3xl bg-slate-950/50 border border-amber-500/10 space-y-4">
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-xs font-bold text-amber-500 uppercase tracking-widest flex items-center gap-2">
+                  <Bug className="w-3 h-3" />
+                  Logi Skanowania (Debug)
+                </h4>
+                <span className="text-[10px] text-slate-500 uppercase font-bold">{searchAttempts.length} prób</span>
+              </div>
+              <div className="space-y-2 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
+                {searchAttempts.map((attempt, i) => (
+                  <div key={i} className="flex items-center justify-between gap-4 p-3 rounded-2xl bg-slate-900/50 border border-slate-800/50 text-[11px] group/log hover:border-amber-500/20 transition-colors">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="shrink-0">
+                        {attempt.status === "success" && <CheckCircle2 className="w-4 h-4 text-emerald-500" />}
+                        {attempt.status === "no_results" && <XCircle className="w-4 h-4 text-slate-600" />}
+                        {attempt.status === "blocked" && <AlertCircle className="w-4 h-4 text-amber-500" />}
+                        {attempt.status === "error" && <AlertCircle className="w-4 h-4 text-red-500" />}
+                        {attempt.status === "pending" && <Loader2 className="w-4 h-4 text-cyan-500 animate-spin" />}
+                      </div>
+                      
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-slate-200 font-bold truncate group-hover/log:text-slate-100 transition-colors">{attempt.title}</span>
+                        <span className="text-slate-500 text-[9px] uppercase tracking-widest font-bold">{attempt.author}</span>
+                      </div>
+                    </div>
+                    
+                    <div className="flex items-center gap-3 shrink-0">
+                      {attempt.itemCount > 0 && (
+                        <span className="px-2 py-0.5 rounded-lg bg-emerald-500/10 text-emerald-500 font-bold border border-emerald-500/20">
+                          {attempt.itemCount}
+                        </span>
+                      )}
+                      <a 
+                        href={attempt.url} 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        className="p-2 rounded-xl bg-slate-800/50 hover:bg-amber-500/10 text-slate-500 hover:text-amber-400 transition-all"
+                        title="Zobacz zapytanie"
+                      >
+                        <ExternalLink className="w-3.5 h-3.5" />
+                      </a>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      
+      {results.length > 0 && (
+        <motion.div 
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          className="grid grid-cols-1 lg:grid-cols-2 gap-4 overflow-hidden"
+        >
+          {results.map((result, idx) => (
+            <div key={idx} className="flex flex-col gap-3 p-5 rounded-3xl border border-rose-500/10 bg-slate-900/40 group/book hover:border-rose-500/30 transition-all hover:shadow-lg hover:shadow-rose-500/5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="text-base font-bold text-slate-100 leading-tight mb-1 truncate group-hover/book:text-rose-400 transition-colors">
+                    {result.title}
+                  </div>
+                  <div className="text-[10px] text-slate-500 uppercase font-bold tracking-[0.2em]">{result.author}</div>
+                </div>
+                <a 
+                  href={result.searchUrl} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="p-2 rounded-xl bg-slate-800/50 text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 transition-all"
+                  title="Otwórz wyszukiwanie Vinted"
+                >
+                  <ExternalLink className="w-4 h-4" />
+                </a>
+              </div>
+              
+              <div className="flex flex-wrap gap-2 mt-2">
+                {result.vintedItems.map((item, i) => (
+                  <a 
+                    key={i}
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 px-3 py-2 rounded-xl bg-rose-500/5 border border-rose-500/10 text-xs font-bold text-rose-400 hover:bg-rose-500/20 hover:border-rose-500/30 transition-all group/item"
+                  >
+                    <span className="group-hover/item:scale-110 transition-transform">{item.price} {item.currency}</span>
+                    <ShoppingCart className="w-3 h-3 opacity-50 group-hover/item:opacity-100" />
+                  </a>
+                ))}
+              </div>
+            </div>
+          ))}
+        </motion.div>
+      )}
+      
+      {results.length === 0 && !isChecking && (
+        <p className="text-xs text-slate-500 italic text-center py-4">Brak wyników z Vinted. Uruchom skanowanie.</p>
+      )}
+    </div>
+  );
+};

--- a/src/components/stats/YearlyProgressItem.tsx
+++ b/src/components/stats/YearlyProgressItem.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Calendar, ChevronDown, ChevronUp, CheckCircle2, Circle } from "lucide-react";
+
+export const YearlyProgressItem: React.FC<{ year: any }> = ({ year }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const percent = year.total > 0 ? Math.round((year.read / year.total) * 100) : 0;
+
+  return (
+    <div className="space-y-2">
+      <div 
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-1 rounded-lg transition-colors group"
+      >
+        <div className="flex items-center gap-2 text-slate-400 group-hover:text-orange-400 transition-colors">
+          <Calendar className="w-3 h-3" />
+          <span>{year.year}</span>
+          {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </div>
+        <div className="text-slate-200">{year.read} / {year.total} ({percent}%)</div>
+      </div>
+      <div className="h-2 bg-slate-950 rounded-full overflow-hidden border border-slate-800 p-0.5">
+        <motion.div 
+          initial={{ width: 0 }}
+          animate={{ width: `${percent}%` }}
+          className="h-full rounded-full bg-gradient-to-r from-orange-500 to-red-600 shadow-lg shadow-orange-500/20"
+        />
+      </div>
+      {isExpanded && (
+        <motion.div 
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          className="pl-4 pt-2 space-y-2 overflow-hidden"
+        >
+          {year.books.map((book: any, idx: number) => (
+            <div key={idx} className="flex items-start gap-2 text-xs leading-tight group/book">
+              {book.read ? (
+                <CheckCircle2 className="w-4 h-4 text-emerald-500 flex-shrink-0 mt-0.5" />
+              ) : (
+                <Circle className="w-4 h-4 text-slate-600 flex-shrink-0 mt-0.5" />
+              )}
+              <div className={book.read ? "text-slate-200" : "text-slate-400"}>
+                <span className="font-bold">{book.title}</span>
+                <span className="mx-1 text-slate-500">—</span>
+                <span className="italic">{book.author}</span>
+              </div>
+            </div>
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+export const PREDEFINED_AWARDS = [
+  { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
+  { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
+  { name: "Nagroda Locus", title: "Locus nagroda powieść" },
+  { name: "Wszystkie Nagrody", title: "Wszystkie" },
+];
+
+export const LIBRARY_BRANCHES = [
+  { id: "felin", name: "Biblioteka Felin", code: "48" },
+  { id: "bronowice", name: "Biblioteka Bronowice", code: "7" }
+];

--- a/src/hooks/__tests__/useConfig.test.ts
+++ b/src/hooks/__tests__/useConfig.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useConfig } from '../useConfig';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('useConfig', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('fetches config on mount', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ isSyncing: false }) }) // health
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ hasNotionKey: true, hasDatabaseId: true }) }); // config
+    
+    (global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(JSON.stringify({ properties: {} })) }); // schema
+
+    const { result } = renderHook(() => useConfig());
+
+    await waitFor(() => expect(result.current.configStatus.loading).toBe(false));
+    expect(result.current.configStatus.hasNotionKey).toBe(true);
+    
+    await waitFor(() => expect(result.current.schema).not.toBe(null));
+    expect(result.current.schema.properties).toBeDefined();
+  });
+});

--- a/src/hooks/__tests__/useStats.test.ts
+++ b/src/hooks/__tests__/useStats.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useStats } from '../useStats';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('useStats', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('fetches stats on mount', async () => {
+    const mockStats = { authorStats: [] };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockStats)
+    });
+
+    const { result } = renderHook(() => useStats());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.stats).toEqual(mockStats);
+  });
+
+  it('handles fetch error', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false
+    });
+
+    const { result } = renderHook(() => useStats());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Błąd podczas pobierania statystyk');
+  });
+});

--- a/src/hooks/__tests__/useSync.test.ts
+++ b/src/hooks/__tests__/useSync.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSync } from '../useSync';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('useSync', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('initializes with correct state', () => {
+    const { result } = renderHook(() => useSync('/api/sync', '/api/stop'));
+    expect(result.current.state.loading).toBe(false);
+    expect(result.current.state.result).toBe(null);
+    expect(result.current.state.error).toBe(null);
+  });
+
+  it('starts sync and handles SSE events', async () => {
+    const encoder = new TextEncoder();
+    const mockReader = {
+      read: vi.fn()
+        .mockResolvedValueOnce({ value: encoder.encode('data: {"type": "status", "message": "Test Status"}\n\n'), done: false })
+        .mockResolvedValueOnce({ value: encoder.encode('data: {"type": "complete", "result": {"success": true}}\n\n'), done: false })
+        .mockResolvedValueOnce({ value: undefined, done: true })
+    };
+
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => mockReader
+      }
+    });
+
+    const { result } = renderHook(() => useSync('/api/sync', '/api/stop'));
+
+    await act(async () => {
+      result.current.startSync();
+    });
+
+    await waitFor(() => expect(result.current.state.loading).toBe(false), { timeout: 2000 });
+    expect(result.current.state.result).toEqual({ success: true });
+    expect(result.current.state.statusMessage).toBe(null);
+  });
+
+  it('handles errors during sync', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Server Error' })
+    });
+
+    const { result } = renderHook(() => useSync('/api/sync', '/api/stop'));
+
+    await act(async () => {
+      result.current.startSync();
+    });
+
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+    expect(result.current.state.error).toBe('Server Error');
+  });
+});

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useConfig() {
+  const [configStatus, setConfigStatus] = useState({
+    hasNotionKey: false,
+    hasDatabaseId: false,
+    loading: true,
+  });
+
+  const [schema, setSchema] = useState<any>(null);
+  const [schemaLoading, setSchemaLoading] = useState(false);
+  const [schemaError, setSchemaError] = useState<string | null>(null);
+
+  const fetchConfig = useCallback(() => {
+    fetch("/api/health")
+      .then((res) => res.json())
+      .then((data) => {
+        fetch("/api/config")
+          .then(res => res.json())
+          .then(configData => {
+            setConfigStatus({ ...configData, isSyncing: data.isSyncing, loading: false });
+          });
+      })
+      .catch(console.error);
+  }, []);
+
+  const fetchSchema = useCallback(async () => {
+    setSchemaLoading(true);
+    setSchemaError(null);
+    try {
+      const res = await fetch("/api/notion/schema");
+      const text = await res.text();
+      
+      if (!text) {
+        throw new Error(`Pusta odpowiedź z serwera (Status: ${res.status})`);
+      }
+      
+      let data;
+      try {
+        data = JSON.parse(text);
+      } catch (e) {
+        throw new Error(`Otrzymano nieprawidłową odpowiedź z serwera (Status: ${res.status}). Spróbuj odświeżyć stronę.`);
+      }
+
+      if (res.ok) {
+        setSchema(data);
+      } else {
+        setSchemaError(data.error || "Wystąpił błąd API");
+      }
+    } catch (err: any) {
+      setSchemaError(err.message);
+    } finally {
+      setSchemaLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  useEffect(() => {
+    if (configStatus.hasNotionKey && configStatus.hasDatabaseId) {
+      fetchSchema();
+    }
+  }, [configStatus.hasNotionKey, configStatus.hasDatabaseId, fetchSchema]);
+
+  return { configStatus, schema, schemaLoading, schemaError, fetchSchema, fetchConfig };
+}

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -1,0 +1,124 @@
+import { useState, useCallback } from "react";
+
+export interface IdentifiedBooks {
+  [libraryId: string]: { title: string; author: string; year?: number | null }[];
+}
+
+export function useLibraryCheck() {
+  const [identifiedBooks, setIdentifiedBooks] = useState<IdentifiedBooks>({});
+  const [checkingLibrary, setCheckingLibrary] = useState<string | null>(null);
+  const [checkProgress, setCheckProgress] = useState<{ current: number; total: number; message: string; startTime: number | null } | null>(null);
+  const [libraryError, setLibraryError] = useState<string | null>(null);
+
+  const checkLibrary = useCallback(async (libraryId: string, libraryCode: string) => {
+    if (checkingLibrary) return;
+    setCheckingLibrary(libraryId);
+    setIdentifiedBooks(prev => ({ ...prev, [libraryId]: [] }));
+    setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
+    setLibraryError(null);
+    
+    return new Promise<void>(async (resolve, reject) => {
+      try {
+        const response = await fetch("/api/library-check", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ libraryCode })
+        });
+
+        if (!response.ok) throw new Error("Błąd podczas sprawdzania biblioteki");
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          resolve();
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value);
+          const lines = chunk.split("\n");
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const data = JSON.parse(line.substring(6));
+              if (data.type === "progress") {
+                setCheckProgress(prev => ({ 
+                  current: data.current, 
+                  total: data.total, 
+                  message: data.message,
+                  startTime: prev?.startTime || Date.now()
+                }));
+              } else if (data.type === "status") {
+                setCheckProgress(prev => ({ 
+                  current: prev?.current || 0, 
+                  total: prev?.total || 0, 
+                  message: data.message,
+                  startTime: prev?.startTime || Date.now()
+                }));
+              } else if (data.type === "match") {
+                setIdentifiedBooks(prev => {
+                  const currentLibraryBooks = prev[libraryId] || [];
+                  // Check if already exists to avoid duplicates (though server shouldn't send them)
+                  if (currentLibraryBooks.some(b => (b as any).id === data.result.id)) return prev;
+                  return {
+                    ...prev,
+                    [libraryId]: [...currentLibraryBooks, data.result]
+                  };
+                });
+              } else if (data.type === "complete") {
+                setIdentifiedBooks(prev => ({
+                  ...prev,
+                  [libraryId]: data.result.results
+                }));
+              } else if (data.type === "error") {
+                throw new Error(data.error);
+              }
+            }
+          }
+        }
+        resolve();
+      } catch (err: any) {
+        setLibraryError(err.message);
+        resolve(); // Resolve anyway so the next library can be checked
+      } finally {
+        setCheckingLibrary(null);
+        setCheckProgress(null);
+      }
+    });
+  }, [checkingLibrary]);
+
+  const stopLibraryCheck = useCallback(async () => {
+    try {
+      await fetch("/api/library-check/stop", { method: "POST" });
+    } catch (err) {
+      console.error("Error stopping library check:", err);
+    }
+  }, []);
+
+  const checkAllLibraries = useCallback(async (branches: { id: string; code: string }[]) => {
+    if (checkingLibrary) return;
+    
+    for (const branch of branches) {
+      // Need to await the completion of each check.
+      // Since checkLibrary sets state and doesn't return a promise that resolves on completion,
+      // we need to wrap the fetch logic or modify checkLibrary to return a promise.
+      // For simplicity, we'll implement the sequential check here or modify checkLibrary.
+      await checkLibrary(branch.id, branch.code);
+      // Wait a moment between libraries
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }, [checkingLibrary, checkLibrary]);
+
+  return { 
+    identifiedBooks, 
+    checkingLibrary, 
+    checkProgress, 
+    libraryError, 
+    checkLibrary, 
+    checkAllLibraries,
+    stopLibraryCheck 
+  };
+}

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface AuthorStat {
+  name: string;
+  read: number;
+  total: number;
+  books: { id: string; title: string; year?: number | null; read: boolean }[];
+}
+
+export interface AwardCoverageStat {
+  name: string;
+  count: number;
+  total: number;
+}
+
+export interface YearlyStat {
+  year: string;
+  read: number;
+  total: number;
+  books: { id: string; title: string; author: string; read: boolean }[];
+}
+
+export interface Stats {
+  authorStats: AuthorStat[];
+  awardBooksStats: { read: number; total: number };
+  ownedUnread: { id: string; title: string; author: string; year?: number | null }[];
+  awardCoverage: AwardCoverageStat[];
+  allAwardsStats: { read: number; total: number };
+  yearlyStats: YearlyStat[];
+  libraryStats: {
+    id: string;
+    name: string;
+    books: { id: string; title: string; author: string; year?: number | null; read: boolean }[];
+  }[];
+}
+
+export interface IdentifiedBooks {
+  [libraryId: string]: { id: string; title: string; author: string; year?: number | null }[];
+}
+
+export function useStats() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/stats?t=${Date.now()}`);
+      if (!res.ok) throw new Error("Błąd podczas pobierania statystyk");
+      const data = await res.json();
+      setStats(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  return { stats, loading, error, fetchStats };
+}

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,0 +1,141 @@
+import { useState, useCallback } from "react";
+import { SyncState, SyncEvent } from "../types";
+
+export function useSync(endpoint: string, stopEndpoint: string, initialState: Partial<SyncState> = {}) {
+  const [state, setState] = useState<SyncState>({
+    loading: false,
+    result: null,
+    error: null,
+    statusMessage: null,
+    progress: null,
+    startTime: null,
+    ...initialState
+  });
+
+  const stopSync = useCallback(async () => {
+    try {
+      const res = await fetch(stopEndpoint, { method: "POST" });
+      const data = await res.json();
+      if (!data.success) {
+        console.warn(data.message);
+      }
+    } catch (err) {
+      console.error("Błąd zatrzymywania synchronizacji:", err);
+    }
+  }, [stopEndpoint]);
+
+  const startSync = useCallback(async (params: any = {}, onComplete?: (result: any) => any, initialStatus: string | null = "Inicjowanie połączenia...") => {
+    setState(prev => ({ 
+      ...prev, 
+      loading: true, 
+      error: null, 
+      result: null, 
+      statusMessage: initialStatus, 
+      progress: null, 
+      startTime: Date.now() 
+    }));
+
+    try {
+      const fetchOptions: RequestInit = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      };
+      
+      if (params && Object.keys(params).length > 0) {
+        fetchOptions.body = JSON.stringify(params);
+      }
+
+      const res = await fetch(endpoint, fetchOptions);
+      
+      if (!res.ok) {
+        let errorMessage = `Błąd serwera: ${res.status}`;
+        try {
+          const errorData = await res.json();
+          errorMessage = errorData.error || errorMessage;
+        } catch (e) {
+          // If not JSON, use default message
+        }
+        throw new Error(errorMessage);
+      }
+      
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n\n');
+          buffer = lines.pop() || "";
+          
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              try {
+                const data: SyncEvent = JSON.parse(line.substring(6));
+                
+                if (data.type === "status") {
+                  setState(prev => ({ ...prev, statusMessage: data.message }));
+                } else if (data.type === "progress") {
+                  setState(prev => ({ 
+                    ...prev, 
+                    statusMessage: data.message,
+                    progress: { current: data.current, total: data.total }
+                  }));
+                } else if (data.type === "complete") {
+                  const finalResult = onComplete ? onComplete(data.result) : data.result;
+                  setState(prev => ({ 
+                    ...prev, 
+                    result: finalResult, 
+                    statusMessage: null, 
+                    progress: null,
+                    loading: false
+                  }));
+                  return finalResult;
+                } else if (data.type === "error") {
+                  setState(prev => ({ 
+                    ...prev, 
+                    error: data.error, 
+                    loading: false,
+                    statusMessage: null,
+                    progress: null
+                  }));
+                  return false;
+                }
+              } catch (e) {
+                console.error("Błąd parsowania SSE:", e);
+              }
+            }
+          }
+        }
+      }
+      return true;
+    } catch (err: any) {
+      console.error(`Sync error for ${endpoint}:`, err);
+      setState(prev => ({ 
+        ...prev, 
+        error: err.message, 
+        loading: false, 
+        statusMessage: null, 
+        progress: null 
+      }));
+      return false;
+    }
+  }, [endpoint]);
+
+  const reset = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      loading: false,
+      result: null,
+      error: null,
+      statusMessage: null,
+      progress: null,
+      startTime: null
+    }));
+  }, []);
+
+  return { state, setState, startSync, stopSync, reset, endpoint };
+}

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -1,0 +1,131 @@
+import { useState, useCallback } from "react";
+
+export interface VintedResult {
+  id: string;
+  title: string;
+  author: string;
+  searchUrl?: string;
+  vintedItems: {
+    id?: string;
+    title: string;
+    price: string | number;
+    currency: string;
+    url: string;
+  }[];
+}
+
+export interface VintedSearchAttempt {
+  id: string;
+  title: string;
+  author: string;
+  url: string;
+  status: "pending" | "success" | "no_results" | "blocked" | "error";
+  itemCount: number;
+}
+
+export function useVintedCheck() {
+  const [vintedResults, setVintedResults] = useState<VintedResult[]>([]);
+  const [searchAttempts, setSearchAttempts] = useState<VintedSearchAttempt[]>([]);
+  const [isChecking, setIsChecking] = useState(false);
+  const [checkProgress, setCheckProgress] = useState<{ current: number; total: number; message: string; startTime: number | null } | null>(null);
+  const [vintedError, setVintedError] = useState<string | null>(null);
+
+  const runVintedCheck = useCallback(async () => {
+    if (isChecking) return;
+    setIsChecking(true);
+    setVintedResults([]);
+    setSearchAttempts([]);
+    setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
+    setVintedError(null);
+    
+    try {
+      const response = await fetch("/api/vinted-check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" }
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || `Błąd serwera: ${response.status}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        setIsChecking(false);
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value);
+        const lines = chunk.split("\n");
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            const data = JSON.parse(line.substring(6));
+            if (data.type === "progress") {
+              setCheckProgress(prev => ({ 
+                current: data.current, 
+                total: data.total, 
+                message: data.message,
+                startTime: prev?.startTime || Date.now()
+              }));
+            } else if (data.type === "status") {
+              setCheckProgress(prev => ({ 
+                current: prev?.current || 0, 
+                total: prev?.total || 0, 
+                message: data.message,
+                startTime: prev?.startTime || Date.now()
+              }));
+            } else if (data.type === "match") {
+              setVintedResults(prev => {
+                if (prev.some(r => r.id === data.result.id)) return prev;
+                return [...prev, data.result];
+              });
+            } else if (data.type === "search_attempt") {
+              setSearchAttempts(prev => {
+                const existing = prev.findIndex(a => a.id === data.result.id);
+                if (existing !== -1) {
+                  const next = [...prev];
+                  next[existing] = data.result;
+                  return next;
+                }
+                return [...prev, data.result];
+              });
+            } else if (data.type === "complete") {
+              setVintedResults(data.result.results);
+            } else if (data.type === "error") {
+              throw new Error(data.error);
+            }
+          }
+        }
+      }
+    } catch (err: any) {
+      setVintedError(err.message);
+    } finally {
+      setIsChecking(false);
+      setCheckProgress(null);
+    }
+  }, [isChecking]);
+
+  const stopVintedCheck = useCallback(async () => {
+    try {
+      await fetch("/api/vinted-check/stop", { method: "POST" });
+    } catch (err) {
+      console.error("Error stopping Vinted check:", err);
+    }
+  }, []);
+
+  return { 
+    vintedResults, 
+    searchAttempts,
+    isChecking, 
+    checkProgress, 
+    vintedError, 
+    runVintedCheck, 
+    stopVintedCheck 
+  };
+}

--- a/src/hooks/useWikiUpdates.ts
+++ b/src/hooks/useWikiUpdates.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+
+export interface WikiLink {
+  name: string;
+  url: string;
+  title: string;
+}
+
+export function useWikiUpdates(wikiLinks: WikiLink[], enabled: boolean) {
+  const [wikiUpdates, setWikiUpdates] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (enabled) {
+      wikiLinks.forEach(async (link) => {
+        try {
+          const res = await fetch(`/api/wiki/last-update?title=${encodeURIComponent(link.title)}`);
+          const data = await res.json();
+          if (data.lastUpdate) {
+            setWikiUpdates(prev => ({ ...prev, [link.name]: data.lastUpdate }));
+          }
+        } catch (error) {
+          console.error(`Failed to fetch update for ${link.name}:`, error);
+        }
+      });
+    }
+  }, [enabled]);
+
+  return wikiUpdates;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,38 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
+@import "tailwindcss";
+
+@theme {
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Space Grotesk", sans-serif;
+}
+
+body {
+  @apply bg-slate-950 text-slate-200 antialiased selection:bg-cyan-500/30 selection:text-white;
+  overflow-x: hidden;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(56, 189, 248, 0.3); /* cyan-400 with opacity */
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(56, 189, 248, 0.5);
+}
+
+.glass-card {
+  @apply bg-slate-900/40 backdrop-blur-xl border border-white/10 shadow-2xl shadow-cyan-500/5;
+}
+
+.text-gradient {
+  @apply bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-purple-600;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/test/setup.tsx
+++ b/src/test/setup.tsx
@@ -1,0 +1,183 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Mocking global objects if needed
+global.fetch = vi.fn();
+
+// Mocking ParticleBackground
+vi.mock('../components/ParticleBackground', () => ({
+  ParticleBackground: () => <div data-testid="particle-background" />
+}));
+
+// Mocking Framer Motion to avoid animation issues in tests
+vi.mock('motion/react', async (importOriginal) => {
+  const React = await import('react');
+  const motionProps = ['whileHover', 'whileTap', 'initial', 'animate', 'exit', 'transition', 'layout', 'variants'];
+  
+  const createMotionComponent = (tag: string) => {
+    return React.forwardRef(({ children, ...props }: any, ref) => {
+      const cleanProps = { ...props };
+      motionProps.forEach(p => delete cleanProps[p]);
+      return React.createElement(tag, { ...cleanProps, ref }, children);
+    });
+  };
+
+  return {
+    motion: {
+      div: createMotionComponent('div'),
+      span: createMotionComponent('span'),
+      button: createMotionComponent('button'),
+      h1: createMotionComponent('h1'),
+      h2: createMotionComponent('h2'),
+      h3: createMotionComponent('h3'),
+      p: createMotionComponent('p'),
+      section: createMotionComponent('section'),
+      header: createMotionComponent('header'),
+      a: createMotionComponent('a'),
+    },
+    AnimatePresence: ({ children }: any) => children,
+  };
+});
+
+// Mocking window.matchMedia
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // deprecated
+      removeListener: vi.fn(), // deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+// Mocking fetch and streaming response
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mocking ReadableStream if not available or for better control
+class MockReadableStream {
+  onData: any;
+  constructor(options: any) {
+    if (options && options.start) {
+      options.start({
+        enqueue: (chunk: any) => {
+          if (this.onData) this.onData(chunk);
+        },
+        close: () => {},
+        error: (err: any) => {}
+      });
+    }
+  }
+  getReader() {
+    const chunks: any[] = [];
+    let resolveRead: any;
+    
+    this.onData = (chunk: any) => {
+      if (resolveRead) {
+        resolveRead({ value: chunk, done: false });
+        resolveRead = null;
+      } else {
+        chunks.push(chunk);
+      }
+    };
+
+    return {
+      read: () => {
+        if (chunks.length > 0) {
+          return Promise.resolve({ value: chunks.shift(), done: false });
+        }
+        return new Promise(resolve => {
+          resolveRead = resolve;
+        });
+      },
+      releaseLock: () => {}
+    };
+  }
+}
+
+(global as any).ReadableStream = MockReadableStream;
+vi.stubGlobal('ReadableStream', MockReadableStream);
+
+let lastStreamController: any = null;
+(global as any).getLastStreamController = () => lastStreamController;
+(global as any).setLastStreamController = (controller: any) => { 
+  lastStreamController = controller; 
+};
+(global as any).resetLastStreamController = () => { 
+  lastStreamController = null; 
+};
+
+// Helper to push events to the stream
+(global as any).pushStreamEvent = (type: string, data: any) => {
+  if (lastStreamController) {
+    const eventString = `data: ${JSON.stringify({ type, ...data })}\n\n`;
+    lastStreamController.enqueue(new TextEncoder().encode(eventString));
+  }
+};
+
+// Mocking Firebase
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(),
+  collection: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  getDocs: vi.fn(() => Promise.resolve({ docs: [] })),
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  doc: vi.fn(),
+  getDoc: vi.fn(() => Promise.resolve({ exists: () => false, data: () => ({}) })),
+  deleteDoc: vi.fn(),
+  onSnapshot: vi.fn(() => vi.fn()), // Returns unsubscribe function
+  getDocFromServer: vi.fn(() => Promise.resolve({ exists: () => false })),
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => ({
+    currentUser: { uid: 'test-user' },
+    onAuthStateChanged: vi.fn((cb) => {
+      cb({ uid: 'test-user' });
+      return vi.fn();
+    }),
+  })),
+  signInWithPopup: vi.fn(),
+  GoogleAuthProvider: vi.fn(),
+}));
+
+vi.mock('../firebase', () => ({
+  db: {},
+  auth: {
+    currentUser: { uid: 'test-user' },
+    onAuthStateChanged: vi.fn((cb) => {
+      cb({ uid: 'test-user' });
+      return vi.fn();
+    }),
+  },
+}));
+
+// Mocking Google GenAI
+vi.mock('@google/genai', () => {
+  return {
+    GoogleGenAI: class {
+      models = {
+        generateContent: vi.fn().mockResolvedValue({
+          text: JSON.stringify([{ title: "Solaris - Stanislaw Lem", price: "45 PLN", link: "https://vinted.pl/123" }])
+        })
+      };
+    }
+  };
+});
+
+// Mocking Lucide icons
+vi.mock('lucide-react', async () => {
+  const actual = await vi.importActual('lucide-react');
+  return {
+    ...actual as any,
+    // Add specific mocks if needed
+  };
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,100 @@
+export interface Book {
+  year: string;
+  author: string;
+  polishTitle: string;
+  originalTitle: string;
+  polishTitleLink: string | null;
+  award: string;
+  awards?: string[];
+}
+
+export interface NotionRichTextItem {
+  plain_text: string;
+  href?: string | null;
+  text?: { content: string; link?: { url: string } | null };
+}
+
+export interface NotionProperty {
+  id?: string;
+  type?: string;
+  title?: NotionRichTextItem[];
+  rich_text?: NotionRichTextItem[];
+  number?: number;
+  select?: { name: string; color?: string } | null;
+  multi_select?: { name: string; color?: string }[];
+  checkbox?: boolean;
+  url?: string | null;
+  name?: string;
+}
+
+export interface NotionPageProperties {
+  [key: string]: NotionProperty;
+}
+
+export interface NotionPage {
+  id: string;
+  properties: NotionPageProperties;
+}
+
+export interface NotionBook {
+  id: string;
+  plTitle: string;
+  origTitle: string;
+  awards: string[];
+  year?: string;
+  author?: string;
+  currentWydawnictwo?: string;
+  currentSeria?: string;
+  currentCzesccyklu?: boolean;
+  lp?: string;
+  zrodlo?: string[];
+  plTitleRichText?: NotionRichTextItem[];
+  origTitleRichText?: NotionRichTextItem[];
+}
+
+export interface SyncState {
+  loading: boolean;
+  result: any | null;
+  error: string | null;
+  statusMessage: string | null;
+  progress: { current: number; total: number } | null;
+  startTime: number | null;
+  awardName?: string;
+  pageTitle?: string;
+  isSyncAll?: boolean;
+  color?: string;
+}
+
+export interface SyncEvent {
+  type: "status" | "progress" | "complete" | "error";
+  message?: string;
+  error?: string;
+  current?: number;
+  total?: number;
+  result?: any;
+}
+
+export interface SyncParams {
+  awardName?: string;
+  pageTitle?: string;
+  syncAll?: boolean;
+}
+
+export interface IntegrityCheckResult {
+  lpUniqueness: { status: boolean; duplicates: string[] };
+  yearCountMatch: { 
+    status: boolean; 
+    diffs: { 
+      year: string; 
+      notion: number; 
+      wiki: number;
+      notionOnly?: string[];
+      wikiOnly?: string[];
+      misplaced?: { title: string, otherYear: string }[];
+      collisions?: { title: string, matches: string[] }[];
+    }[] 
+  };
+  originalTitleUniqueness: { status: boolean; duplicates: string[] };
+  polishTitleUniqueness: { status: boolean; duplicates: string[] };
+  awardCountMatch: { status: boolean; diffs: { award: string; notion: number; wiki: number }[] };
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,14 @@
+export const formatETA = (current: number, total: number, startTime: number | null) => {
+  if (!startTime || current <= 0 || current >= total) return null;
+  const elapsed = Date.now() - startTime;
+  const estimatedTotal = (elapsed / current) * total;
+  const remaining = estimatedTotal - elapsed;
+  
+  const seconds = Math.floor((remaining / 1000) % 60);
+  const minutes = Math.floor((remaining / (1000 * 60)) % 60);
+  
+  if (minutes > 0) {
+    return `pozostało: ~${minutes}m ${seconds}s`;
+  }
+  return `pozostało: ~${seconds}s`;
+};

--- a/test-compare.ts
+++ b/test-compare.ts
@@ -1,0 +1,32 @@
+const existingBook = {
+  id: "1",
+  plTitle: "Diuna",
+  origTitle: "Dune",
+  awards: ["Nagroda Hugo", "Nagroda Nebula"]
+};
+
+const book = {
+  polishTitle: "Diuna",
+  originalTitle: "Dune",
+  awards: ["Nagroda Hugo", "Nagroda Nebula"]
+};
+
+const newAwards = book.awards || [];
+const existingAwards = existingBook.awards || [];
+let awardsUpdated = false;
+const combinedAwards = [...existingAwards];
+for (const aw of newAwards) {
+  if (!combinedAwards.includes(aw)) {
+    combinedAwards.push(aw);
+    awardsUpdated = true;
+  }
+}
+const hasHugo = combinedAwards.includes("Nagroda Hugo");
+const hasNebula = combinedAwards.includes("Nagroda Nebula");
+const hasLocus = combinedAwards.includes("Nagroda Locus");
+if (hasHugo && hasNebula && hasLocus && !combinedAwards.includes("Wszystkie")) {
+  combinedAwards.push("Wszystkie");
+  awardsUpdated = true;
+}
+
+console.log({ awardsUpdated, combinedAwards });

--- a/test-merge.ts
+++ b/test-merge.ts
@@ -1,0 +1,20 @@
+const allBooksToSync = [
+  { polishTitle: "Diuna", originalTitle: "Dune", award: "Nagroda Hugo", awards: [] as string[] },
+  { polishTitle: "Diuna", originalTitle: "Dune", award: "Nagroda Nebula", awards: [] as string[] }
+];
+
+const mergedBooksMap = new Map();
+for (const book of allBooksToSync) {
+  const key = (book.polishTitle || book.originalTitle || "").trim().toLowerCase();
+  if (!key) continue;
+  if (mergedBooksMap.has(key)) {
+    const existing = mergedBooksMap.get(key);
+    if (!existing.awards?.includes(book.award)) existing.awards?.push(book.award);
+  } else {
+    book.awards = [book.award];
+    mergedBooksMap.set(key, book);
+  }
+}
+
+const booksToSync = Array.from(mergedBooksMap.values());
+console.log(JSON.stringify(booksToSync, null, 2));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "allowJs": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,84 @@
+export interface Book {
+  year: string;
+  author: string;
+  polishTitle: string;
+  originalTitle: string;
+  polishTitleLink: string | null;
+  award: string;
+  awards?: string[];
+}
+
+export interface NotionBook {
+  id: string;
+  plTitle: string;
+  origTitle: string;
+  awards: string[];
+  year?: string;
+  author?: string;
+  currentWydawnictwo?: string;
+  currentSeria?: string;
+  currentCzesccyklu?: boolean;
+  lp?: string;
+}
+
+export interface SyncState {
+  loading: boolean;
+  result: any | null;
+  error: string | null;
+  statusMessage: string | null;
+  progress: { current: number; total: number } | null;
+  startTime: number | null;
+  awardName?: string;
+  pageTitle?: string;
+  isSyncAll?: boolean;
+  color?: string;
+}
+
+export interface SyncEvent {
+  type: "status" | "progress" | "complete" | "error";
+  message?: string;
+  error?: string;
+  current?: number;
+  total?: number;
+  result?: any;
+}
+
+export interface SyncParams {
+  awardName?: string;
+  pageTitle?: string;
+  syncAll?: boolean;
+}
+
+export interface IntegrityCheckResult {
+  lpUniqueness: { status: boolean; duplicates: string[] };
+  yearCountMatch: { 
+    status: boolean; 
+    diffs: { 
+      year: string; 
+      notion: number; 
+      wiki: number;
+      notionOnly?: string[];
+      wikiOnly?: string[];
+      misplaced?: { title: string, otherYear: string }[];
+    }[] 
+  };
+  originalTitleUniqueness: { status: boolean; duplicates: string[] };
+  polishTitleUniqueness: { status: boolean; duplicates: string[] };
+  awardCountMatch: { 
+    status: boolean; 
+    diffs: { 
+      award: string; 
+      notion: number; 
+      wiki: number;
+      notionOnly?: string[];
+      wikiOnly?: string[];
+    }[] 
+  };
+  cycleCountMatch: { 
+    status: boolean; 
+    notionCount: number; 
+    wikiCount: number;
+    notionOnly?: string[];
+    wikiOnly?: string[];
+  };
+}

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,109 @@
+export function cleanTitle(title: string): string {
+  if (!title) return "";
+  return title.replace(/\s+/g, ' ').trim();
+}
+
+export function sanitizeNotionString(s: string, maxLength: number = 2000): string {
+  if (!s) return "";
+  // Notion doesn't like some control characters or very long strings
+  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, '')
+          .replace(/\s+/g, ' ')
+          .trim()
+          .substring(0, maxLength);
+}
+
+export function sanitizeNotionTag(s: string): string {
+  if (!s) return "";
+  // Notion multi-select/select options cannot contain commas and have a 100 char limit
+  return s.replace(/,/g, '')
+          .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, '')
+          .replace(/\s+/g, ' ')
+          .trim()
+          .substring(0, 100);
+}
+
+export function isValidUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function stripWikiFormatting(title: string): string {
+  if (!title) return "";
+  return title
+    .replace(/''+/g, '') // Remove wiki italics/bold
+    .replace(/\[\[([^\]|]+\|)?([^\]]+)\]\]/g, '$2') // Remove wiki links, keep text
+    .replace(/\s+/g, ' ') // Normalize spaces
+    .trim();
+}
+
+export function calculateSimilarity(s1: string, s2: string): number {
+  const longer = s1.length > s2.length ? s1 : s2;
+  const shorter = s1.length > s2.length ? s2 : s1;
+  if (longer.length === 0) return 1.0;
+  
+  const costs = new Array();
+  for (let i = 0; i <= shorter.length; i++) {
+    let lastValue = i;
+    for (let j = 0; j <= longer.length; j++) {
+      if (i === 0) costs[j] = j;
+      else {
+        if (j > 0) {
+          let newValue = costs[j - 1];
+          if (shorter.charAt(i - 1) !== longer.charAt(j - 1))
+            newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+          costs[j - 1] = lastValue;
+          lastValue = newValue;
+        }
+      }
+    }
+    if (i > 0) costs[longer.length] = lastValue;
+  }
+  return (longer.length - costs[longer.length]) / parseFloat(longer.length.toString());
+}
+
+export function countCommonWords(title1: string, title2: string): number {
+  const STOP_WORDS = new Set(['w', 'na', 'nad', 'pod', 'z', 'ze', 'i', 'a', 'o', 'do', 'dla', 'od', 'the', 'a', 'an', 'of', 'in', 'on', 'at', 'to', 'for', 'and', 'with']);
+  
+  const getSignificantWords = (title: string) => 
+    new Set(title.toLowerCase().split(/\s+/).filter(w => w.length > 2 && !STOP_WORDS.has(w)));
+
+  const words1 = getSignificantWords(title1);
+  const words2 = getSignificantWords(title2);
+  
+  let common = 0;
+  for (const w1 of words1) {
+    if (words2.has(w1)) common++;
+  }
+  return common;
+}
+
+export function normalizeAuthor(author: string): string {
+  if (!author) return "";
+  
+  // Remove years in parentheses like (1968- ) or (1968-2020)
+  let normalized = author.replace(/\(\d{4}-\s*\d*\)/g, '');
+  
+  // Remove other parentheses and their contents
+  normalized = normalized.replace(/\(.*?\)/g, '');
+  
+  // Convert to lowercase
+  normalized = normalized.toLowerCase();
+  
+  // Handle "Last, First" format
+  if (normalized.includes(',')) {
+    const parts = normalized.split(',').map(p => p.trim());
+    if (parts.length === 2) {
+      normalized = `${parts[1]} ${parts[0]}`;
+    }
+  }
+  
+  // Remove special characters and extra spaces
+  normalized = normalized.replace(/[^\w\s\u0100-\u017F]/g, '').replace(/\s+/g, ' ').trim();
+  
+  return normalized;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,29 @@
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import {defineConfig, loadEnv} from 'vite';
+
+export default defineConfig(({mode}) => {
+  const env = loadEnv(mode, '.', '');
+  return {
+    plugins: [react(), tailwindcss()],
+    define: {
+      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '.'),
+      },
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/test/setup.tsx'],
+    },
+    server: {
+      // HMR is disabled in AI Studio via DISABLE_HMR env var.
+      // Do not modifyâfile watching is disabled to prevent flickering during agent edits.
+      hmr: process.env.DISABLE_HMR !== 'true',
+    },
+  };
+});

--- a/wiki.adapter.ts
+++ b/wiki.adapter.ts
@@ -1,0 +1,241 @@
+import axios from "axios";
+import http from "http";
+import https from "https";
+import { withRetry } from "./retry";
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+
+const wikiAxios = axios.create({
+  httpAgent,
+  httpsAgent,
+  timeout: 30000,
+  headers: {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'Accept': 'application/json, text/plain, */*',
+    'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7'
+  }
+});
+
+export class WikiAdapter {
+  private readonly baseUrl = "https://encyklopediafantastyki.pl/api.php";
+
+  async fetchPageContent(title: string): Promise<string> {
+    try {
+      const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
+        params: {
+          action: "query",
+          prop: "revisions",
+          rvprop: "content",
+          titles: title,
+          redirects: 1,
+          format: "json",
+          formatversion: 2
+        }
+      }), 3, 2000);
+
+      const pages = response.data.query.pages;
+      const pageId = Object.keys(pages)[0];
+      const page = pages[pageId];
+
+      if (!page || !page.revisions || pageId === "-1") {
+        console.warn(`Nie znaleziono strony "${title}" w encyklopedii.`);
+        return "";
+      }
+
+      return page.revisions[0]["*"];
+    } catch (error: any) {
+      console.warn(`Błąd pobierania strony "${title}": ${error.message} (zablokowane IP?)`);
+      return "";
+    }
+  }
+
+  async fetchPageContentWithSlots(title: string): Promise<string> {
+    try {
+      const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
+        params: {
+          action: "query",
+          prop: "revisions",
+          rvprop: "content",
+          rvslots: "main",
+          titles: title,
+          redirects: 1,
+          format: "json"
+        }
+      }), 3, 2000);
+
+      const pages = response.data.query.pages;
+      const pageId = Object.keys(pages)[0];
+
+      if (pageId === "-1") {
+        console.warn(`Nie znaleziono strony "${title}" w encyklopedii.`);
+        return "";
+      }
+
+      const rev = pages[pageId].revisions[0];
+      return rev.slots?.main?.["*"] || rev["*"] || rev.content || "";
+    } catch (error: any) {
+      console.warn(`Błąd pobierania strony "${title}": ${error.message} (zablokowane IP?)`);
+      return "";
+    }
+  }
+
+  async fetchPagesContentBulk(titles: string[]): Promise<Record<string, string>> {
+    const results: Record<string, string> = {};
+    
+    // MediaWiki API allows up to 50 titles per request
+    const chunkSize = 50;
+    for (let i = 0; i < titles.length; i += chunkSize) {
+      const chunk = titles.slice(i, i + chunkSize);
+      const titlesParam = chunk.join('|');
+      
+      try {
+        const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
+          params: {
+            action: "query",
+            prop: "revisions",
+            rvprop: "content",
+            rvslots: "main",
+            titles: titlesParam,
+            redirects: 1,
+            format: "json"
+          }
+        }), 3, 2000);
+
+        const pages = response.data.query?.pages;
+        if (pages) {
+          for (const pageId of Object.keys(pages)) {
+            const page = pages[pageId];
+            if (pageId !== "-1" && page.revisions && page.revisions.length > 0) {
+              const rev = page.revisions[0];
+              const content = rev.slots?.main?.["*"] || rev["*"] || rev.content || "";
+              results[page.title.toLowerCase()] = content;
+            }
+          }
+        }
+        
+        // Map normalized titles back to original requested titles
+        const normalized = response.data.query?.normalized;
+        if (normalized) {
+          for (const norm of normalized) {
+            if (results[norm.to.toLowerCase()]) {
+              results[norm.from.toLowerCase()] = results[norm.to.toLowerCase()];
+            }
+          }
+        }
+
+        // Map redirects back to original requested titles
+        const redirects = response.data.query?.redirects;
+        if (redirects) {
+          for (const redir of redirects) {
+            if (results[redir.to.toLowerCase()]) {
+              results[redir.from.toLowerCase()] = results[redir.to.toLowerCase()];
+            }
+          }
+        }
+      } catch (error: any) {
+        if (error.response?.status === 403) {
+          console.warn(`Wiki API 403 Forbidden dla bulk fetch. Prawdopodobnie blokada IP.`);
+        } else {
+          console.warn(`Error fetching bulk pages:`, error.message);
+        }
+        // Continue with other chunks even if one fails
+      }
+    }
+    
+    return results;
+  }
+
+  async searchPage(query: string, limit: number = 3): Promise<string[]> {
+    try {
+      const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
+        params: {
+          action: "query",
+          list: "search",
+          srsearch: query,
+          srlimit: limit,
+          format: "json"
+        }
+      }), 3, 2000);
+
+      const results = response.data.query?.search;
+      if (results && results.length > 0) {
+        return results.map((r: any) => r.title);
+      }
+      return [];
+    } catch (error: any) {
+      console.warn(`Błąd wyszukiwania "${query}": ${error.message} (zablokowane IP?)`);
+      return [];
+    }
+  }
+
+  async fetchCategoryMembers(category: string): Promise<string[]> {
+    let allTitles: string[] = [];
+    let cmcontinue: string | undefined = undefined;
+
+    try {
+      do {
+        const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
+          params: {
+            action: "query",
+            list: "categorymembers",
+            cmtitle: category,
+            cmlimit: 500,
+            cmcontinue: cmcontinue,
+            format: "json",
+            formatversion: 2
+          }
+        }), 3, 2000);
+
+        const members = response.data.query.categorymembers;
+        if (members) {
+          allTitles = allTitles.concat(members.map((m: any) => m.title));
+        }
+
+        cmcontinue = response.data.continue?.cmcontinue;
+      } while (cmcontinue);
+
+      return allTitles;
+    } catch (error: any) {
+      console.warn(`Błąd pobierania kategorii "${category}": ${error.message} (zablokowane IP?)`);
+      return [];
+    }
+  }
+
+  async fetchLastRevisionDate(title: string): Promise<string> {
+    try {
+      const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
+        params: {
+          action: "query",
+          prop: "revisions",
+          rvprop: "timestamp",
+          titles: title,
+          format: "json",
+          formatversion: 2
+        }
+      }), 3, 2000);
+
+      const query = response.data.query;
+      if (!query || !query.pages) return "Nieznana";
+
+      const pages = query.pages;
+      const page = Array.isArray(pages) ? pages[0] : pages[Object.keys(pages)[0]];
+
+      if (!page || page.missing || page.invalid) {
+        return "Nieznana";
+      }
+
+      const timestamp = page.revisions?.[0]?.timestamp;
+      if (!timestamp) return "Nieznana";
+
+      return new Date(timestamp).toLocaleDateString("pl-PL", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit"
+      });
+    } catch (error: any) {
+      console.warn(`Wiki API error for "${title}": ${error.message}`);
+      return "Nieznana"; // Graceful degradation for 403 Forbidden / blocks
+    }
+  }
+}

--- a/wiki.parser.ts
+++ b/wiki.parser.ts
@@ -1,0 +1,238 @@
+export class WikiParser {
+  static cleanWikitext(text: string): string {
+    if (!text) return "";
+    return text
+      .replace(/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g, '$1')
+      .replace(/\{\{sortname\|([^|}]+)\|([^|}]+)(?:\|[^}]+)?\}\}/gi, '$1 $2')
+      .replace(/\{\{Autor\|([^|}]+)(?:\|[^}]*)?\}\}/gi, '$1')
+      .replace(/<br\s*\/?>/gi, ' ')
+      .replace(/<[^>]+>/g, '')
+      .replace(/''+/g, '')
+      .replace(/\{\{[^}]+\}\}/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  static extractPublisherAndSeries(wikitext: string): { wydawca: string, seria: string } {
+    let wydawca = "";
+    let seria = "";
+
+    // 1. Pobierz wartości ogólne z {{Książka}} (jako fallback)
+    const wydawcaMatch = wikitext.match(/\|\s*wydawca\s*=\s*([^\n|]+)/i);
+    if (wydawcaMatch) wydawca = this.cleanWikitext(wydawcaMatch[1]);
+
+    const seriaMatch = wikitext.match(/\|\s*seria\s*=\s*([^\n|]+)/i);
+    if (seriaMatch) seria = this.cleanWikitext(seriaMatch[1]);
+
+    // 2. Pobierz wartości z {{tabela wydania}} (infowydanie) - priorytet dla najwyższego N z danymi
+    const infoRegex = /\|\s*informacja(\d+)\s*=\s*\{\{infowydanie\s*\|([\s\S]*?)\}\}/gi;
+    
+    let match;
+    const infos: { n: number, content: string }[] = [];
+    while ((match = infoRegex.exec(wikitext)) !== null) {
+      infos.push({ n: parseInt(match[1], 10), content: match[2] });
+    }
+
+    // Sortuj od najwyższego N, aby znaleźć najnowsze wydanie z danymi
+    infos.sort((a, b) => b.n - a.n);
+
+    for (const info of infos) {
+      const infoWydawcaMatch = info.content.match(/wydawca\s*=\s*([^|]+)/i);
+      const infoSeriaMatch = info.content.match(/seria\s*=\s*([^|]+)/i);
+
+      const foundWydawca = infoWydawcaMatch ? this.cleanWikitext(infoWydawcaMatch[1]) : "";
+      const foundSeria = infoSeriaMatch ? this.cleanWikitext(infoSeriaMatch[1]) : "";
+
+      if (foundWydawca || foundSeria) {
+        if (foundWydawca) wydawca = foundWydawca;
+        if (foundSeria) seria = foundSeria;
+        // Znaleźliśmy najnowsze wydanie z danymi, przerywamy szukanie głębiej
+        break;
+      }
+    }
+
+    return { wydawca, seria };
+  }
+
+  static extractAuthor(wikitext: string): string {
+    // Look for autor, twórca, or redaktor in infoboxes
+    const authorRegex = /\|\s*(autor|twórca|redaktor|scenariusz|tekst)\s*=\s*([^\n|]+)/gi;
+    let match;
+    let authors: string[] = [];
+    
+    while ((match = authorRegex.exec(wikitext)) !== null) {
+      let rawAuthor = match[2];
+      rawAuthor = rawAuthor.replace(/\{\{sortname\|([^|}]+)\|([^|}]+)(?:\|[^}]+)?\}\}/gi, '$1 $2');
+      rawAuthor = rawAuthor.replace(/\{\{Autor\|([^|}]+)(?:\|[^}]*)?\}\}/gi, '$1');
+      authors.push(this.cleanWikitext(rawAuthor));
+    }
+    
+    if (authors.length > 0) return authors.join(", ");
+
+    // Fallback: look for author in the first paragraph if no infobox match
+    const firstPara = wikitext.split('\n').find(l => l.trim().length > 50 && !l.trim().startsWith('{') && !l.trim().startsWith('|'));
+    if (firstPara) {
+      const authorLinkMatch = firstPara.match(/\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/);
+      if (authorLinkMatch) return authorLinkMatch[2] || authorLinkMatch[1];
+    }
+
+    return "";
+  }
+
+  static checkCycle(wikitext: string): boolean {
+    if (!wikitext) return false;
+    
+    // 1. Parameters in infoboxes
+    const hasCycleParam = /\|\s*(cykl(e)?|seria)\s*=\s*[^\s|}]/i.test(wikitext);
+    if (hasCycleParam) return true;
+    
+    // 2. Templates
+    const hasCycleTemplate = /\{\{(C|c)ykl\s*\|/i.test(wikitext);
+    if (hasCycleTemplate) return true;
+    
+    const hasSeriaTemplate = /\{\{(S|s)eria\s*\|/i.test(wikitext);
+    if (hasSeriaTemplate) return true;
+    
+    // 3. Specific Cycle/Series Infoboxes
+    const hasCycleInfobox = /\{\{(Cykl|Seria)\s+infobox/i.test(wikitext);
+    if (hasCycleInfobox) return true;
+    
+    // 4. Categories (excluding general lists)
+    const hasCycleCategory = /\[\[Kategoria:\s*(Cykl|Seria)(?!e)/i.test(wikitext);
+    if (hasCycleCategory) return true;
+    
+    return false;
+  }
+
+  static extractBooksFromAwardTable(wikitext: string, awardName: string): any[] {
+    const books: any[] = [];
+    let processedWikitext = wikitext;
+    
+    // Ignorowanie wybranych tabel dla nagrody Locus
+    if (awardName === "Nagroda Locus") {
+      processedWikitext = processedWikitext.replace(/={2,}\s*Zwycięzcy w kategorii Powieść dla młodzieży\s*={2,}[^]*?(?=\n==|$)/i, '');
+    }
+
+    let cleanedWiki = processedWikitext
+      .replace(/\{\{sortname\|([^|}]+)\|([^|}]+)(?:\|[^}]+)?\}\}/gi, '$1 $2')
+      .replace(/<br\s*\/?>/gi, ' ')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\|\}[\s\S]*?\{\|[^\n]*\n/g, '\n|-\n');
+
+    const rows = cleanedWiki.split(/\|-/);
+    let lastYear = "";
+    
+    let colMap = {
+      rok: 0,
+      autor: 1,
+      tytulOryginalny: 2,
+      tytulPolski: 3,
+      expectedLength: 4
+    };
+
+    const parseCell = (cell: string, extractLink = false, extractItalics = false) => {
+      if (!cell) return extractLink ? { text: "", link: null } : "";
+      let text = cell.trim();
+
+      // Remove table cell attributes (e.g., rowspan="2"|, style="..."|, etc.)
+      // Attributes are separated from content by a single pipe '|'.
+      // We only strip if the part before '|' contains an '=' and doesn't contain brackets.
+      const pipeIndex = text.indexOf('|');
+      if (pipeIndex > 0) {
+        const potentialAttr = text.substring(0, pipeIndex);
+        if (potentialAttr.includes('=') && !potentialAttr.includes('[[') && !potentialAttr.includes('{{')) {
+          text = text.substring(pipeIndex + 1).trim();
+        }
+      }
+
+      let link = null;
+
+      if (extractLink) {
+        const linkMatch = text.match(/\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/);
+        if (linkMatch) {
+          link = linkMatch[1];
+          text = linkMatch[2] || linkMatch[1];
+        } else {
+          text = text.replace(/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g, '$1');
+        }
+      } else {
+        text = text.replace(/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g, '$1');
+      }
+
+      if (extractItalics) {
+        const italicMatch = text.match(/''([^']+)''/);
+        if (italicMatch) {
+          text = italicMatch[1];
+        }
+      }
+
+      text = text.replace(/''+/g, '')
+                 .replace(/\{\{[^}]+\}\}/g, '')
+                 .replace(/<[^>]+>/g, '')
+                 .trim();
+
+      return extractLink ? { text, link } : text;
+    };
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i].trim();
+      if (!row || row.startsWith('!')) continue;
+
+      const cells = row.split(/\n\||\|\|/).map(c => c.replace(/^\|/, '').trim());
+      
+      if (cells.length === 0) continue;
+
+      let yearCell = cells[0];
+      let yearMatch = yearCell.match(/\[\[(\d{4})\]\]/);
+      if (!yearMatch) yearMatch = yearCell.match(/(\d{4})/);
+      
+      let year = yearMatch ? yearMatch[1] : "";
+      
+      if (year && cells.length < colMap.expectedLength) {
+        lastYear = year;
+        continue;
+      }
+
+      if (!year && lastYear) {
+        year = lastYear;
+      } else if (year) {
+        lastYear = year;
+      }
+
+      let authorIndex = colMap.autor;
+      let origTitleIndex = colMap.tytulOryginalny;
+      let plTitleIndex = colMap.tytulPolski;
+
+      if (cells.length === colMap.expectedLength - 1 && lastYear) {
+        authorIndex--;
+        origTitleIndex--;
+        plTitleIndex--;
+      }
+
+      const author = parseCell(cells[authorIndex]) as string;
+      const origTitleData = parseCell(cells[origTitleIndex], true, true) as { text: string, link: string | null };
+      const plTitleData = parseCell(cells[plTitleIndex], true, true) as { text: string, link: string | null };
+
+      let origTitle = origTitleData.text;
+      let plTitle = plTitleData.text;
+      
+      if (!origTitle && !plTitle) continue;
+
+      if (origTitle && !plTitle && awardName === "Nagroda im. Janusza A. Zajdla") {
+        plTitle = origTitle;
+        origTitle = "";
+      }
+
+      books.push({
+        rok: year,
+        autor: author,
+        tytulOryginalny: origTitle,
+        tytulPolski: plTitle,
+        linkOryginalny: origTitleData.link,
+        linkPolski: plTitleData.link
+      });
+    }
+
+    return books;
+  }
+}


### PR DESCRIPTION
## Summary

- Import the full application source: Vite + Express hybrid (React 19 frontend, Express backend), sync services, Notion/MediaWiki adapters, `/docs` algorithm documentation, and the Vitest test suite
- Add `CLAUDE.md` with an architecture map, commands, and pointers to `COGITATOR_GUIDELINES.md` and `/docs` as required reading
- Add a SessionStart hook (`.claude/hooks/session-start.sh` + `.claude/settings.json`) that runs `npm install` in Claude Code on the web sessions so tests and type-checking work out of the box
- Update the `wiki.adapter` test to match the implementation's graceful-degradation behavior (`fetchPageContent` returns an empty string for missing pages instead of throwing)
- Ignore `*.tsbuildinfo` build artifacts

## Validation

- `npm test`: 22 test files, 79/79 tests passing
- `npm run lint` (`tsc --noEmit`): clean
- Session hook validated by direct execution with `CLAUDE_CODE_REMOTE=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_