### PR TITLE
Make production server deployable on Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx server.ts",
     "start": "node dist/server.cjs",
-    "build": "vite build && esbuild server.ts --bundle --platform=node --target=node18 --outfile=dist/server.cjs --format=cjs",
+    "build": "vite build && esbuild server.ts --bundle --platform=node --target=node18 --external:vite --outfile=dist/server.cjs --format=cjs",
     "preview": "vite preview",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: cogitator-omnissiah
+    runtime: node
+    plan: free
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    healthCheckPath: /api/health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: NOTION_API_KEY
+        sync: false
+      - key: NOTION_DATABASE_ID
+        sync: false
+      - key: GEMINI_API_KEY
+        sync: false

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import { createServer as createViteServer } from "vite";
 import path from "path";
 import { NotionAdapter } from "./notion.adapter";
 import { WikiAdapter } from "./wiki.adapter";
@@ -584,12 +583,14 @@ export const app = express();
 app.use(express.json());
 app.use("/api", syncRoutes);
 
-const PORT = 3000;
+const PORT = parseInt(process.env.PORT || "3000", 10);
 let server: any;
 
 export async function startServer() {
   // Vite middleware for development
   if (process.env.NODE_ENV !== "production" && !process.env.VITEST) {
+    // Dynamic import keeps vite out of the production bundle
+    const { createServer: createViteServer } = await import("vite");
     const vite = await createViteServer({
       server: { middlewareMode: true },
       appType: "spa",


### PR DESCRIPTION
## Summary

- Read the listen port from the `PORT` env var (Render assigns it at runtime), falling back to 3000 locally
- Load vite via dynamic import in dev only and mark it `--external:vite` in the esbuild bundle — the statically bundled vite crashed the production server on startup (`ERR_INVALID_URL` from `import.meta` resolution in CJS) and bloated `dist/server.cjs` from 5.6 MB to 1.5 MB
- Add a `render.yaml` blueprint: Node web service, `npm install && npm run build` / `npm start`, health check on `/api/health`, env var placeholders for `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `GEMINI_API_KEY`

## Validation

- `npm run build` + `NODE_ENV=production PORT=10000 node dist/server.cjs`: server binds to the assigned port; `/api/health` and the frontend both return 200
- `npm test`: 79/79 passing; `npm run lint` (`tsc --noEmit`): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_