### PR TITLE
Statystyki: dynamiczne (optymistyczne) uzupełnianie sekcji bibliotek po otagowaniu

### DIFF
--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -11,8 +11,10 @@ import { IdentifiedLibraryItem } from "./stats/IdentifiedLibraryItem";
 import { LIBRARY_BRANCHES } from "../constants";
 
 export const StatsSection: React.FC = () => {
-  const { stats, loading, error, fetchStats } = useStats();
+  const { stats, loading, error, fetchStats, addBookToLibrarySection } = useStats();
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
+
+  const LIBRARY_TAGS = ["Biblioteka", "Biblioteka 9"];
   const [markingId, setMarkingId] = useState<string | null>(null);
   // Pozycje oznaczone w tej sesji — klucz „{tag}:{pageId}". Skan biblioteki
   // wyklucza już otagowane książki, więc pozycja z listy skanera trafia tu
@@ -33,7 +35,18 @@ export const StatsSection: React.FC = () => {
       if (!res.ok) throw new Error("Błąd podczas oznaczania pozycji");
       const sourceTag = tag ?? "Przeczytane";
       setMarkedIds(prev => new Set(prev).add(`${sourceTag}:${pageId}`));
-      await fetchStats();
+
+      // Tag filii dopisuje pozycję wyłącznie do sekcji „Książki dostępne w
+      // bibliotekach" — aktualizujemy ją optymistycznie (natychmiast, odporne na
+      // opóźnienie odczytu Notiona). „Przeczytane" zmienia wiele przekrojów
+      // (autorzy, chronologia, posiadane), więc tam robimy pełny refetch.
+      if (LIBRARY_TAGS.includes(sourceTag)) {
+        const book = Object.values(identifiedBooks).flat().find(b => b.id === pageId);
+        if (book) addBookToLibrarySection(sourceTag, book);
+        else await fetchStats();
+      } else {
+        await fetchStats();
+      }
     } catch (err: any) {
       console.error(err.message);
       alert(`Błąd: ${err.message}`);

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -70,9 +70,25 @@ export function useStats() {
     }
   }, []);
 
+  // Optymistyczne dopisanie książki do sekcji „Książki dostępne w bibliotekach"
+  // zaraz po otagowaniu (Biblioteka / Biblioteka 9), bez czekania na kolejny
+  // refetch — Notion bywa opóźniony w odczycie tuż po zapisie, więc pełne
+  // odświeżenie potrafi jeszcze nie widzieć nowego tagu. `libraryStats[].id`
+  // to nazwa tagu, więc dopasowujemy filię po znaczniku.
+  const addBookToLibrarySection = useCallback((tag: string, book: { id: string; title: string; author: string; year?: number | null }) => {
+    setStats(prev => {
+      if (!prev) return prev;
+      const libraryStats = prev.libraryStats.map(ls => {
+        if (ls.id !== tag || ls.books.some(b => b.id === book.id)) return ls;
+        return { ...ls, books: [...ls.books, { ...book, read: false }] };
+      });
+      return { ...prev, libraryStats };
+    });
+  }, []);
+
   useEffect(() => {
     fetchStats();
   }, [fetchStats]);
 
-  return { stats, loading, error, fetchStats };
+  return { stats, loading, error, fetchStats, addBookToLibrarySection };
 }


### PR DESCRIPTION
## Kontekst

Sprawdziłem mechanizm odświeżania: **jest już globalny**. `fetchStats()` refetchuje całe `/api/stats` (z cache-bustem `?t=`) i podmienia wszystkie sekcje naraz. Ten sam handler jest podpięty pod przycisk „Odśwież" (`onClick={fetchStats}`) **oraz** wołany automatycznie w `handleMarkAsRead` po każdym udanym otagowaniu.

## Problem

Refetch tuż po zapisie tagu potrafił zwrócić jeszcze **stare dane z Notiona** (opóźnienie odczytu po zapisie), więc sekcja „Książki dostępne w bibliotekach" uzupełniała się dopiero po ręcznym kliknięciu „Odśwież" chwilę później.

## Rozwiązanie — dynamicznie

Tag filii (`Biblioteka` / `Biblioteka 9`) dopisuje pozycję **wyłącznie do tej jednej sekcji** — żaden inny przekrój statystyk się nie zmienia. Zamiast pełnego refetchu robimy **optymistyczną aktualizację**: książka trafia do właściwej filii natychmiast, niezależnie od timingu Notiona. `Przeczytane` nadal wywołuje pełny `fetchStats()` (zmienia autorów, chronologię, zasoby posiadane).

## Zmiany

- **`src/hooks/useStats.ts`** — nowy helper `addBookToLibrarySection(tag, book)`: dopisuje książkę do `libraryStats` o `id == tag` (idempotentnie, bez duplikatów).
- **`src/components/StatsSection.tsx`** — `handleMarkAsRead`: dla tagów `Biblioteka`/`Biblioteka 9` szuka pozycji w wynikach skanera (`identifiedBooks`) i aktualizuje sekcję optymistycznie; fallback do `fetchStats()` gdy pozycji brak.

Przycisk „Odśwież" działa jak dotychczas (globalny refetch). `tsc --noEmit` czysty, testy zielone (159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_