### PR TITLE
Defeat SSE proxy buffering on hosting + client stall watchdog

### DIFF
--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -130,6 +130,10 @@ const setupSSE = (res: Response) => {
   res.setHeader("X-Accel-Buffering", "no");
   // Wyślij nagłówki natychmiast, żeby połączenie było otwarte zanim ruszy zadanie.
   res.flushHeaders?.();
+  // Padding ~2KB komentarza: niektóre proxy (Render) buforują odpowiedź do progu
+  // kilku KB zanim zaczną strumieniować — to wypycha bufor i wymusza flush,
+  // dzięki czemu klient dostaje zdarzenia na bieżąco (a nie dopiero na końcu).
+  res.write(`:${" ".repeat(2048)}\n\n`);
   return (data: SyncEvent) => {
     if (!res.writableEnded) res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
@@ -164,9 +168,11 @@ const executeSyncTask = async (
   sendEvent({ type: "status", message: "Połączono z serwerem. Inicjacja rytuału..." });
   log.info("Sync task started", { endpoint: req.path });
 
+  // Częstszy keepalive (5s) utrzymuje strumień "gorący" u proxy, które inaczej
+  // zbierają dane w bufor między rzadkimi zapisami długiego zadania.
   const keepAlive = setInterval(() => {
     if (!res.writableEnded) res.write(": keepalive\n\n");
-  }, 15000);
+  }, 5000);
 
   // Rozłączenie klienta (zamknięta karta, utrata sieci) — anuluj zadanie,
   // żeby osierocony sync nie blokował kolejnych rytuałów godzinami

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -35,18 +35,34 @@ export function useSync(endpoint: string, stopEndpoint: string, initialState: Pa
       startTime: Date.now() 
     }));
 
+    // Watchdog: jeśli strumień zawiśnie (proxy buforuje, brak jakiegokolwiek
+    // ruchu), przerwij po 30 s ciszy. Serwer wysyła keepalive co 5 s, więc na
+    // zdrowym połączeniu timer jest stale resetowany i nigdy nie odpala.
+    const controller = new AbortController();
+    let watchdog: ReturnType<typeof setTimeout> | null = null;
+    let stalled = false;
+    const armWatchdog = () => {
+      if (watchdog) clearTimeout(watchdog);
+      watchdog = setTimeout(() => {
+        stalled = true;
+        controller.abort();
+      }, 30000);
+    };
+
     try {
       const fetchOptions: RequestInit = {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
       };
-      
+
       if (params && Object.keys(params).length > 0) {
         fetchOptions.body = JSON.stringify(params);
       }
 
+      armWatchdog();
       const res = await fetch(endpoint, fetchOptions);
-      
+
       if (!res.ok) {
         let errorMessage = `Błąd serwera: ${res.status}`;
         try {
@@ -57,16 +73,17 @@ export function useSync(endpoint: string, stopEndpoint: string, initialState: Pa
         }
         throw new Error(errorMessage);
       }
-      
+
       const reader = res.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = "";
-      
+
       if (reader) {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          
+          armWatchdog(); // każdy fragment (także keepalive) resetuje watchdog
+
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split('\n\n');
           buffer = lines.pop() || "";
@@ -116,15 +133,20 @@ export function useSync(endpoint: string, stopEndpoint: string, initialState: Pa
       setState(prev => ({ ...prev, loading: false, statusMessage: null, progress: null }));
       return false;
     } catch (err: any) {
+      const message = stalled
+        ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież stronę i spróbuj ponownie; jeśli się powtarza, uruchom Diagnostykę."
+        : err?.message || "Błąd synchronizacji.";
       console.error(`Sync error for ${endpoint}:`, err);
-      setState(prev => ({ 
-        ...prev, 
-        error: err.message, 
-        loading: false, 
-        statusMessage: null, 
-        progress: null 
+      setState(prev => ({
+        ...prev,
+        error: message,
+        loading: false,
+        statusMessage: null,
+        progress: null
       }));
       return false;
+    } finally {
+      if (watchdog) clearTimeout(watchdog);
     }
   }, [endpoint]);
 


### PR DESCRIPTION
## Root cause

Your `/api/diagnostics` output proved the backend is healthy on Render: Notion OK (12 properties), all three award pages fetched **and** parsed (395/377/167 books). So the earlier IP-block hypothesis was wrong.

The real signature is in the logs: `/sync-schema` starts and finishes, but `/sync` (the book sync) never appears — and we log `Sync task started` at the very entry of the handler, so if the request had reached the server it would be logged. It doesn't. That points to a hosting proxy **buffering the SSE response**: the browser never receives a terminal event, `loading` stays `true`, and `isAnySyncLoading` then disables every sync button — so subsequent clicks (including the book sync) never fire a request. That matches "click does nothing" exactly.

## Fix

- **Server**: write a ~2 KB comment padding at stream start to push past the proxy's buffer threshold and force it to begin streaming; drop the keepalive interval 15s → 5s so the stream stays "hot" between a long task's sparse writes.
- **Client (`useSync`)**: an `AbortController` watchdog that aborts after 30s of total silence (keepalive every 5s keeps a healthy stream alive, so it only fires on a genuinely stalled/buffered connection) and surfaces a clear message instead of a silently-disabled UI.

Both build on the already-merged SSE hardening (`X-Accel-Buffering: no`, `flushHeaders`, immediate "connected" event).

## Validation

- Verified locally: the stream now begins with the padding comment and still delivers all `data:` events (3/3 for schema).
- `npm test`: 86/86; `npm run lint` (strict): clean; production build boots.

After this deploys, please retry a sync. If it still hangs, the new watchdog will show a specific "connection stalled" message rather than a dead UI — tell me if you see it, and we'll switch the transport (e.g. EventSource/GET or chunked-poll) as the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_