### PR TITLE
Bughunt PR2: author accent stripping (M1) + parser pipe truncation (M2)

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -76,5 +76,13 @@ describe('utils', () => {
       expect(normalizeAuthor('Stanisław Lem (1921-2006)')).toBe('stanisław lem');
       expect(normalizeAuthor('George R. R. Martin')).toBe('george r r martin');
     });
+
+    it('preserves accented Latin-1 letters (must not drop ó/é/á)', () => {
+      // Regression: the old ASCII \w + Latin-Extended-A class silently deleted
+      // Latin-1 accented letters, corrupting author-match keys.
+      expect(normalizeAuthor('Wróblewski')).toBe('wróblewski');
+      expect(normalizeAuthor('Różewicz')).toBe('różewicz');
+      expect(normalizeAuthor('José Saramago')).toBe('josé saramago');
+    });
   });
 });

--- a/__tests__/wiki.parser.test.ts
+++ b/__tests__/wiki.parser.test.ts
@@ -113,6 +113,19 @@ describe('WikiParser', () => {
       const wikitext = '{{Książka\n | autor           = Isaac Asimov\n | redaktor        = \n | autor okladki   = Chris Moore\n}}';
       expect(WikiParser.extractAuthor(wikitext)).toBe('Isaac Asimov');
     });
+
+    it('does not truncate a {{sortname}} author at the first pipe', () => {
+      // Regression: [^\n|]+ captured only "{{sortname" and the cleanup was dead.
+      expect(WikiParser.extractAuthor('| autor = {{sortname|Ursula K.|Le Guin}}')).toBe('Ursula K. Le Guin');
+    });
+
+    it('resolves a {{Autor}} template author', () => {
+      expect(WikiParser.extractAuthor('| autor = {{Autor|Jan Kowalski|1950}}')).toBe('Jan Kowalski');
+    });
+
+    it('resolves a piped wikilink author without leaking brackets', () => {
+      expect(WikiParser.extractAuthor('| autor = [[Stanisław Lem|Lem, Stanisław]]')).toBe('Lem, Stanisław');
+    });
   });
 
 });

--- a/utils.ts
+++ b/utils.ts
@@ -102,8 +102,11 @@ export function normalizeAuthor(author: string): string {
     }
   }
   
-  // Remove special characters and extra spaces
-  normalized = normalized.replace(/[^\w\s\u0100-\u017F]/g, '').replace(/\s+/g, ' ').trim();
-  
+  // Remove punctuation/symbols but KEEP every Unicode letter and digit.
+  // The old class [^\w\s\u0100-\u017F] used ASCII \w plus only Latin Extended-A,
+  // so it silently deleted Latin-1 accented letters \u2014 "Wr\u00F3blewski" \u2192 "wrblewski",
+  // "Jos\u00E9" \u2192 "jos" \u2014 corrupting author-match keys. \p{L} keeps all letters.
+  normalized = normalized.replace(/[^\p{L}\p{N}\s]/gu, '').replace(/\s+/g, ' ').trim();
+
   return normalized;
 }

--- a/wiki.parser.ts
+++ b/wiki.parser.ts
@@ -59,17 +59,21 @@ export class WikiParser {
   }
 
   static extractAuthor(wikitext: string): string {
-    // Look for autor, twórca, or redaktor in infoboxes
-    const authorRegex = /\|\s*(autor|twórca|redaktor|scenariusz|tekst)\s*=\s*([^\n|]+)/gi;
+    // Look for autor, twórca, or redaktor in infoboxes.
+    // Wartość może zawierać szablony/linki z pipe: {{sortname|Ursula K.|Le Guin}},
+    // {{Autor|Jan Kowalski}}, [[Stanisław Lem|Lem, Stanisław]]. Dopasuj całe
+    // [[...]]/{{...}} jako jeden token — inaczej capture `[^\n|]+` ucinał wartość na
+    // pierwszym `|` (np. do "{{sortname"), przez co czyszczenie szablonów w
+    // cleanWikitext nigdy nie miało czego przetworzyć.
+    const authorRegex = /\|\s*(autor|twórca|redaktor|scenariusz|tekst)\s*=\s*((?:\[\[[^\]]*\]\]|\{\{[^{}]*\}\}|[^\n|])+)/gi;
     let match;
     let authors: string[] = [];
-    
+
     while ((match = authorRegex.exec(wikitext)) !== null) {
-      let rawAuthor = match[2];
-      rawAuthor = rawAuthor.replace(/\{\{sortname\|([^|}]+)\|([^|}]+)(?:\|[^}]+)?\}\}/gi, '$1 $2');
-      rawAuthor = rawAuthor.replace(/\{\{Autor\|([^|}]+)(?:\|[^}]*)?\}\}/gi, '$1');
-      const cleaned = this.cleanWikitext(rawAuthor);
-      // Pusty parametr (np. "| redaktor = " ze spacją) matchuje [^\n|]+ — odfiltruj
+      // cleanWikitext rozwija [[Cel|Etykieta]]→Etykieta, {{sortname|a|b}}→"a b",
+      // {{Autor|a}}→a i usuwa pozostałe szablony/znaczniki.
+      const cleaned = this.cleanWikitext(match[2]);
+      // Pusty parametr (np. "| redaktor = " ze spacją) matchuje — odfiltruj
       if (cleaned) authors.push(cleaned);
     }
     


### PR DESCRIPTION
Dwa błędy parsingu/normalizacji autora (oba potwierdzone egzekucją).

## M1 — `normalizeAuthor` usuwał akcentowane litery (MEDIUM)

Klasa `[^\w\sĀ-ſ]` używała ASCII `\w` + tylko Latin Extended-A, więc `"Wróblewski" → "wrblewski"`, `"José" → "jos"` — cicho psuła klucze dopasowania autora używane przez skan biblioteki, wykrywanie duplikatów i sync cykli/pól (false-negative za każdym razem, gdy źródła różnią się użyciem akcentu). Zamienione na `[^\p{L}\p{N}\s]/u` — zachowuje każdą literę/cyfrę Unicode, nadal usuwa interpunkcję.

## M2 — `extractAuthor` ucinał wartość na pierwszym `|` (MEDIUM)

Capture `[^\n|]+` zamieniał `{{sortname|Ursula K.|Le Guin}}` w `"{{sortname"`, a `[[Lem|Lem, Stanisław]]` w `"[[Stanisław Lem"`. Przez to czyszczenie `sortname`/`Autor` było martwym kodem, a `wikiFieldSyncService` cicho **pomijał sync wydawcy/serii** dla tych książek (niedopasowanie weryfikacji autora). Capture łapie teraz całe tokeny `[[...]]`/`{{...}}`; resztę robi `cleanWikitext` (który już rozwija sortname/Autor/linki z pipe), więc redundantne inline-replace zniknęły.

## Testy regresji

- `normalizeAuthor` zachowuje ó/é/á.
- `extractAuthor` rozwiązuje autorów `sortname`, `Autor` i linki z pipe bez ucinania.

Weryfikacja: `npm run lint` czysto, `npm test` 126/126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_