### PR TITLE
Polish round: remaining code-review findings

### DIFF
--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -7,6 +7,7 @@ export class NotionAdapter {
   private notion: Client;
   private actualDataSourceId: string | null = null;
   private isDataSource: boolean = true;
+  private initPromise: Promise<void> | null = null;
 
   constructor(apiKey: string, private databaseId: string) {
     this.notion = new Client({ auth: apiKey });
@@ -14,16 +15,26 @@ export class NotionAdapter {
 
   async init(): Promise<void> {
     if (this.actualDataSourceId) return; // Already initialized
+    // Deduplikuj równoległe wywołania init() — jedna inicjalizacja w locie
+    if (!this.initPromise) {
+      this.initPromise = this.doInit().catch((err) => {
+        this.initPromise = null; // pozwól spróbować ponownie po błędzie
+        throw err;
+      });
+    }
+    return this.initPromise;
+  }
 
+  private async doInit(): Promise<void> {
     try {
-      // Try as data_source first
-      await (this.notion as any).dataSources.retrieve({ data_source_id: this.databaseId });
+      // Try as data_source first (withRetry nie ponawia 404 — tylko 429/5xx/sieć)
+      await withRetry(() => (this.notion as any).dataSources.retrieve({ data_source_id: this.databaseId }));
       this.actualDataSourceId = this.databaseId;
       this.isDataSource = true;
     } catch (e: any) {
       // Fallback to database
       try {
-        const database = await this.notion.databases.retrieve({ database_id: this.databaseId }) as any;
+        const database = await withRetry(() => this.notion.databases.retrieve({ database_id: this.databaseId })) as any;
         if (database.data_sources && database.data_sources.length > 0) {
           this.actualDataSourceId = database.data_sources[0].id;
           this.isDataSource = true;
@@ -33,7 +44,11 @@ export class NotionAdapter {
           this.isDataSource = false;
         }
       } catch (dbError: any) {
-        throw new Error(`Nie można znaleźć bazy danych ani źródła danych o ID: ${this.databaseId}. Upewnij się, że integracja ma dostęp.`);
+        // "Brak dostępu" tylko przy prawdziwym 404 — timeout to nie problem uprawnień
+        if (dbError?.code === "object_not_found" || dbError?.status === 404) {
+          throw new Error(`Nie można znaleźć bazy danych ani źródła danych o ID: ${this.databaseId}. Upewnij się, że integracja ma dostęp.`);
+        }
+        throw new Error(`Błąd połączenia z Notion podczas inicjalizacji: ${dbError?.message || dbError}`);
       }
     }
   }
@@ -210,36 +225,10 @@ export class NotionAdapter {
     return allBooks;
   }
 
-  async getBooksForStats(onProgress?: (count: number) => void): Promise<NotionBook[]> {
-    await this.init();
-    const allBooks: NotionBook[] = [];
-    let hasMore = true;
-    let nextCursor: string | undefined = undefined;
-
-    while (hasMore) {
-      let response: any;
-      if (this.isDataSource) {
-        response = await withRetry(() => (this.notion as any).dataSources.query({
-          data_source_id: this.actualDataSourceId!,
-          start_cursor: nextCursor,
-        }));
-      } else {
-        response = await withRetry(() => (this.notion.databases as any).query({
-          database_id: this.actualDataSourceId!,
-          start_cursor: nextCursor,
-        }));
-      }
-
-      for (const page of response.results) {
-        allBooks.push(this.parseNotionPageToBook(page as NotionPage));
-      }
-
-      hasMore = response.has_more;
-      nextCursor = response.next_cursor ?? undefined;
-      if (onProgress) onProgress(allBooks.length);
-    }
-
-    return allBooks;
+  async getBooksForStats(onProgress?: (count: number) => void, checkCancellation?: () => boolean): Promise<NotionBook[]> {
+    // Ta sama pętla co queryAllBooks — jedna implementacja, żeby skany
+    // biblioteki/Vinted też dało się anulować w fazie pobierania z Notion
+    return this.queryAllBooks(onProgress, checkCancellation);
   }
 
   buildPropertyValue(value: string, type: string): any {

--- a/server.ts
+++ b/server.ts
@@ -140,7 +140,7 @@ class SyncManager {
   async checkLibraryAvailability(libraryCode: string, sendEvent: (data: any) => void) {
     await this.executeTask('library', async (checkCancellation) => {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-      const allBooks = await this.notion.getBooksForStats();
+      const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation);
       
       // Filter books that are NOT (Przeczytane, Biblioteka, Biblioteka 9, Posiadam)
       const candidates = allBooks.filter(b => {
@@ -278,7 +278,7 @@ class SyncManager {
     await this.executeTask('vinted', async (checkCancellation) => {
       try {
         sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-        const allBooks = await this.notion.getBooksForStats();
+        const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation);
         
         // Filter books:
         // - Have Polish title
@@ -376,6 +376,9 @@ class SyncManager {
               type: "search_attempt",
               result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
             });
+            // Odczekaj jak przy każdym innym zapytaniu — pomijanie opóźnienia
+            // przy braku wyników (częsty przypadek) to prosta droga do blokady
+            await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
             continue;
           }
           

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -90,9 +90,14 @@ export class BookSyncService {
       }
 
       if (cells.length === 1) {
-        if (books.length > 0) {
-          let extraAuthor = parseCell(cells[0]) as string;
-          extraAuthor = extraAuthor.replace(/\s*\(remis\)/gi, '').trim();
+        const cellText = parseCell(cells[0]) as string;
+        const yearOnly = cellText.replace(/['\[\]]/g, '').trim().match(/^(\d{4})$/);
+        if (yearOnly) {
+          // Wiersz zawierający wyłącznie rok (rowspan) — to nowy rocznik,
+          // nie dodatkowy autor poprzedniej książki
+          lastYear = yearOnly[1];
+        } else if (books.length > 0) {
+          const extraAuthor = cellText.replace(/\s*\(remis\)/gi, '').trim();
           books[books.length - 1].author += ", " + extraAuthor;
         }
         continue;

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -89,7 +89,7 @@ export class DuplicateSyncService {
         }
         
         if (i % 10 === 0 || i === allBooks.length - 1) {
-          sendEvent({ type: "progress", message: "Sprawdzanie duplikatów...", current: i, total: allBooks.length });
+          sendEvent({ type: "progress", message: "Sprawdzanie duplikatów...", current: i + 1, total: allBooks.length });
         }
       }
       

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -65,6 +65,11 @@ export class IntegrityService {
           .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
           .replace(/\s{2,}/g, " ")
           .trim();
+
+        // Pusty tytuł → pusty klucz, żeby .filter(Boolean) go odrzucił.
+        // Klucz "|autor" scalałby różne książki tego samego autora.
+        if (!normTitle) return "";
+
         return `${normTitle}|${normAuthor}`;
       };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,9 +350,10 @@ export default function App() {
 
               {/* Sync Summary Result */}
               <AnimatePresence>
-                <SyncSummaryResult 
+                <SyncSummaryResult
                   syncs={syncs}
                   fullSyncResults={fullSyncResults}
+                  onClearFullResults={() => setFullSyncResults(null)}
                 />
               </AnimatePresence>
 

--- a/src/components/IntegrityCheckCard.tsx
+++ b/src/components/IntegrityCheckCard.tsx
@@ -96,9 +96,11 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {checks.map((check) => (
           <div key={check.id} className="relative">
-            <div 
+            <button
+              type="button"
               onClick={() => toggleExpand(check.id)}
-              className={`flex flex-col p-2 rounded-xl border transition-all cursor-pointer ${
+              aria-expanded={expanded === check.id}
+              className={`w-full flex flex-col p-2 rounded-xl border transition-all cursor-pointer text-left ${
                 result ? (check.status ? 'bg-emerald-500/5 border-emerald-500/10' : 'bg-rose-500/5 border-rose-500/20 animate-pulse') : 'bg-slate-950/30 border-slate-800/50'
               } hover:border-slate-600`}
             >
@@ -115,8 +117,8 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
                   {renderStatus(check.status)}
                 </div>
               )}
-            </div>
-            
+            </button>
+
             <AnimatePresence>
               {expanded === check.id && check.details.length > 0 && (
                 <motion.div

--- a/src/components/ProgressAndResults.tsx
+++ b/src/components/ProgressAndResults.tsx
@@ -18,7 +18,7 @@ export const ProgressAndResults: React.FC<ProgressAndResultsProps> = ({
   const state = activeSync.state;
   const color = state.color || "cyan";
   const progress = state.progress || { current: 0, total: 1 };
-  const percent = Math.round((progress.current / progress.total) * 100);
+  const percent = progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
 
   // Map color names to Tailwind classes
   const colorMap: Record<string, { text: string, border: string, bg: string, shadow: string }> = {

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -173,7 +173,10 @@ export function SchemaEditor({ schema, onSchemaUpdated }: SchemaEditorProps) {
         Konfiguracja Systemowa Kolumn
       </h3>
       <div className="space-y-5">
-        {Object.entries(schema).sort((a, b) => a[0].localeCompare(b[0])).map(([key, value]: [string, any], index) => {
+        {schema._empty && (
+          <p className="text-xs text-slate-500 font-mono">{(schema._empty as any).type}</p>
+        )}
+        {Object.entries(schema).filter(([key]) => key !== "_empty").sort((a, b) => a[0].localeCompare(b[0])).map(([key, value]: [string, any], index) => {
           const isSelectType = value.type === 'multi_select' || value.type === 'select';
           const options = isSelectType ? [...(value[value.type]?.options || [])].sort((a, b) => a.name.localeCompare(b.name)) : [];
           const isOverLimit = options.length >= NOTION_OPTION_LIMIT;

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -106,8 +106,8 @@ export const StatsSection: React.FC = () => {
             Indeks Autorów
           </h3>
           <div className="space-y-4 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.authorStats.map((author, idx) => (
-              <AuthorProgressItem key={idx} author={author} />
+            {stats.authorStats.map((author) => (
+              <AuthorProgressItem key={author.name} author={author} />
             ))}
           </div>
         </motion.div>
@@ -167,8 +167,8 @@ export const StatsSection: React.FC = () => {
             Chronologia Przeczytanych
           </h3>
           <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.yearlyStats.map((year, idx) => (
-              <YearlyProgressItem key={idx} year={year} />
+            {stats.yearlyStats.map((year) => (
+              <YearlyProgressItem key={year.year} year={year} />
             ))}
           </div>
         </motion.div>
@@ -232,9 +232,9 @@ export const StatsSection: React.FC = () => {
             Książki dostępne w bibliotekach
           </h3>
           <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.libraryStats.map((library, idx) => (
+            {stats.libraryStats.map((library) => (
               <LibraryProgressItem 
-                key={idx} 
+                key={library.id} 
                 library={library} 
                 onMarkAsRead={handleMarkAsRead}
                 markingId={markingId}

--- a/src/components/SyncSummaryResult.tsx
+++ b/src/components/SyncSummaryResult.tsx
@@ -3,14 +3,26 @@ import { XCircle, CheckCircle2, RefreshCw, AlertCircle, Copy, Check } from "luci
 import { motion } from "motion/react";
 import { useSync } from "../hooks/useSync";
 
+const stepDotColorMap: Record<string, string> = {
+  emerald: "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]",
+  amber: "bg-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.5)]",
+  cyan: "bg-cyan-500 shadow-[0_0_8px_rgba(6,182,212,0.5)]",
+  blue: "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)]",
+  rose: "bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.5)]",
+  indigo: "bg-indigo-500 shadow-[0_0_8px_rgba(99,102,241,0.5)]",
+  purple: "bg-purple-500 shadow-[0_0_8px_rgba(168,85,247,0.5)]",
+};
+
 interface SyncSummaryResultProps {
   syncs: ReturnType<typeof useSync>[];
   fullSyncResults?: any[] | null;
+  onClearFullResults?: () => void;
 }
 
 export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
   syncs,
-  fullSyncResults
+  fullSyncResults,
+  onClearFullResults
 }) => {
   const [copied, setCopied] = useState(false);
   
@@ -26,10 +38,8 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
     const allDuplicates = fullSyncResults.flatMap(curr => curr.result?.summary?.duplicates || []);
 
     const handleCloseFull = () => {
-      // In App.tsx we should probably have a way to clear this, 
-      // but for now we can just reset all syncs which is what handleClose does
       syncs.forEach(s => s.setState(prev => ({ ...prev, result: null })));
-      // Note: fullSyncResults is managed by App.tsx, so we might need a prop to clear it
+      onClearFullResults?.();
     };
 
     return (
@@ -43,8 +53,8 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
             <h3 className="text-xl font-bold font-display text-cyan-400 uppercase tracking-widest">Podsumowanie Wielkiego Rytuału</h3>
             <p className="text-[10px] text-slate-500 uppercase font-bold tracking-widest mt-1">Pełna Synchronizacja Archiwów Zakończona</p>
           </div>
-          <button 
-            onClick={() => window.location.reload()} // Simplest way to clear everything for now or just wait for next sync
+          <button
+            onClick={handleCloseFull}
             className="text-slate-500 hover:text-slate-200 transition-colors"
             title="Zamknij podsumowanie"
           >
@@ -69,10 +79,11 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
         <div className="space-y-4">
           <h4 className="text-xs font-bold text-slate-400 uppercase tracking-[0.3em] mb-4">Szczegóły Poszczególnych Kroków</h4>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-            {fullSyncResults.map((res, i) => (
-              <div key={i} className="p-3 rounded-xl bg-slate-900/40 border border-slate-800/50 flex items-center justify-between">
+            {fullSyncResults.map((res) => (
+              <div key={res.name} className="p-3 rounded-xl bg-slate-900/40 border border-slate-800/50 flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                  <div className={`w-2 h-2 rounded-full bg-${res.color}-500 shadow-[0_0_8px_rgba(var(--${res.color}-500-rgb),0.5)]`} />
+                  {/* Tailwind nie generuje klas budowanych dynamicznie — mapuj statycznie */}
+                  <div className={`w-2 h-2 rounded-full ${stepDotColorMap[res.color] || stepDotColorMap.cyan}`} />
                   <span className="text-xs font-bold text-slate-300 uppercase tracking-wider">{res.name}</span>
                 </div>
                 <div className="text-[10px] font-mono text-slate-500">
@@ -168,7 +179,7 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
             {[
               { label: "Dodano", count: summary.added?.length || 0, color: "text-emerald-400", bg: "bg-emerald-500/10" },
-              { label: "Zaktualizowano", count: (summary.updated?.length || 0) + (activeResult.updated || 0) - (summary.updated?.length || 0), color: theme.text, bg: theme.bg },
+              { label: "Zaktualizowano", count: activeResult.updated || summary.updated?.length || 0, color: theme.text, bg: theme.bg },
               { label: "Pominięto", count: summary.skipped?.length || 0, color: "text-slate-400", bg: "bg-slate-500/10" },
               { label: "Duplikaty", count: summary.duplicates?.length || 0, color: "text-amber-400", bg: "bg-amber-500/10" }
             ].map((stat, i) => (

--- a/src/components/stats/AuthorProgressItem.tsx
+++ b/src/components/stats/AuthorProgressItem.tsx
@@ -11,9 +11,11 @@ export const AuthorProgressItem: React.FC<{ author: any }> = ({ author }) => {
 
   return (
     <div className="space-y-2">
-      <div 
+      <button
+        type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-1 rounded-lg transition-colors group"
+        aria-expanded={isExpanded}
+        className="w-full flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-1 rounded-lg transition-colors group text-left"
       >
         <div className="flex items-center gap-2 text-slate-400 group-hover:text-cyan-400 transition-colors">
           <User className="w-3 h-3" />
@@ -21,7 +23,7 @@ export const AuthorProgressItem: React.FC<{ author: any }> = ({ author }) => {
           {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         </div>
         <div className="text-slate-200">{author.read} / {author.total} ({percent}%)</div>
-      </div>
+      </button>
       <div className="h-2 bg-slate-950 rounded-full overflow-hidden border border-slate-800 p-0.5">
         <motion.div 
           initial={{ width: 0 }}

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -42,14 +42,16 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
       <div 
         className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter p-2 rounded-xl border border-slate-800/50 bg-slate-900/20"
       >
-        <div 
+        <button
+          type="button"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-2 text-slate-400 cursor-pointer hover:text-blue-400 transition-colors flex-1"
+          aria-expanded={isExpanded}
+          className="flex items-center gap-2 text-slate-400 cursor-pointer hover:text-blue-400 transition-colors flex-1 text-left"
         >
           <Search className="w-4 h-4" />
           <span className="text-sm">{library.name}</span>
           {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-        </div>
+        </button>
         
         <div className="flex items-center gap-3">
           {books.length > 0 && (

--- a/src/components/stats/LibraryProgressItem.tsx
+++ b/src/components/stats/LibraryProgressItem.tsx
@@ -13,9 +13,11 @@ export const LibraryProgressItem: React.FC<LibraryProgressItemProps> = ({ librar
 
   return (
     <div className="space-y-4">
-      <div 
+      <button
+        type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-2 rounded-xl transition-colors group border border-transparent hover:border-blue-500/20"
+        aria-expanded={isExpanded}
+        className="w-full flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-2 rounded-xl transition-colors group border border-transparent hover:border-blue-500/20 text-left"
       >
         <div className="flex items-center gap-2 text-slate-400 group-hover:text-blue-400 transition-colors">
           <Library className="w-4 h-4" />
@@ -25,7 +27,7 @@ export const LibraryProgressItem: React.FC<LibraryProgressItemProps> = ({ librar
         <div className="text-slate-200 bg-blue-500/10 px-2 py-0.5 rounded-full border border-blue-500/20">
           {library.books.length}
         </div>
-      </div>
+      </button>
       
       {isExpanded && (
         <motion.div 

--- a/src/components/stats/YearlyProgressItem.tsx
+++ b/src/components/stats/YearlyProgressItem.tsx
@@ -8,9 +8,11 @@ export const YearlyProgressItem: React.FC<{ year: any }> = ({ year }) => {
 
   return (
     <div className="space-y-2">
-      <div 
+      <button
+        type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-1 rounded-lg transition-colors group"
+        aria-expanded={isExpanded}
+        className="w-full flex items-center justify-between text-xs font-bold uppercase tracking-tighter cursor-pointer hover:bg-slate-900/50 p-1 rounded-lg transition-colors group text-left"
       >
         <div className="flex items-center gap-2 text-slate-400 group-hover:text-orange-400 transition-colors">
           <Calendar className="w-3 h-3" />
@@ -18,7 +20,7 @@ export const YearlyProgressItem: React.FC<{ year: any }> = ({ year }) => {
           {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         </div>
         <div className="text-slate-200">{year.read} / {year.total} ({percent}%)</div>
-      </div>
+      </button>
       <div className="h-2 bg-slate-950 rounded-full overflow-hidden border border-slate-800 p-0.5">
         <motion.div 
           initial={{ width: 0 }}

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -1,8 +1,7 @@
 import { useState, useCallback, useRef } from "react";
+import { IdentifiedBooks } from "./useStats";
 
-export interface IdentifiedBooks {
-  [libraryId: string]: { title: string; author: string; year?: number | null }[];
-}
+export type { IdentifiedBooks };
 
 export function useLibraryCheck() {
   const [identifiedBooks, setIdentifiedBooks] = useState<IdentifiedBooks>({});
@@ -76,7 +75,7 @@ export function useLibraryCheck() {
                 setIdentifiedBooks(prev => {
                   const currentLibraryBooks = prev[libraryId] || [];
                   // Check if already exists to avoid duplicates (though server shouldn't send them)
-                  if (currentLibraryBooks.some(b => (b as any).id === data.result.id)) return prev;
+                  if (currentLibraryBooks.some(b => b.id === data.result.id)) return prev;
                   return {
                     ...prev,
                     [libraryId]: [...currentLibraryBooks, data.result]

--- a/src/hooks/useWikiUpdates.ts
+++ b/src/hooks/useWikiUpdates.ts
@@ -10,20 +10,23 @@ export function useWikiUpdates(wikiLinks: WikiLink[], enabled: boolean) {
   const [wikiUpdates, setWikiUpdates] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (enabled) {
-      wikiLinks.forEach(async (link) => {
-        try {
-          const res = await fetch(`/api/wiki/last-update?title=${encodeURIComponent(link.title)}`);
-          const data = await res.json();
-          if (data.lastUpdate) {
-            setWikiUpdates(prev => ({ ...prev, [link.name]: data.lastUpdate }));
-          }
-        } catch (error) {
-          console.error(`Failed to fetch update for ${link.name}:`, error);
+    if (!enabled) return;
+    let cancelled = false;
+
+    wikiLinks.forEach(async (link) => {
+      try {
+        const res = await fetch(`/api/wiki/last-update?title=${encodeURIComponent(link.title)}`);
+        const data = await res.json();
+        if (!cancelled && data.lastUpdate) {
+          setWikiUpdates(prev => ({ ...prev, [link.name]: data.lastUpdate }));
         }
-      });
-    }
-  }, [enabled]);
+      } catch (error) {
+        console.error(`Failed to fetch update for ${link.name}:`, error);
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [enabled, wikiLinks]);
 
   return wikiUpdates;
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -3,10 +3,14 @@ export const formatETA = (current: number, total: number, startTime: number | nu
   const elapsed = Date.now() - startTime;
   const estimatedTotal = (elapsed / current) * total;
   const remaining = estimatedTotal - elapsed;
-  
+
   const seconds = Math.floor((remaining / 1000) % 60);
   const minutes = Math.floor((remaining / (1000 * 60)) % 60);
-  
+  const hours = Math.floor(remaining / (1000 * 60 * 60));
+
+  if (hours > 0) {
+    return `pozostało: ~${hours}h ${minutes}m`;
+  }
   if (minutes > 0) {
     return `pozostało: ~${minutes}m ${seconds}s`;
   }


### PR DESCRIPTION
## Summary

Closes out the remaining findings from the code review (after the four main stages merged in #4).

**Backend**
- Integrity robust keys return `""` for empty titles so `filter(Boolean)` actually drops them — a `"|author"` key was cross-merging unrelated books by the same author in year counts
- Award-table parser treats a single-cell year row (rowspan layout) as a new year instead of appending e.g. "1953" to the previous book's author
- `notion.adapter.init()`: wrapped in `withRetry`, memoizes the in-flight promise, and shows the "check integration access" message only on a genuine 404 (a timeout no longer masquerades as a permissions problem); `getBooksForStats` delegates to `queryAllBooks`, making library/Vinted scans cancellable during the Notion fetch phase
- Vinted scanner waits the anti-bot delay on the no-results path (the common case was firing requests back-to-back — exactly what earns Cloudflare blocks)
- Duplicate-check progress reaches n/n instead of stopping at n-1

**Frontend**
- Full-sync summary closes via state instead of `window.location.reload()`; step dots use static Tailwind classes (dynamic `bg-${color}` classes were never generated by the compiler)
- All expandable panels are real `<button>` elements with `aria-expanded` — keyboard and screen-reader accessible
- Stats lists keyed by `name`/`year`/`id` instead of array index (expansion state stuck to positions after a refetch reorder)
- Shared `IdentifiedBooks` type with `id`; `formatETA` shows hours; NaN% guard for `total: 0`; `_empty` schema sentinel renders as a message instead of a bogus column card; `useWikiUpdates` gets correct deps and unmount cleanup

Deliberately skipped: the winner/`background` row-classification heuristic — the wiki is unreachable from this environment, so the change couldn't be verified against real award tables.

## Validation

- `npm test`: 22 files, 84/84 passing
- `npm run lint` (strict `tsc --noEmit`): clean
- Production build + smoke test: `/api/health` and frontend return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_