### PR TITLE
Bughunt PR1: comma-injected author tags (H1) + duplicate-row retries (H2)

### DIFF
--- a/__tests__/retry.test.ts
+++ b/__tests__/retry.test.ts
@@ -57,6 +57,40 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('does NOT retry a non-idempotent op on a transient network error', async () => {
+    // pages.create (addRow) may have already written before the socket reset —
+    // retrying would duplicate the row, so idempotent=false must not retry it.
+    const netErr = new Error('socket hang up');
+    (netErr as any).code = 'ECONNRESET';
+    const fn = vi.fn().mockRejectedValue(netErr);
+
+    await expect(withRetry(fn, 3, 100, 2, false)).rejects.toThrow('socket hang up');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT retry a non-idempotent op on a 5xx error', async () => {
+    const error503 = new Error('Service Unavailable');
+    (error503 as any).status = 503;
+    const fn = vi.fn().mockRejectedValue(error503);
+
+    await expect(withRetry(fn, 3, 100, 2, false)).rejects.toThrow('Service Unavailable');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('still retries a non-idempotent op on 429 (request was rejected, not processed)', async () => {
+    const error429 = new Error('Rate limit');
+    (error429 as any).status = 429;
+    const fn = vi.fn()
+      .mockRejectedValueOnce(error429)
+      .mockResolvedValueOnce('success');
+
+    const promise = withRetry(fn, 3, 100, 2, false);
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
   it('throws after max retries', async () => {
     const error500 = new Error('Server error');
     (error500 as any).status = 500;

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -362,10 +362,13 @@ export class NotionAdapter {
       ? { type: "data_source_id", data_source_id: this.actualDataSourceId! }
       : { type: "database_id", database_id: this.actualDataSourceId! };
 
+    // idempotent=false: pages.create tworzy nowy wiersz — po błędzie sieci/5xx
+    // ponowienie mogłoby zdublować książkę (błąd resetu socketu po zapisie).
+    // 429 nadal jest ponawiane (żądanie odrzucone przed przetworzeniem).
     const response = await withRetry(() => this.notion.pages.create({
       parent: parent,
       properties
-    } as any));
+    } as any), 3, 1000, 2, false);
     return response;
   }
 }

--- a/retry.ts
+++ b/retry.ts
@@ -2,7 +2,8 @@ export async function withRetry<T>(
   fn: () => Promise<T>,
   retries = 3,
   delayMs = 1000,
-  backoffFactor = 2
+  backoffFactor = 2,
+  idempotent = true
 ): Promise<T> {
   let attempt = 0;
   while (attempt < retries) {
@@ -14,20 +15,26 @@ export async function withRetry<T>(
         throw error;
       }
 
-      // Check if it's a rate limit error (429) or server error (5xx)
+      // 429 (rate limit) oznacza, że żądanie zostało ODRZUCONE przed przetworzeniem
+      // — ponowienie jest zawsze bezpieczne, nawet dla operacji nieidempotentnych.
       const isRateLimit = error?.status === 429 || error?.response?.status === 429;
-      const isServerError = error?.status >= 500 || error?.response?.status >= 500;
+
+      // 5xx i błędy sieci (socket hang up itd.) mogą zostawić żądanie CZĘŚCIOWO
+      // przetworzone: dla operacji nieidempotentnych (np. pages.create) ponowienie
+      // tworzy duplikat. Ponawiaj je tylko, gdy wołający deklaruje idempotent=true.
+      const isServerError = idempotent && (error?.status >= 500 || error?.response?.status >= 500);
 
       const transientCodes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED', 'EPIPE', 'ENOTFOUND', 'EAI_AGAIN', 'ERR_HTTP2_GOAWAY_SESSION', 'ERR_STREAM_WRITE_AFTER_END'];
-      const isTransientNetworkError = transientCodes.includes(error?.code) ||
+      const isTransientNetworkError = idempotent && (transientCodes.includes(error?.code) ||
                                      (error?.message && (
                                        error.message.toLowerCase().includes('socket hang up') ||
                                        error.message.toLowerCase().includes('connreset') ||
                                        error.message.toLowerCase().includes('timeout')
-                                     ));
+                                     )));
 
       if (!isRateLimit && !isServerError && !isTransientNetworkError) {
-        // Don't retry client errors (4xx) other than 429
+        // Nie ponawiaj błędów klienta (4xx poza 429) ani — dla operacji
+        // nieidempotentnych — błędów 5xx/sieci, które mogły już zapisać dane.
         throw error;
       }
 

--- a/services/__tests__/bookSyncService.test.ts
+++ b/services/__tests__/bookSyncService.test.ts
@@ -1,8 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BookSyncService } from '../bookSyncService';
+import { BookSyncService, buildAuthorTags } from '../bookSyncService';
 import { NotionAdapter } from '../../notion.adapter';
 import { WikiAdapter } from '../../wiki.adapter';
 import { Book, NotionBook } from '../../src/types';
+
+describe('buildAuthorTags', () => {
+  it('never emits a multi_select tag containing a comma, even when a mapping injects one', () => {
+    // "Liu Cixin" maps to "Liu Cixin, Ken Liu"; Notion rejects commas in options.
+    const tags = buildAuthorTags('Liu Cixin');
+    expect(tags).toEqual(['Liu Cixin', 'Ken Liu']);
+    expect(tags.some(t => t.includes(','))).toBe(false);
+  });
+
+  it('splits an already-merged comma author string into clean tags and dedups', () => {
+    const tags = buildAuthorTags('Liu Cixin, Ken Liu');
+    expect(tags).toEqual(['Liu Cixin', 'Ken Liu']);
+  });
+
+  it('handles the Hamilton pseudonym mapping without a comma tag', () => {
+    const tags = buildAuthorTags('Edmond Hamilton (jako Brett Sterling)');
+    expect(tags).toEqual(['Edmond Hamilton', 'Brett Sterling']);
+    expect(tags.some(t => t.includes(','))).toBe(false);
+  });
+
+  it('passes ordinary single authors through unchanged', () => {
+    expect(buildAuthorTags('Stanisław Lem')).toEqual(['Stanisław Lem']);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(buildAuthorTags('')).toEqual([]);
+  });
+});
 
 describe('BookSyncService', () => {
   let service: BookSyncService;

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -8,6 +8,33 @@ import { createLogger } from "../logger";
 
 const log = createLogger("BookSync");
 
+/**
+ * Buduje listę tagów autora dla pola multi_select. KOLEJNOŚĆ MA ZNACZENIE:
+ * najpierw normalizacja (mapowania potrafią rozwinąć jedno nazwisko w kilka
+ * rozdzielonych przecinkiem, np. "Liu Cixin" → "Liu Cixin, Ken Liu"), potem
+ * podział po przecinku, a sanitizacja NA KOŃCU. `sanitizeNotionTag` usuwa
+ * przecinki (Notion nie dopuszcza ich w opcjach select/multi_select) — gdy
+ * sanitizacja biegła PRZED normalizacją, wstrzyknięty przez mapowanie przecinek
+ * trafiał do nazwy opcji i Notion odrzucał cały wiersz (laureat gubiony w ciszy).
+ * Deduplikacja jest case-insensitive, z zachowaniem pierwszej napotkanej pisowni.
+ */
+export function buildAuthorTags(raw: string): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const part of raw.split(",")) {
+    const normalized = normalizeData(part.trim(), "author");
+    for (const piece of normalized.split(",")) {
+      const tag = sanitizeNotionTag(piece);
+      if (tag && !seen.has(tag.toLowerCase())) {
+        seen.add(tag.toLowerCase());
+        tags.push(tag);
+      }
+    }
+  }
+  return tags;
+}
+
 export class BookSyncService {
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
 
@@ -189,11 +216,7 @@ export class BookSyncService {
     // normalizowanie tylko nowej wartości (np. "A. E. Van Vogt" vs zapisane
     // "A. E. van Vogt") powodowało aktualizację przy każdym sync, która nigdy nie
     // "chwytała". Aktualizuj tylko, gdy faktycznie dochodzi nowy autor.
-    const parseAuthors = (raw: string) =>
-      raw.split(',')
-        .map((a: string) => sanitizeNotionTag(a))
-        .filter(Boolean)
-        .map((a: string) => normalizeData(a, 'author'));
+    const parseAuthors = (raw: string) => buildAuthorTags(raw);
 
     const newAuthors = parseAuthors(book.author || "");
     const existingAuthors = parseAuthors(existingBook.author || "");
@@ -380,11 +403,7 @@ export class BookSyncService {
               properties["Rok"] = { multi_select: [{ name: book.year.toString() }] };
             }
             if (book.author) {
-              const authors = Array.from(new Set(
-                book.author.split(',')
-                  .map((a: string) => normalizeData(sanitizeNotionTag(a), 'author'))
-                  .filter(Boolean)
-              ));
+              const authors = buildAuthorTags(book.author);
               properties["Autor"] = { multi_select: authors.slice(0, 100).map(name => ({ name })) };
             }
             if (book.awards && book.awards.length > 0) {


### PR DESCRIPTION
Dwa błędy danych znalezione podczas bughuntingu (oba potwierdzone egzekucją).

## H1 — laureaci cicho gubieni (HIGH)

Część mapowań autorów rozwija jedno nazwisko w parę z przecinkiem (`"Liu Cixin" → "Liu Cixin, Ken Liu"`). Oba buildery tagów sanitizowały **przed** normalizacją, więc przecinek wstrzyknięty przez `normalizeData` przechodził do nazwy opcji `multi_select`. Notion odrzuca przecinki w opcjach → `addRow` rzuca → błąd ląduje w `errors[]`, a run i tak raportuje `complete`. *The Three-Body Problem* (i każdy tytuł Cixina/Hamiltona) **nigdy się nie dodaje**, choć sync wygląda na udany.

**Fix:** nowy współdzielony `buildAuthorTags()` — najpierw normalizacja, potem podział po przecinku, sanitizacja **na końcu** (dedup case-insensitive). Używają go ścieżki nowego wiersza i aktualizacji.

## H2 — samoistne duplikaty wierszy (HIGH)

`addRow` (`pages.create`, nieidempotentne) był opakowany w `withRetry`, które ponawia `ECONNRESET`/timeout/5xx. Reset socketu po tym, jak Notion już utworzył stronę → ponowienie → **druga identyczna książka**, w aplikacji, której celem jest wykrywanie duplikatów.

**Fix:** `withRetry` dostaje flagę `idempotent` (domyślnie `true`); `addRow` przekazuje `false`, więc ponawiane jest tylko `429` (żądanie odrzucone przed przetworzeniem), nigdy błędy sieci/5xx.

## Testy regresji

- `buildAuthorTags` nigdy nie emituje tagu z przecinkiem i dzieli scalone stringi (Liu Cixin, Hamilton).
- `withRetry` z `idempotent=false` nie ponawia sieci/5xx, ale nadal ponawia `429`.

Weryfikacja: `npm run lint` czysto, `npm test` 122/122, `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_