### PR TITLE
Set app title and favicon to match the Mechanicus theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,19 @@
 <!doctype html>
-<html lang="en">
+<html lang="pl">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>My Google AI Studio App</title>
+    <title>Cogitator Omnissiah — Archiwum Nagród Fantastyki</title>
+    <meta name="description" content="Cogitator Omnissiah — rytuał synchronizacji nagród literackich (Hugo, Nebula, Locus) z Archiwum Encyklopedii Fantastyki do osobistego archiwum Notion." />
+    <meta name="theme-color" content="#020617" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2064%2064'%3E%3Crect%20width='64'%20height='64'%20rx='14'%20fill='%23020617'/%3E%3Cg%20fill='none'%20stroke='%2322d3ee'%20stroke-width='3.5'%20stroke-linejoin='round'%3E%3Cpath%20d='M32%206v8M32%2050v8M6%2032h8M50%2032h8M13.5%2013.5l5.7%205.7M44.8%2044.8l5.7%205.7M50.5%2013.5l-5.7%205.7M19.2%2044.8l-5.7%205.7'/%3E%3Ccircle%20cx='32'%20cy='32'%20r='16'/%3E%3C/g%3E%3Ccircle%20cx='32'%20cy='32'%20r='6.5'%20fill='%23a855f7'/%3E%3C/svg%3E"
+    />
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-


### PR DESCRIPTION
## Summary

- Replaced the placeholder `<title>My Google AI Studio App</title>` with **"Cogitator Omnissiah — Archiwum Nagród Fantastyki"** — no AI references, focused on what the app is (a sci-fi award archivist) in its Adeptus Mechanicus flavor. Also set `lang="pl"`, a description meta, and `theme-color`.
- Added an inline SVG **favicon** — an Omnissiah cog (cyan teeth, purple core, on a `slate-950` rounded square) matching the app's palette — as a self-contained `data:` URI so it works under production static serving with no extra asset file or build path.

## Validation

- `npm run build`: both the new title and the favicon land in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_