### PR TITLE
God-object PR5: extract SSE stream plumbing from syncController

### DIFF
--- a/controllers/sseStream.ts
+++ b/controllers/sseStream.ts
@@ -1,0 +1,97 @@
+import { Request, Response } from "express";
+import { SyncEvent } from "../src/types";
+import { syncManager } from "../syncManager";
+import { createLogger } from "../logger";
+
+const log = createLogger("SSE");
+
+/**
+ * Plumbing strumienia SSE dla długich rytuałów — nagłówki, hardening pod proxy,
+ * keepalive, anulowanie przy rozłączeniu klienta. Wydzielone z kontrolera, który
+ * powinien trzymać tylko parsowanie żądań i delegację; tu żyje transport.
+ */
+
+/** Ustaw nagłówki SSE + hardening pod buforujące proxy; zwróć funkcję `sendEvent`. */
+export const setupSSE = (res: Response) => {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  // Wyłącz buforowanie po stronie proxy (nginx/Render) — bez tego zdarzenia SSE
+  // nie docierają do klienta na bieżąco i UI "nie reaguje" na hostingu.
+  res.setHeader("X-Accel-Buffering", "no");
+  // Wyślij nagłówki natychmiast, żeby połączenie było otwarte zanim ruszy zadanie.
+  res.flushHeaders?.();
+  // Padding ~2KB komentarza: niektóre proxy (Render) buforują odpowiedź do progu
+  // kilku KB zanim zaczną strumieniować — to wypycha bufor i wymusza flush,
+  // dzięki czemu klient dostaje zdarzenia na bieżąco (a nie dopiero na końcu).
+  res.write(`:${" ".repeat(2048)}\n\n`);
+  return (data: SyncEvent) => {
+    // Po abort klienta socket bywa `destroyed` przy wciąż `writableEnded === false`
+    // — sam guard writableEnded przepuszczał zapis do martwego socketu, co rzucało
+    // nieobsłużony 'error' na strumieniu. Sprawdzaj też destroyed.
+    if (!res.writableEnded && !res.destroyed) res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+};
+
+/**
+ * Uruchom zadanie sync jako strumień SSE: guard pojedynczego rytuału, keepalive
+ * co 5 s, anulowanie przy rozłączeniu klienta (na `res`, nie `req`) i mapowanie
+ * błędu na zdarzenie `error`.
+ */
+export const executeSyncTask = async (
+  req: Request,
+  res: Response,
+  task: (sendEvent: (data: SyncEvent) => void) => Promise<void>,
+  errorMessage: string
+) => {
+  if (syncManager.isSyncing) return res.status(400).json({ error: "Inna synchronizacja jest już w toku." });
+
+  const sendEvent = setupSSE(res);
+  // Natychmiastowy sygnał, że połączenie żyje — użytkownik widzi reakcję od razu,
+  // nawet jeśli pierwszy krok zadania (pobranie z wiki) trwa kilka sekund.
+  sendEvent({ type: "status", message: "Połączono z serwerem. Inicjacja rytuału..." });
+  log.info("Sync task started", { endpoint: req.path });
+
+  // Częstszy keepalive (5s) utrzymuje strumień "gorący" u proxy, które inaczej
+  // zbierają dane w bufor między rzadkimi zapisami długiego zadania.
+  const keepAlive = setInterval(() => {
+    if (!res.writableEnded && !res.destroyed) res.write(": keepalive\n\n");
+  }, 5000);
+
+  // Rozłączenie klienta (zamknięta karta, utrata sieci) — anuluj zadanie,
+  // żeby osierocony sync nie blokował kolejnych rytuałów godzinami.
+  // UWAGA: nasłuchujemy na res, nie req. Dla POST z ciałem req emituje "close"
+  // po skonsumowaniu ciała przez express.json() — nie przy rozłączeniu klienta —
+  // co anulowało aktywny sync tuż po starcie. res "close" odpala się dopiero gdy
+  // odpowiedź faktycznie się zamyka; przy normalnym końcu writableEnded==true,
+  // więc guard poniżej nie anuluje niczego przez pomyłkę.
+  res.on("close", () => {
+    if (!res.writableEnded) {
+      clearInterval(keepAlive);
+      log.warn("Klient rozłączył się w trakcie synchronizacji — przerywam zadanie.", { endpoint: req.path });
+      syncManager.stopActiveSync();
+    }
+  });
+
+  try {
+    await task(sendEvent);
+    clearInterval(keepAlive);
+    log.info("Sync task finished", { endpoint: req.path });
+    res.end();
+  } catch (error: any) {
+    clearInterval(keepAlive);
+    log.error(`${errorMessage} ${error?.message || ""}`, {
+      endpoint: req.path,
+      name: error?.name,
+      classification: error?.classification,
+      status: error?.status,
+      stack: error?.stack?.split("\n").slice(0, 4).join(" | "),
+    });
+    // WikiFetchError niesie userHint z konkretną wskazówką — pokaż ją użytkownikowi.
+    const userMessage = error?.userHint
+      ? `${error.message}`
+      : error?.message || errorMessage;
+    sendEvent({ type: "error", error: userMessage });
+    res.end();
+  }
+};

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
 import { syncManager, SyncTaskName } from "../syncManager";
-import { SyncEvent, SyncParams } from "../src/types";
+import { SyncParams } from "../src/types";
 import { createLogger } from "../logger";
+import { executeSyncTask } from "./sseStream";
 
 const log = createLogger("SyncController");
 
@@ -119,30 +120,9 @@ export const stopDuplicatesSync = makeStopHandler("Zatrzymywanie sprawdzania dup
 export const stopLibraryCheck = makeStopHandler("Zatrzymywanie skanowania biblioteki...");
 export const stopIntegrityCheck = makeStopHandler("Zatrzymano skanowanie integralności.");
 
-const setupSSE = (res: Response) => {
-  res.setHeader("Content-Type", "text/event-stream");
-  res.setHeader("Cache-Control", "no-cache, no-transform");
-  res.setHeader("Connection", "keep-alive");
-  // Wyłącz buforowanie po stronie proxy (nginx/Render) — bez tego zdarzenia SSE
-  // nie docierają do klienta na bieżąco i UI "nie reaguje" na hostingu.
-  res.setHeader("X-Accel-Buffering", "no");
-  // Wyślij nagłówki natychmiast, żeby połączenie było otwarte zanim ruszy zadanie.
-  res.flushHeaders?.();
-  // Padding ~2KB komentarza: niektóre proxy (Render) buforują odpowiedź do progu
-  // kilku KB zanim zaczną strumieniować — to wypycha bufor i wymusza flush,
-  // dzięki czemu klient dostaje zdarzenia na bieżąco (a nie dopiero na końcu).
-  res.write(`:${" ".repeat(2048)}\n\n`);
-  return (data: SyncEvent) => {
-    // Po abort klienta socket bywa `destroyed` przy wciąż `writableEnded === false`
-    // — sam guard writableEnded przepuszczał zapis do martwego socketu, co rzucało
-    // nieobsłużony 'error' na strumieniu. Sprawdzaj też destroyed.
-    if (!res.writableEnded && !res.destroyed) res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
-};
-
 export const runSync = async (req: Request, res: Response) => {
   const { awardName, pageTitle, syncAll } = req.body as SyncParams;
-  
+
   if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
     return res.status(400).json({ error: "Brak kluczy API Notion." });
   }
@@ -153,64 +133,6 @@ export const runSync = async (req: Request, res: Response) => {
     (sendEvent) => syncManager.run("book", sendEvent, { awardName, pageTitle, syncAll }),
     "Sync Error:"
   );
-};
-
-const executeSyncTask = async (
-  req: Request,
-  res: Response,
-  task: (sendEvent: (data: SyncEvent) => void) => Promise<void>,
-  errorMessage: string
-) => {
-  if (syncManager.isSyncing) return res.status(400).json({ error: "Inna synchronizacja jest już w toku." });
-
-  const sendEvent = setupSSE(res);
-  // Natychmiastowy sygnał, że połączenie żyje — użytkownik widzi reakcję od razu,
-  // nawet jeśli pierwszy krok zadania (pobranie z wiki) trwa kilka sekund.
-  sendEvent({ type: "status", message: "Połączono z serwerem. Inicjacja rytuału..." });
-  log.info("Sync task started", { endpoint: req.path });
-
-  // Częstszy keepalive (5s) utrzymuje strumień "gorący" u proxy, które inaczej
-  // zbierają dane w bufor między rzadkimi zapisami długiego zadania.
-  const keepAlive = setInterval(() => {
-    if (!res.writableEnded && !res.destroyed) res.write(": keepalive\n\n");
-  }, 5000);
-
-  // Rozłączenie klienta (zamknięta karta, utrata sieci) — anuluj zadanie,
-  // żeby osierocony sync nie blokował kolejnych rytuałów godzinami.
-  // UWAGA: nasłuchujemy na res, nie req. Dla POST z ciałem req emituje "close"
-  // po skonsumowaniu ciała przez express.json() — nie przy rozłączeniu klienta —
-  // co anulowało aktywny sync tuż po starcie. res "close" odpala się dopiero gdy
-  // odpowiedź faktycznie się zamyka; przy normalnym końcu writableEnded==true,
-  // więc guard poniżej nie anuluje niczego przez pomyłkę.
-  res.on("close", () => {
-    if (!res.writableEnded) {
-      clearInterval(keepAlive);
-      log.warn("Klient rozłączył się w trakcie synchronizacji — przerywam zadanie.", { endpoint: req.path });
-      syncManager.stopActiveSync();
-    }
-  });
-
-  try {
-    await task(sendEvent);
-    clearInterval(keepAlive);
-    log.info("Sync task finished", { endpoint: req.path });
-    res.end();
-  } catch (error: any) {
-    clearInterval(keepAlive);
-    log.error(`${errorMessage} ${error?.message || ""}`, {
-      endpoint: req.path,
-      name: error?.name,
-      classification: error?.classification,
-      status: error?.status,
-      stack: error?.stack?.split("\n").slice(0, 4).join(" | "),
-    });
-    // WikiFetchError niesie userHint z konkretną wskazówką — pokaż ją użytkownikowi.
-    const userMessage = error?.userHint
-      ? `${error.message}`
-      : error?.message || errorMessage;
-    sendEvent({ type: "error", error: userMessage });
-    res.end();
-  }
 };
 
 // Rytuały bez parametrów żądania mają identyczny handler — różnią się tylko


### PR DESCRIPTION
## Domykający porządek — `syncController` mieszał HTTP z transportem SSE

Kontroler trzymał obok handlerów HTTP całą maszynerię transportu SSE — `setupSSE` (nagłówki, hardening pod buforujące proxy, padding 2KB, guard martwego socketu) i `executeSyncTask` (guard pojedynczego zadania, keepalive 5 s, anulowanie przy rozłączeniu klienta na `res.on("close")`, mapowanie błędu na zdarzenie). To odrębny koncept od parsowania żądania i delegacji do serwisu.

## Zmiany

- Oba wyniesione do **`controllers/sseStream.ts`**. Kontroler importuje teraz `executeSyncTask` i trzyma tylko handlery (**273 → 195 linii**); subtelna semantyka `res`-vs-`req` close i guardy martwego socketu żyją w jednym module.

Zachowanie bez zmian — testy kontraktu SSE nadal ćwiczą tę ścieżkę przez trasę.

Weryfikacja: `npm run lint` czysto, `npm test` 148/148, `npm run build` OK.

---

To domyka **god-object hunt** (G1–G5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_