### PR TITLE
Fix library scanner: OPAC TLS chain (unable to verify first certificate)

### DIFF
--- a/scrapingClient.ts
+++ b/scrapingClient.ts
@@ -18,10 +18,24 @@ const USER_AGENTS = [
 
 export const getRandomUserAgent = () => USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
 
-/** Keep-alive agent współdzielony przez skanery — te same parametry co dotychczas inline. */
-export const createScrapingAgent = () => new https.Agent({
+export interface ScrapingAgentOptions {
+  /** Maks. równoległych połączeń do jednego hosta (domyślnie 5). */
+  maxSockets?: number;
+  /**
+   * Domyślnie `true` (pełna weryfikacja TLS). Ustaw `false` TYLKO dla hostów,
+   * które błędnie konfigurują łańcuch certyfikatów (np. nie wysyłają certyfikatu
+   * pośredniego → Node zgłasza „unable to verify the first certificate"). Skanery
+   * czytają WYŁĄCZNIE publiczne dane (katalog biblioteki) i nie wysyłają żadnych
+   * sekretów, więc ryzyko jest znikome; mimo to trzymaj to per-host, nie globalnie.
+   */
+  rejectUnauthorized?: boolean;
+}
+
+/** Keep-alive agent współdzielony przez skanery HTML. */
+export const createScrapingAgent = (opts: ScrapingAgentOptions = {}) => new https.Agent({
   keepAlive: true,
   keepAliveMsecs: 1000,
   timeout: 45000,
-  maxSockets: 5,
+  maxSockets: opts.maxSockets ?? 5,
+  rejectUnauthorized: opts.rejectUnauthorized ?? true,
 });

--- a/services/libraryCheckService.ts
+++ b/services/libraryCheckService.ts
@@ -34,7 +34,12 @@ export class LibraryCheckService {
     sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia...` });
 
     const results: any[] = [];
-    const httpsAgent = createScrapingAgent();
+    // OPAC MBP Lublin nie wysyła certyfikatu pośredniego, przez co Node zgłasza
+    // „unable to verify the first certificate" i KAŻDE żądanie leci wyjątkiem
+    // (0 trafień, mimo że skan „idzie"). Wyłączamy weryfikację TLS tylko dla tego
+    // agenta — czytamy publiczny katalog, bez wysyłania sekretów. Vinted zostaje
+    // przy pełnej weryfikacji.
+    const httpsAgent = createScrapingAgent({ rejectUnauthorized: false });
 
     for (let i = 0; i < candidates.length; i++) {
       if (checkCancellation()) {


### PR DESCRIPTION
## Przyczyna

OPAC (`opac.mbp.lublin.pl`) **nie wysyła certyfikatu pośredniego**, więc Node odrzucał każde żądanie z `unable to verify the first certificate` — skan „szedł", ale leciał błędem na *każdej* książce (0 trafień). To awaria transportu, niezależna od jakości dopasowań.

## Fix

`createScrapingAgent` dostaje opcję `rejectUnauthorized` (domyślnie `true` = pełna weryfikacja). Skaner biblioteki używa dedykowanego agenta z `rejectUnauthorized: false` — czyta wyłącznie publiczny katalog i nie wysyła sekretów, więc ryzyko jest znikome; trzymane per-host (skaner Vinted zostaje przy pełnej weryfikacji TLS).

Weryfikacja: `npm run lint` czysto, testy skanerów 6/6.

> To tylko odblokowanie transportu. Przepisanie parsera/dopasowań pod „OPAC różnie zwraca wyniki" + wydajność (współbieżność) idzie osobno, na realnych próbkach HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_