### PR TITLE
Fix churny author/publisher re-updates (case-insensitive compare)

### DIFF
--- a/services/__tests__/bookSyncService.test.ts
+++ b/services/__tests__/bookSyncService.test.ts
@@ -182,6 +182,68 @@ describe('BookSyncService', () => {
       expect(names).toContain('Frank Herbert');
       expect(names).toContain('Kevin J. Anderson');
     });
+
+    it('is idempotent when Notion stores a different-case author (no churny re-updates)', () => {
+      // Notion keeps its own option casing ("van Vogt"); wiki normalizes to
+      // "Van Vogt". These are the same author — must NOT trigger an update.
+      const existing: NotionBook = {
+        id: '1',
+        plTitle: 'Slan',
+        origTitle: 'Slan',
+        author: 'A. E. van Vogt', // stored casing from Notion
+        year: '1941',
+        awards: ['Nagroda Hugo'],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      };
+      const newBook: Book = {
+        polishTitle: 'Slan',
+        originalTitle: 'Slan',
+        author: 'A. E. Van Vogt', // wiki-normalized casing
+        year: '1941',
+        award: 'Nagroda Hugo',
+        awards: ['Nagroda Hugo'],
+        polishTitleLink: null
+      };
+
+      const updates = service.compareBooks(existing, newBook);
+      expect(updates).not.toHaveProperty('Autor');
+    });
+
+    it('is idempotent for a multi-author book with mixed casing', () => {
+      const existing: NotionBook = {
+        id: '1',
+        plTitle: 'The Winged Man',
+        origTitle: 'The Winged Man',
+        author: 'A. E. van Vogt, Edna Mayne Hull',
+        year: '1945',
+        awards: ['Nagroda Hugo'],
+        zrodlo: [],
+        currentWydawnictwo: '',
+        currentSeria: '',
+        currentCzesccyklu: false,
+        lp: '1',
+        plTitleRichText: [],
+        origTitleRichText: []
+      };
+      const newBook: Book = {
+        polishTitle: 'The Winged Man',
+        originalTitle: 'The Winged Man',
+        author: 'A. E. Van Vogt, Edna Mayne Hull',
+        year: '1945',
+        award: 'Nagroda Hugo',
+        awards: ['Nagroda Hugo'],
+        polishTitleLink: null
+      };
+
+      const updates = service.compareBooks(existing, newBook);
+      expect(updates).not.toHaveProperty('Autor');
+    });
   });
 
   describe('runBookSync', () => {

--- a/services/__tests__/diffEngine.test.ts
+++ b/services/__tests__/diffEngine.test.ts
@@ -7,6 +7,8 @@ describe('DiffEngine', () => {
     expect(DiffEngine.isMultiSelectEqual('Zysk, MAG', 'MAG, Zysk, Rebis')).toBe(false);
     expect(DiffEngine.isMultiSelectEqual('  Zysk  ', 'Zysk')).toBe(true);
     expect(DiffEngine.isMultiSelectEqual('', null as any)).toBe(true);
+    // Różnica samej wielkości liter to nie zmiana (Notion i tak scala opcje case-insensitive)
+    expect(DiffEngine.isMultiSelectEqual('Zysk i S-ka', 'Zysk i s-ka')).toBe(true);
   });
 
   it('compares strings correctly', () => {

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -183,20 +183,29 @@ export class BookSyncService {
       updates["Tytuł oryginalny"] = { rich_text: [{ text: { content: cleanExistingOrig } }] };
     }
 
-    // Update Author if it differs
-    const newAuthors = Array.from(new Set(
-      normalizeData(book.author || "", 'author').split(',')
+    // Update Author if it differs.
+    // Normalizuj i porównuj OBIE strony case-insensitive: Notion dopasowuje opcje
+    // multi_select bez względu na wielkość liter i zachowuje własną pisownię, więc
+    // normalizowanie tylko nowej wartości (np. "A. E. Van Vogt" vs zapisane
+    // "A. E. van Vogt") powodowało aktualizację przy każdym sync, która nigdy nie
+    // "chwytała". Aktualizuj tylko, gdy faktycznie dochodzi nowy autor.
+    const parseAuthors = (raw: string) =>
+      raw.split(',')
         .map((a: string) => sanitizeNotionTag(a))
         .filter(Boolean)
-    ));
-    const existingAuthors = (existingBook.author || "").split(',')
-      .map((a: string) => sanitizeNotionTag(a))
-      .filter(Boolean);
-    
+        .map((a: string) => normalizeData(a, 'author'));
+
+    const newAuthors = parseAuthors(book.author || "");
+    const existingAuthors = parseAuthors(existingBook.author || "");
+    const existingLower = new Set(existingAuthors.map(a => a.toLowerCase()));
+
     // Merge authors (union) — never drop authors added manually in Notion
     const combinedAuthors = [...existingAuthors];
     for (const a of newAuthors) {
-      if (!combinedAuthors.includes(a)) combinedAuthors.push(a);
+      if (!existingLower.has(a.toLowerCase())) {
+        combinedAuthors.push(a);
+        existingLower.add(a.toLowerCase());
+      }
     }
     const authorsChanged = combinedAuthors.length !== existingAuthors.length;
 
@@ -373,7 +382,7 @@ export class BookSyncService {
             if (book.author) {
               const authors = Array.from(new Set(
                 book.author.split(',')
-                  .map((a: string) => sanitizeNotionTag(a))
+                  .map((a: string) => normalizeData(sanitizeNotionTag(a), 'author'))
                   .filter(Boolean)
               ));
               properties["Autor"] = { multi_select: authors.slice(0, 100).map(name => ({ name })) };

--- a/services/diffEngine.ts
+++ b/services/diffEngine.ts
@@ -2,16 +2,20 @@ export class DiffEngine {
   /**
    * Porównuje dwie wartości typu multi_select (np. "Zysk, MAG" i "MAG, Zysk").
    * Rozdziela po przecinku, usuwa białe znaki, sortuje i porównuje.
+   * Porównanie jest case-insensitive: Notion dopasowuje opcje multi_select bez
+   * względu na wielkość liter i zachowuje własną pisownię, więc różnica samej
+   * wielkości liter (np. "Zysk i S-ka" vs "Zysk i s-ka") nie jest realną zmianą
+   * i nie może wywoływać aktualizacji przy każdym sync.
    */
   static isMultiSelectEqual(val1: string, val2: string): boolean {
-    const normalize = (s: string) => 
+    const normalize = (s: string) =>
       (s || "")
         .split(',')
-        .map(t => t.trim())
+        .map(t => t.trim().toLowerCase())
         .filter(t => t.length > 0)
         .sort()
         .join(',');
-        
+
     return normalize(val1) === normalize(val2);
   }
 


### PR DESCRIPTION
## Cause

Four Van Vogt Hugo entries reported **"Zaktualizowano: Autor"** on every sync, even though nothing changed:
```
Slan - A. E. Van Vogt (1941) (Zaktualizowano: Autor)
Producenci broni - A. E. Van Vogt (1941) (Zaktualizowano: Autor)
The Winged Man - A. E. Van Vogt, Edna Mayne Hull (1945) (Zaktualizowano: Autor)
Świat Nie-A - A. E. Van Vogt (1946) (Zaktualizowano: Autor)
```

`compareBooks` normalized the **new** author (`dataNormalizer` maps `A. E. van Vogt` → `A. E. Van Vogt`) but read the **existing** Notion author raw and compared it **case-sensitively**. Notion matches `multi_select` options case-insensitively and persists its own casing (`A. E. van Vogt`), so the normalized capital-V value never "stuck": every sync saw a diff, rewrote it, Notion collapsed it back to its option casing, and the next sync diffed again — forever. All four books share the one Notion option, so they churned together.

Confirmed by parsing the real Hugo page: the wiki yields `A. E. Van Vogt` for all four (via the `van Vogt`→`Van Vogt` mapping).

## Fix

- **`compareBooks`**: normalize **both** sides per-author and compare case-insensitively; only update when a genuinely new author is added (the union still preserves manually-added authors).
- **New-row path**: normalize each author too, so freshly created rows store canonical casing from the start.
- **`DiffEngine.isMultiSelectEqual`**: now case-insensitive — kills the identical latent churn for the publisher/series syncs (a Notion `Zysk i s-ka` vs wiki `Zysk i S-ka` would have churned the same way).

## Validation

- New regression tests: idempotency with a mixed-case single author and a mixed-case multi-author existing value; DiffEngine treats a case-only difference as equal.
- `npm test`: 22 files, 88/88 passing; `npm run lint` (strict): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_