### PR TITLE
Skaner bibliotek: nieaktywny haczyk przy pozycji już oznaczonej tagiem filii

### DIFF
--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -14,6 +14,10 @@ export const StatsSection: React.FC = () => {
   const { stats, loading, error, fetchStats } = useStats();
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
   const [markingId, setMarkingId] = useState<string | null>(null);
+  // Pozycje oznaczone w tej sesji — klucz „{tag}:{pageId}". Skan biblioteki
+  // wyklucza już otagowane książki, więc pozycja z listy skanera trafia tu
+  // dopiero po kliknięciu; wtedy ma zostać widoczna, lecz z wyłączonym haczykiem.
+  const [markedIds, setMarkedIds] = useState<Set<string>>(new Set());
 
   // tag domyślnie „Przeczytane" (zasoby posiadane / statystyki biblioteczne);
   // skaner filii przekazuje znacznik filii („Biblioteka" / „Biblioteka 9").
@@ -27,6 +31,8 @@ export const StatsSection: React.FC = () => {
         body: JSON.stringify({ pageId, tag })
       });
       if (!res.ok) throw new Error("Błąd podczas oznaczania pozycji");
+      const sourceTag = tag ?? "Przeczytane";
+      setMarkedIds(prev => new Set(prev).add(`${sourceTag}:${pageId}`));
       await fetchStats();
     } catch (err: any) {
       console.error(err.message);
@@ -290,6 +296,7 @@ export const StatsSection: React.FC = () => {
                 onStop={stopLibraryCheck}
                 onMarkAsRead={handleMarkAsRead}
                 markingId={markingId}
+                markedIds={markedIds}
                 isChecking={checkingLibrary === library.id}
                 progress={checkingLibrary === library.id ? checkProgress : null}
               />

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "motion/react";
-import { Search, ChevronDown, ChevronUp, Loader2, Library } from "lucide-react";
+import { Search, ChevronDown, ChevronUp, Loader2, Library, CheckCircle2 } from "lucide-react";
 import { formatETA } from "../../utils/time";
 import { IdentifiedBook } from "../../hooks/useStats";
 
@@ -11,6 +11,8 @@ interface IdentifiedLibraryItemProps {
   onStop: () => void;
   onMarkAsRead: (pageId: string, tag?: string) => void;
   markingId: string | null;
+  // Klucze „{tag}:{pageId}" pozycji już oznaczonych znacznikiem filii.
+  markedIds: Set<string>;
   isChecking: boolean;
   progress: any;
 }
@@ -22,8 +24,9 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
   onStop, 
   onMarkAsRead,
   markingId,
-  isChecking, 
-  progress 
+  markedIds,
+  isChecking,
+  progress
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(true);
 
@@ -120,6 +123,7 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
         >
           {sortedBooks.map((book: any, idx: number) => {
             const isExactMatch = book.extractedTitle && book.extractedTitle.toLowerCase() === book.title.toLowerCase();
+            const isMarked = markedIds.has(`${library.sourceTag}:${book.id}`);
             return (
             <div key={idx} className={`flex items-start gap-3 p-3 rounded-xl border transition-colors group/book ${
               isExactMatch 
@@ -144,16 +148,24 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
 
               <button
                 onClick={() => onMarkAsRead(book.id, library.sourceTag)}
-                disabled={markingId !== null}
-                className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
-                  markingId === book.id
-                    ? 'bg-blue-500/20 border-blue-500/50 text-blue-400'
-                    : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-blue-400 hover:border-blue-500/30'
+                disabled={markingId !== null || isMarked}
+                className={`p-2 rounded-lg border transition-all ${
+                  isMarked
+                    ? 'opacity-100 bg-emerald-500/10 border-emerald-500/40 text-emerald-500/80 cursor-not-allowed'
+                    : `opacity-40 group-hover/book:opacity-100 ${
+                        markingId === book.id
+                          ? 'bg-blue-500/20 border-blue-500/50 text-blue-400'
+                          : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-blue-400 hover:border-blue-500/30'
+                      }`
                 }`}
-                title={`Oznacz jako dostępne w filii (tag „${library.sourceTag}")`}
+                title={isMarked
+                  ? `Oznaczono w tej filii (tag „${library.sourceTag}")`
+                  : `Oznacz jako dostępne w filii (tag „${library.sourceTag}")`}
               >
                 {markingId === book.id ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
+                ) : isMarked ? (
+                  <CheckCircle2 className="w-4 h-4" />
                 ) : (
                   <Library className="w-4 h-4" />
                 )}


### PR DESCRIPTION
## Cel

Po oznaczeniu znalezionej pozycji znacznikiem filii (`Biblioteka` / `Biblioteka 9`) książka ma **zostać widoczna** na liście skanera, ale jej przycisk ma być **nieaktywny** (haczyk „done"), zamiast pozwalać na ponowne kliknięcie.

## Zachowanie

- Skan wyklucza z kandydatów książki już otagowane, więc pozycja z listy skanera trafia w stan „oznaczone" dopiero **po kliknięciu w tej sesji**.
- Oznaczone pozycje śledzone lokalnie w `StatsSection` kluczem `"{tag}:{pageId}"` — otagowanie w Felin (`Biblioteka`) nie wygasza tej samej książki pod Bronowice (`Biblioteka 9`) i odwrotnie.
- Oznaczony przycisk: zielony `CheckCircle2`, `cursor-not-allowed`, `disabled`, tooltip „Oznaczono w tej filii".

## Sekcja „Książki dostępne w bibliotekach"

Zasila się sama — `statsService` buduje `libraryStats` z tagów `Biblioteka`/`Biblioteka 9`, a `handleMarkAsRead` woła `fetchStats()` po zapisie, więc otagowana książka pojawia się tam automatycznie. Bez zmian w kodzie.

## Zmiany

- **`src/components/StatsSection.tsx`** — stan `markedIds: Set<string>`, dopis klucza `"{tag}:{pageId}"` po sukcesie, przekazanie do `IdentifiedLibraryItem`.
- **`src/components/stats/IdentifiedLibraryItem.tsx`** — prop `markedIds`, `isMarked` per pozycja, wyłączenie przycisku + stan „oznaczone".

`tsc --noEmit` czysty, testy zielone (27 frontend / 159 całość).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_