### PR TITLE
God-object PR4: extract Notion page-mapper + collapse dual-mode branching

### DIFF
--- a/__tests__/notionMapper.test.ts
+++ b/__tests__/notionMapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { mapPageToBook } from "../notionMapper";
+import { NotionPage } from "../src/types";
+
+const rt = (s: string) => [{ plain_text: s } as any];
+
+describe("mapPageToBook", () => {
+  it("maps a full page into a NotionBook", () => {
+    const page: NotionPage = {
+      id: "page-1",
+      properties: {
+        "Tytuł polski": { type: "title", title: rt("Solaris") },
+        "Tytuł oryginalny": { type: "rich_text", rich_text: rt("Solaris") },
+        "Autor": { type: "multi_select", multi_select: [{ name: "Stanisław Lem" }] },
+        "Rok": { type: "multi_select", multi_select: [{ name: "1961" }] },
+        "Wydawnictwo": { type: "select", select: { name: "Wydawnictwo Literackie" } },
+        "Seria": { type: "rich_text", rich_text: rt("Dzieła") },
+        "Część cyklu": { type: "checkbox", checkbox: true },
+        "Lp": { type: "title", title: rt("1") },
+        "Nagroda": { type: "multi_select", multi_select: [{ name: "Nagroda Hugo" }, { name: "Nagroda Locus" }] },
+        "Źródło": { type: "multi_select", multi_select: [{ name: "Przeczytane" }] },
+      },
+    };
+
+    const book = mapPageToBook(page);
+    expect(book).toMatchObject({
+      id: "page-1",
+      plTitle: "Solaris",
+      origTitle: "Solaris",
+      author: "Stanisław Lem",
+      year: "1961",
+      currentWydawnictwo: "Wydawnictwo Literackie",
+      currentSeria: "Dzieła",
+      currentCzesccyklu: true,
+      lp: "1",
+      awards: ["Nagroda Hugo", "Nagroda Locus"],
+      zrodlo: ["Przeczytane"],
+    });
+  });
+
+  it("resolves properties case-insensitively and tolerates missing ones", () => {
+    const page: NotionPage = {
+      id: "page-2",
+      properties: {
+        "tytuł polski": { type: "title", title: rt("Diuna") }, // lowercase key
+      },
+    };
+    const book = mapPageToBook(page);
+    expect(book.plTitle).toBe("Diuna");
+    expect(book.author).toBe("");
+    expect(book.awards).toEqual([]);
+    expect(book.currentCzesccyklu).toBe(false);
+    expect(book.year).toBeUndefined();
+  });
+
+  it("reads a single select award as a one-element list", () => {
+    const page: NotionPage = {
+      id: "p", properties: { "Nagroda": { type: "select", select: { name: "Nagroda Nebula" } } },
+    };
+    expect(mapPageToBook(page).awards).toEqual(["Nagroda Nebula"]);
+  });
+});

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -1,7 +1,8 @@
 import { Client } from "@notionhq/client";
 import { withRetry } from "./retry";
 import { sanitizeNotionString, sanitizeNotionTag } from "./utils";
-import { NotionPage, NotionProperty, NotionPageProperties, NotionBook } from "./src/types";
+import { NotionPage, NotionBook } from "./src/types";
+import { mapPageToBook } from "./notionMapper";
 
 export class NotionAdapter {
   private notion: Client;
@@ -53,142 +54,50 @@ export class NotionAdapter {
     }
   }
 
+  // --- Dual-mode helpers ---
+  // Notion udostępnia bazę jako "data source" (nowe API) lub klasyczną "database".
+  // Te trzy helpery kapsułkują rozgałęzienie isDataSource, które wcześniej było
+  // powielone w ~7 metodach.
+
+  private async retrieveSource(id: string): Promise<any> {
+    return this.isDataSource
+      ? await withRetry(() => (this.notion as any).dataSources.retrieve({ data_source_id: id }))
+      : await withRetry(() => this.notion.databases.retrieve({ database_id: id }));
+  }
+
+  private async updateSource(id: string, properties: any): Promise<void> {
+    if (this.isDataSource) {
+      await withRetry(() => (this.notion as any).dataSources.update({ data_source_id: id, properties }));
+    } else {
+      await withRetry(() => this.notion.databases.update({ database_id: id, properties } as any));
+    }
+  }
+
+  private async querySource(startCursor?: string): Promise<any> {
+    return this.isDataSource
+      ? await withRetry(() => (this.notion as any).dataSources.query({ data_source_id: this.actualDataSourceId!, start_cursor: startCursor }))
+      : await withRetry(() => (this.notion.databases as any).query({ database_id: this.actualDataSourceId!, start_cursor: startCursor }));
+  }
+
   async getSchema(): Promise<any> {
     await this.init();
-    if (this.isDataSource) {
-      const dataSource = await withRetry(() => (this.notion as any).dataSources.retrieve({
-        data_source_id: this.actualDataSourceId!,
-      }));
-      return (dataSource as any).properties;
-    } else {
-      const database = await withRetry(() => this.notion.databases.retrieve({
-        database_id: this.actualDataSourceId!,
-      }));
-      return (database as any).properties;
-    }
+    const source = await this.retrieveSource(this.actualDataSourceId!);
+    return source.properties;
   }
 
   async updateSchema(propertyName: string, propertyType: string, newOptions: any): Promise<void> {
     await this.init();
-    const propertiesPayload: any = {
-      [propertyName]: {
-        [propertyType]: {
-          options: newOptions
-        }
-      }
-    };
-
-    if (this.isDataSource) {
-      await withRetry(() => (this.notion as any).dataSources.update({
-        data_source_id: this.actualDataSourceId!,
-        properties: propertiesPayload
-      }));
-    } else {
-      await withRetry(() => this.notion.databases.update({
-        database_id: this.actualDataSourceId!,
-        properties: propertiesPayload
-      } as any));
-    }
+    await this.updateSource(this.actualDataSourceId!, {
+      [propertyName]: { [propertyType]: { options: newOptions } }
+    });
   }
 
   async createColumnIfNeeded(columnName: string, type: string = "rich_text"): Promise<void> {
     await this.init();
     const schema = await this.getSchema();
     if (!schema[columnName]) {
-      if (this.isDataSource) {
-        await withRetry(() => (this.notion as any).dataSources.update({
-          data_source_id: this.actualDataSourceId!,
-          properties: {
-            [columnName]: { [type]: {} }
-          }
-        }));
-      } else {
-        await withRetry(() => this.notion.databases.update({
-          database_id: this.actualDataSourceId!,
-          properties: {
-            [columnName]: { [type]: {} }
-          }
-        } as any));
-      }
+      await this.updateSource(this.actualDataSourceId!, { [columnName]: { [type]: {} } });
     }
-  }
-
-  private getProp(props: NotionPageProperties, name: string): NotionProperty | undefined {
-    if (props[name]) return props[name];
-    const lowerName = name.toLowerCase();
-    for (const key in props) {
-      if (key.toLowerCase() === lowerName) return props[key];
-    }
-    return undefined;
-  }
-
-  private getPlainText(prop?: NotionProperty): string {
-    if (!prop) return "";
-    const type = prop.type;
-    if (type === "title") return prop.title?.map((t) => t.plain_text).join("") || "";
-    if (type === "rich_text") return prop.rich_text?.map((t) => t.plain_text).join("") || "";
-    if (type === "number") return prop.number !== undefined && prop.number !== null ? prop.number.toString() : "";
-    if (type === "select") return prop.select?.name || "";
-    if (type === "multi_select") return prop.multi_select?.map((x) => x.name).join(", ") || "";
-    if (type === "checkbox") return prop.checkbox?.toString() || "";
-    if (type === "url") return prop.url || "";
-    return "";
-  }
-
-  private parseNotionPageToBook(page: NotionPage): NotionBook {
-    const props = page.properties;
-    
-    const plTitle = this.getPlainText(this.getProp(props, "Tytuł polski"));
-    const origTitle = this.getPlainText(this.getProp(props, "Tytuł oryginalny"));
-    const author = this.getPlainText(this.getProp(props, "Autor"));
-    
-    const plTitleProp = this.getProp(props, "Tytuł polski");
-    const origTitleProp = this.getProp(props, "Tytuł oryginalny");
-    const plTitleRichText = plTitleProp?.type === "title" ? plTitleProp.title : plTitleProp?.rich_text || [];
-    const origTitleRichText = origTitleProp?.type === "title" ? origTitleProp.title : origTitleProp?.rich_text || [];
-
-    const yearProp = this.getProp(props, "Rok");
-    let year: string | undefined = undefined;
-    if (yearProp) {
-      if (yearProp.type === "multi_select") {
-        year = yearProp.multi_select?.map((x) => x.name).join(", ");
-      } else if (yearProp.type === "number") {
-        year = yearProp.number !== undefined && yearProp.number !== null ? yearProp.number.toString() : undefined;
-      } else {
-        year = this.getPlainText(yearProp).trim() || undefined;
-      }
-    }
-
-    const currentWydawnictwo = this.getPlainText(this.getProp(props, "Wydawnictwo"));
-    const currentSeria = this.getPlainText(this.getProp(props, "Seria"));
-    const currentCzesccyklu = this.getProp(props, "Część cyklu")?.checkbox || false;
-    const lp = this.getPlainText(this.getProp(props, "Lp"));
-
-    const nagrodaProp = this.getProp(props, "Nagroda");
-    const awards = nagrodaProp?.type === "multi_select"
-      ? nagrodaProp.multi_select?.map((x) => x.name) || []
-      : (nagrodaProp?.type === "select" && nagrodaProp.select?.name ? [nagrodaProp.select.name] : []);
-
-    const zrodloProp = this.getProp(props, "Źródło");
-    const zrodlo = zrodloProp?.type === "multi_select" 
-      ? zrodloProp.multi_select?.map((x) => x.name) || []
-      : (zrodloProp?.type === "select" && zrodloProp.select?.name ? [zrodloProp.select.name] : []);
-
-    return { 
-      id: page.id, 
-      plTitle, 
-      origTitle, 
-      author, 
-      year, 
-      currentWydawnictwo, 
-      currentSeria, 
-      currentCzesccyklu, 
-      lp, 
-      awards, 
-      zrodlo,
-      plTitleRichText, 
-      origTitleRichText 
-    };
   }
 
   async queryAllBooks(onProgress?: (count: number) => void, checkCancellation?: () => boolean): Promise<NotionBook[]> {
@@ -199,22 +108,11 @@ export class NotionAdapter {
 
     while (hasMore) {
       if (checkCancellation && checkCancellation()) break;
-      
-      let response: any;
-      if (this.isDataSource) {
-        response = await withRetry(() => (this.notion as any).dataSources.query({
-          data_source_id: this.actualDataSourceId!,
-          start_cursor: nextCursor,
-        }));
-      } else {
-        response = await withRetry(() => (this.notion.databases as any).query({
-          database_id: this.actualDataSourceId!,
-          start_cursor: nextCursor,
-        }));
-      }
+
+      const response = await this.querySource(nextCursor);
 
       for (const page of response.results) {
-        allBooks.push(this.parseNotionPageToBook(page as NotionPage));
+        allBooks.push(mapPageToBook(page as NotionPage));
       }
 
       hasMore = response.has_more;
@@ -309,47 +207,17 @@ export class NotionAdapter {
 
   async retrieveDataSource(dataSourceId: string): Promise<any> {
     await this.init();
-    if (this.isDataSource) {
-      return await withRetry(() => (this.notion as any).dataSources.retrieve({ data_source_id: dataSourceId }));
-    } else {
-      return await withRetry(() => this.notion.databases.retrieve({ database_id: dataSourceId }));
-    }
+    return this.retrieveSource(dataSourceId);
   }
 
   async updateDatabaseProperty(databaseId: string, propertyName: string, propertyType: string): Promise<void> {
     await this.init();
-    const propertiesPayload = {
-      [propertyName]: { [propertyType]: {} }
-    };
-    if (this.isDataSource) {
-      await withRetry(() => (this.notion as any).dataSources.update({
-        data_source_id: databaseId,
-        properties: propertiesPayload
-      }));
-    } else {
-      await withRetry(() => this.notion.databases.update({
-        database_id: databaseId,
-        properties: propertiesPayload
-      } as any));
-    }
+    await this.updateSource(databaseId, { [propertyName]: { [propertyType]: {} } });
   }
 
   async renameProperty(databaseId: string, oldName: string, newName: string): Promise<void> {
     await this.init();
-    const propertiesPayload = {
-      [oldName]: { name: newName }
-    };
-    if (this.isDataSource) {
-      await withRetry(() => (this.notion as any).dataSources.update({
-        data_source_id: databaseId,
-        properties: propertiesPayload
-      }));
-    } else {
-      await withRetry(() => this.notion.databases.update({
-        database_id: databaseId,
-        properties: propertiesPayload
-      } as any));
-    }
+    await this.updateSource(databaseId, { [oldName]: { name: newName } });
   }
 
   async updatePage(pageId: string, properties: any): Promise<void> {

--- a/notionMapper.ts
+++ b/notionMapper.ts
@@ -1,0 +1,87 @@
+import { NotionPage, NotionProperty, NotionPageProperties, NotionBook } from "./src/types";
+
+/**
+ * Mapowanie strony Notion → domenowy `NotionBook`. To logika domenowa (nie czyste
+ * opakowanie API), więc mieszka poza `NotionAdapter` — czysta funkcja, testowalna
+ * bez klienta Notion. Adapter tylko pobiera strony i woła `mapPageToBook`.
+ */
+
+/** Pobierz właściwość po nazwie, case-insensitive (Notion bywa niespójny w wielkości liter). */
+function getProp(props: NotionPageProperties, name: string): NotionProperty | undefined {
+  if (props[name]) return props[name];
+  const lowerName = name.toLowerCase();
+  for (const key in props) {
+    if (key.toLowerCase() === lowerName) return props[key];
+  }
+  return undefined;
+}
+
+/** Wyciągnij tekst z dowolnego typu właściwości Notion. */
+function getPlainText(prop?: NotionProperty): string {
+  if (!prop) return "";
+  const type = prop.type;
+  if (type === "title") return prop.title?.map((t) => t.plain_text).join("") || "";
+  if (type === "rich_text") return prop.rich_text?.map((t) => t.plain_text).join("") || "";
+  if (type === "number") return prop.number !== undefined && prop.number !== null ? prop.number.toString() : "";
+  if (type === "select") return prop.select?.name || "";
+  if (type === "multi_select") return prop.multi_select?.map((x) => x.name).join(", ") || "";
+  if (type === "checkbox") return prop.checkbox?.toString() || "";
+  if (type === "url") return prop.url || "";
+  return "";
+}
+
+/** Wartości multi_select (lub pojedynczy select) jako lista nazw. */
+function multiSelectNames(prop?: NotionProperty): string[] {
+  if (prop?.type === "multi_select") return prop.multi_select?.map((x) => x.name) || [];
+  if (prop?.type === "select" && prop.select?.name) return [prop.select.name];
+  return [];
+}
+
+export function mapPageToBook(page: NotionPage): NotionBook {
+  const props = page.properties;
+
+  const plTitle = getPlainText(getProp(props, "Tytuł polski"));
+  const origTitle = getPlainText(getProp(props, "Tytuł oryginalny"));
+  const author = getPlainText(getProp(props, "Autor"));
+
+  const plTitleProp = getProp(props, "Tytuł polski");
+  const origTitleProp = getProp(props, "Tytuł oryginalny");
+  const plTitleRichText = plTitleProp?.type === "title" ? plTitleProp.title : plTitleProp?.rich_text || [];
+  const origTitleRichText = origTitleProp?.type === "title" ? origTitleProp.title : origTitleProp?.rich_text || [];
+
+  const yearProp = getProp(props, "Rok");
+  let year: string | undefined = undefined;
+  if (yearProp) {
+    if (yearProp.type === "multi_select") {
+      year = yearProp.multi_select?.map((x) => x.name).join(", ");
+    } else if (yearProp.type === "number") {
+      year = yearProp.number !== undefined && yearProp.number !== null ? yearProp.number.toString() : undefined;
+    } else {
+      year = getPlainText(yearProp).trim() || undefined;
+    }
+  }
+
+  const currentWydawnictwo = getPlainText(getProp(props, "Wydawnictwo"));
+  const currentSeria = getPlainText(getProp(props, "Seria"));
+  const currentCzesccyklu = getProp(props, "Część cyklu")?.checkbox || false;
+  const lp = getPlainText(getProp(props, "Lp"));
+
+  const awards = multiSelectNames(getProp(props, "Nagroda"));
+  const zrodlo = multiSelectNames(getProp(props, "Źródło"));
+
+  return {
+    id: page.id,
+    plTitle,
+    origTitle,
+    author,
+    year,
+    currentWydawnictwo,
+    currentSeria,
+    currentCzesccyklu,
+    lp,
+    awards,
+    zrodlo,
+    plTitleRichText,
+    origTitleRichText
+  };
+}


### PR DESCRIPTION
## G4 — `NotionAdapter` był adapterem z wtopioną logiką domenową (377 LOC, 36 metod)

Dwie rzeczy go rozdymały: mapowanie strona→domena (logika domenowa, której wg wytycznych adaptery trzymać nie powinny) oraz rozgałęzienie `isDataSource` skopiowane w siedmiu metodach.

## Zmiany

- **`notionMapper.ts`** trzyma czyste mapowanie strona Notion → `NotionBook` (`getProp`/`getPlainText`/`multiSelectNames` + `mapPageToBook`), testowalne bez klienta Notion; duplikacja select-vs-multi_select dla nagród/źródła złożona w jeden helper `multiSelectNames`.
- **Trzy prywatne helpery** — `retrieveSource` / `updateSource` / `querySource` — kapsułkują rozgałęzienie „data source vs klasyczna database" raz; `getSchema`, `updateSchema`, `createColumnIfNeeded`, `queryAllBooks`, `retrieveDataSource`, `updateDatabaseProperty`, `renameProperty` wołają je zamiast rozgałęziać się każda z osobna.

Adapter spada **377 → 245 linii** i wraca do roli cienkiego opakowania API. Zachowanie bez zmian.

## Testy

Mapper: pełne mapowanie, case-insensitive lookup właściwości, brakujące właściwości, pojedynczy select nagrody.

Weryfikacja: `npm run lint` czysto, `npm test` 148/148, `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_