### PR TITLE
Tier 1: Tighten types (SyncEvent union, stats types, drop allowJs)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,7 @@ import { IntegrityService } from "./services/integrityService";
 import { withRetry } from "./retry";
 import syncRoutes from "./routes/syncRoutes";
 import { createLogger, classifyHttpError } from "./logger";
+import { SyncEvent } from "./src/types";
 
 dotenv.config();
 
@@ -96,39 +97,39 @@ class SyncManager {
     }
   }
 
-  async runBookSync(params: { awardName?: string; pageTitle?: string; syncAll?: boolean }, sendEvent: (data: any) => void) {
+  async runBookSync(params: { awardName?: string; pageTitle?: string; syncAll?: boolean }, sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('book', (checkCancellation) => bookSyncService.runBookSync(params, sendEvent, checkCancellation));
   }
 
-  async runPurifySync(sendEvent: (data: any) => void) {
+  async runPurifySync(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('purify', (checkCancellation) => purificationService.runPurification(sendEvent, checkCancellation));
   }
 
-  async runSchemaSync(sendEvent: (data: any) => void) {
+  async runSchemaSync(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('schema', (checkCancellation) => schemaValidationService.runSchemaValidation(sendEvent, checkCancellation));
   }
 
-  async runPublisherSync(sendEvent: (data: any) => void) {
+  async runPublisherSync(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('publisher', (checkCancellation) => publisherSyncService.runPublisherSync(sendEvent, checkCancellation));
   }
 
-  async runSeriesSync(sendEvent: (data: any) => void) {
+  async runSeriesSync(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('series', (checkCancellation) => seriesSyncService.runSeriesSync(sendEvent, checkCancellation));
   }
 
-  async runDuplicateCheck(sendEvent: (data: any) => void) {
+  async runDuplicateCheck(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('duplicates', (checkCancellation) => duplicateSyncService.runDuplicateCheck(sendEvent, checkCancellation));
   }
 
-  async runLpSync(sendEvent: (data: any) => void) {
+  async runLpSync(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('lp', (checkCancellation) => lpSyncService.runLpSync(sendEvent, checkCancellation));
   }
 
-  async runCyclesSync(sendEvent: (data: any) => void) {
+  async runCyclesSync(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('cycles', (checkCancellation) => cyclesSyncService.runCyclesSync(sendEvent, checkCancellation));
   }
 
-  async runIntegrityCheck(sendEvent: (data: any) => void) {
+  async runIntegrityCheck(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('integrity', (checkCancellation) => integrityService.runIntegrityCheck(sendEvent, checkCancellation));
   }
 
@@ -140,7 +141,7 @@ class SyncManager {
     return await this.notion.addTagToMultiSelect(pageId, "Źródło", "Przeczytane");
   }
 
-  async checkLibraryAvailability(libraryCode: string, sendEvent: (data: any) => void) {
+  async checkLibraryAvailability(libraryCode: string, sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('library', async (checkCancellation) => {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation);
@@ -277,7 +278,7 @@ class SyncManager {
     });
   }
 
-  async checkVintedAvailability(sendEvent: (data: any) => void) {
+  async checkVintedAvailability(sendEvent: (data: SyncEvent) => void) {
     await this.executeTask('vinted', async (checkCancellation) => {
       try {
         sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });

--- a/src/components/stats/AuthorProgressItem.tsx
+++ b/src/components/stats/AuthorProgressItem.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { motion } from "motion/react";
 import { User, ChevronDown, ChevronUp, CheckCircle2, Circle } from "lucide-react";
+import { AuthorStat } from "../../hooks/useStats";
 
-export const AuthorProgressItem: React.FC<{ author: any }> = ({ author }) => {
+export const AuthorProgressItem: React.FC<{ author: AuthorStat }> = ({ author }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const percent = author.total > 0 ? Math.round((author.read / author.total) * 100) : 0;
   const color = author.read === author.total ? "emerald" : "cyan";

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { motion } from "motion/react";
 import { Search, ChevronDown, ChevronUp, Loader2, CheckCircle2 } from "lucide-react";
 import { formatETA } from "../../utils/time";
+import { IdentifiedBook } from "../../hooks/useStats";
 
 interface IdentifiedLibraryItemProps {
-  library: { id: string; name: string; code: string }; 
-  books: any[]; 
+  library: { id: string; name: string; code: string };
+  books: IdentifiedBook[];
   onCheck: () => void;
   onStop: () => void;
   onMarkAsRead: (pageId: string) => void;

--- a/src/components/stats/LibraryProgressItem.tsx
+++ b/src/components/stats/LibraryProgressItem.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { motion } from "motion/react";
 import { Library, ChevronDown, ChevronUp, CheckCircle2, Loader2 } from "lucide-react";
+import { LibraryStat } from "../../hooks/useStats";
 
 interface LibraryProgressItemProps {
-  library: any;
+  library: LibraryStat;
   onMarkAsRead: (pageId: string) => void;
   markingId: string | null;
 }

--- a/src/components/stats/YearlyProgressItem.tsx
+++ b/src/components/stats/YearlyProgressItem.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { motion } from "motion/react";
 import { Calendar, ChevronDown, ChevronUp, CheckCircle2, Circle } from "lucide-react";
+import { YearlyStat } from "../../hooks/useStats";
 
-export const YearlyProgressItem: React.FC<{ year: any }> = ({ year }) => {
+export const YearlyProgressItem: React.FC<{ year: YearlyStat }> = ({ year }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const percent = year.total > 0 ? Math.round((year.read / year.total) * 100) : 0;
 

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -20,6 +20,22 @@ export interface YearlyStat {
   books: { id: string; title: string; author: string; read: boolean }[];
 }
 
+export interface LibraryStat {
+  id: string;
+  name: string;
+  books: { id: string; title: string; author: string; year?: number | null; read: boolean }[];
+}
+
+export interface IdentifiedBook {
+  id: string;
+  title: string;
+  author: string;
+  year?: number | null;
+  // Wypełniane przez skan biblioteki (OPAC) — tytuł/autor odczytany z katalogu
+  extractedTitle?: string | null;
+  extractedAuthor?: string | null;
+}
+
 export interface Stats {
   authorStats: AuthorStat[];
   awardBooksStats: { read: number; total: number };
@@ -27,15 +43,11 @@ export interface Stats {
   awardCoverage: AwardCoverageStat[];
   allAwardsStats: { read: number; total: number };
   yearlyStats: YearlyStat[];
-  libraryStats: {
-    id: string;
-    name: string;
-    books: { id: string; title: string; author: string; year?: number | null; read: boolean }[];
-  }[];
+  libraryStats: LibraryStat[];
 }
 
 export interface IdentifiedBooks {
-  [libraryId: string]: { id: string; title: string; author: string; year?: number | null }[];
+  [libraryId: string]: IdentifiedBook[];
 }
 
 export function useStats() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,8 @@ export interface SyncState {
 }
 
 export interface SyncEvent {
-  type: "status" | "progress" | "complete" | "error";
+  // "match" / "search_attempt" są emitowane przez skanery (Vinted/Biblioteka)
+  type: "status" | "progress" | "complete" | "error" | "match" | "search_attempt";
   message?: string;
   error?: string;
   current?: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "moduleResolution": "bundler",
     "isolatedModules": true,
     "moduleDetection": "force",
-    "allowJs": true,
     "jsx": "react-jsx",
     "paths": {
       "@/*": [


### PR DESCRIPTION
First of the Tier-1 architecture-audit fixes — type safety.

- **`SyncEvent` union** extended with `"match"` / `"search_attempt"` — the scanners actually emit these (8× in `server.ts`), but the union only had `status|progress|complete|error`; the hole was masked by `sendEvent` typed as `any`.
- **`SyncManager` `sendEvent` params** typed as `SyncEvent` instead of `any` (11 signatures).
- **Stats components** now use the real types (`AuthorStat`, `YearlyStat`, `LibraryStat`, `IdentifiedBook`) that already existed in `useStats.ts` but were discarded at the prop boundary (`author: any`, …). Extracted `LibraryStat`/`IdentifiedBook` as named types and added the OPAC `extractedTitle`/`extractedAuthor` fields the library scan returns.
- **Removed `allowJs`** from `tsconfig.json` (TS-only project — unnecessarily widened the type surface).

Near-zero-risk change: a backend field rename in these areas now fails at `npm run lint` instead of silently at runtime.

## Validation
- `npm test`: 88/88; `npm run lint` (strict): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_