### PR TITLE
Make latest edition fully authoritative for publisher/series

### DIFF
--- a/COGITATOR_GUIDELINES.md
+++ b/COGITATOR_GUIDELINES.md
@@ -26,7 +26,8 @@
 ## 3. DATA INTEGRITY & SYNC LOGIC
 - **Duplicate Detection**: Multi-signal (Title PL, Title Orig, Author Similarity, Common Words).
 - **Purification Ritual (SRP)**: Deep cleaning (Wiki syntax stripping, native Notion formatting removal) is EXCLUSIVE to `PurificationService`. `BookSyncService` stays with simple whitespace normalization to avoid scope creep.
-- **Wiki Parser Priority**: When extracting from `{{tabela wydania}}`, always pick the highest indexed `informacjaN` that is NOT empty. Fallback to `{{Książka}}` only if no valid `infowydanie` is found.
+- **Wiki Parser Priority**: When extracting from `{{tabela wydania}}`, always pick the highest indexed `informacjaN` that is NOT empty, and take both `wydawca` and `seria` from that single (latest) edition — never backfill an empty field from an older edition (the latest edition is authoritative so the data mirrors current reality). Fallback to `{{Książka}}` only if no valid `infowydanie` is found.
+- **Locus Categories**: Exclude only the YA category ("Powieść dla młodzieży"). All other Locus categories (incl. Horror/Dark Fantasy and Pierwsza powieść) are intentionally synced as "Nagroda Locus".
 - **Notion Schema**: Always check for column existence before writing. Handled by `SchemaValidationService`.
 - **Library Scan**: 30000ms timeout, 500ms delay, 4 retries. Fail-fast on network error. Uses `withRetry`.
 - **Vinted Scan**: 30000ms timeout, 3 retries, 3-5s delay with jitter.

--- a/__tests__/wiki.parser.test.ts
+++ b/__tests__/wiki.parser.test.ts
@@ -74,6 +74,20 @@ describe('WikiParser', () => {
       expect(result.seria).toBe('Klasyka');
     });
 
+    it('takes both fields from the latest edition and does not backfill series from an older one', () => {
+      // Decyzja projektowa: najnowsze wydanie jest miarodajne. Wydanie 2022 (Rebis)
+      // ma wydawcę, ale pustą serię — seria z wydania 1989 NIE ma się cofać.
+      const wikitext = `
+        {{tabela wydania
+        |informacja1={{infowydanie|wydawca= klubówka |seria= Wielkie Serie SF|isbn= }}
+        |informacja3={{infowydanie|wydawca= Rebis|seria= |isbn= 9788381885492}}
+        }}
+      `;
+      const result = WikiParser.extractPublisherAndSeries(wikitext);
+      expect(result.wydawca).toBe('Rebis');
+      expect(result.seria).toBe('');
+    });
+
     it('does not match wydawca inside współwydawca', () => {
       const wikitext = `
         {{tabela wydania

--- a/docs/book-sync.md
+++ b/docs/book-sync.md
@@ -13,7 +13,7 @@ Synchronizes book data from MediaWiki award tables (Hugo, Nebula, Locus) to a No
     - Removes table attributes (e.g., `rowspan`, `style`).
     - Strips wiki links `[[Page|Text]]` -> `Text`.
     - Extracts links for Polish titles to use as Notion URLs.
-    - Handles special cases like "Nagroda Locus" (skipping YA category if requested).
+    - Handles special cases like "Nagroda Locus": only the "Powieść dla młodzieży" (YA) category is excluded. All other Locus categories — Powieść, Powieść SF, Powieść fantasy, Pierwsza powieść, and Horror/Dark Fantasy — are intentionally included and tagged "Nagroda Locus".
 - **Normalization**: Original titles and authors are normalized using `dataNormalizer`.
 
 ## 3. Comparison & Update Logic (`compareBooks`)

--- a/docs/publisher-series-sync.md
+++ b/docs/publisher-series-sync.md
@@ -9,6 +9,8 @@ Extracts publisher and series information from individual book pages in the Arch
   - Scans for `informacjaN` where N is the highest index (e.g., `informacja3` > `informacja1`).
   - This ensures the *latest* Polish edition's data is used.
   - Extracts `wydawca` and `seria` from the `{{infowydanie}}` template.
+  - **Latest edition is authoritative (by design)**: the newest edition that has *any* value (publisher or series) wins, and both fields are taken from that one edition. If the newest edition has a publisher but no series, the series stays empty — the algorithm deliberately does NOT backfill the series from an older edition, so the data reflects the current-reality edition rather than a mix of editions. Do not "fix" this to merge fields across editions.
+  - Note: `współwydawca` / `podseria` and similar parameters are excluded (the match is anchored to the exact parameter name).
 - **Priority 2 (Fallback)**: `{{Książka}}` template.
   - Used only if no valid `infowydanie` is found.
   - Extracts `wydawca` and `seria` fields.

--- a/wiki.parser.ts
+++ b/wiki.parser.ts
@@ -46,9 +46,11 @@ export class WikiParser {
       const foundSeria = infoSeriaMatch ? this.cleanWikitext(infoSeriaMatch[1]) : "";
 
       if (foundWydawca || foundSeria) {
-        if (foundWydawca) wydawca = foundWydawca;
-        if (foundSeria) seria = foundSeria;
-        // Znaleźliśmy najnowsze wydanie z danymi, przerywamy szukanie głębiej
+        // Najnowsze wydanie z danymi jest miarodajne w całości — przypisz OBA pola,
+        // także puste. Nie pozwól, by seria ze starszego wydania (lub z globalnego
+        // fallbacku {{Książka}}) przeciekła, gdy najnowsze wydanie jej nie ma.
+        wydawca = foundWydawca;
+        seria = foundSeria;
         break;
       }
     }


### PR DESCRIPTION
## Summary

Validating the parser against the real "Kamyk na niebie" wiki page surfaced a latent, order-dependent defect in `extractPublisherAndSeries`. The old flow pre-filled `wydawca`/`seria` from a global scan (the `{{Książka}}` fallback, or whatever `seria=` appeared first in the text) and then let the latest `{{tabela wydania}}` edition overwrite only its **non-empty** fields. Consequence: when the newest edition had a publisher but no series, a series from an **older** edition (or the main infobox) could leak into the result — the opposite of "the latest edition reflects current reality."

Now, once an edition with any data is found, its `wydawca` **and** `seria` fully define the result (including empty). The `{{Książka}}` fallback only survives when no edition has data at all.

This aligns the code with the two design decisions you confirmed, both now documented in `docs/` and `COGITATOR_GUIDELINES.md` so they aren't "fixed" back later:
- **Publisher/series**: latest edition is authoritative; no cross-edition backfill.
- **Locus categories**: only YA ("Powieść dla młodzieży") is excluded; Horror, First-novel, SF, and Fantasy are intentionally synced.

## Validation

- New regression test: latest edition with an empty series yields an empty series (no backfill)
- Re-ran the parser harness against the real Kamyk page → `{wydawca: "Rebis", seria: ""}` (correct)
- `npm test`: 22 files, 86/86 passing; `npm run lint` (strict): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_