### PR TITLE
Skaner bibliotek: tag filii zamiast „Przeczytane" na znalezionych pozycjach

### DIFF
--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -111,6 +111,56 @@ describe("SyncManager lifecycle", () => {
   afterAll(() => closeServer());
 });
 
+describe("POST /api/mark-as-read", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NOTION_API_KEY = "test-key";
+    process.env.NOTION_DATABASE_ID = "test-db";
+  });
+
+  it("defaults to the 'Przeczytane' tag when none is provided", async () => {
+    const spy = vi.spyOn(syncManager, "markAsRead").mockResolvedValue(undefined);
+
+    const res = await request(app).post("/api/mark-as-read").send({ pageId: "page-1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(spy).toHaveBeenCalledWith("page-1", "Przeczytane");
+  });
+
+  it("threads a branch source tag through to the sync manager", async () => {
+    const spy = vi.spyOn(syncManager, "markAsRead").mockResolvedValue(undefined);
+
+    await request(app).post("/api/mark-as-read").send({ pageId: "page-2", tag: "Biblioteka" });
+    await request(app).post("/api/mark-as-read").send({ pageId: "page-3", tag: "Biblioteka 9" });
+
+    expect(spy).toHaveBeenNthCalledWith(1, "page-2", "Biblioteka");
+    expect(spy).toHaveBeenNthCalledWith(2, "page-3", "Biblioteka 9");
+  });
+
+  it("rejects an unknown tag with 400 and never touches Notion", async () => {
+    const spy = vi.spyOn(syncManager, "markAsRead").mockResolvedValue(undefined);
+
+    const res = await request(app).post("/api/mark-as-read").send({ pageId: "page-4", tag: "Posiadam" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Niedozwolony znacznik/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("requires a pageId", async () => {
+    const spy = vi.spyOn(syncManager, "markAsRead").mockResolvedValue(undefined);
+
+    const res = await request(app).post("/api/mark-as-read").send({ tag: "Biblioteka" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Missing pageId/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  afterAll(() => closeServer());
+});
+
 describe("SSE event stream (POST /api/sync)", () => {
   beforeEach(() => {
     process.env.NOTION_API_KEY = "test-key";

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -155,15 +155,26 @@ export const stopPurifySync = makeStopHandler("Zatrzymano rytuał puryfikacji.")
 
 export const stopSchemaSync = makeStopHandler("Zatrzymano inicjalizację schematu.");
 
+// Znaczniki „Źródło", które wolno dopisać z tego endpointu. Ograniczone do
+// znanego zbioru — endpoint jedynie oznacza pozycję (przeczytana / dostępna w
+// danej filii), nie może wstrzykiwać dowolnych tagów do bazy Notion.
+const ALLOWED_SOURCE_TAGS = new Set(["Przeczytane", "Biblioteka", "Biblioteka 9"]);
+
 export const markAsRead = async (req: Request, res: Response) => {
   try {
-    const { pageId } = req.body;
+    const { pageId, tag } = req.body;
     if (!pageId) return res.status(400).json({ error: "Missing pageId parameter" });
-    await syncManager.markAsRead(pageId);
+
+    const sourceTag = tag ?? "Przeczytane";
+    if (!ALLOWED_SOURCE_TAGS.has(sourceTag)) {
+      return res.status(400).json({ error: `Niedozwolony znacznik: ${sourceTag}.` });
+    }
+
+    await syncManager.markAsRead(pageId, sourceTag);
     res.json({ success: true });
   } catch (error: any) {
     console.error("Mark as Read Error:", error);
-    res.status(500).json({ error: error.message || "Wystąpił błąd podczas oznaczania jako przeczytane." });
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas oznaczania pozycji." });
   }
 };
 

--- a/docs/library-check.md
+++ b/docs/library-check.md
@@ -28,3 +28,6 @@ Worked example: for "Gra o tron" (G. R. R. Martin) at Filia Felin, the branch ho
 - **Retries/timeout**: `withRetry(2, 1500ms)`, 20 000 ms per request. No fixed inter-request delay; concurrency is the throttle.
 - **Cancellation**: cooperative — each task checks the token before firing; `complete` reports `cancelled: true` when stopped.
 - **Progress**: a shared counter emits `Sprawdzono {done}/{total} (znaleziono {n})` as tasks finish.
+
+## 6. Tagging a hit (`POST /api/mark-as-read`)
+Each identified book carries a button that writes a **branch-specific `Źródło` tag** instead of `Przeczytane`: `Biblioteka` for Filia Felin and `Biblioteka 9` for Filia Bronowice (mapped from `sourceTag` in `src/constants.ts` → `LIBRARY_BRANCHES`). Those two tags are exactly the ones excluded from candidates (§2), so tagging a book also removes it from later scans of that branch. The endpoint (`controllers/syncController.ts` → `syncManager.markAsRead(pageId, tag)`) validates `tag` against an allow-list (`Przeczytane`, `Biblioteka`, `Biblioteka 9`); omitting it defaults to `Przeczytane` (used by the owned-unread / library-stats buttons). The tag is appended via `notion.addTagToMultiSelect("Źródło", …)`, which is idempotent.

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -15,16 +15,18 @@ export const StatsSection: React.FC = () => {
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
   const [markingId, setMarkingId] = useState<string | null>(null);
 
-  const handleMarkAsRead = async (pageId: string) => {
+  // tag domyślnie „Przeczytane" (zasoby posiadane / statystyki biblioteczne);
+  // skaner filii przekazuje znacznik filii („Biblioteka" / „Biblioteka 9").
+  const handleMarkAsRead = async (pageId: string, tag?: string) => {
     if (markingId) return;
     setMarkingId(pageId);
     try {
       const res = await fetch("/api/mark-as-read", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pageId })
+        body: JSON.stringify({ pageId, tag })
       });
-      if (!res.ok) throw new Error("Błąd podczas oznaczania jako przeczytane");
+      if (!res.ok) throw new Error("Błąd podczas oznaczania pozycji");
       await fetchStats();
     } catch (err: any) {
       console.error(err.message);

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { motion } from "motion/react";
-import { Search, ChevronDown, ChevronUp, Loader2, CheckCircle2 } from "lucide-react";
+import { Search, ChevronDown, ChevronUp, Loader2, Library } from "lucide-react";
 import { formatETA } from "../../utils/time";
 import { IdentifiedBook } from "../../hooks/useStats";
 
 interface IdentifiedLibraryItemProps {
-  library: { id: string; name: string; code: string };
+  library: { id: string; name: string; code: string; sourceTag: string };
   books: IdentifiedBook[];
   onCheck: () => void;
   onStop: () => void;
-  onMarkAsRead: (pageId: string) => void;
+  onMarkAsRead: (pageId: string, tag?: string) => void;
   markingId: string | null;
   isChecking: boolean;
   progress: any;
@@ -143,19 +143,19 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
               </div>
 
               <button
-                onClick={() => onMarkAsRead(book.id)}
+                onClick={() => onMarkAsRead(book.id, library.sourceTag)}
                 disabled={markingId !== null}
                 className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
-                  markingId === book.id 
-                    ? 'bg-emerald-500/20 border-emerald-500/50 text-emerald-400' 
-                    : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-emerald-400 hover:border-emerald-500/30'
+                  markingId === book.id
+                    ? 'bg-blue-500/20 border-blue-500/50 text-blue-400'
+                    : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-blue-400 hover:border-blue-500/30'
                 }`}
-                title="Oznacz jako przeczytane"
+                title={`Oznacz jako dostępne w filii (tag „${library.sourceTag}")`}
               >
                 {markingId === book.id ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
                 ) : (
-                  <CheckCircle2 className="w-4 h-4" />
+                  <Library className="w-4 h-4" />
                 )}
               </button>
             </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,11 @@ export const PREDEFINED_AWARDS = [
   { name: "Wszystkie Nagrody", title: "Wszystkie" },
 ];
 
+// sourceTag = znacznik „Źródło" dopisywany po kliknięciu na znalezionej pozycji.
+// Jest to zarazem tag wykluczający pozycję z kolejnych skanów (zob.
+// services/libraryCheckService.ts — lista `excluded`), więc oznaczenie książki
+// jednocześnie usuwa ją z puli kandydatów danej filii.
 export const LIBRARY_BRANCHES = [
-  { id: "felin", name: "Biblioteka Felin", code: "48" },
-  { id: "bronowice", name: "Biblioteka Bronowice", code: "7" }
+  { id: "felin", name: "Biblioteka Felin", code: "48", sourceTag: "Biblioteka" },
+  { id: "bronowice", name: "Biblioteka Bronowice", code: "7", sourceTag: "Biblioteka 9" }
 ];

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -136,8 +136,12 @@ class SyncManager {
     return await this.wiki.fetchLastRevisionDate(pageTitle);
   }
 
-  async markAsRead(pageId: string) {
-    return await this.notion.addTagToMultiSelect(pageId, "Źródło", "Przeczytane");
+  // Dopisuje znacznik „Źródło" na stronie książki. Domyślnie „Przeczytane"
+  // (przycisk w zasobach posiadanych / bibliotecznych statystykach), ale skaner
+  // bibliotek podaje znacznik filii („Biblioteka" = Felin, „Biblioteka 9" =
+  // Bronowice), aby oznaczyć, w której filii pozycja jest dostępna.
+  async markAsRead(pageId: string, tag: string = "Przeczytane") {
+    return await this.notion.addTagToMultiSelect(pageId, "Źródło", tag);
   }
 
   /**


### PR DESCRIPTION
## Cel

Zmiana akcji przycisku przy pozycjach **znalezionych przez skaner biblioteki**. Kliknięcie zamiast oznaczać książkę jako „Przeczytane" dopisuje teraz **znacznik `Źródło` zależny od filii**:

- **Biblioteka Felin** → tag `Biblioteka`
- **Biblioteka Bronowice** → tag `Biblioteka 9`

Oba tagi są jednocześnie tagami wykluczającymi z przyszłych skanów (`services/libraryCheckService.ts` — lista `excluded`), więc oznaczenie pozycji naturalnie usuwa ją z puli kandydatów danej filii przy kolejnym skanowaniu.

## Zmiany

- **`src/constants.ts`** — `LIBRARY_BRANCHES` zyskuje pole `sourceTag` (Felin → `Biblioteka`, Bronowice → `Biblioteka 9`).
- **`src/components/stats/IdentifiedLibraryItem.tsx`** — przycisk przekazuje `library.sourceTag` do `onMarkAsRead`; ikona (`Library`) i tooltip odzwierciedlają nowe znaczenie.
- **`src/components/StatsSection.tsx`** — `handleMarkAsRead(pageId, tag?)` przekazuje `tag` w ciele żądania. Przyciski zasobów posiadanych i statystyk bibliotecznych wołają bez tagu → zachowują „Przeczytane".
- **`controllers/syncController.ts`** — `POST /api/mark-as-read` przyjmuje opcjonalny `tag` walidowany względem listy dozwolonych (`Przeczytane`, `Biblioteka`, `Biblioteka 9`); nieznany tag → `400`, brak = `Przeczytane`.
- **`syncManager.ts`** — `markAsRead(pageId, tag = "Przeczytane")` (dopisanie idempotentne przez `addTagToMultiSelect`).

## Testy

Nowe testy endpointu w `__tests__/syncManager.test.ts`: domyślny tag, przekazanie tagu filii, odrzucenie niedozwolonego tagu (bez wywołania Notion), wymagany `pageId`. Cała suita zielona (159 testów), `tsc --noEmit` czysty. Docs (`docs/library-check.md`) zaktualizowane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_