### PR TITLE
Rewrite library scanner: media-aware matching + concurrency

### DIFF
--- a/docs/library-check.md
+++ b/docs/library-check.md
@@ -1,28 +1,30 @@
 # Library Availability Check Algorithm (`services/libraryCheckService.ts`)
 
 ## 1. Overview
-Scrapes the OPAC (Online Public Access Catalog) of the Municipal Public Library in Lublin (MBP Lublin) to check the availability of books in specific branches.
+Scrapes the OPAC (Prolib Integro) of the Municipal Public Library in Lublin (MBP Lublin) to check whether a given branch holds the **book** edition of each unread/unowned title from Notion. The branch is selected via the `f2` query filter, so the OPAC already scopes results to that agenda — presence of a matching record means the branch has it in its collection.
 
-## 2. Scraping Logic (`LibraryCheckService.runLibraryCheck`)
-- **Source**: `https://opac.mbp.lublin.pl/search/description?q={title}&index=1&scope=full&f2%5B0%5D={libraryCode}`.
-- **Target**: Books in Notion that are NOT marked as "Przeczytane", "Biblioteka", "Biblioteka 9", or "Posiadam".
-- **Parsing Strategy**:
-  - Fetches the HTML content of the search results page.
-  - **Availability Check**:
-    - If the HTML contains "Brak wyników" or "Nie znaleziono", the book is marked as unavailable.
-    - If the HTML contains `class="record"` or "Szczegóły", the book is considered potentially available.
-  - **Title Extraction**:
-    - Uses a regex to extract the title from the OPAC page: `<dt[^>]*>\s*Tytuł:\s*<\/dt>\s*<dd[^>]*>\s*<span[^>]*>(.*?)<\/span>/i`.
-    - This helps verify if the search result actually matches the book being checked.
+## 2. Request
+- **URL**: `https://opac.mbp.lublin.pl/search/description?q={title}&index=1&scope=full&f2%5B0%5D={libraryCode}` (all fields, extended scope, branch filter).
+- **Target**: Notion books NOT tagged `Przeczytane`, `Biblioteka`, `Biblioteka 9`, or `Posiadam`, with a non-empty Polish title.
+- **TLS**: the OPAC omits its intermediate certificate (Node → "unable to verify the first certificate"), so the library scanner uses a dedicated agent with `rejectUnauthorized: false` (public catalog, no secrets). The Vinted scanner keeps full verification.
 
-## 3. Reliability & Performance
-- **Retry Pattern**: Uses `withRetry` (3 attempts, 2000ms delay) to handle network timeouts or temporary OPAC unavailability.
-- **Concurrency**: Sequential — one book at a time. The scan is fail-fast on network errors to surface problems early rather than hammering the OPAC.
-- **Throttling**: Adds a 500ms delay between requests to ensure a steady, non-aggressive scraping pace.
-- **Timeout**: The keep-alive `https.Agent` uses a 45 000 ms socket timeout.
-- **Input safety**: `libraryCode` is URL-encoded before being interpolated into the OPAC query.
+## 3. Parsing (`services/opacParser.ts` — pure, unit-tested)
+`parseOpacResults(html) → OpacRecord[]`. The results page lists each item as an `<article data-item-id="…">` containing a `<dl class="dl-horizontal">`:
+- **Title** from `<dt>Tytuł:</dt>`.
+- **Author** from `<dt>Autorzy:</dt>` (note: `Autorzy`, not `Autor`) — the value sits inside an `<a>` link.
+- **Document type** from the media icon: `pdt-p-book` → *książka*, `pdt-p-audiobook` → *książka mówiona*, `pdt-p-movie` → *film*.
 
-## 4. Implementation Details
-- **HTTPS Agent**: A keep-alive `https.Agent` with normal TLS verification (both OPAC and the app use valid certificates).
-- **Progress Reporting**: Sends SSE events for each book being checked, including the current progress (e.g., "Sprawdzanie: Tytuł (5/100)").
-- **Output**: Returns a list of available books with their extracted titles and authors.
+## 4. Matching (`findBookMatch`)
+A single search like "gra o tron" returns mixed media (the audiobook, TV-series discs) **and** other works by the same author (caught by series/subject). So a naive "first record" match is wrong. `findBookMatch`:
+1. Keeps only **book** records (`ksiazka`) — films and audiobooks are excluded by default (`includeAudiobook` opts them back in).
+2. Requires a **title match** (similarity > 0.8 or whole-string containment; parallel "Original = Polish" titles are compared on both sides) — this rejects a *different* book by the same author.
+3. Requires an **author match** when the Notion author is known (normalized both sides; similarity > 0.6 or containment).
+4. Returns the best-scoring book record, or `null`.
+
+Worked example: for "Gra o tron" (G. R. R. Martin) at Filia Felin, the branch holds only the audiobook and the TV series plus other Martin books (Rycerz Siedmiu Królestw, Ogień i krew) — so the scan correctly reports **no book match** instead of a false positive on the audiobook.
+
+## 5. Performance & pacing
+- **Concurrency**: up to 6 parallel requests via `p-limit` (agent `maxSockets` matched), instead of the old one-at-a-time loop — ~6× faster over a couple hundred titles.
+- **Retries/timeout**: `withRetry(2, 1500ms)`, 20 000 ms per request. No fixed inter-request delay; concurrency is the throttle.
+- **Cancellation**: cooperative — each task checks the token before firing; `complete` reports `cancelled: true` when stopped.
+- **Progress**: a shared counter emits `Sprawdzono {done}/{total} (znaleziono {n})` as tasks finish.

--- a/services/__tests__/libraryCheckService.test.ts
+++ b/services/__tests__/libraryCheckService.test.ts
@@ -11,22 +11,22 @@ import { NotionAdapter } from '../../notion.adapter';
 
 const mockedGet = axios.get as unknown as ReturnType<typeof vi.fn>;
 
-const OPAC_HIT = `
-<html><body>
-  <div class="record">
-    <dl>
-      <dt>Tytuł:</dt><dd><span>Solaris</span></dd>
-      <dt>Autor:</dt><dd><span>Stanisław Lem</span></dd>
-    </dl>
-  </div>
-</body></html>`;
-
-const OPAC_MISS = `<html><body><p>Brak wyników</p></body></html>`;
+// Odwzorowanie realnej struktury OPAC (Prolib Integro): <article> + <dl> + ikona typu.
+const ICON = { book: 'pdt-p-book', movie: 'pdt-p-movie', audiobook: 'pdt-p-audiobook' } as const;
+const article = (id: string, title: string, author: string, icon: keyof typeof ICON) => `
+<article data-item-id="${id}" data-type="cataloged" class="fixed-height-article">
+  <dl class="dl-horizontal">
+    <dt>Tytuł:</dt><dd><span class="">${title} </span><br /></dd>
+    ${author ? `<dt>Autorzy:</dt><dd><span class=""><a href="#">${author}</a></span><br /></dd>` : ''}
+    <dt>Rok wydania:</dt><dd><span class="">2014</span></dd>
+  </dl>
+  <div class="document-type document-type-result-list "><span class="${ICON[icon]}"></span><div class="document-type-text ">x</div></div>
+</article>`;
+const opacPage = (...articles: string[]) => `<div class="result-box">${articles.join('')}</div>`;
+const OPAC_MISS = `<div class="result-box"></div>`;
 
 function makeNotion(books: any[]) {
-  return {
-    getBooksForStats: vi.fn().mockResolvedValue(books),
-  } as unknown as NotionAdapter;
+  return { getBooksForStats: vi.fn().mockResolvedValue(books) } as unknown as NotionAdapter;
 }
 
 describe('LibraryCheckService', () => {
@@ -46,41 +46,57 @@ describe('LibraryCheckService', () => {
     ]);
     mockedGet.mockResolvedValue({ data: OPAC_MISS });
 
-    const svc = new LibraryCheckService(notion);
-    await svc.runLibraryCheck('LUB01', sendEvent, never);
+    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, never);
 
-    // Only book #1 is a valid candidate (2 is read, 3 has empty title)
-    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedGet).toHaveBeenCalledTimes(1); // only book #1 is a valid candidate
     const complete = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'complete');
     expect(complete?.result.success).toBe(true);
     expect(complete?.result.results).toHaveLength(0);
   });
 
-  it('emits a match when OPAC returns a matching record', async () => {
-    const notion = makeNotion([
-      { id: '1', plTitle: 'Solaris', author: 'Stanisław Lem', zrodlo: [] },
-    ]);
-    mockedGet.mockResolvedValue({ data: OPAC_HIT });
+  it('matches a physical book and ignores the film/audiobook of the same title', async () => {
+    const notion = makeNotion([{ id: '1', plTitle: 'Solaris', author: 'Stanisław Lem', zrodlo: [] }]);
+    mockedGet.mockResolvedValue({
+      data: opacPage(
+        article('a', 'Solaris', '', 'movie'),                     // film — ignorowany
+        article('b', 'Solaris', 'Lem, Stanisław', 'audiobook'),   // audiobook — ignorowany
+        article('c', 'Solaris', 'Lem, Stanisław (1921-2006)', 'book'), // książka — TO trafienie
+      ),
+    });
 
-    const svc = new LibraryCheckService(notion);
-    await svc.runLibraryCheck('LUB01', sendEvent, never);
+    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, never);
 
     const match = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'match');
     expect(match).toBeDefined();
     expect(match.result.id).toBe('1');
     expect(match.result.extractedTitle).toBe('Solaris');
+    expect(match.result.extractedAuthor).toContain('Lem');
+  });
+
+  it('reports no match when only other media / other titles are held (real "Gra o tron" case)', async () => {
+    const notion = makeNotion([{ id: '1', plTitle: 'Gra o tron', author: 'George R. R. Martin', zrodlo: [] }]);
+    mockedGet.mockResolvedValue({
+      data: opacPage(
+        article('a', 'Gra o tron', 'Martin, George R. R. (1948- )', 'audiobook'), // audiobook — nie liczy się
+        article('b', 'Game of thrones. Sezon 1 = Gra o tron', '', 'movie'),        // film
+        article('c', 'Rycerz Siedmiu Królestw', 'Martin, George R. R. (1948- )', 'book'), // inna książka Martina
+      ),
+    });
+
+    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, never);
+
+    const match = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'match');
+    expect(match).toBeUndefined();
+    const complete = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'complete');
+    expect(complete.result.results).toHaveLength(0);
   });
 
   it('reports cancellation without throwing', async () => {
-    const notion = makeNotion([
-      { id: '1', plTitle: 'Solaris', author: 'Stanisław Lem', zrodlo: [] },
-    ]);
+    const notion = makeNotion([{ id: '1', plTitle: 'Solaris', author: 'Stanisław Lem', zrodlo: [] }]);
     mockedGet.mockResolvedValue({ data: OPAC_MISS });
 
-    const svc = new LibraryCheckService(notion);
-    await svc.runLibraryCheck('LUB01', sendEvent, () => true);
+    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, () => true);
 
-    // Cancelled before the first request → no HTTP call, complete reports cancelled
     expect(mockedGet).not.toHaveBeenCalled();
     const complete = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'complete');
     expect(complete?.result.cancelled).toBe(true);

--- a/services/__tests__/opacParser.test.ts
+++ b/services/__tests__/opacParser.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { parseOpacResults, findBookMatch } from "../opacParser";
+
+const ICON = { book: "pdt-p-book", movie: "pdt-p-movie", audiobook: "pdt-p-audiobook" } as const;
+const article = (id: string, title: string, author: string, icon: keyof typeof ICON) => `
+<article data-item-id="${id}" data-type="cataloged" class="fixed-height-article">
+  <dl class="dl-horizontal">
+    <dt  >Tytuł:</dt><dd ><span class="">${title} </span><br /></dd>
+    ${author ? `<dt  >Autorzy:</dt><dd ><span class=""><a href="/search/description?q=x&amp;index=3">${author}</a></span><br /></dd>` : ""}
+    <dt  >Wydawca:</dt><dd ><span class="">Poznań : Zysk i S-ka</span></dd>
+  </dl>
+  <div class="document-type document-type-result-list "><span class="${ICON[icon]}"></span><div class="document-type-text ">x</div></div>
+</article>`;
+const page = (...a: string[]) => `<div class="result-box">${a.join("")}</div>`;
+
+describe("parseOpacResults", () => {
+  it("extracts id, title, author (from Autorzy:) and document type per <article>", () => {
+    const html = page(
+      article("111", "Gra o tron", "Martin, George R. R. (1948- )", "audiobook"),
+      article("222", "Rycerz Siedmiu Królestw", "Martin, George R. R. (1948- )", "book"),
+      article("333", "Game of thrones. Sezon 1 = Gra o tron", "", "movie"),
+    );
+    const recs = parseOpacResults(html);
+    expect(recs).toHaveLength(3);
+    expect(recs[0]).toEqual({ id: "111", title: "Gra o tron", author: "Martin, George R. R. (1948- )", documentType: "audiobook" });
+    expect(recs[1].documentType).toBe("ksiazka");
+    expect(recs[2].documentType).toBe("film");
+    expect(recs[2].author).toBe(""); // films have no Autorzy field
+  });
+
+  it("returns [] for an empty result box", () => {
+    expect(parseOpacResults(`<div class="result-box"></div>`)).toEqual([]);
+  });
+});
+
+describe("findBookMatch", () => {
+  it("matches the physical book and ignores same-title film/audiobook", () => {
+    const recs = parseOpacResults(page(
+      article("a", "Solaris", "", "movie"),
+      article("b", "Solaris", "Lem, Stanisław", "audiobook"),
+      article("c", "Solaris", "Lem, Stanisław (1921-2006)", "book"),
+    ));
+    const hit = findBookMatch(recs, "Solaris", "Stanisław Lem");
+    expect(hit?.id).toBe("c");
+    expect(hit?.documentType).toBe("ksiazka");
+  });
+
+  it('returns null when the library holds only the audiobook/film + other titles by the author', () => {
+    const recs = parseOpacResults(page(
+      article("a", "Gra o tron", "Martin, George R. R. (1948- )", "audiobook"),
+      article("b", "Game of thrones. Sezon 1 = Gra o tron", "", "movie"),
+      article("c", "Rycerz Siedmiu Królestw", "Martin, George R. R. (1948- )", "book"),
+    ));
+    expect(findBookMatch(recs, "Gra o tron", "George R. R. Martin")).toBeNull();
+  });
+
+  it("can opt into audiobooks when asked", () => {
+    const recs = parseOpacResults(page(article("a", "Gra o tron", "Martin, George R. R. (1948- )", "audiobook")));
+    expect(findBookMatch(recs, "Gra o tron", "George R. R. Martin")).toBeNull();
+    expect(findBookMatch(recs, "Gra o tron", "George R. R. Martin", { includeAudiobook: true })?.id).toBe("a");
+  });
+
+  it("rejects a different book by the same author (title guard)", () => {
+    const recs = parseOpacResults(page(article("c", "Ogień i krew", "Martin, George R. R. (1948- )", "book")));
+    expect(findBookMatch(recs, "Gra o tron", "George R. R. Martin")).toBeNull();
+  });
+});

--- a/services/libraryCheckService.ts
+++ b/services/libraryCheckService.ts
@@ -1,17 +1,22 @@
 import axios from "axios";
+import pLimit from "p-limit";
 import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent } from "../src/types";
-import { cleanTitle, calculateSimilarity, normalizeAuthor } from "../utils";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
 import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
+import { parseOpacResults, findBookMatch } from "./opacParser";
 
 const log = createLogger("LibraryCheck");
 
+const CONCURRENCY = 6;
+const REQUEST_TIMEOUT = 20000;
+
 /**
- * Skaner dostępności w bibliotece (OPAC MBP Lublin). Scrapuje HTML wyszukiwarki
- * dla każdej książki, która nie jest jeszcze oznaczona jako posiadana/przeczytana,
- * i emituje trafienia przez SSE. Zob. docs/library-check.md.
+ * Skaner dostępności w bibliotece (OPAC MBP Lublin, Prolib Integro). Dla każdej
+ * nieprzeczytanej/nieposiadanej książki odpytuje OPAC zawężony do wybranej filii
+ * (param f2), parsuje rekordy i szuka dopasowania KSIĄŻKI (filmy/audiobooki są
+ * pomijane). Zob. docs/library-check.md i services/opacParser.ts.
  */
 export class LibraryCheckService {
   constructor(private notion: NotionAdapter) {}
@@ -24,134 +29,89 @@ export class LibraryCheckService {
     sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
     const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation);
 
-    // Filter books that are NOT (Przeczytane, Biblioteka, Biblioteka 9, Posiadam)
-    const candidates = allBooks.filter(b => {
+    // Kandydaci: mają polski tytuł i NIE są już przeczytane/posiadane/w bibliotece.
+    const candidates = allBooks.filter((b) => {
       const zrodlo = b.zrodlo || [];
       const excluded = ["Przeczytane", "Biblioteka", "Biblioteka 9", "Posiadam"];
-      return !zrodlo.some(z => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
+      return !zrodlo.some((z) => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
     });
 
     sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia...` });
 
     const results: any[] = [];
-    // OPAC MBP Lublin nie wysyła certyfikatu pośredniego, przez co Node zgłasza
-    // „unable to verify the first certificate" i KAŻDE żądanie leci wyjątkiem
-    // (0 trafień, mimo że skan „idzie"). Wyłączamy weryfikację TLS tylko dla tego
-    // agenta — czytamy publiczny katalog, bez wysyłania sekretów. Vinted zostaje
-    // przy pełnej weryfikacji.
-    const httpsAgent = createScrapingAgent({ rejectUnauthorized: false });
+    // OPAC MBP Lublin nie wysyła certyfikatu pośredniego → Node zgłasza „unable to
+    // verify the first certificate" i każde żądanie leci wyjątkiem. Wyłączamy
+    // weryfikację TLS tylko dla tego agenta (czytamy publiczny katalog, bez sekretów).
+    const httpsAgent = createScrapingAgent({ rejectUnauthorized: false, maxSockets: CONCURRENCY });
+    const limit = pLimit(CONCURRENCY);
+    let processed = 0;
 
-    for (let i = 0; i < candidates.length; i++) {
-      if (checkCancellation()) {
-        sendEvent({ type: "status", message: "Skanowanie przerwane przez użytkownika." });
-        break;
-      }
-      const book = candidates[i];
-      const title = book.plTitle;
-      const fullName = `${title} ${book.author || ""}`.trim();
+    const tasks = candidates.map((book) =>
+      limit(async () => {
+        if (checkCancellation()) return;
 
-      sendEvent({
-        type: "progress",
-        message: `Sprawdzanie: ${fullName} (${i + 1}/${candidates.length})`,
-        current: i + 1,
-        total: candidates.length
-      });
+        const title = book.plTitle;
+        const url = `https://opac.mbp.lublin.pl/search/description?q=${encodeURIComponent(title)}&index=1&scope=full&f2%5B0%5D=${encodeURIComponent(libraryCode)}`;
+        const headers = {
+          "User-Agent": getRandomUserAgent(),
+          "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7",
+          "Cache-Control": "no-cache",
+        };
 
-      const url = `https://opac.mbp.lublin.pl/search/description?q=${encodeURIComponent(title)}&index=1&scope=full&f2%5B0%5D=${encodeURIComponent(libraryCode)}`;
+        try {
+          const response = await withRetry(
+            () => axios.get(url, { httpsAgent, headers, timeout: REQUEST_TIMEOUT }),
+            2,
+            1500,
+          );
 
-      const headers = {
-        'User-Agent': getRandomUserAgent(),
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-        'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
-        'Cache-Control': 'no-cache',
-        'Pragma': 'no-cache',
-        'Connection': 'keep-alive'
-      };
+          const records = parseOpacResults(response.data);
+          const match = findBookMatch(records, book.plTitle, book.author || "");
 
-      try {
-        const response = await withRetry(async () => {
-          return await axios.get(url, {
-            httpsAgent,
-            headers,
-            timeout: 30000
-          });
-        }, 4, 3000);
-
-        const html = response.data;
-
-        // Simple check for results: if it doesn't contain "Brak wyników" or "Nie znaleziono"
-        // and contains something that looks like a record (e.g., "record-item" or "Szczegóły")
-        const noResults = html.includes("Brak wyników") || html.includes("Nie znaleziono");
-        const hasResults = !noResults && (html.includes("class=\"record\"") || html.includes("Szczegóły"));
-
-        if (hasResults) {
-          let extractedTitle = null;
-          let extractedAuthor = null;
-
-          const titleRegex = /<dt[^>]*>\s*Tytuł:\s*<\/dt>\s*<dd[^>]*>\s*<span[^>]*>(.*?)<\/span>/i;
-          const match = html.match(titleRegex);
           if (match) {
-            extractedTitle = match[1].replace(/<[^>]+>/g, '').trim();
-          }
-
-          const authorRegex = /<dt[^>]*>\s*Autor:\s*<\/dt>\s*<dd[^>]*>\s*<span[^>]*>(.*?)<\/span>/i;
-          const authorMatch = html.match(authorRegex);
-          if (authorMatch) {
-            extractedAuthor = authorMatch[1].replace(/<[^>]+>/g, '').trim();
-          }
-
-          let isMatch = false;
-
-          // Title match
-          const normNotionTitle = cleanTitle(book.plTitle || "").toLowerCase();
-          const normOpacTitle = cleanTitle(extractedTitle || "").toLowerCase();
-          const titleSimilarity = calculateSimilarity(normNotionTitle, normOpacTitle);
-          const titleMatch = titleSimilarity > 0.8 || normOpacTitle.includes(normNotionTitle) || normNotionTitle.includes(normOpacTitle) || !extractedTitle;
-
-          // Author match
-          const normNotionAuthor = normalizeAuthor(book.author || "");
-          const normOpacAuthor = normalizeAuthor(extractedAuthor || "");
-
-          let authorMatchBool = false;
-          if (!normNotionAuthor) {
-              authorMatchBool = true;
-          } else if (normOpacAuthor) {
-              const authorSimilarity = calculateSimilarity(normNotionAuthor, normOpacAuthor);
-              authorMatchBool = authorSimilarity > 0.7 || normOpacAuthor.includes(normNotionAuthor) || normNotionAuthor.includes(normOpacAuthor);
-          } else {
-              const authorParts = normNotionAuthor.split(' ').filter((p: string) => p.length > 2);
-              const allPartsFound = authorParts.length > 0 && authorParts.every((part: string) => html.toLowerCase().includes(part));
-              authorMatchBool = allPartsFound;
-          }
-
-          if (titleMatch && authorMatchBool) {
             const matchResult = {
               id: book.id,
               title: book.plTitle,
               author: book.author,
               year: book.year,
-              extractedTitle: extractedTitle,
-              extractedAuthor: extractedAuthor
+              extractedTitle: match.title,
+              extractedAuthor: match.author,
             };
             results.push(matchResult);
             sendEvent({ type: "match", result: matchResult });
           }
+        } catch (err: any) {
+          log.warn("Błąd sprawdzania książki w bibliotece", { title, error: err.message || "Nieznany błąd" });
+          sendEvent({
+            type: "status",
+            message: `⚠️ Błąd sprawdzania "${title}": ${err.message || "Timeout/Błąd sieci"}. Kontynuuję...`,
+          });
+        } finally {
+          processed++;
+          sendEvent({
+            type: "progress",
+            message: `Sprawdzono ${processed}/${candidates.length} (znaleziono ${results.length})`,
+            current: processed,
+            total: candidates.length,
+          });
         }
-      } catch (err: any) {
-        log.warn(`Błąd sprawdzania książki w bibliotece`, { title, error: err.message || "Nieznany błąd" });
-        // Don't throw, just continue with the next book
-        // We can optionally send a status update about the error
-        sendEvent({
-          type: "status",
-          message: `⚠️ Błąd sprawdzania "${title}": ${err.message || "Timeout/Błąd sieci"}. Kontynuuję...`
-        });
-      }
+      }),
+    );
 
-      // Add a small delay between requests
-      await new Promise(resolve => setTimeout(resolve, 500));
-    }
+    await Promise.all(tasks);
 
     const wasCancelled = checkCancellation();
-    sendEvent({ type: "complete", result: { success: !wasCancelled, cancelled: wasCancelled, results, message: wasCancelled ? `Skanowanie przerwane. Znaleziono ${results.length} książek przed przerwaniem.` : `Zakończono sprawdzanie. Znaleziono ${results.length} książek.` } });
+    sendEvent({
+      type: "complete",
+      result: {
+        success: !wasCancelled,
+        cancelled: wasCancelled,
+        results,
+        message: wasCancelled
+          ? `Skanowanie przerwane. Znaleziono ${results.length} książek przed przerwaniem.`
+          : `Zakończono sprawdzanie. Znaleziono ${results.length} książek.`,
+      },
+    });
   }
 }

--- a/services/opacParser.ts
+++ b/services/opacParser.ts
@@ -1,0 +1,107 @@
+import { cleanTitle, calculateSimilarity, normalizeAuthor } from "../utils";
+
+/**
+ * Parser wyników OPAC (Prolib Integro, MBP Lublin). Czysty (bez I/O) — skaner
+ * podaje HTML, dostaje listę rekordów. Struktura strony wyników:
+ *   <article data-item-id="…"> … <dl class="dl-horizontal">
+ *       <dt>Tytuł:</dt><dd><span>…</span></dd>
+ *       <dt>Autorzy:</dt><dd><span><a>Nazwisko, Imię (rok- )</a></span></dd> …
+ *   </dl>
+ *   <span class="pdt-p-book|pdt-p-movie|pdt-p-audiobook"></span>  ← typ nośnika
+ * Zapytanie jest już zawężone do filii (param f2), więc obecność rekordu = filia
+ * ma dany egzemplarz w zbiorach.
+ */
+
+export type OpacDocType = "ksiazka" | "audiobook" | "film" | "inne";
+
+export interface OpacRecord {
+  id: string;
+  title: string;
+  author: string;
+  documentType: OpacDocType;
+}
+
+const stripTags = (s: string) => s.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+
+/** Wyciąga wartość pola z listy <dl>: <dt>Label:</dt><dd>…</dd>. */
+function dlField(block: string, labelRe: string): string {
+  const re = new RegExp(`<dt[^>]*>\\s*${labelRe}\\s*</dt>\\s*<dd[^>]*>([\\s\\S]*?)</dd>`, "i");
+  const m = block.match(re);
+  return m ? stripTags(m[1]) : "";
+}
+
+function docTypeOf(block: string): OpacDocType {
+  if (/pdt-p-book/.test(block)) return "ksiazka";
+  if (/pdt-p-audiobook/.test(block)) return "audiobook";
+  if (/pdt-p-movie/.test(block)) return "film";
+  return "inne";
+}
+
+export function parseOpacResults(html: string): OpacRecord[] {
+  const records: OpacRecord[] = [];
+  const articleRe = /<article\b[^>]*\bdata-item-id="([^"]+)"[^>]*>([\s\S]*?)<\/article>/g;
+  let m: RegExpExecArray | null;
+  while ((m = articleRe.exec(html)) !== null) {
+    const id = m[1];
+    const block = m[0];
+    const title = dlField(block, "Tytuł:");
+    const author = dlField(block, "Autor(?:zy)?:");
+    if (!title) continue;
+    records.push({ id, title, author, documentType: docTypeOf(block) });
+  }
+  return records;
+}
+
+/**
+ * Znajduje najlepiej pasujący rekord KSIĄŻKI (domyślnie z wykluczeniem filmów i
+ * audiobooków — wyszukiwanie „gra o tron" zwraca też seriale i inne dzieła autora,
+ * a użytkownik szuka konkretnej książki). Dopasowanie = zgodność tytułu (z obsługą
+ * tytułów równoległych „Oryginał = Polski") ORAZ autora (gdy znany po obu stronach).
+ * Zwraca najlepszy rekord ponad progiem albo null.
+ */
+export function findBookMatch(
+  records: OpacRecord[],
+  title: string,
+  author: string,
+  opts: { includeAudiobook?: boolean } = {},
+): OpacRecord | null {
+  const wanted: OpacDocType[] = opts.includeAudiobook ? ["ksiazka", "audiobook"] : ["ksiazka"];
+  const books = records.filter((r) => wanted.includes(r.documentType));
+
+  const normTitle = cleanTitle(title || "").toLowerCase();
+  const normAuthor = normalizeAuthor(author || "");
+  if (!normTitle) return null;
+
+  let best: OpacRecord | null = null;
+  let bestSim = 0;
+
+  for (const r of books) {
+    // Tytuły równoległe: „Game of thrones … = Gra o tron" — porównaj każdą stronę.
+    const parts = r.title.split("=").map((s) => cleanTitle(s).toLowerCase()).filter(Boolean);
+    let titleSim = 0;
+    for (const p of parts) {
+      titleSim = Math.max(titleSim, calculateSimilarity(normTitle, p));
+      if (normTitle.length > 3 && (p.includes(normTitle) || normTitle.includes(p))) {
+        titleSim = Math.max(titleSim, 0.9);
+      }
+    }
+    if (titleSim <= 0.8) continue;
+
+    // Autor: gdy znamy autora z Notion, musi zgadzać się z rekordem (redukuje
+    // fałszywe trafienia na inne dzieła tego samego autora złapane po serii/temacie).
+    let authorOk = true;
+    if (normAuthor) {
+      const recAuthor = normalizeAuthor(r.author || "");
+      authorOk = !!recAuthor && (
+        calculateSimilarity(normAuthor, recAuthor) > 0.6 ||
+        recAuthor.includes(normAuthor) ||
+        normAuthor.includes(recAuthor)
+      );
+    }
+    if (authorOk && titleSim > bestSim) {
+      best = r;
+      bestSim = titleSim;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
Oparte na realnej odpowiedzi OPAC (Prolib Integro), którą podrzuciłeś.

## Dlaczego było źle

Skaner był wolny **i** mylił się. Mylił, bo: czytał tylko **pierwszy** rekord ze strony, szukał `Autor:` gdy OPAC oznacza pole `Autorzy:`, i sprawdzał `class="record"`, którego markup nie używa. Efekt dla „Gra o tron": trafiał na **audiobook** i znajdował „Martin" gdzieś na stronie → fałszywe trafienie, podczas gdy filia **nie ma fizycznej książki** o tym tytule (tylko audiobook, serial i inne powieści Martina złapane po serii/temacie).

## Nowy czysty parser `services/opacParser.ts`

- **`parseOpacResults(html)`** — jeden rekord na `<article data-item-id>`: tytuł, autor (z pola `Autorzy:`) i **typ nośnika** z ikony (`pdt-p-book` / `-audiobook` / `-movie`).
- **`findBookMatch(records, title, author)`** — zostawia tylko rekordy **książki** (filmy i audiobooki domyślnie pomijane), wymaga realnej zgodności **tytułu** (odrzuca inną książkę tego samego autora) **oraz** autora, gdy znany.

## Skaner

`libraryCheckService` pobiera teraz **współbieżnie** (`p-limit(6)`) zamiast sekwencyjnej pętli ze sztywnym opóźnieniem 500 ms (~6× szybciej przy ~200 tytułach), z lżejszym retry (2 × 1500 ms), i deleguje parsowanie/dopasowanie do czystego modułu. Agent TLS OPAC (`rejectUnauthorized:false`) zostaje.

## Testy (na realnej strukturze article/dl/ikona)

Klasyfikacja i ekstrakcja pól; `findBookMatch` wybiera książkę zamiast filmu/audiobooka o tym samym tytule, zwraca `null` dla realnego „Gra o tron", odrzuca inną książkę tego samego autora, i umie włączyć audiobooki na życzenie. Doc przepisany.

Weryfikacja: `npm run lint` czysto, `npm test` **155/155**, `npm run build` OK.

---

**Do decyzji:** domyślnie liczę tylko **książki** (nie audiobooki). Chcesz, żeby audiobooki też się liczyły jako trafienie? Jest gotowy przełącznik `includeAudiobook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_