### PR TITLE
Bughunt PR4: stall watchdog for library/Vinted scan hooks (M4)

### DIFF
--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from "react";
 import { IdentifiedBooks } from "./useStats";
 import { consumeSSE } from "../utils/sse";
+import { createStallWatchdog } from "../utils/stallWatchdog";
 
 export type { IdentifiedBooks };
 
@@ -21,12 +22,16 @@ export function useLibraryCheck() {
     setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
     setLibraryError(null);
     
-    return new Promise<void>(async (resolve, reject) => {
+    const watchdog = createStallWatchdog();
+
+    return new Promise<void>(async (resolve) => {
       try {
+        watchdog.arm();
         const response = await fetch("/api/library-check", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ libraryCode })
+          body: JSON.stringify({ libraryCode }),
+          signal: watchdog.signal
         });
 
         if (!response.ok) throw new Error("Błąd podczas sprawdzania biblioteki");
@@ -64,12 +69,17 @@ export function useLibraryCheck() {
           } else if (data.type === "error") {
             throw new Error(data.error);
           }
-        });
+        }, watchdog.arm);
         resolve();
       } catch (err: any) {
-        setLibraryError(err.message);
+        setLibraryError(
+          watchdog.stalled
+            ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
+            : err.message
+        );
         resolve(); // Resolve anyway so the next library can be checked
       } finally {
+        watchdog.clear();
         isCheckingRef.current = false;
         setCheckingLibrary(null);
         setCheckProgress(null);

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { consumeSSE } from "../utils/sse";
+import { createStallWatchdog } from "../utils/stallWatchdog";
 
 export interface VintedResult {
   id: string;
@@ -41,11 +42,15 @@ export function useVintedCheck() {
     setSearchAttempts([]);
     setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
     setVintedError(null);
-    
+
+    const watchdog = createStallWatchdog();
+
     try {
+      watchdog.arm();
       const response = await fetch("/api/vinted-check", {
         method: "POST",
-        headers: { "Content-Type": "application/json" }
+        headers: { "Content-Type": "application/json" },
+        signal: watchdog.signal
       });
 
       if (!response.ok) {
@@ -88,10 +93,15 @@ export function useVintedCheck() {
         } else if (data.type === "error") {
           throw new Error(data.error);
         }
-      });
+      }, watchdog.arm);
     } catch (err: any) {
-      setVintedError(err.message);
+      setVintedError(
+        watchdog.stalled
+          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
+          : err.message
+      );
     } finally {
+      watchdog.clear();
       isCheckingRef.current = false;
       setIsChecking(false);
       setCheckProgress(null);

--- a/src/utils/__tests__/stallWatchdog.test.ts
+++ b/src/utils/__tests__/stallWatchdog.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createStallWatchdog } from "../stallWatchdog";
+
+describe("createStallWatchdog", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("aborts and flags stalled after the timeout when never re-armed", () => {
+    const w = createStallWatchdog(30000);
+    w.arm();
+    expect(w.signal.aborted).toBe(false);
+    expect(w.stalled).toBe(false);
+
+    vi.advanceTimersByTime(30000);
+
+    expect(w.signal.aborted).toBe(true);
+    expect(w.stalled).toBe(true);
+  });
+
+  it("re-arming resets the countdown (keepalive keeps the stream alive)", () => {
+    const w = createStallWatchdog(30000);
+    w.arm();
+    vi.advanceTimersByTime(29000);
+    w.arm(); // a chunk (or keepalive) arrived just in time
+    vi.advanceTimersByTime(29000);
+    expect(w.signal.aborted).toBe(false); // 58s elapsed but re-armed at 29s
+
+    vi.advanceTimersByTime(1000); // now 30s of true silence
+    expect(w.signal.aborted).toBe(true);
+    expect(w.stalled).toBe(true);
+  });
+
+  it("clear() cancels a pending abort (normal completion path)", () => {
+    const w = createStallWatchdog(30000);
+    w.arm();
+    w.clear();
+    vi.advanceTimersByTime(60000);
+    expect(w.signal.aborted).toBe(false);
+    expect(w.stalled).toBe(false);
+  });
+});

--- a/src/utils/stallWatchdog.ts
+++ b/src/utils/stallWatchdog.ts
@@ -1,0 +1,43 @@
+/**
+ * Watchdog przeciw zawieszeniu strumienia SSE. Hosting/proxy potrafi zbuforować
+ * odpowiedź tak, że `reader.read()` nigdy nie wraca — bez tego skan zostawiał
+ * wieczny spinner. Serwer wysyła keepalive co 5 s, więc na zdrowym połączeniu
+ * `arm()` (wołane per chunk przez consumeSSE) stale resetuje odliczanie i abort
+ * nigdy nie następuje; po `timeoutMs` ciszy sygnał jest przerywany.
+ */
+export interface StallWatchdog {
+  /** Przekaż do `fetch(..., { signal })`. */
+  signal: AbortSignal;
+  /** Zresetuj odliczanie (wołaj po każdym odebranym fragmencie strumienia). */
+  arm: () => void;
+  /** Zatrzymaj watchdog (wołaj w finally). */
+  clear: () => void;
+  /** Czy watchdog przerwał połączenie z powodu ciszy. */
+  readonly stalled: boolean;
+}
+
+export function createStallWatchdog(timeoutMs = 30000): StallWatchdog {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stalled = false;
+
+  return {
+    signal: controller.signal,
+    arm() {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        stalled = true;
+        controller.abort();
+      }, timeoutMs);
+    },
+    clear() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+    get stalled() {
+      return stalled;
+    },
+  };
+}


### PR DESCRIPTION
## M4 — wieczny spinner przy zawieszonym strumieniu (MEDIUM)

`useSync` ma 30-sekundowy watchdog (AbortController resetowany per chunk), ale `useLibraryCheck` i `useVintedCheck` konsumowały strumień SSE bez timeoutu. Gdy strumień zawiśnie (buforowanie proxy na hostingu — dokładnie ta awaria, z którą walczy padding/keepalive), `reader.read()` blokuje się na zawsze: `isChecking`/`isCheckingRef` zostają ustawione, spinner nie gaśnie, skanu nie da się ponowić.

## Zmiany

- **Nowy `src/utils/stallWatchdog.ts`** (`createStallWatchdog`: `signal` + `arm` + `clear` + `stalled`) — wyniesiony watchdog, wpięty w oba hooki: `signal` na `fetch`, `arm()` jako `onChunk` dla `consumeSSE` (keepalive go resetuje), `clear()` w `finally`, przyjazny komunikat przy abort.
- Helper **deterministycznie testowany** fake-timerami (abort przy ciszy, reset przy re-arm, `clear` anuluje).
- Przy okazji usunięty nieużywany argument `reject` z executora Promise w `useLibraryCheck`.

Weryfikacja: `npm run lint` czysto, `npm test` 133/133, `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_