### PR TITLE
Fix sync self-cancelling: listen on res close, not req close

### DIFF
--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -175,10 +175,16 @@ const executeSyncTask = async (
   }, 5000);
 
   // Rozłączenie klienta (zamknięta karta, utrata sieci) — anuluj zadanie,
-  // żeby osierocony sync nie blokował kolejnych rytuałów godzinami
-  req.on("close", () => {
+  // żeby osierocony sync nie blokował kolejnych rytuałów godzinami.
+  // UWAGA: nasłuchujemy na res, nie req. Dla POST z ciałem req emituje "close"
+  // po skonsumowaniu ciała przez express.json() — nie przy rozłączeniu klienta —
+  // co anulowało aktywny sync tuż po starcie. res "close" odpala się dopiero gdy
+  // odpowiedź faktycznie się zamyka; przy normalnym końcu writableEnded==true,
+  // więc guard poniżej nie anuluje niczego przez pomyłkę.
+  res.on("close", () => {
     if (!res.writableEnded) {
       clearInterval(keepAlive);
+      log.warn("Klient rozłączył się w trakcie synchronizacji — przerywam zadanie.", { endpoint: req.path });
       syncManager.stopActiveSync();
     }
   });


### PR DESCRIPTION
## Cause

With SSE now streaming (the padding fix from #9 worked — events reach the browser), the book sync ran but immediately returned **"Synchronizacja przerwana przez użytkownika."**

The client-disconnect handler listened on `req.on("close")`. For a POST with a body, `req` emits `"close"` as soon as `express.json()` finishes consuming the request stream — while the response is still active (`writableEnded === false`). The `if (!res.writableEnded)` guard therefore passed and `stopActiveSync()` cancelled the task right after it started, so `checkCancellation()` returned true and the sync aborted itself.

## Fix

Listen on `res.on("close")` instead. It fires only when the *response* closes: on normal completion `writableEnded` is `true` (guard skips, no cancel), and on a genuine client disconnect it is `false` (task cancelled, as intended).

## Proof

Standalone repro of the exact timing:
```
REQ close, writableEnded= false   ← fires MID-response (the bug)
ENDED normally
RES close, writableEnded= true    ← fires POST-end (guard skips → no spurious cancel)
CLIENT got 3 data chunks
```

## Validation

- `npm test`: 86/86; `npm run lint` (strict): clean; production build boots.

This was a real bug all along — it was simply masked earlier by the SSE buffering (the request never streamed far enough to hit the cancellation check). With streaming fixed, a sync should now run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_