### PR TITLE
Bughunt PR5: batch of low-severity fixes (L1–L5 + SSE reader cleanup)

### DIFF
--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -133,7 +133,10 @@ const setupSSE = (res: Response) => {
   // dzięki czemu klient dostaje zdarzenia na bieżąco (a nie dopiero na końcu).
   res.write(`:${" ".repeat(2048)}\n\n`);
   return (data: SyncEvent) => {
-    if (!res.writableEnded) res.write(`data: ${JSON.stringify(data)}\n\n`);
+    // Po abort klienta socket bywa `destroyed` przy wciąż `writableEnded === false`
+    // — sam guard writableEnded przepuszczał zapis do martwego socketu, co rzucało
+    // nieobsłużony 'error' na strumieniu. Sprawdzaj też destroyed.
+    if (!res.writableEnded && !res.destroyed) res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
 };
 
@@ -169,7 +172,7 @@ const executeSyncTask = async (
   // Częstszy keepalive (5s) utrzymuje strumień "gorący" u proxy, które inaczej
   // zbierają dane w bufor między rzadkimi zapisami długiego zadania.
   const keepAlive = setInterval(() => {
-    if (!res.writableEnded) res.write(": keepalive\n\n");
+    if (!res.writableEnded && !res.destroyed) res.write(": keepalive\n\n");
   }, 5000);
 
   // Rozłączenie klienta (zamknięta karta, utrata sieci) — anuluj zadanie,

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -219,6 +219,9 @@ export class NotionAdapter {
 
       hasMore = response.has_more;
       nextCursor = response.next_cursor ?? undefined;
+      // Zabezpieczenie: has_more === true bez kursora oznaczałoby ponowne pobranie
+      // strony 1 od początku w kółko (i podwójne liczenie). Przerwij zamiast zawisnąć.
+      if (hasMore && !nextCursor) break;
       if (onProgress) onProgress(allBooks.length);
     }
 

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -239,26 +239,33 @@ export class BookSyncService {
     const newAwards = (book.awards || []).map(sanitizeNotionTag).filter(Boolean);
     const existingAwards = (existingBook.awards || []).map(sanitizeNotionTag).filter(Boolean);
     
-    const combinedAwardsSet = new Set([...existingAwards]);
+    // Case-insensitive union (jak autorzy/wydawca/seria). Notion dopasowuje opcje
+    // multi_select bez względu na wielkość liter i zachowuje własną pisownię, więc
+    // porównanie case-sensitive mogło re-dodać istniejący tag (np. ręcznie wpisane
+    // "nagroda hugo" obok wygenerowanego "Nagroda Hugo"). Zob. GUIDELINES §3.
+    const awardsLower = new Set(existingAwards.map(a => a.toLowerCase()));
+    const combinedAwards = [...existingAwards];
     let awardsUpdated = false;
 
     for (const aw of newAwards) {
-      if (!combinedAwardsSet.has(aw)) {
-        combinedAwardsSet.add(aw);
+      if (!awardsLower.has(aw.toLowerCase())) {
+        combinedAwards.push(aw);
+        awardsLower.add(aw.toLowerCase());
         awardsUpdated = true;
       }
     }
-    
-    const hasHugo = combinedAwardsSet.has("Nagroda Hugo");
-    const hasNebula = combinedAwardsSet.has("Nagroda Nebula");
-    const hasLocus = combinedAwardsSet.has("Nagroda Locus");
-    if (hasHugo && hasNebula && hasLocus && !combinedAwardsSet.has("Wszystkie")) {
-      combinedAwardsSet.add("Wszystkie");
+
+    const hasHugo = awardsLower.has("nagroda hugo");
+    const hasNebula = awardsLower.has("nagroda nebula");
+    const hasLocus = awardsLower.has("nagroda locus");
+    if (hasHugo && hasNebula && hasLocus && !awardsLower.has("wszystkie")) {
+      combinedAwards.push("Wszystkie");
+      awardsLower.add("wszystkie");
       awardsUpdated = true;
     }
-    
+
     if (awardsUpdated) {
-      updates["Nagroda"] = { multi_select: Array.from(combinedAwardsSet).map(name => ({ name })) };
+      updates["Nagroda"] = { multi_select: combinedAwards.slice(0, 100).map(name => ({ name })) };
     }
 
     // Update Year if it differs

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -107,15 +107,18 @@ export class CyclesSyncService {
           }
 
           // 4. Direct Fetch Fallback (Exact title from Notion)
+          // Bez wewnętrznego catch — fetchPageContent zwraca "" dla brakującej
+          // strony, ale RZUCA przy awarii infrastruktury (blokada IP/timeout).
+          // Połykanie tego rzutu zamieniało "sieć padła" w "brak danych → pomiń",
+          // przez co awaria widoczna tylko w tej ścieżce znikała po cichu. Teraz
+          // propaguje do per-book catch niżej i trafia do errors[].
           if (!wikitext && plTitle) {
-            try {
-              const content = await this.wiki.fetchPageContent(plTitle);
-              const wikiAuthor = WikiParser.extractAuthor(content);
-              if (isAuthorMatch(wikiAuthor, notionAuthor)) {
-                wikitext = content;
-                foundSource = `Direct Fetch: ${plTitle}`;
-              }
-            } catch (e) {}
+            const content = await this.wiki.fetchPageContent(plTitle);
+            const wikiAuthor = WikiParser.extractAuthor(content);
+            if (isAuthorMatch(wikiAuthor, notionAuthor)) {
+              wikitext = content;
+              foundSource = `Direct Fetch: ${plTitle}`;
+            }
           }
 
           if (!wikitext) return;

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -199,7 +199,7 @@ export class VintedSyncService {
                 items.push({
                   id: item.id,
                   title: item.title || itemTitle,
-                  price: item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || item.price || "??",
+                  price: item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || "??",
                   currency: item.price?.currency_code || item.currency || "PLN",
                   url: item.url ? (item.url.startsWith('http') ? item.url : `https://www.vinted.pl${item.url}`) : `https://www.vinted.pl/items/${item.id}`
                 });
@@ -216,7 +216,10 @@ export class VintedSyncService {
                 const block = itemBlocks[j];
                 const urlMatch = block.match(/href="(\/items\/[^"]+)"/);
                 const titleMatch = block.match(/title="([^"]+)"/);
-                const priceMatch = block.match(/aria-label="([^"]*?(\d+[.,]\d+)\s*([A-Z]{3}|zł))"/i) ||
+                // Oba warianty mają teraz group1 = kwota, group2 = waluta (wcześniej
+                // wariant aria-label miał grupę 1 = cały tekst etykiety, więc jako
+                // cena pokazywał się śmieć typu "Marka: …, cena: 25,00 zł").
+                const priceMatch = block.match(/aria-label="[^"]*?(\d+[.,]\d+)\s*([A-Z]{3}|zł)"/i) ||
                                    block.match(/>(\d+[.,]\d+)\s*([A-Z]{3}|zł)</i);
 
                 if (urlMatch && titleMatch) {
@@ -226,7 +229,7 @@ export class VintedSyncService {
                       title: itemTitle,
                       url: `https://www.vinted.pl${urlMatch[1]}`,
                       price: priceMatch ? priceMatch[1] : "Sprawdź",
-                      currency: priceMatch ? (priceMatch[3] || priceMatch[2]) : "PLN"
+                      currency: priceMatch ? priceMatch[2] : "PLN"
                     });
                   }
                 }

--- a/src/utils/__tests__/sse.test.ts
+++ b/src/utils/__tests__/sse.test.ts
@@ -11,8 +11,9 @@ function mockBody(chunks: string[]) {
       if (i < chunks.length) return { value: enc.encode(chunks[i++]), done: false };
       return { value: undefined, done: true };
     }),
+    cancel: vi.fn(async () => {}),
   };
-  return { getReader: () => reader } as any;
+  return { getReader: () => reader, _reader: reader } as any;
 }
 
 describe("consumeSSE", () => {
@@ -39,7 +40,7 @@ describe("consumeSSE", () => {
     expect(events).toEqual([{ type: "status", message: "joined" }]);
   });
 
-  it("stops early when the callback returns true", async () => {
+  it("stops early when the callback returns true and cancels the reader", async () => {
     const body = mockBody([
       'data: {"type":"complete","result":1}\n\n',
       'data: {"type":"status","message":"after"}\n\n',
@@ -51,6 +52,14 @@ describe("consumeSSE", () => {
     });
     expect(seen).toHaveLength(1);
     expect(seen[0].type).toBe("complete");
+    // early exit must release the stream so the fetch connection isn't leaked
+    expect(body._reader.cancel).toHaveBeenCalled();
+  });
+
+  it("does NOT cancel the reader on natural stream completion", async () => {
+    const body = mockBody(['data: {"type":"status","message":"A"}\n\n']);
+    await consumeSSE(body, () => {});
+    expect(body._reader.cancel).not.toHaveBeenCalled();
   });
 
   it("skips malformed JSON without aborting the stream", async () => {

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -20,27 +20,37 @@ export async function consumeSSE(
 
   const decoder = new TextDecoder();
   let buffer = "";
+  let finished = false;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    onChunk?.();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) { finished = true; break; }
+      onChunk?.();
 
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n\n");
-    buffer = lines.pop() || "";
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n\n");
+      buffer = lines.pop() || "";
 
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue;
-      let event: SyncEvent;
-      try {
-        event = JSON.parse(line.substring(6));
-      } catch (e) {
-        console.error("Błąd parsowania SSE:", e);
-        continue;
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        let event: SyncEvent;
+        try {
+          event = JSON.parse(line.substring(6));
+        } catch (e) {
+          console.error("Błąd parsowania SSE:", e);
+          continue;
+        }
+        const signal = await onEvent(event);
+        if (signal === true || signal === "stop") return;
       }
-      const signal = await onEvent(event);
-      if (signal === true || signal === "stop") return;
+    }
+  } finally {
+    // Gdy wychodzimy wcześniej (stop na complete/error albo rzut z onEvent),
+    // strumień fetch zostałby zablokowany i nieanulowany. Anuluj czytnik, by
+    // zwolnić połączenie — poza przypadkiem naturalnego końca (done).
+    if (!finished) {
+      try { await reader.cancel(); } catch { /* czytnik może nie wspierać cancel */ }
     }
   }
 }


### PR DESCRIPTION
Zbiorczy PR na drobne, potwierdzone znaleziska.

- **L1 — cena Vinted (fallback HTML):** regex `aria-label` łapał całą etykietę jako grupę 1, więc jako cena pokazywał się śmieć (`"Marka: …, cena: 25,00 zł"`); oba warianty fallbacku mają teraz `group1=kwota`, `group2=waluta`. Usunięty catch-all `|| item.price`, który przy `amount=null/0` renderował obiekt jako `[object Object]`.
- **L2 — fallback cykli połykał awarię infrastruktury:** `fetchPageContent` **rzuca** przy blokadzie IP/timeout (a `""` dla brakującej strony); wewnętrzny `catch` zamieniał „sieć padła" w „brak danych → pomiń". Usunięty — propaguje do per-book `errors[]` jak pozostałe ścieżki.
- **L3 — porównanie nagród case-sensitive** (w przeciwieństwie do autorów/wydawcy/serii) → ręcznie przekazowany tag mógł zostać zdublowany. Teraz case-insensitive union, zgodnie z GUIDELINES §3.
- **L4 — zapisy SSE** strzeżone tylko `!writableEnded`, które po abort klienta zostaje `false`, gdy socket jest `destroyed` → zapis rzucał nieobsłużony błąd strumienia. `sendEvent` i keepalive sprawdzają teraz też `!res.destroyed`.
- **L5 — paginacja Notion:** `has_more===true` z `next_cursor===null` pobierałoby stronę 1 w kółko (i podwójnie liczyło). `break` zamiast zawiśnięcia.
- **consumeSSE** anuluje teraz czytnik przy wcześniejszym wyjściu/rzucie (`try+finally`, pomijane przy naturalnym końcu), żeby zatrzymany strumień nie wyciekał połączenia fetch.

## Testy

- `consumeSSE` anuluje czytnik przy wczesnym stopie, ale nie przy naturalnym końcu; resztę pokrywa istniejąca suita.
- `npm run lint` czysto, `npm test` 134/134, `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_