### PR TITLE
Tier 3-B: Unify sync-service dispatch behind a task registry

### DIFF
--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -55,12 +55,12 @@ describe("SyncManager lifecycle", () => {
       return new Promise<void>((res) => { release = res; });
     };
 
-    const running = syncManager.runBookSync({}, vi.fn());
+    const running = syncManager.run("book", vi.fn(), {});
     // executeTask ustawia currentTask synchronicznie, zanim odda sterowanie
     expect(syncManager.isSyncing).toBe(true);
     expect(syncManager.activeTask).toBe("book");
 
-    await expect(syncManager.runPurifySync(vi.fn())).rejects.toThrow(/już w toku/);
+    await expect(syncManager.run("purify", vi.fn())).rejects.toThrow(/już w toku/);
 
     // stopActiveSync ustawia flagę anulowania widoczną przez token zadania
     expect(captured()).toBe(false);
@@ -83,7 +83,7 @@ describe("SyncManager lifecycle", () => {
       return new Promise<void>((res) => { release = res; });
     };
 
-    const running = syncManager.runBookSync({}, vi.fn());
+    const running = syncManager.run("book", vi.fn(), {});
     expect(syncManager.isSyncing).toBe(true);
 
     syncManager.resetSyncState();
@@ -92,9 +92,10 @@ describe("SyncManager lifecycle", () => {
     expect(syncManager.activeTask).toBe(null);
     expect(captured()).toBe(true);
 
-    // Nowe zadanie może wystartować, mimo że stare jeszcze "wisi"
+    // Nowe zadanie może wystartować, mimo że stare jeszcze "wisi" — użyj
+    // sterowalnego zadania `book` (zmockowanego), by test był deterministyczny
     h.runBook = () => Promise.resolve();
-    await syncManager.runPurifySync(vi.fn());
+    await syncManager.run("book", vi.fn(), {});
 
     release(); // sprzątanie starego zadania — jego finally nie ruszy nowego stanu
     await running;
@@ -103,6 +104,11 @@ describe("SyncManager lifecycle", () => {
 
   it("stopActiveSync returns false when nothing is running", () => {
     expect(syncManager.stopActiveSync()).toBe(false);
+  });
+
+  it("run() rejects an unknown ritual name without taking the lock", async () => {
+    await expect(syncManager.run("bogus" as any, vi.fn())).rejects.toThrow(/Nieznany rytuał/);
+    expect(syncManager.isSyncing).toBe(false);
   });
 
   afterAll(() => closeServer());

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { syncManager } from "../syncManager";
+import { syncManager, SyncTaskName } from "../syncManager";
 import { SyncEvent, SyncParams } from "../src/types";
 import { createLogger } from "../logger";
 
@@ -105,37 +105,19 @@ const stopSyncTask = (res: Response, message: string) => {
   }
 };
 
-export const stopSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie synchronizacji...");
-};
+// Zatrzymanie jest globalne (anuluje aktywne zadanie, jakiekolwiek by nie było) —
+// handlery różnią się wyłącznie komunikatem. Generujemy je z fabryki.
+const makeStopHandler = (message: string) =>
+  (_req: Request, res: Response) => stopSyncTask(res, message);
 
-export const stopPublisherSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie synchronizacji wydawnictw...");
-};
-
-export const stopSeriesSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie synchronizacji serii...");
-};
-
-export const stopCyclesSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie synchronizacji cykli...");
-};
-
-export const stopLpSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie aktualizacji Lp...");
-};
-
-export const stopDuplicatesSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie sprawdzania duplikatów...");
-};
-
-export const stopLibraryCheck = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie skanowania biblioteki...");
-};
-
-export const stopIntegrityCheck = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymano skanowanie integralności.");
-};
+export const stopSync = makeStopHandler("Zatrzymywanie synchronizacji...");
+export const stopPublisherSync = makeStopHandler("Zatrzymywanie synchronizacji wydawnictw...");
+export const stopSeriesSync = makeStopHandler("Zatrzymywanie synchronizacji serii...");
+export const stopCyclesSync = makeStopHandler("Zatrzymywanie synchronizacji cykli...");
+export const stopLpSync = makeStopHandler("Zatrzymywanie aktualizacji Lp...");
+export const stopDuplicatesSync = makeStopHandler("Zatrzymywanie sprawdzania duplikatów...");
+export const stopLibraryCheck = makeStopHandler("Zatrzymywanie skanowania biblioteki...");
+export const stopIntegrityCheck = makeStopHandler("Zatrzymano skanowanie integralności.");
 
 const setupSSE = (res: Response) => {
   res.setHeader("Content-Type", "text/event-stream");
@@ -165,7 +147,7 @@ export const runSync = async (req: Request, res: Response) => {
   await executeSyncTask(
     req,
     res,
-    (sendEvent) => syncManager.runBookSync({ awardName, pageTitle, syncAll }, sendEvent),
+    (sendEvent) => syncManager.run("book", sendEvent, { awardName, pageTitle, syncAll }),
     "Sync Error:"
   );
 };
@@ -228,85 +210,25 @@ const executeSyncTask = async (
   }
 };
 
-export const runPublisherSync = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runPublisherSync(sendEvent),
-    "Sync Publisher Error:"
-  );
-};
+// Rytuały bez parametrów żądania mają identyczny handler — różnią się tylko
+// nazwą zadania i etykietą błędu. Generujemy je z tabeli zamiast powielać.
+const makeSyncHandler = (task: SyncTaskName, errorLabel: string) =>
+  async (req: Request, res: Response) => {
+    await executeSyncTask(req, res, (sendEvent) => syncManager.run(task, sendEvent), errorLabel);
+  };
 
-export const runSeriesSync = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runSeriesSync(sendEvent),
-    "Sync Series Error:"
-  );
-};
+export const runPublisherSync = makeSyncHandler("publisher", "Sync Publisher Error:");
+export const runSeriesSync = makeSyncHandler("series", "Sync Series Error:");
+export const runCyclesSync = makeSyncHandler("cycles", "Sync Cycles Error:");
+export const runLpSync = makeSyncHandler("lp", "Sync Lp Error:");
+export const runDuplicateCheck = makeSyncHandler("duplicates", "Sync Duplicates Error:");
+export const runPurifySync = makeSyncHandler("purify", "Sync Purify Error:");
+export const runSchemaSync = makeSyncHandler("schema", "Sync Schema Error:");
+export const runIntegrityCheck = makeSyncHandler("integrity", "Integrity Check Error:");
 
-export const runCyclesSync = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runCyclesSync(sendEvent),
-    "Sync Cycles Error:"
-  );
-};
+export const stopPurifySync = makeStopHandler("Zatrzymano rytuał puryfikacji.");
 
-export const runLpSync = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runLpSync(sendEvent),
-    "Sync Lp Error:"
-  );
-};
-
-export const runDuplicateCheck = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runDuplicateCheck(sendEvent),
-    "Sync Duplicates Error:"
-  );
-};
-
-export const runPurifySync = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runPurifySync(sendEvent),
-    "Sync Purify Error:"
-  );
-};
-
-export const stopPurifySync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymano rytuał puryfikacji.");
-};
-
-export const runSchemaSync = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runSchemaSync(sendEvent),
-    "Sync Schema Error:"
-  );
-};
-
-export const runIntegrityCheck = async (req: Request, res: Response) => {
-  await executeSyncTask(
-    req,
-    res,
-    (sendEvent) => syncManager.runIntegrityCheck(sendEvent),
-    "Integrity Check Error:"
-  );
-};
-
-export const stopSchemaSync = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymano inicjalizację schematu.");
-};
+export const stopSchemaSync = makeStopHandler("Zatrzymano inicjalizację schematu.");
 
 export const markAsRead = async (req: Request, res: Response) => {
   try {
@@ -328,14 +250,12 @@ export const checkVintedAvailability = async (req: Request, res: Response) => {
   await executeSyncTask(
     req,
     res,
-    (sendEvent) => syncManager.checkVintedAvailability(sendEvent),
+    (sendEvent) => syncManager.run("vinted", sendEvent),
     "Vinted Check Error:"
   );
 };
 
-export const stopVintedCheck = (req: Request, res: Response) => {
-  stopSyncTask(res, "Zatrzymywanie skanowania Vinted...");
-};
+export const stopVintedCheck = makeStopHandler("Zatrzymywanie skanowania Vinted...");
 
 export const checkLibraryAvailability = async (req: Request, res: Response) => {
   const { libraryCode } = req.body;
@@ -344,7 +264,7 @@ export const checkLibraryAvailability = async (req: Request, res: Response) => {
   await executeSyncTask(
     req,
     res,
-    (sendEvent) => syncManager.checkLibraryAvailability(libraryCode, sendEvent),
+    (sendEvent) => syncManager.run("library", sendEvent, { libraryCode }),
     "Library Check Error:"
   );
 };

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -44,6 +44,43 @@ interface SyncTask {
   cancelRequested: boolean;
 }
 
+/** Kanoniczne nazwy rytuałów synchronizacji — jedno źródło prawdy dla dispatchu. */
+export type SyncTaskName =
+  | "book"
+  | "purify"
+  | "schema"
+  | "publisher"
+  | "series"
+  | "duplicates"
+  | "lp"
+  | "cycles"
+  | "integrity"
+  | "library"
+  | "vinted";
+
+type TaskFn = (checkCancellation: () => boolean) => Promise<void>;
+
+/**
+ * Rejestr rytuałów: nazwa → fabryka `taskFn`. Każdy serwis ma inaczej nazwaną
+ * metodę `run*`, ale wszystkie mają ten sam kontrakt `(sendEvent, checkCancellation)`;
+ * rejestr spina je w jedną tablicę, dzięki czemu SyncManager.run() jest jednym
+ * generycznym dispatcherem zamiast kilkunastu bliźniaczych metod. `book` i
+ * `library` przyjmują dodatkowe parametry z żądania (przez argument `params`).
+ */
+const TASK_REGISTRY: Record<SyncTaskName, (sendEvent: (data: SyncEvent) => void, params?: any) => TaskFn> = {
+  book:       (s, p) => (cc) => bookSyncService.runBookSync(p ?? {}, s, cc),
+  purify:     (s) => (cc) => purificationService.runPurification(s, cc),
+  schema:     (s) => (cc) => schemaValidationService.runSchemaValidation(s, cc),
+  publisher:  (s) => (cc) => publisherSyncService.runPublisherSync(s, cc),
+  series:     (s) => (cc) => seriesSyncService.runSeriesSync(s, cc),
+  duplicates: (s) => (cc) => duplicateSyncService.runDuplicateCheck(s, cc),
+  lp:         (s) => (cc) => lpSyncService.runLpSync(s, cc),
+  cycles:     (s) => (cc) => cyclesSyncService.runCyclesSync(s, cc),
+  integrity:  (s) => (cc) => integrityService.runIntegrityCheck(s, cc),
+  library:    (s, p) => (cc) => libraryCheckService.runLibraryCheck(p.libraryCode, s, cc),
+  vinted:     (s) => (cc) => vintedSyncService.runVintedCheck(s, cc),
+};
+
 class SyncManager {
   private currentTask: SyncTask | null = null;
 
@@ -84,40 +121,15 @@ class SyncManager {
     }
   }
 
-  async runBookSync(params: { awardName?: string; pageTitle?: string; syncAll?: boolean }, sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('book', (checkCancellation) => bookSyncService.runBookSync(params, sendEvent, checkCancellation));
-  }
-
-  async runPurifySync(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('purify', (checkCancellation) => purificationService.runPurification(sendEvent, checkCancellation));
-  }
-
-  async runSchemaSync(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('schema', (checkCancellation) => schemaValidationService.runSchemaValidation(sendEvent, checkCancellation));
-  }
-
-  async runPublisherSync(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('publisher', (checkCancellation) => publisherSyncService.runPublisherSync(sendEvent, checkCancellation));
-  }
-
-  async runSeriesSync(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('series', (checkCancellation) => seriesSyncService.runSeriesSync(sendEvent, checkCancellation));
-  }
-
-  async runDuplicateCheck(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('duplicates', (checkCancellation) => duplicateSyncService.runDuplicateCheck(sendEvent, checkCancellation));
-  }
-
-  async runLpSync(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('lp', (checkCancellation) => lpSyncService.runLpSync(sendEvent, checkCancellation));
-  }
-
-  async runCyclesSync(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('cycles', (checkCancellation) => cyclesSyncService.runCyclesSync(sendEvent, checkCancellation));
-  }
-
-  async runIntegrityCheck(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('integrity', (checkCancellation) => integrityService.runIntegrityCheck(sendEvent, checkCancellation));
+  /**
+   * Generyczny dispatch rytuału: pobiera fabrykę z rejestru, buduje `taskFn`
+   * i uruchamia ją pod blokadą pojedynczego zadania. `params` niosą dane
+   * z żądania dla rytuałów, które ich wymagają (`book`, `library`).
+   */
+  async run(taskName: SyncTaskName, sendEvent: (data: SyncEvent) => void, params?: any) {
+    const makeTaskFn = TASK_REGISTRY[taskName];
+    if (!makeTaskFn) throw new Error(`Nieznany rytuał synchronizacji: ${taskName}`);
+    await this.executeTask(taskName, makeTaskFn(sendEvent, params));
   }
 
   async getWikiLastUpdate(pageTitle: string) {
@@ -126,14 +138,6 @@ class SyncManager {
 
   async markAsRead(pageId: string) {
     return await this.notion.addTagToMultiSelect(pageId, "Źródło", "Przeczytane");
-  }
-
-  async checkLibraryAvailability(libraryCode: string, sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('library', (checkCancellation) => libraryCheckService.runLibraryCheck(libraryCode, sendEvent, checkCancellation));
-  }
-
-  async checkVintedAvailability(sendEvent: (data: SyncEvent) => void) {
-    await this.executeTask('vinted', (checkCancellation) => vintedSyncService.runVintedCheck(sendEvent, checkCancellation));
   }
 
   /**


### PR DESCRIPTION
## Cel

`SyncManager` niósł jedenaście niemal identycznych metod `run*`, a kontroler — jedenaście niemal identycznych handlerów `run*` plus jedenaście jednoliniowych `stop*`. Mapowanie „nazwa rytuału → serwis" było rozmazane po obu plikach i utrzymywane ręcznie.

## Zmiany — jedno źródło prawdy

- **`syncManager.ts`**: `TASK_REGISTRY` (`SyncTaskName` → fabryka `taskFn`) + jeden generyczny `run(taskName, sendEvent, params?)`, który wyszukuje fabrykę i uruchamia ją pod istniejącą blokadą pojedynczego zadania. 11 metod-wrapperów znika; `book`/`library` przekazują parametry żądania przez argument `params`. `run()` rzuca na nieznanej nazwie rytuału **zanim** przejmie blokadę.
- **`controllers/syncController.ts`**: `makeSyncHandler(task, errorLabel)` generuje 8 bezparametrowych handlerów `run`; `runSync`/`vinted`/`library` zostają jawne, bo niosą walidację żądania. `makeStopHandler(message)` generuje wszystkie 11 handlerów `stop` (zatrzymanie jest globalne — różnią się tylko komunikatem).
- Nazwy tras i powierzchnia HTTP **bez zmian**.

## Weryfikacja

- Nowy test straży rejestru (`run("bogus")` → odrzucenie bez przejęcia blokady); testy cyklu życia / SSE napędzają teraz `syncManager.run()`.
- `npm run lint` — czysto
- `npm test` — 114/114
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_