### PR TITLE
God-object PR3: extract parseVintedItems pure function

### DIFF
--- a/services/__tests__/vintedParser.test.ts
+++ b/services/__tests__/vintedParser.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { parseVintedItems } from "../vintedParser";
+
+// Catalog blob with &quot;-escaped JSON, as in the real page
+const catalogHtml = (json: object) =>
+  `<html><body><div data-component-name="Catalog" data-props="${JSON.stringify(json)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')}"></div></body></html>`;
+
+describe("parseVintedItems", () => {
+  it("parses relevant offers from the catalog JSON blob", () => {
+    const html = catalogHtml({
+      items: { list: [{ id: 123, title: "Solaris Lem", price: { amount: "15", currency_code: "PLN" }, url: "/items/123" }] },
+    });
+    const items = parseVintedItems(html, "Solaris", "Lem");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ id: 123, price: "15", currency: "PLN", url: "https://www.vinted.pl/items/123" });
+  });
+
+  it("filters out irrelevant offers (no title or author overlap)", () => {
+    const html = catalogHtml({
+      items: { list: [{ id: 9, title: "Zupełnie inna książka", price: { amount: "5" }, url: "/items/9" }] },
+    });
+    expect(parseVintedItems(html, "Solaris", "Lem")).toHaveLength(0);
+  });
+
+  it("caps results at 5", () => {
+    const list = Array.from({ length: 8 }, (_, i) => ({ id: i, title: "Solaris", price: { amount: "1" }, url: `/items/${i}` }));
+    const items = parseVintedItems(catalogHtml({ items: { list } }), "Solaris", "Lem");
+    expect(items).toHaveLength(5);
+  });
+
+  it("does not leak the price object when amount is missing", () => {
+    const html = catalogHtml({ items: { list: [{ id: 1, title: "Solaris", price: { amount: null, currency_code: "PLN" }, url: "/items/1" }] } });
+    const items = parseVintedItems(html, "Solaris", "Lem");
+    expect(items[0].price).toBe("??");
+    expect(typeof items[0].price).toBe("string");
+  });
+
+  it("falls back to feed-grid blocks and reads the amount (not the whole aria-label)", () => {
+    const html = `<div class="feed-grid__item">` +
+      `<a href="/items/77" title="Solaris Lem"></a>` +
+      `<span aria-label="Marka: Książka, cena: 25,00 zł">25,00 zł</span></div>`;
+    const items = parseVintedItems(html, "Solaris", "Lem");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ title: "Solaris Lem", url: "https://www.vinted.pl/items/77", price: "25,00", currency: "zł" });
+  });
+
+  it("returns [] when nothing matches any path", () => {
+    expect(parseVintedItems("<html><body>nic</body></html>", "Solaris", "Lem")).toEqual([]);
+  });
+});

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -1,0 +1,144 @@
+import { createLogger } from "../logger";
+
+const log = createLogger("VintedParse");
+
+export interface VintedItem {
+  id?: string | number;
+  title: string;
+  price: string | number;
+  currency: string;
+  url: string;
+}
+
+/**
+ * Czysty parser wyników katalogu Vinted (HTML → oferty). Bez I/O ani zdarzeń SSE —
+ * skaner tylko podaje surowy HTML, tytuł i autora, a dostaje do 5 dopasowanych
+ * ofert. Cztery kaskadowe ścieżki: (1) blob JSON `data-component-name="Catalog"`,
+ * (2) fallback po regexie `"items":[…]` z domykaniem nawiasów, (3) bloki
+ * `feed-grid__item`, (4) globalny regex `href=/items/…`. Wyodrębnione, by tę
+ * kruchą logikę dało się testować jednostkowo na utrwalonym HTML.
+ */
+export function parseVintedItems(html: string, title: string, author: string): VintedItem[] {
+  const items: VintedItem[] = [];
+  let rawItems: any[] = [];
+
+  // 1. Blob JSON w atrybucie data-props / treści skryptu Catalog
+  const catalogMatch = html.match(/data-component-name="Catalog"[^>]*data-props="([^"]+)"/s) ||
+                       html.match(/data-component-name="Catalog"[^>]*>\s*({.*?})\s*<\/script>/s);
+
+  if (catalogMatch) {
+    try {
+      // Atrybuty HTML używają &quot; zamiast "
+      let jsonStr = catalogMatch[1];
+      if (jsonStr.includes('&quot;')) {
+        jsonStr = jsonStr.replace(/&quot;/g, '"')
+                         .replace(/&amp;/g, '&')
+                         .replace(/&lt;/g, '<')
+                         .replace(/&gt;/g, '>')
+                         .replace(/&#39;/g, "'");
+      }
+      const catalogData = JSON.parse(jsonStr);
+      rawItems = catalogData.items?.list ||
+                 catalogData.items ||
+                 catalogData.catalog?.results?.items ||
+                 catalogData.catalog?.items ||
+                 [];
+      log.info(`Znaleziono elementy w JSON`, { title, count: rawItems.length });
+    } catch (e) {
+      log.warn("Nie udało się sparsować JSON katalogu Vinted", { title });
+    }
+  }
+
+  // 2. Fallback po starym regexie "items" (z domykaniem nawiasów tablicy)
+  if (rawItems.length === 0) {
+    const jsonMatch = html.match(/"items":\s*(\[.*?\])/);
+    if (jsonMatch) {
+      try {
+        let bracketCount = 0;
+        let endIndex = -1;
+        const str = jsonMatch[1];
+        for (let i = 0; i < str.length; i++) {
+          if (str[i] === '[') bracketCount++;
+          else if (str[i] === ']') {
+            bracketCount--;
+            if (bracketCount === 0) {
+              endIndex = i + 1;
+              break;
+            }
+          }
+        }
+        const jsonStr = endIndex !== -1 ? str.substring(0, endIndex) : str;
+        rawItems = JSON.parse(jsonStr);
+      } catch (e) {
+        // Regex bywa zbyt prosty — trudno; przejdź do fallbacków HTML
+      }
+    }
+  }
+
+  if (Array.isArray(rawItems)) {
+    for (const item of rawItems) {
+      if (items.length >= 5) break;
+
+      const itemTitle = (item.title || "").toLowerCase();
+      const searchTitle = title.toLowerCase();
+      const searchAuthor = (author || "").toLowerCase();
+
+      // Elastyczne dopasowanie: tytuł oferty zawiera tytuł książki (lub odwrotnie),
+      // albo tytuł oferty zawiera nazwisko autora.
+      const hasTitle = itemTitle.includes(searchTitle) || searchTitle.includes(itemTitle);
+      const hasAuthor = searchAuthor && itemTitle.includes(searchAuthor);
+
+      if (hasTitle || hasAuthor) {
+        items.push({
+          id: item.id,
+          title: item.title || itemTitle,
+          price: item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || "??",
+          currency: item.price?.currency_code || item.currency || "PLN",
+          url: item.url ? (item.url.startsWith('http') ? item.url : `https://www.vinted.pl${item.url}`) : `https://www.vinted.pl/items/${item.id}`
+        });
+      }
+    }
+  }
+
+  // 3. Fallback po blokach feed-grid__item
+  if (items.length === 0) {
+    const itemBlocks = html.split('class="feed-grid__item"');
+    if (itemBlocks.length > 1) {
+      for (let j = 1; j < itemBlocks.length && items.length < 5; j++) {
+        const block = itemBlocks[j];
+        const urlMatch = block.match(/href="(\/items\/[^"]+)"/);
+        const titleMatch = block.match(/title="([^"]+)"/);
+        // Oba warianty mają group1 = kwota, group2 = waluta.
+        const priceMatch = block.match(/aria-label="[^"]*?(\d+[.,]\d+)\s*([A-Z]{3}|zł)"/i) ||
+                           block.match(/>(\d+[.,]\d+)\s*([A-Z]{3}|zł)</i);
+
+        if (urlMatch && titleMatch) {
+          const itemTitle = titleMatch[1];
+          if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
+            items.push({
+              title: itemTitle,
+              url: `https://www.vinted.pl${urlMatch[1]}`,
+              price: priceMatch ? priceMatch[1] : "Sprawdź",
+              currency: priceMatch ? priceMatch[2] : "PLN"
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // 4. Ostateczność: prosty globalny regex
+  if (items.length === 0) {
+    const itemRegex = /href="(\/items\/[^"]+)"[^>]*title="([^"]+)"/g;
+    let match;
+    while ((match = itemRegex.exec(html)) !== null && items.length < 5) {
+      const itemUrl = `https://www.vinted.pl${match[1]}`;
+      const itemTitle = match[2];
+      if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
+        items.push({ title: itemTitle, url: itemUrl, price: "Sprawdź", currency: "PLN" });
+      }
+    }
+  }
+
+  return items;
+}

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -4,6 +4,7 @@ import { SyncEvent } from "../src/types";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
 import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
+import { parseVintedItems } from "./vintedParser";
 
 const log = createLogger("VintedScan");
 
@@ -120,141 +121,7 @@ export class VintedSyncService {
             continue;
           }
 
-          const items: any[] = [];
-
-          // Vinted often stores data in a script tag with data-component-name="Catalog"
-          // or similar. We'll try to find the JSON blob more reliably.
-          let rawItems: any[] = [];
-
-          // Try to find JSON in script tag content or data-props attribute
-          const catalogMatch = html.match(/data-component-name="Catalog"[^>]*data-props="([^"]+)"/s) ||
-                               html.match(/data-component-name="Catalog"[^>]*>\s*({.*?})\s*<\/script>/s);
-
-          if (catalogMatch) {
-            try {
-              // HTML attributes use &quot; instead of "
-              let jsonStr = catalogMatch[1];
-              if (jsonStr.includes('&quot;')) {
-                jsonStr = jsonStr.replace(/&quot;/g, '"')
-                                 .replace(/&amp;/g, '&')
-                                 .replace(/&lt;/g, '<')
-                                 .replace(/&gt;/g, '>')
-                                 .replace(/&#39;/g, "'");
-              }
-              const catalogData = JSON.parse(jsonStr);
-              rawItems = catalogData.items?.list ||
-                         catalogData.items ||
-                         catalogData.catalog?.results?.items ||
-                         catalogData.catalog?.items ||
-                         [];
-              log.info(`Znaleziono elementy w JSON`, { title, count: rawItems.length });
-            } catch (e) {
-              log.warn("Nie udało się sparsować JSON katalogu Vinted", { title });
-            }
-          }
-
-          // Fallback to the old "items" regex if the above failed
-          if (rawItems.length === 0) {
-            const jsonMatch = html.match(/"items":\s*(\[.*?\])/);
-            if (jsonMatch) {
-              try {
-                // Try to find the matching closing bracket for the array
-                let bracketCount = 0;
-                let endIndex = -1;
-                const str = jsonMatch[1];
-                for (let i = 0; i < str.length; i++) {
-                  if (str[i] === '[') bracketCount++;
-                  else if (str[i] === ']') {
-                    bracketCount--;
-                    if (bracketCount === 0) {
-                      endIndex = i + 1;
-                      break;
-                    }
-                  }
-                }
-                const jsonStr = endIndex !== -1 ? str.substring(0, endIndex) : str;
-                rawItems = JSON.parse(jsonStr);
-              } catch (e) {
-                // If it fails, it might be because the regex was too simple
-              }
-            }
-          }
-
-          if (Array.isArray(rawItems)) {
-            for (const item of rawItems) {
-              if (items.length >= 5) break;
-
-              const itemTitle = (item.title || "").toLowerCase();
-              const searchTitle = title.toLowerCase();
-              const searchAuthor = (book.author || "").toLowerCase();
-
-              // More flexible relevance check:
-              // 1. Item title contains the book title
-              // 2. OR Book title contains the item title
-              // 3. OR Item title contains the author's name
-              const hasTitle = itemTitle.includes(searchTitle) || searchTitle.includes(itemTitle);
-              const hasAuthor = searchAuthor && itemTitle.includes(searchAuthor);
-
-              if (hasTitle || hasAuthor) {
-                items.push({
-                  id: item.id,
-                  title: item.title || itemTitle,
-                  price: item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || "??",
-                  currency: item.price?.currency_code || item.currency || "PLN",
-                  url: item.url ? (item.url.startsWith('http') ? item.url : `https://www.vinted.pl${item.url}`) : `https://www.vinted.pl/items/${item.id}`
-                });
-              }
-            }
-          }
-
-          // Fallback to regex if JSON parsing failed or found no items
-          if (items.length === 0) {
-            // Look for item blocks
-            const itemBlocks = html.split('class="feed-grid__item"');
-            if (itemBlocks.length > 1) {
-              for (let j = 1; j < itemBlocks.length && items.length < 5; j++) {
-                const block = itemBlocks[j];
-                const urlMatch = block.match(/href="(\/items\/[^"]+)"/);
-                const titleMatch = block.match(/title="([^"]+)"/);
-                // Oba warianty mają teraz group1 = kwota, group2 = waluta (wcześniej
-                // wariant aria-label miał grupę 1 = cały tekst etykiety, więc jako
-                // cena pokazywał się śmieć typu "Marka: …, cena: 25,00 zł").
-                const priceMatch = block.match(/aria-label="[^"]*?(\d+[.,]\d+)\s*([A-Z]{3}|zł)"/i) ||
-                                   block.match(/>(\d+[.,]\d+)\s*([A-Z]{3}|zł)</i);
-
-                if (urlMatch && titleMatch) {
-                  const itemTitle = titleMatch[1];
-                  if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
-                    items.push({
-                      title: itemTitle,
-                      url: `https://www.vinted.pl${urlMatch[1]}`,
-                      price: priceMatch ? priceMatch[1] : "Sprawdź",
-                      currency: priceMatch ? priceMatch[2] : "PLN"
-                    });
-                  }
-                }
-              }
-            }
-          }
-
-          // Last resort: simple global regex
-          if (items.length === 0) {
-            const itemRegex = /href="(\/items\/[^"]+)"[^>]*title="([^"]+)"/g;
-            let match;
-            while ((match = itemRegex.exec(html)) !== null && items.length < 5) {
-              const itemUrl = `https://www.vinted.pl${match[1]}`;
-              const itemTitle = match[2];
-
-              if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
-                items.push({
-                  title: itemTitle,
-                  url: itemUrl,
-                  price: "Sprawdź",
-                  currency: "PLN"
-                });
-              }
-            }
-          }
+          const items = parseVintedItems(html, title, book.author || "");
 
           if (items.length > 0) {
             const matchResult = {


### PR DESCRIPTION
## G3 — parsing wtopiony w orkiestrację `runVintedCheck`

Metoda mieszała orkiestrację (żądania/delaye/SSE) z ~135 liniami kruchego parsowania HTML/JSON (blob `data-props` katalogu, regex `"items"` z domykaniem nawiasów, fallback `feed-grid`, globalny regex `href`) — nietestowalnego bez żywego przepływu HTTP, przez co wcześniejsze bugi ceny (grupa/wyciek obiektu) właśnie tam się chowały.

## Zmiany

- Wszystkie cztery ścieżki parsowania → czysta `parseVintedItems(html, title, author): VintedItem[]` w `services/vintedParser.ts`.
- Skaner tylko ją woła i zostaje przy orkiestracji; parsowanie w `runVintedCheck` kurczy się do jednej linii, `vintedSyncService` spada **317 → 184 linie**.

## Testy jednostkowe (na utrwalonym HTML/JSON)

Parsowanie blobu katalogu, filtr trafności, limit 5 ofert, brak wycieku obiektu ceny przy `amount=null`, fallback `feed-grid` czytający kwotę (nie całą aria-label), pusto przy braku dopasowań.

Weryfikacja: `npm run lint` czysto, `npm test` 145/145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_