### PR TITLE
Add structured error logging and a diagnostics endpoint

### DIFF
--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from "express";
 import { syncManager } from "../server";
 import { SyncEvent, SyncParams } from "../src/types";
+import { createLogger } from "../logger";
+
+const log = createLogger("SyncController");
 
 export const getStats = async (req: Request, res: Response) => {
   try {
@@ -21,6 +24,17 @@ export const getWikiLastUpdate = async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error("Wiki Last Update Error:", error);
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania daty aktualizacji." });
+  }
+};
+
+export const getDiagnostics = async (req: Request, res: Response) => {
+  try {
+    const report = await syncManager.runDiagnostics();
+    // Zwróć 200 zawsze — raport sam opisuje status; ułatwia odczyt w przeglądarce.
+    res.json(report);
+  } catch (error: any) {
+    log.error("Diagnostics endpoint failed", { message: error?.message });
+    res.status(500).json({ error: error?.message || "Diagnostyka nie powiodła się." });
   }
 };
 
@@ -109,8 +123,13 @@ export const stopIntegrityCheck = (req: Request, res: Response) => {
 
 const setupSSE = (res: Response) => {
   res.setHeader("Content-Type", "text/event-stream");
-  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
   res.setHeader("Connection", "keep-alive");
+  // Wyłącz buforowanie po stronie proxy (nginx/Render) — bez tego zdarzenia SSE
+  // nie docierają do klienta na bieżąco i UI "nie reaguje" na hostingu.
+  res.setHeader("X-Accel-Buffering", "no");
+  // Wyślij nagłówki natychmiast, żeby połączenie było otwarte zanim ruszy zadanie.
+  res.flushHeaders?.();
   return (data: SyncEvent) => {
     if (!res.writableEnded) res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
@@ -140,6 +159,11 @@ const executeSyncTask = async (
   if (syncManager.isSyncing) return res.status(400).json({ error: "Inna synchronizacja jest już w toku." });
 
   const sendEvent = setupSSE(res);
+  // Natychmiastowy sygnał, że połączenie żyje — użytkownik widzi reakcję od razu,
+  // nawet jeśli pierwszy krok zadania (pobranie z wiki) trwa kilka sekund.
+  sendEvent({ type: "status", message: "Połączono z serwerem. Inicjacja rytuału..." });
+  log.info("Sync task started", { endpoint: req.path });
+
   const keepAlive = setInterval(() => {
     if (!res.writableEnded) res.write(": keepalive\n\n");
   }, 15000);
@@ -156,11 +180,22 @@ const executeSyncTask = async (
   try {
     await task(sendEvent);
     clearInterval(keepAlive);
+    log.info("Sync task finished", { endpoint: req.path });
     res.end();
   } catch (error: any) {
     clearInterval(keepAlive);
-    console.error(errorMessage, error);
-    sendEvent({ type: "error", error: error.message || errorMessage });
+    log.error(`${errorMessage} ${error?.message || ""}`, {
+      endpoint: req.path,
+      name: error?.name,
+      classification: error?.classification,
+      status: error?.status,
+      stack: error?.stack?.split("\n").slice(0, 4).join(" | "),
+    });
+    // WikiFetchError niesie userHint z konkretną wskazówką — pokaż ją użytkownikowi.
+    const userMessage = error?.userHint
+      ? `${error.message}`
+      : error?.message || errorMessage;
+    sendEvent({ type: "error", error: userMessage });
     res.end();
   }
 };

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,96 @@
+// Prosty strukturalny logger. Jedna linia na wpis, czytelna w logach Rendera,
+// z komponentem, poziomem i opcjonalnym kontekstem (bez sekretów).
+
+type Level = "info" | "warn" | "error";
+
+const LEVEL_TAG: Record<Level, string> = {
+  info: "INFO ",
+  warn: "WARN ",
+  error: "ERROR",
+};
+
+function emit(level: Level, component: string, message: string, context?: Record<string, unknown>) {
+  // Nie logujemy sekretów — kontekst powinien zawierać tylko metadane.
+  const parts = [`[${LEVEL_TAG[level]}]`, `[${component}]`, message];
+  let line = parts.join(" ");
+  if (context && Object.keys(context).length > 0) {
+    try {
+      line += " " + JSON.stringify(context);
+    } catch {
+      line += " [context not serializable]";
+    }
+  }
+  const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+  sink(line);
+}
+
+export interface Logger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export function createLogger(component: string): Logger {
+  return {
+    info: (m, c) => emit("info", component, m, c),
+    warn: (m, c) => emit("warn", component, m, c),
+    error: (m, c) => emit("error", component, m, c),
+  };
+}
+
+/**
+ * Klasyfikuje błąd żądania HTTP (axios/network) do zrozumiałej kategorii.
+ * Używane, by odróżnić blokadę IP/Cloudflare od zwykłego timeoutu czy
+ * błędu aplikacyjnego — kluczowe przy diagnozie "sync nie działa".
+ */
+export type ErrorClass =
+  | "ip_blocked"        // 403 / Cloudflare challenge — najczęstsza przyczyna na hostingu
+  | "rate_limited"      // 429
+  | "server_error"      // 5xx po stronie wiki
+  | "timeout"           // przekroczony czas / zerwane połączenie
+  | "dns"               // nie rozwiązano hosta
+  | "http_error"        // inny status HTTP
+  | "unknown";
+
+export function classifyHttpError(error: any): { class: ErrorClass; status?: number; code?: string; hint: string; snippet?: string } {
+  const status: number | undefined = error?.response?.status ?? error?.status;
+  const code: string | undefined = error?.code;
+  const bodyRaw = error?.response?.data;
+  const body = typeof bodyRaw === "string" ? bodyRaw : bodyRaw != null ? safeStringify(bodyRaw) : "";
+  const looksCloudflare = /cloudflare|cf-ray|attention required|captcha|checking your browser|just a moment/i.test(body);
+  const snippet = body ? body.slice(0, 300) : undefined;
+
+  if (status === 403 || (status === 503 && looksCloudflare) || looksCloudflare) {
+    return {
+      class: "ip_blocked",
+      status,
+      code,
+      snippet,
+      hint: "Encyklopedia odrzuciła żądanie (403/Cloudflare). Najprawdopodobniej IP serwera (np. Render) jest blokowane. Rozwiązania: uruchom lokalnie/z innej sieci, użyj proxy o zaufanym IP, albo hostuj tam, gdzie IP nie jest zablokowane.",
+    };
+  }
+  if (status === 429) {
+    return { class: "rate_limited", status, code, snippet, hint: "Zbyt wiele żądań (429). Odczekaj i spróbuj ponownie." };
+  }
+  if (status && status >= 500) {
+    return { class: "server_error", status, code, snippet, hint: `Błąd po stronie encyklopedii (${status}).` };
+  }
+  if (code === "ETIMEDOUT" || code === "ECONNABORTED" || code === "ECONNRESET" || /timeout|socket hang up/i.test(error?.message || "")) {
+    return { class: "timeout", status, code, hint: "Przekroczono czas połączenia z encyklopedią. Sieć wolna lub host niedostępny." };
+  }
+  if (code === "ENOTFOUND" || code === "EAI_AGAIN") {
+    return { class: "dns", status, code, hint: "Nie udało się rozwiązać adresu encyklopedii (DNS/sieć)." };
+  }
+  if (status) {
+    return { class: "http_error", status, code, snippet, hint: `Nieoczekiwany status HTTP ${status}.` };
+  }
+  return { class: "unknown", status, code, hint: error?.message || "Nieznany błąd sieciowy." };
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -6,6 +6,7 @@ const router = express.Router();
 router.get("/stats", syncController.getStats);
 router.get("/wiki/last-update", syncController.getWikiLastUpdate);
 router.get("/health", syncController.getHealth);
+router.get("/diagnostics", syncController.getDiagnostics);
 router.get("/config", syncController.getConfig);
 router.get("/notion/schema", syncController.getNotionSchema);
 router.patch("/notion/schema", syncController.updateNotionSchema);

--- a/server.ts
+++ b/server.ts
@@ -20,8 +20,11 @@ import { SchemaValidationService } from "./services/schemaValidationService";
 import { IntegrityService } from "./services/integrityService";
 import { withRetry } from "./retry";
 import syncRoutes from "./routes/syncRoutes";
+import { createLogger, classifyHttpError } from "./logger";
 
 dotenv.config();
+
+const serverLog = createLogger("Server");
 
 const USER_AGENTS = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -575,6 +578,86 @@ class SyncManager {
     });
   }
 
+  /**
+   * Diagnostyka end-to-end: sprawdza połączenie z Notion oraz pobranie i
+   * parsowanie każdej strony nagrody z encyklopedii. Zwraca strukturę JSON,
+   * którą można otworzyć w przeglądarce (GET /api/diagnostics) — jedno miejsce,
+   * by zobaczyć, DLACZEGO sync nie działa (blokada IP, brak strony, 0 książek).
+   */
+  async runDiagnostics() {
+    const startedAt = Date.now();
+    const report: any = {
+      env: {
+        hasNotionKey: !!process.env.NOTION_API_KEY,
+        hasDatabaseId: !!process.env.NOTION_DATABASE_ID,
+        hasGeminiKey: !!process.env.GEMINI_API_KEY,
+        nodeEnv: process.env.NODE_ENV || "(unset)",
+      },
+      notion: { ok: false } as any,
+      wiki: [] as any[],
+      summary: "",
+    };
+
+    // 1. Notion — inicjalizacja i lekki odczyt schematu
+    try {
+      await this.notion.init();
+      const schema = await this.notion.getSchema();
+      report.notion = { ok: true, propertyCount: schema ? Object.keys(schema).length : 0 };
+      serverLog.info("Diagnostics: Notion OK", report.notion);
+    } catch (err: any) {
+      report.notion = { ok: false, error: err?.message, code: err?.code };
+      serverLog.error("Diagnostics: Notion FAILED", report.notion);
+    }
+
+    // 2. Wiki — pobranie każdej strony nagrody z osobna
+    const AWARDS = [
+      { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
+      { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
+      { name: "Nagroda Locus", title: "Locus nagroda powieść" },
+    ];
+    for (const aw of AWARDS) {
+      const t0 = Date.now();
+      try {
+        const books = await bookSyncService.fetchBooksFromMediaWiki(aw.title, aw.name, () => {});
+        const entry = {
+          award: aw.name, pageTitle: aw.title, ok: true,
+          booksParsed: books.length, ms: Date.now() - t0,
+          note: books.length === 0 ? "Pobrano stronę, ale sparsowano 0 książek — sprawdź tytuł strony lub układ tabeli." : undefined,
+        };
+        report.wiki.push(entry);
+        serverLog.info("Diagnostics: wiki page OK", entry);
+      } catch (err: any) {
+        const info = classifyHttpError(err);
+        const entry = {
+          award: aw.name, pageTitle: aw.title, ok: false,
+          classification: err?.classification || info.class,
+          status: err?.status || info.status,
+          hint: err?.userHint || info.hint,
+          error: err?.message, ms: Date.now() - t0,
+        };
+        report.wiki.push(entry);
+        serverLog.error("Diagnostics: wiki page FAILED", entry);
+      }
+    }
+
+    // 3. Podsumowanie diagnozy
+    const wikiOk = report.wiki.filter((w: any) => w.ok);
+    const wikiBlocked = report.wiki.filter((w: any) => w.classification === "ip_blocked");
+    if (!report.notion.ok) {
+      report.summary = "Notion nie odpowiada — sprawdź NOTION_API_KEY / NOTION_DATABASE_ID i dostęp integracji.";
+    } else if (wikiBlocked.length > 0) {
+      report.summary = "Encyklopedia blokuje żądania serwera (403/Cloudflare). To najczęstsza przyczyna niedziałających synchronizacji na hostingu — IP serwera jest zablokowane. Uruchom lokalnie lub użyj proxy o zaufanym IP.";
+    } else if (wikiOk.length > 0 && wikiOk.every((w: any) => w.booksParsed === 0)) {
+      report.summary = "Strony pobrane, ale sparsowano 0 książek — prawdopodobnie zmienił się tytuł strony w encyklopedii albo układ tabeli.";
+    } else if (wikiOk.length === report.wiki.length) {
+      report.summary = "Wszystko działa: Notion i encyklopedia odpowiadają, książki są parsowane. Jeśli sync nadal nie działa, sprawdź logi konkretnego rytuału.";
+    } else {
+      report.summary = "Częściowa awaria pobierania z encyklopedii — szczegóły w polu 'wiki'.";
+    }
+    report.ms = Date.now() - startedAt;
+    return report;
+  }
+
   stopActiveSync() {
     if (this.currentTask) {
       this.currentTask.cancelRequested = true;
@@ -622,16 +705,26 @@ export async function startServer() {
   }
 
   server = app.listen(PORT, "0.0.0.0", () => {
-    console.log(`Server running on http://localhost:${PORT}`);
+    serverLog.info(`Server running on port ${PORT}`, {
+      port: PORT,
+      nodeEnv: process.env.NODE_ENV || "(unset)",
+      hasNotionKey: !!process.env.NOTION_API_KEY,
+      hasDatabaseId: !!process.env.NOTION_DATABASE_ID,
+      hasGeminiKey: !!process.env.GEMINI_API_KEY,
+      diagnostics: "GET /api/diagnostics",
+    });
+    if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+      serverLog.warn("Brak NOTION_API_KEY lub NOTION_DATABASE_ID — synchronizacje z Notion nie zadziałają.");
+    }
   });
 }
 
 process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  serverLog.error('Unhandled Rejection', { reason: (reason as any)?.message || String(reason) });
 });
 
 process.on('uncaughtException', (err) => {
-  console.error('Uncaught Exception thrown:', err);
+  serverLog.error('Uncaught Exception', { message: err?.message, stack: err?.stack?.split("\n").slice(0, 4).join(" | ") });
 });
 
 if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -4,6 +4,9 @@ import { WikiAdapter } from "../wiki.adapter";
 import { calculateSimilarity, countCommonWords, cleanTitle, sanitizeNotionString, sanitizeNotionTag, isValidUrl } from "../utils";
 import { Book, NotionBook, SyncEvent, SyncParams } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
+import { createLogger } from "../logger";
+
+const log = createLogger("BookSync");
 
 export class BookSyncService {
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
@@ -11,7 +14,12 @@ export class BookSyncService {
   async fetchBooksFromMediaWiki(pageTitle: string, awardName: string, sendEvent: (data: SyncEvent) => void): Promise<Book[]> {
     sendEvent({ type: "status", message: `Inicjacja ekstrakcji danych z Archiwum Encyklopedii: ${awardName}...` });
     const wikitext = await this.wiki.fetchPageContent(pageTitle);
-    
+
+    if (!wikitext) {
+      // Strona istnieje w kodzie, ale wiki zwróciła pustą treść (brak strony / zmieniony tytuł)
+      log.warn(`Pusta treść strony "${pageTitle}" — 0 książek dla ${awardName}`, { pageTitle, awardName });
+    }
+
     sendEvent({ type: "status", message: `Dekodowanie tablic wyników: ${awardName}...` });
     const books: Book[] = [];
     
@@ -148,6 +156,7 @@ export class BookSyncService {
         });
       }
     }
+    log.info(`Sparsowano ${books.length} książek dla ${awardName}`, { awardName, pageTitle, wikitextLength: wikitext.length, books: books.length });
     return books;
   }
 

--- a/src/components/StatusSection.tsx
+++ b/src/components/StatusSection.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Zap, Loader2, ExternalLink, History } from "lucide-react";
-import { motion } from "motion/react";
+import { Zap, Loader2, ExternalLink, History, Stethoscope, CheckCircle2, XCircle } from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
 import { useWikiUpdates, WikiLink } from "../hooks/useWikiUpdates";
+import { useDiagnostics } from "../hooks/useDiagnostics";
 
 interface StatusSectionProps {
   configStatus: {
@@ -20,6 +21,7 @@ const WIKI_LINKS: WikiLink[] = [
 
 export const StatusSection: React.FC<StatusSectionProps> = ({ configStatus }) => {
   const wikiUpdates = useWikiUpdates(WIKI_LINKS, !configStatus.loading);
+  const { report, loading: diagLoading, error: diagError, runDiagnostics } = useDiagnostics();
 
   return (
     <motion.section 
@@ -93,6 +95,61 @@ export const StatusSection: React.FC<StatusSectionProps> = ({ configStatus }) =>
                 </motion.div>
               ))}
             </div>
+          </div>
+
+          <div className="pt-4 border-t border-slate-800/50">
+            <div className="flex items-center justify-between gap-4 flex-wrap">
+              <div className="text-[10px] font-bold text-slate-500 uppercase tracking-[0.2em] ml-1">
+                Diagnostyka Połączeń (Notion + Encyklopedia)
+              </div>
+              <button
+                onClick={() => runDiagnostics()}
+                disabled={diagLoading}
+                className="flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-900/50 border border-cyan-500/30 hover:border-cyan-400/60 text-cyan-400 transition-all text-xs font-bold uppercase tracking-widest disabled:opacity-50"
+              >
+                {diagLoading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Stethoscope className="w-3.5 h-3.5" />}
+                {diagLoading ? "Diagnozuję..." : "Uruchom Diagnostykę"}
+              </button>
+            </div>
+
+            <AnimatePresence>
+              {diagError && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }}
+                  className="mt-3 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-xs font-medium"
+                >
+                  {diagError}
+                </motion.div>
+              )}
+              {report && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }}
+                  className="mt-3 space-y-2 overflow-hidden"
+                >
+                  <div className="p-3 rounded-xl bg-slate-950/60 border border-slate-800 text-xs text-slate-300 font-medium leading-relaxed">
+                    {report.summary}
+                  </div>
+                  <div className="flex items-center gap-2 text-[11px] font-mono">
+                    {report.notion.ok
+                      ? <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
+                      : <XCircle className="w-3.5 h-3.5 text-red-500 shrink-0" />}
+                    <span className="text-slate-400">Notion: {report.notion.ok ? `OK (${report.notion.propertyCount} kolumn)` : (report.notion.error || "błąd")}</span>
+                  </div>
+                  {report.wiki.map((w) => (
+                    <div key={w.award} className="flex items-start gap-2 text-[11px] font-mono">
+                      {w.ok && (w.booksParsed ?? 0) > 0
+                        ? <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500 shrink-0 mt-0.5" />
+                        : <XCircle className="w-3.5 h-3.5 text-red-500 shrink-0 mt-0.5" />}
+                      <span className="text-slate-400">
+                        {w.award}: {w.ok ? `${w.booksParsed} książek` : `${w.classification || "błąd"}${w.status ? ` (HTTP ${w.status})` : ""}`}
+                        {w.hint && !w.ok && <span className="block text-slate-500 mt-0.5">{w.hint}</span>}
+                        {w.note && <span className="block text-amber-500/80 mt-0.5">{w.note}</span>}
+                      </span>
+                    </div>
+                  ))}
+                </motion.div>
+              )}
+            </AnimatePresence>
           </div>
         </div>
       )}

--- a/src/hooks/useDiagnostics.ts
+++ b/src/hooks/useDiagnostics.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback, useRef } from "react";
+
+export interface WikiDiagnostic {
+  award: string;
+  pageTitle: string;
+  ok: boolean;
+  booksParsed?: number;
+  classification?: string;
+  status?: number;
+  hint?: string;
+  error?: string;
+  note?: string;
+  ms?: number;
+}
+
+export interface DiagnosticsReport {
+  env: { hasNotionKey: boolean; hasDatabaseId: boolean; hasGeminiKey: boolean; nodeEnv: string };
+  notion: { ok: boolean; propertyCount?: number; error?: string };
+  wiki: WikiDiagnostic[];
+  summary: string;
+  ms?: number;
+}
+
+export function useDiagnostics() {
+  const [report, setReport] = useState<DiagnosticsReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const runningRef = useRef(false);
+
+  const runDiagnostics = useCallback(async () => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setLoading(true);
+    setError(null);
+    setReport(null);
+    try {
+      const res = await fetch("/api/diagnostics");
+      if (!res.ok) throw new Error(`Serwer zwrócił status ${res.status}`);
+      const data = await res.json();
+      setReport(data);
+    } catch (err: any) {
+      setError(err?.message || "Diagnostyka nie powiodła się.");
+    } finally {
+      runningRef.current = false;
+      setLoading(false);
+    }
+  }, []);
+
+  return { report, loading, error, runDiagnostics };
+}

--- a/wiki.adapter.ts
+++ b/wiki.adapter.ts
@@ -2,6 +2,9 @@ import axios from "axios";
 import http from "http";
 import https from "https";
 import { withRetry } from "./retry";
+import { createLogger, classifyHttpError, ErrorClass } from "./logger";
+
+const log = createLogger("WikiAdapter");
 
 const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
@@ -16,6 +19,26 @@ const wikiAxios = axios.create({
     'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7'
   }
 });
+
+/**
+ * Błąd pobierania z encyklopedii z rozpoznaną klasą przyczyny.
+ * Serwisy i diagnostyka mogą odczytać `classification` i `userHint`,
+ * żeby pokazać użytkownikowi konkretną, użyteczną informację.
+ */
+export class WikiFetchError extends Error {
+  classification: ErrorClass;
+  status?: number;
+  code?: string;
+  userHint: string;
+  constructor(message: string, info: { class: ErrorClass; status?: number; code?: string; hint: string }) {
+    super(message);
+    this.name = "WikiFetchError";
+    this.classification = info.class;
+    this.status = info.status;
+    this.code = info.code;
+    this.userHint = info.hint;
+  }
+}
 
 export class WikiAdapter {
   private readonly baseUrl = "https://encyklopediafantastyki.pl/api.php";
@@ -53,8 +76,15 @@ export class WikiAdapter {
       const rev = page.revisions[0];
       return rev.content ?? rev["*"] ?? rev.slots?.main?.content ?? "";
     } catch (error: any) {
-      console.warn(`Błąd pobierania strony "${title}": ${error.message} (zablokowane IP?)`);
-      throw new Error(`Nie udało się pobrać strony "${title}" z encyklopedii: ${error.message}`);
+      const info = classifyHttpError(error);
+      log.error(`Nie udało się pobrać strony "${title}"`, {
+        title, class: info.class, status: info.status, code: info.code,
+        message: error?.message, snippet: info.snippet,
+      });
+      throw new WikiFetchError(
+        `Nie udało się pobrać strony "${title}" z encyklopedii (${info.class}${info.status ? ` / HTTP ${info.status}` : ""}). ${info.hint}`,
+        info
+      );
     }
   }
 
@@ -156,11 +186,12 @@ export class WikiAdapter {
           continueParams = response.data.continue || {};
         } while (Object.keys(continueParams).length > 0);
       } catch (error: any) {
-        if (error.response?.status === 403) {
-          console.warn(`Wiki API 403 Forbidden dla bulk fetch. Prawdopodobnie blokada IP.`);
-        } else {
-          console.warn(`Error fetching bulk pages:`, error.message);
-        }
+        const info = classifyHttpError(error);
+        log.warn(`Bulk fetch chunku nieudany (${chunk.length} tytułów pominięto)`, {
+          class: info.class, status: info.status, code: info.code,
+          message: error?.message, snippet: info.snippet,
+          firstTitles: chunk.slice(0, 3),
+        });
         // Continue with other chunks even if one fails, but record what was lost
         failedTitles.push(...chunk);
       }
@@ -187,7 +218,8 @@ export class WikiAdapter {
       }
       return [];
     } catch (error: any) {
-      console.warn(`Błąd wyszukiwania "${query}": ${error.message} (zablokowane IP?)`);
+      const info = classifyHttpError(error);
+      log.warn(`Wyszukiwanie "${query}" nieudane`, { class: info.class, status: info.status, code: info.code, message: error?.message });
       return [];
     }
   }
@@ -220,7 +252,8 @@ export class WikiAdapter {
 
       return allTitles;
     } catch (error: any) {
-      console.warn(`Błąd pobierania kategorii "${category}": ${error.message} (zablokowane IP?)`);
+      const info = classifyHttpError(error);
+      log.warn(`Pobieranie kategorii "${category}" nieudane (zwracam ${allTitles.length} zebranych)`, { class: info.class, status: info.status, code: info.code, message: error?.message });
       // Zwróć to, co udało się zebrać przed awarią, zamiast wyrzucać częściowe wyniki
       return allTitles;
     }


### PR DESCRIPTION
## Why

Syncs pull data from the encyclopedia (MediaWiki); Notion works (you confirmed edits go through). When the encyclopedia blocks the server's IP (403 / Cloudflare — very common on datacenter hosting like Render), the failure was opaque and the UI gave no feedback. This adds end-to-end observability and pins down the cause.

## What

- **`logger.ts`** — leveled structured logger + `classifyHttpError()` mapping a failed request to a cause (`ip_blocked` / `rate_limited` / `server_error` / `timeout` / `dns` / `http_error`) with a user-facing hint.
- **WikiAdapter** — throws a typed `WikiFetchError` carrying the classification and hint; every fetch path logs status/code/body-snippet.
- **SyncController** — SSE hardening for hosting proxies (`X-Accel-Buffering: no`, `flushHeaders()`, `no-transform`) plus an immediate "connected" event so the UI reacts instantly instead of appearing dead; errors now log name/class/status/stack and surface the `WikiFetchError` hint to the user.
- **`GET /api/diagnostics`** — one call that checks Notion init + fetches & parses each award page, returning a JSON report with a plain-language `summary` of why syncs fail. Openable straight in the browser.
- **Frontend** — an "Uruchom Diagnostykę" button in the Status card that always gives immediate feedback (independent of the SSE sync path) and renders the per-check result.
- **BookSync** — logs parsed-book counts per award, warns on an empty page.
- **Startup log** — reports port and which env vars are present (booleans only, no secrets).

## Likely root cause

Reproduced locally: `/api/diagnostics` returns a structured report and classifies the encyclopedia host block as `ip_blocked (HTTP 403)` — the same block that affects datacenter IPs. On Render this is the most probable reason syncs don't run. The diagnostics endpoint will confirm it in one click and the logs will show the exact status/snippet.

## Validation

- `npm test`: 22 files, 86/86 passing; `npm run lint` (strict): clean
- Production build + smoke test: frontend 200, startup log emits config booleans, `/api/diagnostics` returns the full report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_