### PR TITLE
Tier 2-D: SyncManager lifecycle + SSE contract tests

### DIFF
--- a/COGITATOR_GUIDELINES.md
+++ b/COGITATOR_GUIDELINES.md
@@ -44,6 +44,7 @@
   - `/src/hooks/__tests__/`: Custom React hooks.
 - **Mocking**: Use `vi.mock` for external dependencies (Notion SDK, Axios).
 - **Environment**: Use `@vitest-environment node` for backend tests and JSDOM for frontend tests.
+- **Orchestration & SSE contract**: `__tests__/syncManager.test.ts` guards the task lifecycle (single-active-task lock, `stopActiveSync`/`resetSyncState` cancellation, lock release) and the SSE stream contract (well-formed `data:` frames, terminal `complete`, `400` on a concurrent sync). Mock the sync service (constructable `vi.fn()` + prototype methods) so the emitted event sequence is deterministic; never assert on real service internals here.
 
 ## 5. TOKEN OPTIMIZATION (AI INSTRUCTIONS)
 - **Surgical Edits**: Use `edit_file` with precise `TargetContent`. Never replace whole files.

--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+
+// Sterowalna implementacja runBookSync — każdy test podstawia własną przez holder.
+const h = vi.hoisted(() => ({
+  runBook: null as null | ((params: any, send: (e: any) => void, checkCancel: () => boolean) => Promise<void>),
+}));
+
+vi.mock("../notion.adapter", () => {
+  const NotionAdapter = vi.fn();
+  NotionAdapter.prototype.init = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.getSchema = vi.fn().mockResolvedValue({});
+  return { NotionAdapter };
+});
+
+vi.mock("../wiki.adapter", () => {
+  const WikiAdapter = vi.fn();
+  return { WikiAdapter };
+});
+
+vi.mock("../services/bookSyncService", () => {
+  const BookSyncService = vi.fn();
+  BookSyncService.prototype.runBookSync = (p: any, s: (e: any) => void, c: () => boolean) =>
+    h.runBook ? h.runBook(p, s, c) : Promise.resolve();
+  BookSyncService.prototype.fetchBooksFromMediaWiki = () => Promise.resolve([]);
+  return { BookSyncService };
+});
+
+import { app, syncManager, closeServer } from "../server";
+
+describe("SyncManager lifecycle", () => {
+  beforeEach(() => {
+    h.runBook = null;
+    process.env.NOTION_API_KEY = "test-key";
+    process.env.NOTION_DATABASE_ID = "test-db";
+    // Upewnij się, że nie zostało nic z poprzedniego testu
+    syncManager.resetSyncState();
+  });
+
+  it("is idle before any task runs", () => {
+    expect(syncManager.isSyncing).toBe(false);
+    expect(syncManager.activeTask).toBe(null);
+  });
+
+  it("holds a single-task lock and rejects a concurrent task", async () => {
+    let release!: () => void;
+    let captured!: () => boolean;
+    h.runBook = (_p, _s, checkCancel) => {
+      captured = checkCancel;
+      return new Promise<void>((res) => { release = res; });
+    };
+
+    const running = syncManager.runBookSync({}, vi.fn());
+    // executeTask ustawia currentTask synchronicznie, zanim odda sterowanie
+    expect(syncManager.isSyncing).toBe(true);
+    expect(syncManager.activeTask).toBe("book");
+
+    await expect(syncManager.runPurifySync(vi.fn())).rejects.toThrow(/już w toku/);
+
+    // stopActiveSync ustawia flagę anulowania widoczną przez token zadania
+    expect(captured()).toBe(false);
+    expect(syncManager.stopActiveSync()).toBe(true);
+    expect(captured()).toBe(true);
+
+    release();
+    await running;
+
+    // Blokada zwolniona po zakończeniu zadania
+    expect(syncManager.isSyncing).toBe(false);
+    expect(syncManager.activeTask).toBe(null);
+  });
+
+  it("resetSyncState cancels the active task and releases the lock immediately", async () => {
+    let release!: () => void;
+    let captured!: () => boolean;
+    h.runBook = (_p, _s, checkCancel) => {
+      captured = checkCancel;
+      return new Promise<void>((res) => { release = res; });
+    };
+
+    const running = syncManager.runBookSync({}, vi.fn());
+    expect(syncManager.isSyncing).toBe(true);
+
+    syncManager.resetSyncState();
+    // Lock wolny od razu, a osierocone zadanie dostało sygnał anulowania
+    expect(syncManager.isSyncing).toBe(false);
+    expect(syncManager.activeTask).toBe(null);
+    expect(captured()).toBe(true);
+
+    // Nowe zadanie może wystartować, mimo że stare jeszcze "wisi"
+    h.runBook = () => Promise.resolve();
+    await syncManager.runPurifySync(vi.fn());
+
+    release(); // sprzątanie starego zadania — jego finally nie ruszy nowego stanu
+    await running;
+    expect(syncManager.isSyncing).toBe(false);
+  });
+
+  it("stopActiveSync returns false when nothing is running", () => {
+    expect(syncManager.stopActiveSync()).toBe(false);
+  });
+
+  afterAll(() => closeServer());
+});
+
+describe("SSE event stream (POST /api/sync)", () => {
+  beforeEach(() => {
+    process.env.NOTION_API_KEY = "test-key";
+    process.env.NOTION_DATABASE_ID = "test-db";
+    syncManager.resetSyncState();
+  });
+
+  const parseFrames = (raw: string) =>
+    raw
+      .split("\n\n")
+      .filter((f) => f.startsWith("data: "))
+      .map((f) => JSON.parse(f.slice("data: ".length)));
+
+  it("streams a well-formed status → progress → complete sequence and closes", async () => {
+    h.runBook = async (_p, send) => {
+      send({ type: "status", message: "krok" });
+      send({ type: "progress", current: 1, total: 2, message: "w toku" });
+      send({ type: "complete", result: { success: true } });
+    };
+
+    const res = await request(app)
+      .post("/api/sync")
+      .send({ awardName: "Nagroda Hugo", pageTitle: "Hugo nagroda powieść", syncAll: false });
+
+    expect(res.status).toBe(200);
+    expect(res.header["content-type"]).toContain("text/event-stream");
+
+    const frames = parseFrames(res.text);
+    const types = frames.map((f) => f.type);
+    // Pierwsze zdarzenie to handshake serwera, ostatnie to complete
+    expect(frames[0]).toMatchObject({ type: "status" });
+    expect(frames[0].message).toMatch(/Połączono/);
+    expect(types).toContain("progress");
+    expect(types[types.length - 1]).toBe("complete");
+    expect(frames[frames.length - 1].result).toEqual({ success: true });
+
+    // Lock zwolniony po zamknięciu strumienia
+    expect(syncManager.isSyncing).toBe(false);
+  });
+
+  it("rejects a second sync with 400 while one is already streaming", async () => {
+    let release!: () => void;
+    h.runBook = () => new Promise<void>((r) => { release = r; });
+
+    // .then() faktycznie wysyła żądanie supertest (jest leniwe) — trzymamy je w locie
+    const firstDone = request(app)
+      .post("/api/sync")
+      .send({ awardName: "A", pageTitle: "B" })
+      .then((r) => r);
+
+    // Poczekaj aż pierwszy sync przejmie blokadę
+    await vi.waitFor(() => expect(syncManager.isSyncing).toBe(true));
+
+    const second = await request(app).post("/api/sync").send({ awardName: "C", pageTitle: "D" });
+    expect(second.status).toBe(400);
+    expect(second.body.error).toMatch(/już w toku/);
+
+    release();
+    await firstDone;
+    expect(syncManager.isSyncing).toBe(false);
+  });
+
+  afterAll(() => closeServer());
+});


### PR DESCRIPTION
## Cel

Warstwa orkiestracji (blokada pojedynczego aktywnego zadania, kooperatywne anulowanie, zwalnianie blokady) i kontrakt strumienia SSE nie miały bezpośredniego pokrycia — istniał tylko happy-path smoke test „strumień startuje". To dokładnie te niezmienniki, których wcześniejsze regresje powodowały fałszywe anulowania i zawieszony stan „ciągle synchronizuję", więc zasługują na jawne testy.

## `__tests__/syncManager.test.ts`

- **Cykl życia**: stan bezczynny; blokada pojedynczego zadania odrzuca równoległy rytuał; token `checkCancellation` zadania przełącza się przy `stopActiveSync`; `resetSyncState` anuluje osierocone zadanie i zwalnia blokadę natychmiast (nowe zadanie może wystartować, gdy stara obietnica jeszcze „wisi"); `stopActiveSync` zwraca `false` w stanie bezczynnym.
- **Kontrakt SSE**: `POST /api/sync` strumieniuje poprawnie sformowane ramki `data:` zaczynające się od handshake'u serwera i kończące na `complete`, po czym zamyka połączenie i zwalnia blokadę; drugi równoległy sync dostaje `400 „już w toku"`.

`bookSyncService` jest mockowany jako konstruowalny `vi.fn()` z metodami na prototypie, dzięki czemu emitowana sekwencja zdarzeń (i sterowalne „wiszące" zadanie) jest deterministyczna. Wzorzec udokumentowany w `COGITATOR_GUIDELINES.md` §4.

## Weryfikacja

- `npm run lint` — czysto
- `npm test` — 113/113 (6 nowych)
- `npm run build` — OK

---

To domyka **Tier 2** (A–D): wyodrębnienie skanerów, motyw kolorów rytuałów, wspólny `consumeSSE`, testy orkiestracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_