### PR TITLE
Fix Render build: force devDependencies via .npmrc (vite: not found)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Hostingi (Render, Heroku…) uruchamiają `npm install` z NODE_ENV=production,
+# co DOMYŚLNIE pomija devDependencies. Build (`npm run build`) wymaga jednak
+# narzędzi z devDeps — vite, esbuild, @vitejs/plugin-react, @tailwindcss/vite —
+# bez których pada z "vite: not found". `include=dev` wymusza ich instalację
+# niezależnie od NODE_ENV i od tego, czy build używa `npm install` czy `npm ci`.
+include=dev


### PR DESCRIPTION
## Problem

Render buduje komendą `npm install; npm run build` przy `NODE_ENV=production`, co **domyślnie pomija `devDependencies`**. Narzędzia buildu (`vite`, `esbuild`, `@vitejs/plugin-react`, `@tailwindcss/vite`) są w devDeps — build padał z `sh: 1: vite: not found` (kilka deployów nie wstało).

## Fix

Dodane `.npmrc` w korzeniu z `include=dev` — wymusza instalację devDependencies **niezależnie od `NODE_ENV`** i od tego, czy host używa `npm install` czy `npm ci`.

**Zweryfikowane** czystą instalacją produkcyjną: z plikiem `vite`/`esbuild` są obecne, bez niego `vite` znika:

```
=== production install WITH .npmrc include=dev ===
vite present? -> YES
esbuild present? -> YES
=== same but WITHOUT .npmrc ===
vite present? -> NO
```

Narzędzia buildu zostają poprawnie w `devDependencies` (bez zaśmiecania zależności runtime). `render.yaml` już używał `npm ci --include=dev`; ten fix czyni build odpornym również na serwis skonfigurowany na zwykłe `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_