### PR TITLE
Filter empty infobox parameters in extractAuthor

### DIFF
--- a/__tests__/wiki.parser.test.ts
+++ b/__tests__/wiki.parser.test.ts
@@ -94,6 +94,11 @@ describe('WikiParser', () => {
       `;
       expect(WikiParser.extractAuthor(wikitext)).toBe('Stanisław Lem');
     });
+
+    it('ignores empty parameters like "redaktor = " (space before newline)', () => {
+      const wikitext = '{{Książka\n | autor           = Isaac Asimov\n | redaktor        = \n | autor okladki   = Chris Moore\n}}';
+      expect(WikiParser.extractAuthor(wikitext)).toBe('Isaac Asimov');
+    });
   });
 
 });

--- a/wiki.parser.ts
+++ b/wiki.parser.ts
@@ -66,7 +66,9 @@ export class WikiParser {
       let rawAuthor = match[2];
       rawAuthor = rawAuthor.replace(/\{\{sortname\|([^|}]+)\|([^|}]+)(?:\|[^}]+)?\}\}/gi, '$1 $2');
       rawAuthor = rawAuthor.replace(/\{\{Autor\|([^|}]+)(?:\|[^}]*)?\}\}/gi, '$1');
-      authors.push(this.cleanWikitext(rawAuthor));
+      const cleaned = this.cleanWikitext(rawAuthor);
+      // Pusty parametr (np. "| redaktor = " ze spacją) matchuje [^\n|]+ — odfiltruj
+      if (cleaned) authors.push(cleaned);
     }
     
     if (authors.length > 0) return authors.join(", ");


### PR DESCRIPTION
## Summary

While validating the parser against real wikitext from the encyclopedia (Hugo/Nebula/Locus award pages + a sample book page), one defect surfaced: an empty infobox parameter with trailing whitespace (`| redaktor = `) matched `extractAuthor`'s value pattern and produced a dangling `", "` in the extracted author string (`"Isaac Asimov, "`). Empty values are now filtered after cleaning, with a regression test based on the real "Kamyk na niebie" infobox.

Everything else in the parser validated cleanly against the real data: 395 Hugo / 377 Nebula / 167 Locus entries extracted with zero markup residue, correct winner/nomination classification (including ties), merged multi-author rows, rowspan year handling, the Retro Hugo extra column, and Locus YA exclusion.

## Validation

- `npm test`: 22 files, 85/85 passing
- `npm run lint` (strict): clean
- Harness run on real award-page wikitext confirms `extractAuthor` now returns `"Isaac Asimov"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_