### PR TITLE
Tier 2-B: Central ritual color theme module

### DIFF
--- a/src/components/ProgressAndResults.tsx
+++ b/src/components/ProgressAndResults.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { motion } from "motion/react";
 import { useSync } from "../hooks/useSync";
+import { getRitualTheme } from "../theme/ritualColors";
 
 interface ProgressAndResultsProps {
   syncs: ReturnType<typeof useSync>[];
@@ -20,19 +21,10 @@ export const ProgressAndResults: React.FC<ProgressAndResultsProps> = ({
   const progress = state.progress || { current: 0, total: 1 };
   const percent = progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
 
-  // Map color names to Tailwind classes
-  const colorMap: Record<string, { text: string, border: string, bg: string, shadow: string }> = {
-    cyan: { text: "text-cyan-400", border: "border-cyan-500/20", bg: "bg-cyan-500", shadow: "shadow-[0_0_15px_rgba(34,211,238,0.4)]" },
-    rose: { text: "text-rose-400", border: "border-rose-500/20", bg: "bg-rose-500", shadow: "shadow-[0_0_15px_rgba(244,63,94,0.4)]" },
-    indigo: { text: "text-indigo-400", border: "border-indigo-500/20", bg: "bg-indigo-500", shadow: "shadow-[0_0_15px_rgba(99,102,241,0.4)]" },
-    blue: { text: "text-blue-400", border: "border-blue-500/20", bg: "bg-blue-500", shadow: "shadow-[0_0_15px_rgba(59,130,246,0.4)]" },
-    purple: { text: "text-purple-400", border: "border-purple-500/20", bg: "bg-purple-500", shadow: "shadow-[0_0_15px_rgba(168,85,247,0.4)]" },
-    orange: { text: "text-orange-400", border: "border-orange-500/20", bg: "bg-orange-500", shadow: "shadow-[0_0_15px_rgba(249,115,22,0.4)]" },
-    amber: { text: "text-amber-400", border: "border-amber-500/20", bg: "bg-amber-500", shadow: "shadow-[0_0_15px_rgba(245,158,11,0.4)]" },
-    emerald: { text: "text-emerald-400", border: "border-emerald-500/20", bg: "bg-emerald-500", shadow: "shadow-[0_0_15px_rgba(16,185,129,0.4)]" },
-  };
-
-  const theme = colorMap[color] || colorMap.cyan;
+  // Motyw rytuału (patrz src/theme/ritualColors.ts). bg = pełne wypełnienie paska,
+  // shadow = poświata paska.
+  const t = getRitualTheme(color);
+  const theme = { text: t.text, border: t.border, bg: t.bgSolid, shadow: t.glow };
 
   return (
     <motion.div 

--- a/src/components/SyncSummaryResult.tsx
+++ b/src/components/SyncSummaryResult.tsx
@@ -2,16 +2,7 @@ import React, { useState } from "react";
 import { XCircle, CheckCircle2, RefreshCw, AlertCircle, Copy, Check } from "lucide-react";
 import { motion } from "motion/react";
 import { useSync } from "../hooks/useSync";
-
-const stepDotColorMap: Record<string, string> = {
-  emerald: "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]",
-  amber: "bg-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.5)]",
-  cyan: "bg-cyan-500 shadow-[0_0_8px_rgba(6,182,212,0.5)]",
-  blue: "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)]",
-  rose: "bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.5)]",
-  indigo: "bg-indigo-500 shadow-[0_0_8px_rgba(99,102,241,0.5)]",
-  purple: "bg-purple-500 shadow-[0_0_8px_rgba(168,85,247,0.5)]",
-};
+import { getRitualTheme, getRitualDot } from "../theme/ritualColors";
 
 interface SyncSummaryResultProps {
   syncs: ReturnType<typeof useSync>[];
@@ -83,7 +74,7 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
               <div key={res.name} className="p-3 rounded-xl bg-slate-900/40 border border-slate-800/50 flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   {/* Tailwind nie generuje klas budowanych dynamicznie — mapuj statycznie */}
-                  <div className={`w-2 h-2 rounded-full ${stepDotColorMap[res.color] || stepDotColorMap.cyan}`} />
+                  <div className={`w-2 h-2 rounded-full ${getRitualDot(res.color)}`} />
                   <span className="text-xs font-bold text-slate-300 uppercase tracking-wider">{res.name}</span>
                 </div>
                 <div className="text-[10px] font-mono text-slate-500">
@@ -131,19 +122,9 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
   const color = activeSync.state.color || "cyan";
   const summary = activeResult?.summary;
 
-  // Map color names to Tailwind classes
-  const colorMap: Record<string, { text: string, border: string, bg: string }> = {
-    cyan: { text: "text-cyan-400", border: "border-cyan-500/20", bg: "bg-cyan-500/10" },
-    rose: { text: "text-rose-400", border: "border-rose-500/20", bg: "bg-rose-500/10" },
-    indigo: { text: "text-indigo-400", border: "border-indigo-500/20", bg: "bg-indigo-500/10" },
-    blue: { text: "text-blue-400", border: "border-blue-500/20", bg: "bg-blue-500/10" },
-    purple: { text: "text-purple-400", border: "border-purple-500/20", bg: "bg-purple-500/10" },
-    orange: { text: "text-orange-400", border: "border-orange-500/20", bg: "bg-orange-500/10" },
-    amber: { text: "text-amber-400", border: "border-amber-500/20", bg: "bg-amber-500/10" },
-    emerald: { text: "text-emerald-400", border: "border-emerald-500/20", bg: "bg-emerald-500/10" },
-  };
-
-  const theme = colorMap[color] || colorMap.cyan;
+  // Motyw rytuału (patrz src/theme/ritualColors.ts). Tu bg = miękkie tło karty.
+  const t = getRitualTheme(color);
+  const theme = { text: t.text, border: t.border, bg: t.bgSoft };
 
   const handleClose = () => {
     syncs.forEach(s => s.setState(prev => ({ ...prev, result: null })));

--- a/src/components/stats/AuthorProgressItem.tsx
+++ b/src/components/stats/AuthorProgressItem.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { motion } from "motion/react";
 import { User, ChevronDown, ChevronUp, CheckCircle2, Circle } from "lucide-react";
 import { AuthorStat } from "../../hooks/useStats";
+import { getRitualGradient } from "../../theme/ritualColors";
 
 export const AuthorProgressItem: React.FC<{ author: AuthorStat }> = ({ author }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const percent = author.total > 0 ? Math.round((author.read / author.total) * 100) : 0;
   const color = author.read === author.total ? "emerald" : "cyan";
-  const colorClass = color === "emerald" ? "from-emerald-500 to-teal-600" : "from-cyan-500 to-blue-600";
-  const shadowClass = color === "emerald" ? "shadow-emerald-500/20" : "shadow-cyan-500/20";
+  const { gradient: colorClass, shadow: shadowClass } = getRitualGradient(color);
 
   return (
     <div className="space-y-2">

--- a/src/components/stats/ProgressBar.tsx
+++ b/src/components/stats/ProgressBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { motion } from "motion/react";
+import { getRitualGradient } from "../../theme/ritualColors";
 
 interface ProgressBarProps {
   current: number;
@@ -11,12 +12,7 @@ interface ProgressBarProps {
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({ current, total, label, icon: Icon, color = "cyan" }) => {
   const percent = total > 0 ? Math.round((current / total) * 100) : 0;
-  const colorClass = color === "cyan" ? "from-cyan-500 to-blue-600" : 
-                     color === "purple" ? "from-purple-500 to-indigo-600" :
-                     color === "orange" ? "from-orange-500 to-red-600" : "from-emerald-500 to-teal-600";
-  const shadowClass = color === "cyan" ? "shadow-cyan-500/20" : 
-                      color === "purple" ? "shadow-purple-500/20" :
-                      color === "orange" ? "shadow-orange-500/20" : "shadow-emerald-500/20";
+  const { gradient: colorClass, shadow: shadowClass } = getRitualGradient(color);
 
   return (
     <div className="space-y-2">

--- a/src/theme/ritualColors.ts
+++ b/src/theme/ritualColors.ts
@@ -1,0 +1,74 @@
+/**
+ * Centralny motyw kolorów rytuałów.
+ *
+ * Każdy rytuał (synchronizacja) niesie swój kolor w `SyncState.color`; paski
+ * postępu, karty podsumowań i kropki kroków dziedziczą go, by wzmacniać tożsamość
+ * rytuału (zob. COGITATOR_GUIDELINES §2 "Dynamic UI"). Wcześniej te same mapy
+ * klas Tailwinda były duplikowane w kilku komponentach — tutaj są w jednym miejscu.
+ *
+ * UWAGA: klasy muszą być pełnymi literałami (`text-cyan-400`, nie `text-${c}-400`),
+ * inaczej skaner JIT Tailwinda ich nie wykryje i nie trafią do builda.
+ */
+
+export type RitualColor =
+  | "cyan"
+  | "rose"
+  | "indigo"
+  | "blue"
+  | "purple"
+  | "orange"
+  | "amber"
+  | "emerald";
+
+export interface RitualTheme {
+  /** Tekst akcentu, np. nagłówki (text-*-400). */
+  text: string;
+  /** Obramowanie kart (border-*-500/20). */
+  border: string;
+  /** Miękkie tło panelu/karty (bg-*-500/10). */
+  bgSoft: string;
+  /** Pełne tło, np. wypełnienie paska postępu (bg-*-500). */
+  bgSolid: string;
+  /** Poświata paska postępu (shadow-[…0.4]). */
+  glow: string;
+  /** Kropka kroku na osi rytuałów (bg-*-500 + mniejsza poświata). */
+  dot: string;
+}
+
+export const ritualTheme: Record<RitualColor, RitualTheme> = {
+  cyan:    { text: "text-cyan-400",    border: "border-cyan-500/20",    bgSoft: "bg-cyan-500/10",    bgSolid: "bg-cyan-500",    glow: "shadow-[0_0_15px_rgba(34,211,238,0.4)]",  dot: "bg-cyan-500 shadow-[0_0_8px_rgba(6,182,212,0.5)]" },
+  rose:    { text: "text-rose-400",    border: "border-rose-500/20",    bgSoft: "bg-rose-500/10",    bgSolid: "bg-rose-500",    glow: "shadow-[0_0_15px_rgba(244,63,94,0.4)]",   dot: "bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.5)]" },
+  indigo:  { text: "text-indigo-400",  border: "border-indigo-500/20",  bgSoft: "bg-indigo-500/10",  bgSolid: "bg-indigo-500",  glow: "shadow-[0_0_15px_rgba(99,102,241,0.4)]",  dot: "bg-indigo-500 shadow-[0_0_8px_rgba(99,102,241,0.5)]" },
+  blue:    { text: "text-blue-400",    border: "border-blue-500/20",    bgSoft: "bg-blue-500/10",    bgSolid: "bg-blue-500",    glow: "shadow-[0_0_15px_rgba(59,130,246,0.4)]",  dot: "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)]" },
+  purple:  { text: "text-purple-400",  border: "border-purple-500/20",  bgSoft: "bg-purple-500/10",  bgSolid: "bg-purple-500",  glow: "shadow-[0_0_15px_rgba(168,85,247,0.4)]",  dot: "bg-purple-500 shadow-[0_0_8px_rgba(168,85,247,0.5)]" },
+  orange:  { text: "text-orange-400",  border: "border-orange-500/20",  bgSoft: "bg-orange-500/10",  bgSolid: "bg-orange-500",  glow: "shadow-[0_0_15px_rgba(249,115,22,0.4)]",  dot: "bg-orange-500 shadow-[0_0_8px_rgba(249,115,22,0.5)]" },
+  amber:   { text: "text-amber-400",   border: "border-amber-500/20",   bgSoft: "bg-amber-500/10",   bgSolid: "bg-amber-500",   glow: "shadow-[0_0_15px_rgba(245,158,11,0.4)]",  dot: "bg-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.5)]" },
+  emerald: { text: "text-emerald-400", border: "border-emerald-500/20", bgSoft: "bg-emerald-500/10", bgSolid: "bg-emerald-500", glow: "shadow-[0_0_15px_rgba(16,185,129,0.4)]",  dot: "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]" },
+};
+
+/** Pełny motyw rytuału z bezpiecznym fallbackiem do cyan. */
+export const getRitualTheme = (color?: string | null): RitualTheme =>
+  ritualTheme[(color as RitualColor)] ?? ritualTheme.cyan;
+
+/** Sama kropka kroku (z fallbackiem do cyan). */
+export const getRitualDot = (color?: string | null): string => getRitualTheme(color).dot;
+
+/**
+ * Gradientowe paski postępu (ProgressBar / AuthorProgressItem). Osobna mapa, bo
+ * gradient ma inny kolor docelowy niż nazwa rytuału (cyan→blue, purple→indigo,
+ * orange→red, emerald→teal). Fallback: emerald (zgodnie z poprzednim zachowaniem).
+ */
+export interface RitualGradient {
+  gradient: string;
+  shadow: string;
+}
+
+export const ritualGradient: Record<string, RitualGradient> = {
+  cyan:    { gradient: "from-cyan-500 to-blue-600",     shadow: "shadow-cyan-500/20" },
+  purple:  { gradient: "from-purple-500 to-indigo-600", shadow: "shadow-purple-500/20" },
+  orange:  { gradient: "from-orange-500 to-red-600",    shadow: "shadow-orange-500/20" },
+  emerald: { gradient: "from-emerald-500 to-teal-600",  shadow: "shadow-emerald-500/20" },
+};
+
+export const getRitualGradient = (color?: string | null): RitualGradient =>
+  ritualGradient[color as string] ?? ritualGradient.emerald;


### PR DESCRIPTION
## Cel

Cztery komponenty trzymały własne, powielone kopie mapy „kolor rytuału → klasy Tailwinda" (paski postępu, karty podsumowań, kropki kroków). Mapy się rozjeżdżały i duplikowały te same literały klas. Ten PR konsoliduje je w jednym źródle prawdy: `src/theme/ritualColors.ts`.

## Zmiany

- **`ritualTheme`** (wszystkie 8 kolorów rytuałów) wystawia fasety `text` / `border` / `bgSoft` / `bgSolid` / `glow` / `dot`; `getRitualTheme()` i `getRitualDot()` rozwiązują z fallbackiem do `cyan`.
- **`ritualGradient` + `getRitualGradient()`** obsługują gradientowe paski (`ProgressBar`, `AuthorProgressItem`) z dotychczasowym fallbackiem do `emerald`.
- `ProgressAndResults`, `SyncSummaryResult`, `ProgressBar`, `AuthorProgressItem` czytają teraz z modułu zamiast z map inline. Literały klas są bajt-w-bajt identyczne, więc render się nie zmienia. Drobny zysk spójności: pomarańczowa kropka kroku renderuje się teraz na pomarańczowo zamiast wpadać w fallback cyan.

## Uwaga o Tailwindzie

Literały klas żyją w module, więc skaner JIT Tailwinda nadal je emituje — **zweryfikowane**: wszystkie klasy `glow` / `dot` / `gradient` są obecne w zbudowanym CSS.

## Weryfikacja

- `npm run lint` — czysto
- `npm test` — 101/101
- `npm run build` — OK (klasy potwierdzone w `dist/assets/*.css`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_