### PR TITLE
Tier 3-C: Extract sync orchestration into useSyncManager hook

### DIFF
--- a/COGITATOR_GUIDELINES.md
+++ b/COGITATOR_GUIDELINES.md
@@ -18,6 +18,7 @@
 - **SSE Parsing**: All streaming hooks MUST consume the stream through the shared `consumeSSE` primitive (`src/utils/sse.ts`), which buffers chunks across TCP reads (split on `\n\n`, keep the remainder) and parses `data:` lines. Never re-implement the read/buffer loop or `JSON.parse` a raw chunk line-by-line. `consumeSSE(body, onEvent, onChunk?)`: `onEvent` returns `true` to stop early (e.g. after `complete`/`error`); `onChunk` re-arms per-read watchdogs (see `useSync`).
 - **Logic Isolation**: No `useEffect` for data fetching in components. Use Custom Hooks:
   - `useSync`: Standard for all long-running server operations.
+  - `useSyncManager`: Owns every ritual's `useSync` instance plus cross-ritual orchestration (mutual reset, the sequential "Wielki Rytuał" full sync, the aggregate result). `App` consumes it and stays presentational — never re-declare the sync instances or full-sync sequence in a component.
   - `useStats`: Global dashboard data.
   - `useLibraryCheck`: Isolated library scanning state.
   - `useConfig`: Notion schema and connection status.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,9 +11,8 @@ import { SyncSummaryResult } from "./components/SyncSummaryResult";
 import { SchemaSection } from "./components/SchemaSection";
 import { SanctityDebugger } from "./components/SanctityDebugger";
 import { ParticleBackground } from "./components/ParticleBackground";
-import { PREDEFINED_AWARDS } from "./constants";
-import { useSync } from "./hooks/useSync";
 import { useConfig } from "./hooks/useConfig";
+import { useSyncManager } from "./hooks/useSyncManager";
 import { formatETA } from "./utils/time";
 import { IntegrityCheckResult } from "./types";
 
@@ -21,7 +20,15 @@ export default function App() {
   const { configStatus, schema, schemaLoading, schemaError, fetchSchema } = useConfig();
   const [activeTab, setActiveTab] = useState<'stats' | 'config' | 'vinted'>('stats');
   const [showScrollTop, setShowScrollTop] = useState(false);
-  const [fullSyncResults, setFullSyncResults] = useState<any[] | null>(null);
+
+  const {
+    sync, publisherSync, seriesSync, cyclesSync, lpSync, integritySync, duplicatesSync, purifySync, schemaSync,
+    syncs, anyError, isAnySyncLoading,
+    fullSyncResults, clearFullSyncResults,
+    handleAwardChange, handleSync, handleFullSync, handleResetSync,
+    handleSyncSchema, handleSyncPurify, handleSyncPublisher, handleSyncSeries,
+    handleCyclesSync, handleSyncLp, handleSyncDuplicates,
+  } = useSyncManager();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -30,139 +37,6 @@ export default function App() {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
-
-  const sync = useSync("/api/sync", "/api/sync/stop", {
-    awardName: PREDEFINED_AWARDS[0].name,
-    pageTitle: PREDEFINED_AWARDS[0].title,
-    color: "cyan"
-  });
-  const publisherSync = useSync("/api/sync-publisher", "/api/sync-publisher/stop", { color: "rose" });
-  const seriesSync = useSync("/api/sync-series", "/api/sync-series/stop", { color: "indigo" });
-  const cyclesSync = useSync("/api/sync-cycles", "/api/sync-cycles/stop", { color: "blue" });
-  const lpSync = useSync("/api/sync-lp", "/api/sync-lp/stop", { color: "purple" });
-  const integritySync = useSync("/api/sync-integrity", "/api/sync-integrity/stop", { color: "cyan" });
-  const duplicatesSync = useSync("/api/sync-duplicates", "/api/sync-duplicates/stop", { color: "orange" });
-  const purifySync = useSync("/api/sync-purify", "/api/sync-purify/stop", { color: "amber" });
-  const schemaSync = useSync("/api/sync-schema", "/api/sync-schema/stop", { color: "emerald" });
-
-  const handleAwardChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedName = e.target.value;
-    const predefined = PREDEFINED_AWARDS.find(a => a.name === selectedName);
-    
-    sync.setState(prev => ({
-      ...prev,
-      awardName: selectedName,
-      pageTitle: predefined ? predefined.title : (selectedName === "Wszystkie Nagrody" ? "" : prev.pageTitle)
-    }));
-  };
-
-  const syncs = [sync, publisherSync, seriesSync, cyclesSync, lpSync, duplicatesSync, purifySync, schemaSync, integritySync];
-  const anyError = syncs.find(s => s.state.error);
-
-  const clearOthers = (currentSync: any) => {
-    syncs.forEach(s => {
-      if (s !== currentSync) {
-        s.reset();
-      }
-    });
-  };
-
-  const handleSyncAction = async (syncService: any, params: any = {}, statusMessage: string | null = null) => {
-    setFullSyncResults(null);
-    clearOthers(syncService);
-    return await syncService.startSync(params, undefined, statusMessage);
-  };
-
-  const handleSyncSchema = () => handleSyncAction(schemaSync);
-  const handleSyncPurify = () => handleSyncAction(purifySync);
-  const handleSyncPublisher = () => handleSyncAction(publisherSync);
-  const handleSyncSeries = () => handleSyncAction(seriesSync);
-  const handleCyclesSync = () => handleSyncAction(cyclesSync);
-  const handleSyncLp = () => handleSyncAction(lpSync);
-
-  const handleSync = () => {
-    const isSyncAll = sync.state.awardName === "Wszystkie Nagrody";
-    handleSyncAction(sync, {
-      awardName: sync.state.awardName,
-      pageTitle: sync.state.pageTitle,
-      syncAll: isSyncAll
-    });
-  };
-
-  const handleFullSync = async () => {
-    setFullSyncResults(null);
-    const results: any[] = [];
-    
-    // 1. Schema Initiation
-    clearOthers(schemaSync);
-    const res1 = await schemaSync.startSync({}, undefined, "Krok 1/7: Rytuał Inicjacji Schematu...");
-    if (!res1 || res1.success === false) return;
-    results.push({ name: "Schemat", result: res1, color: "emerald" });
-
-    // 2. Purification
-    clearOthers(purifySync);
-    const res2 = await purifySync.startSync({}, undefined, "Krok 2/7: Rytuał Puryfikacji...");
-    if (!res2 || res2.success === false) return;
-    results.push({ name: "Puryfikacja", result: res2, color: "amber" });
-
-    // 3. Sync Awards (Wszystkie)
-    clearOthers(sync);
-    const res3 = await sync.startSync({
-      awardName: "Wszystkie Nagrody",
-      syncAll: true
-    }, undefined, "Krok 3/7: Synchronizacja Nagród...");
-    if (!res3 || res3.success === false) return;
-    results.push({ name: "Nagrody", result: res3, color: "cyan" });
-
-    // 4. Cycles Marking
-    clearOthers(cyclesSync);
-    const res4 = await cyclesSync.startSync({}, undefined, "Krok 4/7: Rytuał Oznaczania Cykli...");
-    if (!res4 || res4.success === false) return;
-    results.push({ name: "Cykle", result: res4, color: "blue" });
-
-    // 5. Publisher Sync
-    clearOthers(publisherSync);
-    const res5 = await publisherSync.startSync({}, undefined, "Krok 5/7: Rytuał Wydania...");
-    if (!res5 || res5.success === false) return;
-    results.push({ name: "Wydawcy", result: res5, color: "rose" });
-
-    // 6. Series Sync
-    clearOthers(seriesSync);
-    const res6 = await seriesSync.startSync({}, undefined, "Krok 6/7: Rytuał Seryjny...");
-    if (!res6 || res6.success === false) return;
-    results.push({ name: "Serie", result: res6, color: "indigo" });
-
-    // 7. Numbers Reconstruction (Lp)
-    clearOthers(lpSync);
-    const res7 = await lpSync.startSync({}, undefined, "Krok 7/7: Rytuał Rekonstrukcji Liczb...");
-    if (res7) {
-      results.push({ name: "Lubimy Czytać", result: res7, color: "purple" });
-    }
-
-    setFullSyncResults(results);
-  };
-  
-  const handleResetSync = async () => {
-    try {
-      await fetch("/api/sync/reset", { method: "POST" });
-      syncs.forEach(s => s.reset());
-    } catch (err) {
-      console.error("Reset Error:", err);
-    }
-  };
-
-  const handleSyncDuplicates = () => {
-    clearOthers(duplicatesSync);
-    duplicatesSync.startSync({}, (result) => {
-      const duplicatesFormatted = result.duplicates.map((d: any) => 
-        `${d.bookA} <-> ${d.bookB} (${d.reason})`
-      );
-      return { 
-        ...result,
-        summary: { duplicates: duplicatesFormatted }
-      };
-    }, null);
-  };
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-200 font-sans selection:bg-cyan-500/30 selection:text-white relative overflow-hidden">
@@ -215,7 +89,7 @@ export default function App() {
                 : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
             }`}
           >
-            <Cog className={`w-5 h-5 ${syncs.some(s => s.state.loading) ? 'animate-spin text-purple-400' : ''}`} />
+            <Cog className={`w-5 h-5 ${isAnySyncLoading ? 'animate-spin text-purple-400' : ''}`} />
             Liturgie Synchronizacji
           </button>
           <button
@@ -316,7 +190,7 @@ export default function App() {
                   handleAwardChange={handleAwardChange}
                   handleSync={handleSync}
                   handleFullSync={handleFullSync}
-                  isAnySyncLoading={syncs.some(s => s.state.loading)}
+                  isAnySyncLoading={isAnySyncLoading}
                 />
 
                 {/* Other Tools Card */}
@@ -336,7 +210,7 @@ export default function App() {
                   handleSyncDuplicates={handleSyncDuplicates}
                   handleSyncLp={handleSyncLp}
                   handleResetSync={handleResetSync}
-                  isAnySyncLoading={syncs.some(s => s.state.loading)}
+                  isAnySyncLoading={isAnySyncLoading}
                 />
               </div>
 
@@ -353,7 +227,7 @@ export default function App() {
                 <SyncSummaryResult
                   syncs={syncs}
                   fullSyncResults={fullSyncResults}
-                  onClearFullResults={() => setFullSyncResults(null)}
+                  onClearFullResults={clearFullSyncResults}
                 />
               </AnimatePresence>
 

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -1,0 +1,161 @@
+import React, { useState } from "react";
+import { useSync } from "./useSync";
+import { PREDEFINED_AWARDS } from "../constants";
+
+/**
+ * Orkiestracja wszystkich rytuałów synchronizacji po stronie frontendu.
+ *
+ * Trzyma dziewięć instancji `useSync` (po jednej na rytuał), wzajemne czyszczenie
+ * stanu, sekwencyjny "Wielki Rytuał" (full sync) oraz wynik zbiorczy. Wyniesione
+ * z `App.tsx`, żeby komponent został przy renderowaniu, a logika żyła w hooku
+ * (zob. COGITATOR_GUIDELINES §2 "Logic Isolation").
+ */
+export function useSyncManager() {
+  const [fullSyncResults, setFullSyncResults] = useState<any[] | null>(null);
+
+  const sync = useSync("/api/sync", "/api/sync/stop", {
+    awardName: PREDEFINED_AWARDS[0].name,
+    pageTitle: PREDEFINED_AWARDS[0].title,
+    color: "cyan"
+  });
+  const publisherSync = useSync("/api/sync-publisher", "/api/sync-publisher/stop", { color: "rose" });
+  const seriesSync = useSync("/api/sync-series", "/api/sync-series/stop", { color: "indigo" });
+  const cyclesSync = useSync("/api/sync-cycles", "/api/sync-cycles/stop", { color: "blue" });
+  const lpSync = useSync("/api/sync-lp", "/api/sync-lp/stop", { color: "purple" });
+  const integritySync = useSync("/api/sync-integrity", "/api/sync-integrity/stop", { color: "cyan" });
+  const duplicatesSync = useSync("/api/sync-duplicates", "/api/sync-duplicates/stop", { color: "orange" });
+  const purifySync = useSync("/api/sync-purify", "/api/sync-purify/stop", { color: "amber" });
+  const schemaSync = useSync("/api/sync-schema", "/api/sync-schema/stop", { color: "emerald" });
+
+  const syncs = [sync, publisherSync, seriesSync, cyclesSync, lpSync, duplicatesSync, purifySync, schemaSync, integritySync];
+  const anyError = syncs.find(s => s.state.error);
+  const isAnySyncLoading = syncs.some(s => s.state.loading);
+
+  const clearOthers = (currentSync: any) => {
+    syncs.forEach(s => {
+      if (s !== currentSync) {
+        s.reset();
+      }
+    });
+  };
+
+  const handleSyncAction = async (syncService: any, params: any = {}, statusMessage: string | null = null) => {
+    setFullSyncResults(null);
+    clearOthers(syncService);
+    return await syncService.startSync(params, undefined, statusMessage);
+  };
+
+  const handleAwardChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedName = e.target.value;
+    const predefined = PREDEFINED_AWARDS.find(a => a.name === selectedName);
+
+    sync.setState(prev => ({
+      ...prev,
+      awardName: selectedName,
+      pageTitle: predefined ? predefined.title : (selectedName === "Wszystkie Nagrody" ? "" : prev.pageTitle)
+    }));
+  };
+
+  const handleSyncSchema = () => handleSyncAction(schemaSync);
+  const handleSyncPurify = () => handleSyncAction(purifySync);
+  const handleSyncPublisher = () => handleSyncAction(publisherSync);
+  const handleSyncSeries = () => handleSyncAction(seriesSync);
+  const handleCyclesSync = () => handleSyncAction(cyclesSync);
+  const handleSyncLp = () => handleSyncAction(lpSync);
+
+  const handleSync = () => {
+    const isSyncAll = sync.state.awardName === "Wszystkie Nagrody";
+    handleSyncAction(sync, {
+      awardName: sync.state.awardName,
+      pageTitle: sync.state.pageTitle,
+      syncAll: isSyncAll
+    });
+  };
+
+  const handleFullSync = async () => {
+    setFullSyncResults(null);
+    const results: any[] = [];
+
+    // 1. Schema Initiation
+    clearOthers(schemaSync);
+    const res1 = await schemaSync.startSync({}, undefined, "Krok 1/7: Rytuał Inicjacji Schematu...");
+    if (!res1 || res1.success === false) return;
+    results.push({ name: "Schemat", result: res1, color: "emerald" });
+
+    // 2. Purification
+    clearOthers(purifySync);
+    const res2 = await purifySync.startSync({}, undefined, "Krok 2/7: Rytuał Puryfikacji...");
+    if (!res2 || res2.success === false) return;
+    results.push({ name: "Puryfikacja", result: res2, color: "amber" });
+
+    // 3. Sync Awards (Wszystkie)
+    clearOthers(sync);
+    const res3 = await sync.startSync({
+      awardName: "Wszystkie Nagrody",
+      syncAll: true
+    }, undefined, "Krok 3/7: Synchronizacja Nagród...");
+    if (!res3 || res3.success === false) return;
+    results.push({ name: "Nagrody", result: res3, color: "cyan" });
+
+    // 4. Cycles Marking
+    clearOthers(cyclesSync);
+    const res4 = await cyclesSync.startSync({}, undefined, "Krok 4/7: Rytuał Oznaczania Cykli...");
+    if (!res4 || res4.success === false) return;
+    results.push({ name: "Cykle", result: res4, color: "blue" });
+
+    // 5. Publisher Sync
+    clearOthers(publisherSync);
+    const res5 = await publisherSync.startSync({}, undefined, "Krok 5/7: Rytuał Wydania...");
+    if (!res5 || res5.success === false) return;
+    results.push({ name: "Wydawcy", result: res5, color: "rose" });
+
+    // 6. Series Sync
+    clearOthers(seriesSync);
+    const res6 = await seriesSync.startSync({}, undefined, "Krok 6/7: Rytuał Seryjny...");
+    if (!res6 || res6.success === false) return;
+    results.push({ name: "Serie", result: res6, color: "indigo" });
+
+    // 7. Numbers Reconstruction (Lp)
+    clearOthers(lpSync);
+    const res7 = await lpSync.startSync({}, undefined, "Krok 7/7: Rytuał Rekonstrukcji Liczb...");
+    if (res7) {
+      results.push({ name: "Lubimy Czytać", result: res7, color: "purple" });
+    }
+
+    setFullSyncResults(results);
+  };
+
+  const handleResetSync = async () => {
+    try {
+      await fetch("/api/sync/reset", { method: "POST" });
+      syncs.forEach(s => s.reset());
+    } catch (err) {
+      console.error("Reset Error:", err);
+    }
+  };
+
+  const handleSyncDuplicates = () => {
+    clearOthers(duplicatesSync);
+    duplicatesSync.startSync({}, (result) => {
+      const duplicatesFormatted = result.duplicates.map((d: any) =>
+        `${d.bookA} <-> ${d.bookB} (${d.reason})`
+      );
+      return {
+        ...result,
+        summary: { duplicates: duplicatesFormatted }
+      };
+    }, null);
+  };
+
+  return {
+    // Instancje rytuałów (przekazywane do komponentów prezentacyjnych)
+    sync, publisherSync, seriesSync, cyclesSync, lpSync, integritySync, duplicatesSync, purifySync, schemaSync,
+    // Stan zbiorczy
+    syncs, anyError, isAnySyncLoading,
+    fullSyncResults, clearFullSyncResults: () => setFullSyncResults(null),
+    // Akcje
+    handleAwardChange, handleSync, handleFullSync, handleResetSync,
+    handleSyncSchema, handleSyncPurify, handleSyncPublisher, handleSyncSeries,
+    handleCyclesSync, handleSyncLp, handleSyncDuplicates,
+  };
+}


### PR DESCRIPTION
## Cel

`App.tsx` deklarował wszystkie dziewięć instancji `useSync` i trzymał w sobie orkiestrację między-rytuałową: wzajemny reset (`clearOthers`), każdy handler per rytuał, siedmiokrokowy sekwencyjny „Wielki Rytuał", formatter duplikatów i stan wyniku zbiorczego. To logika danych/przepływu żyjąca w komponencie — wbrew regule Logic-Isolation z wytycznych.

## Zmiany

- **Nowy `src/hooks/useSyncManager.ts`** — zwraca instancje rytuałów, tablicę `syncs`, `anyError`/`isAnySyncLoading`, stan wyników pełnej synchronizacji z helperem `clearFullSyncResults()` oraz wszystkie handlery.
- **`App.tsx`** destrukturyzuje teraz hook i tylko renderuje — traci ~130 linii (**409 → 282**) i nie importuje już `useSync` ani `PREDEFINED_AWARDS`.
- Zachowanie bez zmian.
- Wytyczne §2 dokumentują `useSyncManager` jako hook orkiestracji.

## Weryfikacja

- `npm run lint` — czysto
- `npm test` — 114/114
- `npm run build` — OK

---

To domyka **Tier 3** (A–C): rozbicie composition-root, ujednolicony rejestr rytuałów, hook orkiestracji frontendu. Wszystkie trzy tiery audytu ukończone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_