### PR TITLE
Tier 1: Opt-in Basic Auth + validate schema mutation

### DIFF
--- a/COGITATOR_GUIDELINES.md
+++ b/COGITATOR_GUIDELINES.md
@@ -11,6 +11,7 @@
 - **Error Handling**: Distinguish "no data" from "infrastructure failure": `fetchPageContent` returns `""` for a missing page but THROWS a typed `WikiFetchError` on network failure/IP block; `fetchPagesContentBulk` returns `{ contents, failedTitles }` and services surface `failedTitles` in their error summaries. A sync must never report a clean `complete` when its data source was unreachable.
 - **Observability**: use the structured `logger.ts` (`createLogger(component)`) and `classifyHttpError()` (maps failures to `ip_blocked`/`rate_limited`/`timeout`/`dns`/… with a user hint). `GET /api/diagnostics` is the end-to-end health check (Notion + parse each award page). Never log secrets — context objects carry metadata only.
 - **Resilience**: `withRetry` handles transient network errors (socket hang up, timeout, ECONNRESET) with exponential backoff and honors `Retry-After` on 429 responses.
+- **Security**: opt-in HTTP Basic Auth (`middleware/basicAuth.ts`) protects the whole service when `BASIC_AUTH_USER`+`BASIC_AUTH_PASSWORD` are set (`/api/health` stays open). Validate privileged mutations before forwarding to Notion — `updateNotionSchema` allows only `select`/`multi_select` and a well-formed `{ name }` option list. Encode/validate any request value interpolated into an outbound URL.
 
 ## 2. FRONTEND ARCHITECTURE (REACT)
 - **Component Decomposition**: Strict SRP. UI components in `src/components/` (atomic parts in subdirs like `stats/`).

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Port pochodzi ze zmiennej `PORT` (domyślnie `3000`).
 Repozytorium zawiera blueprint **[`render.yaml`](./render.yaml)**:
 
 - **Runtime:** Node
-- **Build:** `npm install && npm run build`
+- **Build:** `npm ci --include=dev && npm run build`
 - **Start:** `npm start`
 - **Health check:** `/api/health`
 - **Zmienne:** ustaw `NOTION_API_KEY`, `NOTION_DATABASE_ID` (oraz opcjonalnie `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD`) jako sekrety; `NODE_ENV=production`.
@@ -174,6 +174,13 @@ Repozytorium zawiera blueprint **[`render.yaml`](./render.yaml)**:
 Możesz wdrożyć jako *Blueprint* (Render odczyta `render.yaml`) albo ręcznie jako *Web Service* z powyższymi ustawieniami. Na darmowym planie instancja usypia po ~15 min bezczynności (pierwsze wejście po przerwie trwa ~30–60 s).
 
 SSE za proxy Rendera jest zahartowane po stronie serwera (padding wymuszający flush, `X-Accel-Buffering: no`, częsty keepalive) — patrz [Rozwiązywanie problemów](#rozwiązywanie-problemów).
+
+### Bezpieczeństwo
+
+To narzędzie osobiste bez wieloużytkownikowej autoryzacji, ale na publicznym URL warto je chronić:
+
+- **Ochrona hasłem (opt-in):** ustaw `BASIC_AUTH_USER` + `BASIC_AUTH_PASSWORD`, aby wymusić HTTP Basic Auth na całym serwisie (SPA + API). Bez tych zmiennych autoryzacja jest wyłączona (brak lockoutu). `/api/health` pozostaje otwarte dla health checku.
+- **Walidacja mutacji schematu:** `PATCH /api/notion/schema` przyjmuje wyłącznie typy `select`/`multi_select` i poprawną listę opcji `{ name }` — reszta jest odrzucana (400).
 
 ---
 

--- a/__tests__/basicAuth.test.ts
+++ b/__tests__/basicAuth.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { basicAuth } from "../middleware/basicAuth";
+
+function mkReq(headers: Record<string, string> = {}, path = "/") {
+  return { headers, path } as any;
+}
+function mkRes() {
+  const res: any = { statusCode: 200, headers: {}, body: undefined };
+  res.setHeader = (k: string, v: string) => { res.headers[k] = v; };
+  res.status = vi.fn((code: number) => { res.statusCode = code; return res; });
+  res.send = vi.fn((b: any) => { res.body = b; return res; });
+  return res;
+}
+
+const creds = () => ({ BASIC_AUTH_USER: "u", BASIC_AUTH_PASSWORD: "p" } as any);
+const basic = (u: string, p: string) => "Basic " + Buffer.from(`${u}:${p}`).toString("base64");
+
+describe("basicAuth", () => {
+  it("is a no-op when credentials are not configured (opt-in)", () => {
+    const next = vi.fn();
+    basicAuth(() => ({} as any))(mkReq(), mkRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("always allows /api/health even when enabled", () => {
+    const next = vi.fn();
+    basicAuth(creds)(mkReq({}, "/api/health"), mkRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a request with no/invalid credentials (401 + WWW-Authenticate)", () => {
+    const next = vi.fn();
+    const res = mkRes();
+    basicAuth(creds)(mkReq({}, "/"), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["WWW-Authenticate"]).toContain("Basic");
+  });
+
+  it("rejects wrong password", () => {
+    const next = vi.fn();
+    const res = mkRes();
+    basicAuth(creds)(mkReq({ authorization: basic("u", "wrong") }, "/"), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("allows correct credentials", () => {
+    const next = vi.fn();
+    basicAuth(creds)(mkReq({ authorization: basic("u", "p") }, "/api/stats"), mkRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -72,6 +72,20 @@ describe('Backend API Endpoints', () => {
     expect(res.body).toEqual({ success: true });
   });
 
+  it('PATCH /api/notion/schema rejects a disallowed property type', async () => {
+    const res = await request(app)
+      .patch('/api/notion/schema')
+      .send({ propertyName: 'Autor', propertyType: 'title', newOptions: [{ name: 'x' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH /api/notion/schema rejects malformed options', async () => {
+    const res = await request(app)
+      .patch('/api/notion/schema')
+      .send({ propertyName: 'Autor', propertyType: 'multi_select', newOptions: "not-an-array" });
+    expect(res.status).toBe(400);
+  });
+
   it('POST /api/sync starts a sync stream', async () => {
     const res = await request(app)
       .post('/api/sync')

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -65,13 +65,29 @@ export const getNotionSchema = async (req: Request, res: Response) => {
   }
 };
 
+// Ten endpoint edytuje wyłącznie opcje kolumn select/multi_select — waliduj
+// wejście zanim trafi do Notion (mutacja schematu jest operacją uprzywilejowaną).
+const ALLOWED_SCHEMA_TYPES = new Set(["select", "multi_select"]);
+
 export const updateNotionSchema = async (req: Request, res: Response) => {
   try {
-    const { propertyName, propertyType, newOptions } = req.body;
+    const { propertyName, propertyType, newOptions } = req.body ?? {};
+
+    if (typeof propertyName !== "string" || propertyName.trim() === "" || propertyName.length > 200) {
+      return res.status(400).json({ error: "Nieprawidłowa nazwa właściwości." });
+    }
+    if (!ALLOWED_SCHEMA_TYPES.has(propertyType)) {
+      return res.status(400).json({ error: `Niedozwolony typ właściwości: ${propertyType}. Dozwolone: select, multi_select.` });
+    }
+    if (!Array.isArray(newOptions) || newOptions.length > 500 ||
+        !newOptions.every(o => o && typeof o === "object" && typeof o.name === "string")) {
+      return res.status(400).json({ error: "Nieprawidłowa lista opcji (oczekiwano tablicy { name })." });
+    }
+
     await syncManager.updateNotionSchema(propertyName, propertyType, newOptions);
     res.json({ success: true });
   } catch (error: any) {
-    console.error("Schema Update Error:", error);
+    log.error("Schema Update Error", { message: error?.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas aktualizacji schematu." });
   }
 };

--- a/middleware/basicAuth.ts
+++ b/middleware/basicAuth.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/**
+ * Opt-in HTTP Basic Auth.
+ *
+ * Aktywne tylko gdy ustawiono OBIE zmienne BASIC_AUTH_USER i
+ * BASIC_AUTH_PASSWORD — w przeciwnym razie middleware przepuszcza wszystko
+ * (zachowanie domyślne, brak lockoutu istniejącego wdrożenia).
+ * `/api/health` jest zawsze otwarte (health check hostingu).
+ *
+ * Chroni cały serwis (SPA + API): przeglądarka pokazuje natywny prompt, a
+ * same-origin `fetch` z SPA automatycznie dołącza poświadczenia po zalogowaniu.
+ */
+export function basicAuth(getEnv: () => NodeJS.ProcessEnv = () => process.env) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const env = getEnv();
+    const user = env.BASIC_AUTH_USER;
+    const pass = env.BASIC_AUTH_PASSWORD;
+
+    // Opt-in: bez skonfigurowanych poświadczeń nie wymuszamy autoryzacji.
+    if (!user || !pass) return next();
+
+    // Health check musi być osiągalny bez logowania (monitoring hostingu).
+    if (req.path === "/api/health") return next();
+
+    const header = req.headers.authorization || "";
+    const [scheme, encoded] = header.split(" ");
+    if (scheme === "Basic" && encoded) {
+      const decoded = Buffer.from(encoded, "base64").toString("utf8");
+      const sep = decoded.indexOf(":");
+      if (sep !== -1) {
+        const u = decoded.slice(0, sep);
+        const p = decoded.slice(sep + 1);
+        if (safeEqual(u, user) && safeEqual(p, pass)) return next();
+      }
+    }
+
+    res.setHeader("WWW-Authenticate", 'Basic realm="Cogitator Omnissiah", charset="UTF-8"');
+    return res.status(401).send("Wymagana autoryzacja.");
+  };
+}

--- a/server.ts
+++ b/server.ts
@@ -22,6 +22,7 @@ import { withRetry } from "./retry";
 import syncRoutes from "./routes/syncRoutes";
 import { createLogger, classifyHttpError } from "./logger";
 import { SyncEvent } from "./src/types";
+import { basicAuth } from "./middleware/basicAuth";
 
 dotenv.config();
 
@@ -680,6 +681,9 @@ class SyncManager {
 export const syncManager = new SyncManager(notionAdapter, wikiAdapter);
 
 export const app = express();
+// Opt-in Basic Auth (aktywne tylko gdy ustawiono BASIC_AUTH_USER + _PASSWORD).
+// Musi być pierwszy, by chronić także SPA i pliki statyczne.
+app.use(basicAuth());
 app.use(express.json());
 app.use("/api", syncRoutes);
 


### PR DESCRIPTION
Final Tier-1 batch — the highest-severity item from the audit: a `0.0.0.0`-bound public service with no auth and an unvalidated privileged mutation endpoint.

- **`middleware/basicAuth.ts`** — opt-in HTTP Basic Auth. Active only when `BASIC_AUTH_USER` + `BASIC_AUTH_PASSWORD` are set (otherwise a no-op, so it **never locks out the current deploy**). Protects the whole service (SPA + API); `/api/health` stays open for the hosting health check; timing-safe credential compare. Mounted as the first middleware so it also guards the static SPA. The browser prompts natively and the same-origin SPA fetches carry the credentials automatically.
- **`updateNotionSchema` input validation** — `propertyName` must be a bounded non-empty string, `propertyType` must be in `{select, multi_select}`, `newOptions` must be a well-formed `{ name }` array; otherwise `400`. Previously the body was forwarded straight to Notion.

## Validation
- New tests: 5 `basicAuth` unit tests (opt-in no-op, health-open, 401, wrong password, correct creds) + 2 schema-validation supertests.
- Smoke-tested both modes: env **off** → `/api/health` and `/` return 200 (no change); env **on** → health 200, `/` 401 without creds, 200 with `-u user:pass`.
- `npm test`: 23 files, **95/95**; `npm run lint` (strict): clean; production build boots.

To enable protection: set `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` in the Render dashboard (placeholders already in `render.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_