### PR TITLE
Tier 2-C: Shared consumeSSE primitive across streaming hooks

### DIFF
--- a/COGITATOR_GUIDELINES.md
+++ b/COGITATOR_GUIDELINES.md
@@ -15,7 +15,7 @@
 
 ## 2. FRONTEND ARCHITECTURE (REACT)
 - **Component Decomposition**: Strict SRP. UI components in `src/components/` (atomic parts in subdirs like `stats/`).
-- **SSE Parsing**: All streaming hooks MUST buffer chunks across TCP reads (`buffer += decoder.decode(value, { stream: true })`, split on `\n\n`, keep the remainder) — see `useSync`. Never `JSON.parse` a raw chunk line-by-line.
+- **SSE Parsing**: All streaming hooks MUST consume the stream through the shared `consumeSSE` primitive (`src/utils/sse.ts`), which buffers chunks across TCP reads (split on `\n\n`, keep the remainder) and parses `data:` lines. Never re-implement the read/buffer loop or `JSON.parse` a raw chunk line-by-line. `consumeSSE(body, onEvent, onChunk?)`: `onEvent` returns `true` to stop early (e.g. after `complete`/`error`); `onChunk` re-arms per-read watchdogs (see `useSync`).
 - **Logic Isolation**: No `useEffect` for data fetching in components. Use Custom Hooks:
   - `useSync`: Standard for all long-running server operations.
   - `useStats`: Global dashboard data.

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { IdentifiedBooks } from "./useStats";
+import { consumeSSE } from "../utils/sse";
 
 export type { IdentifiedBooks };
 
@@ -30,68 +31,40 @@ export function useLibraryCheck() {
 
         if (!response.ok) throw new Error("Błąd podczas sprawdzania biblioteki");
 
-        const reader = response.body?.getReader();
-        if (!reader) {
-          resolve();
-          return;
-        }
-
-        // Buforuj między chunkami (wzorzec z useSync) — zdarzenie SSE może być
-        // rozcięte między dwa odczyty TCP i JSON.parse na fragmencie wywala skan
-        const decoder = new TextDecoder();
-        let buffer = "";
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n\n");
-          buffer = lines.pop() || "";
-
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              let data: any;
-              try {
-                data = JSON.parse(line.substring(6));
-              } catch (e) {
-                console.error("Błąd parsowania SSE:", e);
-                continue;
-              }
-              if (data.type === "progress") {
-                setCheckProgress(prev => ({ 
-                  current: data.current, 
-                  total: data.total, 
-                  message: data.message,
-                  startTime: prev?.startTime || Date.now()
-                }));
-              } else if (data.type === "status") {
-                setCheckProgress(prev => ({ 
-                  current: prev?.current || 0, 
-                  total: prev?.total || 0, 
-                  message: data.message,
-                  startTime: prev?.startTime || Date.now()
-                }));
-              } else if (data.type === "match") {
-                setIdentifiedBooks(prev => {
-                  const currentLibraryBooks = prev[libraryId] || [];
-                  // Check if already exists to avoid duplicates (though server shouldn't send them)
-                  if (currentLibraryBooks.some(b => b.id === data.result.id)) return prev;
-                  return {
-                    ...prev,
-                    [libraryId]: [...currentLibraryBooks, data.result]
-                  };
-                });
-              } else if (data.type === "complete") {
-                setIdentifiedBooks(prev => ({
-                  ...prev,
-                  [libraryId]: data.result.results
-                }));
-              } else if (data.type === "error") {
-                throw new Error(data.error);
-              }
-            }
+        await consumeSSE(response.body, (data) => {
+          if (data.type === "progress") {
+            setCheckProgress(prev => ({
+              current: data.current ?? 0,
+              total: data.total ?? 0,
+              message: data.message ?? "",
+              startTime: prev?.startTime || Date.now()
+            }));
+          } else if (data.type === "status") {
+            setCheckProgress(prev => ({
+              current: prev?.current || 0,
+              total: prev?.total || 0,
+              message: data.message ?? "",
+              startTime: prev?.startTime || Date.now()
+            }));
+          } else if (data.type === "match") {
+            setIdentifiedBooks(prev => {
+              const currentLibraryBooks = prev[libraryId] || [];
+              // Check if already exists to avoid duplicates (though server shouldn't send them)
+              if (currentLibraryBooks.some(b => b.id === data.result.id)) return prev;
+              return {
+                ...prev,
+                [libraryId]: [...currentLibraryBooks, data.result]
+              };
+            });
+          } else if (data.type === "complete") {
+            setIdentifiedBooks(prev => ({
+              ...prev,
+              [libraryId]: data.result.results
+            }));
+          } else if (data.type === "error") {
+            throw new Error(data.error);
           }
-        }
+        });
         resolve();
       } catch (err: any) {
         setLibraryError(err.message);

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { SyncState, SyncEvent } from "../types";
+import { consumeSSE } from "../utils/sse";
 
 export function useSync(endpoint: string, stopEndpoint: string, initialState: Partial<SyncState> = {}) {
   const [state, setState] = useState<SyncState>({
@@ -74,59 +75,46 @@ export function useSync(endpoint: string, stopEndpoint: string, initialState: Pa
         throw new Error(errorMessage);
       }
 
-      const reader = res.body?.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-
-      if (reader) {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          armWatchdog(); // każdy fragment (także keepalive) resetuje watchdog
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n\n');
-          buffer = lines.pop() || "";
-          
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              try {
-                const data: SyncEvent = JSON.parse(line.substring(6));
-                
-                if (data.type === "status") {
-                  setState(prev => ({ ...prev, statusMessage: data.message ?? null }));
-                } else if (data.type === "progress") {
-                  setState(prev => ({
-                    ...prev,
-                    statusMessage: data.message ?? null,
-                    progress: { current: data.current ?? 0, total: data.total ?? 0 }
-                  }));
-                } else if (data.type === "complete") {
-                  const finalResult = onComplete ? onComplete(data.result) : data.result;
-                  setState(prev => ({ 
-                    ...prev, 
-                    result: finalResult, 
-                    statusMessage: null, 
-                    progress: null,
-                    loading: false
-                  }));
-                  return finalResult;
-                } else if (data.type === "error") {
-                  setState(prev => ({
-                    ...prev,
-                    error: data.error ?? "Nieznany błąd synchronizacji",
-                    loading: false,
-                    statusMessage: null,
-                    progress: null
-                  }));
-                  return false;
-                }
-              } catch (e) {
-                console.error("Błąd parsowania SSE:", e);
-              }
-            }
-          }
+      // Konsumpcja strumienia SSE; onChunk resetuje watchdog przy każdym odczycie
+      // (także keepalive liczy się jako aktywność). Wynik complete/error łapiemy
+      // do `outcome`, bo callback nie może bezpośrednio wyjść z startSync.
+      let outcome: { type: "complete"; result: any } | { type: "error" } | null = null;
+      await consumeSSE(res.body, (data: SyncEvent) => {
+        if (data.type === "status") {
+          setState(prev => ({ ...prev, statusMessage: data.message ?? null }));
+        } else if (data.type === "progress") {
+          setState(prev => ({
+            ...prev,
+            statusMessage: data.message ?? null,
+            progress: { current: data.current ?? 0, total: data.total ?? 0 }
+          }));
+        } else if (data.type === "complete") {
+          const finalResult = onComplete ? onComplete(data.result) : data.result;
+          setState(prev => ({
+            ...prev,
+            result: finalResult,
+            statusMessage: null,
+            progress: null,
+            loading: false
+          }));
+          outcome = { type: "complete", result: finalResult };
+          return true;
+        } else if (data.type === "error") {
+          setState(prev => ({
+            ...prev,
+            error: data.error ?? "Nieznany błąd synchronizacji",
+            loading: false,
+            statusMessage: null,
+            progress: null
+          }));
+          outcome = { type: "error" };
+          return true;
         }
+      }, armWatchdog);
+
+      if (outcome) {
+        const result = outcome as { type: "complete"; result: any } | { type: "error" };
+        return result.type === "complete" ? result.result : false;
       }
       // Strumień zakończył się bez zdarzenia complete/error (np. anulowanie po
       // stronie serwera) — nie zostawiaj UI w wiecznym stanie ładowania

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from "react";
+import { consumeSSE } from "../utils/sse";
 
 export interface VintedResult {
   id: string;
@@ -52,70 +53,42 @@ export function useVintedCheck() {
         throw new Error(errorData.error || `Błąd serwera: ${response.status}`);
       }
 
-      const reader = response.body?.getReader();
-      if (!reader) {
-        setIsChecking(false);
-        return;
-      }
-
-      // Buforuj między chunkami (wzorzec z useSync) — zdarzenie SSE może być
-      // rozcięte między dwa odczyty TCP i JSON.parse na fragmencie wywala skan
-      const decoder = new TextDecoder();
-      let buffer = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (line.startsWith("data: ")) {
-            let data: any;
-            try {
-              data = JSON.parse(line.substring(6));
-            } catch (e) {
-              console.error("Błąd parsowania SSE:", e);
-              continue;
+      await consumeSSE(response.body, (data) => {
+        if (data.type === "progress") {
+          setCheckProgress(prev => ({
+            current: data.current ?? 0,
+            total: data.total ?? 0,
+            message: data.message ?? "",
+            startTime: prev?.startTime || Date.now()
+          }));
+        } else if (data.type === "status") {
+          setCheckProgress(prev => ({
+            current: prev?.current || 0,
+            total: prev?.total || 0,
+            message: data.message ?? "",
+            startTime: prev?.startTime || Date.now()
+          }));
+        } else if (data.type === "match") {
+          setVintedResults(prev => {
+            if (prev.some(r => r.id === data.result.id)) return prev;
+            return [...prev, data.result];
+          });
+        } else if (data.type === "search_attempt") {
+          setSearchAttempts(prev => {
+            const existing = prev.findIndex(a => a.id === data.result.id);
+            if (existing !== -1) {
+              const next = [...prev];
+              next[existing] = data.result;
+              return next;
             }
-            if (data.type === "progress") {
-              setCheckProgress(prev => ({ 
-                current: data.current, 
-                total: data.total, 
-                message: data.message,
-                startTime: prev?.startTime || Date.now()
-              }));
-            } else if (data.type === "status") {
-              setCheckProgress(prev => ({ 
-                current: prev?.current || 0, 
-                total: prev?.total || 0, 
-                message: data.message,
-                startTime: prev?.startTime || Date.now()
-              }));
-            } else if (data.type === "match") {
-              setVintedResults(prev => {
-                if (prev.some(r => r.id === data.result.id)) return prev;
-                return [...prev, data.result];
-              });
-            } else if (data.type === "search_attempt") {
-              setSearchAttempts(prev => {
-                const existing = prev.findIndex(a => a.id === data.result.id);
-                if (existing !== -1) {
-                  const next = [...prev];
-                  next[existing] = data.result;
-                  return next;
-                }
-                return [...prev, data.result];
-              });
-            } else if (data.type === "complete") {
-              setVintedResults(data.result.results);
-            } else if (data.type === "error") {
-              throw new Error(data.error);
-            }
-          }
+            return [...prev, data.result];
+          });
+        } else if (data.type === "complete") {
+          setVintedResults(data.result.results);
+        } else if (data.type === "error") {
+          throw new Error(data.error);
         }
-      }
+      });
     } catch (err: any) {
       setVintedError(err.message);
     } finally {

--- a/src/utils/__tests__/sse.test.ts
+++ b/src/utils/__tests__/sse.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { consumeSSE } from "../sse";
+
+const enc = new TextEncoder();
+
+/** Build a minimal SSE body whose reader yields the given string chunks in order. */
+function mockBody(chunks: string[]) {
+  let i = 0;
+  const reader = {
+    read: vi.fn(async () => {
+      if (i < chunks.length) return { value: enc.encode(chunks[i++]), done: false };
+      return { value: undefined, done: true };
+    }),
+  };
+  return { getReader: () => reader } as any;
+}
+
+describe("consumeSSE", () => {
+  it("parses complete events and dispatches them in order", async () => {
+    const body = mockBody([
+      'data: {"type":"status","message":"A"}\n\n',
+      'data: {"type":"progress","current":1,"total":2}\n\n',
+    ]);
+    const events: any[] = [];
+    await consumeSSE(body, (e) => { events.push(e); });
+    expect(events).toEqual([
+      { type: "status", message: "A" },
+      { type: "progress", current: 1, total: 2 },
+    ]);
+  });
+
+  it("reassembles an event split across two TCP reads", async () => {
+    const body = mockBody([
+      'data: {"type":"sta',
+      'tus","message":"joined"}\n\n',
+    ]);
+    const events: any[] = [];
+    await consumeSSE(body, (e) => { events.push(e); });
+    expect(events).toEqual([{ type: "status", message: "joined" }]);
+  });
+
+  it("stops early when the callback returns true", async () => {
+    const body = mockBody([
+      'data: {"type":"complete","result":1}\n\n',
+      'data: {"type":"status","message":"after"}\n\n',
+    ]);
+    const seen: any[] = [];
+    await consumeSSE(body, (e) => {
+      seen.push(e);
+      if (e.type === "complete") return true;
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe("complete");
+  });
+
+  it("skips malformed JSON without aborting the stream", async () => {
+    const body = mockBody([
+      'data: {broken\n\n',
+      'data: {"type":"status","message":"ok"}\n\n',
+    ]);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const events: any[] = [];
+    await consumeSSE(body, (e) => { events.push(e); });
+    expect(events).toEqual([{ type: "status", message: "ok" }]);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("fires onChunk once per read and is a no-op on a null body", async () => {
+    const onChunk = vi.fn();
+    const body = mockBody(['data: {"type":"status"}\n\n', 'data: {"type":"status"}\n\n']);
+    await consumeSSE(body, () => {}, onChunk);
+    expect(onChunk).toHaveBeenCalledTimes(2);
+
+    const cb = vi.fn();
+    await consumeSSE(null, cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("propagates a throw from the callback (error events)", async () => {
+    const body = mockBody(['data: {"type":"error","error":"boom"}\n\n']);
+    await expect(
+      consumeSSE(body, (e) => { if (e.type === "error") throw new Error(e.error); })
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -1,0 +1,46 @@
+import { SyncEvent } from "../types";
+
+/**
+ * Wspólny odczyt strumienia SSE dla wszystkich hooków (useSync, useLibraryCheck,
+ * useVintedCheck). Buforuje fragmenty między odczytami TCP — pojedyncze zdarzenie
+ * SSE bywa rozcięte na granicy chunku, a `JSON.parse` na połówce wywala skan.
+ * Dzieli po `\n\n`, zachowuje resztę, parsuje linie `data: ` i woła `onEvent`.
+ *
+ * `onEvent` może zwrócić `true` (lub `"stop"`), by zakończyć konsumpcję wcześniej
+ * (np. po zdarzeniu `complete`/`error`). `onChunk` odpala się po każdym odczycie —
+ * useSync używa go do resetu watchdoga (keepalive też liczy się jako aktywność).
+ */
+export async function consumeSSE(
+  body: ReadableStream<Uint8Array> | null | undefined,
+  onEvent: (event: SyncEvent) => boolean | "stop" | void | Promise<boolean | "stop" | void>,
+  onChunk?: () => void,
+): Promise<void> {
+  const reader = body?.getReader();
+  if (!reader) return;
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    onChunk?.();
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      let event: SyncEvent;
+      try {
+        event = JSON.parse(line.substring(6));
+      } catch (e) {
+        console.error("Błąd parsowania SSE:", e);
+        continue;
+      }
+      const signal = await onEvent(event);
+      if (signal === true || signal === "stop") return;
+    }
+  }
+}


### PR DESCRIPTION
## Cel

`useSync`, `useLibraryCheck` i `useVintedCheck` — każdy powielał tę samą pętlę odczytu strumienia SSE z buforowaniem chunków (`getReader` → `decode(stream:true)` → split po `\n\n` → zachowaj resztę → parsuj linie `data:`). To dokładnie ta finezyjna, podatna na błędy pętla, w której mieszkała wcześniejsza klasa bugów „sync cicho umiera w połowie strumienia" — powinna istnieć **raz**.

## Zmiany

- **Nowe `src/utils/sse.ts`** eksportuje `consumeSSE(body, onEvent, onChunk?)`: buforuje między odczytami TCP, parsuje linie `data:`, loguje+pomija zepsuty JSON. `onEvent` może zwrócić `true`, by zakończyć wcześniej (po `complete`/`error`); `onChunk` odpala się po każdym odczycie, żeby `useSync` mógł resetować swój 30-sekundowy watchdog (keepalive liczy się jako aktywność).
- Wszystkie trzy hooki delegują teraz odczyt strumienia do `consumeSSE` i zachowują tylko własny switch dyspozycji zdarzeń oraz kształt stanu. Zachowanie bez zmian; `useSync` nadal zwraca wynik końcowy i utrzymuje ścieżkę watchdog/abort.
- **Testy** `consumeSSE`: sklejanie zdarzenia rozciętego między odczytami, wczesne zakończenie, odporność na zepsuty JSON, licznik `onChunk`, no-op na pustym body, propagacja rzuconego wyjątku.
- Reguła parsowania SSE w `COGITATOR_GUIDELINES.md` §2 wymaga teraz `consumeSSE`.

## Weryfikacja

- `npm run lint` — czysto
- `npm test` — 107/107
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_