### PR TITLE
Optymalizacja: współdzielone pobranie książek między skanami + fix klucza React

### DIFF
--- a/__tests__/notion.adapter.test.ts
+++ b/__tests__/notion.adapter.test.ts
@@ -13,6 +13,7 @@ const mockClient = {
     query: vi.fn(),
   },
   pages: {
+    retrieve: vi.fn(),
     update: vi.fn(),
     create: vi.fn(),
   }
@@ -113,6 +114,60 @@ describe('NotionAdapter', () => {
         year: '1961',
         awards: ['Zajdel']
       }));
+    });
+  });
+
+  describe('getBooksForStats caching', () => {
+    const page = (id: string) => ({
+      id,
+      properties: { 'Tytuł polski': { type: 'title', title: [{ plain_text: `T-${id}` }] } },
+    });
+
+    it('shares one Notion fetch across cached reads until invalidated', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValue({ id: 'test-db-id' }); // init
+      mockClient.dataSources.query.mockResolvedValue({ results: [page('1')], has_more: false });
+
+      // Pierwszy skan pobiera z Notion...
+      const first = await adapter.getBooksForStats(undefined, undefined, { cache: true });
+      // ...drugi (np. kolejna filia) korzysta z cache — bez nowego query.
+      const second = await adapter.getBooksForStats(undefined, undefined, { cache: true });
+
+      expect(first).toHaveLength(1);
+      expect(second).toEqual(first);
+      expect(mockClient.dataSources.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not serve the cache to non-cached (stats) reads', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValue({ id: 'test-db-id' });
+      mockClient.dataSources.query.mockResolvedValue({ results: [page('1')], has_more: false });
+
+      await adapter.getBooksForStats(undefined, undefined, { cache: true }); // primes cache
+      await adapter.getBooksForStats(); // stats path — musi pobrać świeżo
+
+      expect(mockClient.dataSources.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates the cache after a write (addTagToMultiSelect)', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValue({ id: 'test-db-id' });
+      mockClient.dataSources.query.mockResolvedValue({ results: [page('1')], has_more: false });
+      mockClient.pages.retrieve.mockResolvedValue({ properties: { 'Źródło': { type: 'multi_select', multi_select: [] } } });
+      mockClient.pages.update.mockResolvedValue({});
+
+      await adapter.getBooksForStats(undefined, undefined, { cache: true }); // primes cache
+      await adapter.addTagToMultiSelect('page-1', 'Źródło', 'Biblioteka'); // invalidates
+      await adapter.getBooksForStats(undefined, undefined, { cache: true }); // must refetch
+
+      expect(mockClient.dataSources.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache a fetch cut short by cancellation', async () => {
+      mockClient.dataSources.retrieve.mockResolvedValue({ id: 'test-db-id' });
+      mockClient.dataSources.query.mockResolvedValue({ results: [page('1')], has_more: false });
+
+      await adapter.getBooksForStats(undefined, () => true, { cache: true }); // cancelled → no cache
+      await adapter.getBooksForStats(undefined, undefined, { cache: true });   // must fetch
+
+      expect(mockClient.dataSources.query).toHaveBeenCalledTimes(1); // first call broke before querying
     });
   });
 

--- a/docs/library-check.md
+++ b/docs/library-check.md
@@ -25,6 +25,7 @@ Worked example: for "Gra o tron" (G. R. R. Martin) at Filia Felin, the branch ho
 
 ## 5. Performance & pacing
 - **Concurrency**: up to 6 parallel requests via `p-limit` (agent `maxSockets` matched), instead of the old one-at-a-time loop — ~6× faster over a couple hundred titles.
+- **Shared Notion fetch**: the candidate list is read via `getBooksForStats(…, { cache: true })`, a short-TTL (5 min) opt-in cache in `NotionAdapter`. "Skanuj wszystkie" therefore downloads the whole Notion DB **once** for both branches instead of once per branch; every book write (tagging included) invalidates the cache, and the stats endpoint reads uncached so `/api/stats` stays fresh.
 - **Retries/timeout**: `withRetry(2, 1500ms)`, 20 000 ms per request. No fixed inter-request delay; concurrency is the throttle.
 - **Cancellation**: cooperative — each task checks the token before firing; `complete` reports `cancelled: true` when stopped.
 - **Progress**: a shared counter emits `Sprawdzono {done}/{total} (znaleziono {n})` as tasks finish.

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -4,14 +4,27 @@ import { sanitizeNotionString, sanitizeNotionTag } from "./utils";
 import { NotionPage, NotionBook } from "./src/types";
 import { mapPageToBook } from "./notionMapper";
 
+// Krótki cache pełnej listy książek dla ścieżek TYLKO-DO-ODCZYTU skanerów
+// (biblioteka „Skanuj wszystkie" odpytywałaby Notion raz na filię). Cache jest
+// opt-in (`{ cache: true }`), więc statystyki (`/api/stats`) zawsze czytają
+// świeże dane, a każdy zapis książki go unieważnia. TTL to tylko bezpiecznik na
+// edycje spoza aplikacji.
+const BOOKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
 export class NotionAdapter {
   private notion: Client;
   private actualDataSourceId: string | null = null;
   private isDataSource: boolean = true;
   private initPromise: Promise<void> | null = null;
+  private booksCache: { data: NotionBook[]; expiresAt: number } | null = null;
 
   constructor(apiKey: string, private databaseId: string) {
     this.notion = new Client({ auth: apiKey });
+  }
+
+  /** Unieważnia cache listy książek — wołane po każdym zapisie zmieniającym książki. */
+  private invalidateBooksCache(): void {
+    this.booksCache = null;
   }
 
   async init(): Promise<void> {
@@ -126,10 +139,27 @@ export class NotionAdapter {
     return allBooks;
   }
 
-  async getBooksForStats(onProgress?: (count: number) => void, checkCancellation?: () => boolean): Promise<NotionBook[]> {
+  async getBooksForStats(
+    onProgress?: (count: number) => void,
+    checkCancellation?: () => boolean,
+    opts?: { cache?: boolean },
+  ): Promise<NotionBook[]> {
     // Ta sama pętla co queryAllBooks — jedna implementacja, żeby skany
-    // biblioteki/Vinted też dało się anulować w fazie pobierania z Notion
-    return this.queryAllBooks(onProgress, checkCancellation);
+    // biblioteki/Vinted też dało się anulować w fazie pobierania z Notion.
+    // `cache: true` współdzieli jedno pobranie między kolejnymi skanami
+    // (np. obie filie w „Skanuj wszystkie") — statystyki wołają bez cache.
+    if (opts?.cache && this.booksCache && this.booksCache.expiresAt > Date.now()) {
+      return this.booksCache.data;
+    }
+
+    const books = await this.queryAllBooks(onProgress, checkCancellation);
+
+    // Nie zapisuj listy urwanej przez anulowanie — byłaby niepełna.
+    const cancelled = checkCancellation ? checkCancellation() : false;
+    if (opts?.cache && !cancelled) {
+      this.booksCache = { data: books, expiresAt: Date.now() + BOOKS_CACHE_TTL_MS };
+    }
+    return books;
   }
 
   buildPropertyValue(value: string, type: string): any {
@@ -159,6 +189,7 @@ export class NotionAdapter {
         "Wydawnictwo": wydawnictwoPayload
       }
     }));
+    this.invalidateBooksCache();
   }
 
   async updateLp(pageId: string, lp: string): Promise<void> {
@@ -168,6 +199,7 @@ export class NotionAdapter {
         "Lp": { title: [{ text: { content: lp } }] }
       }
     }));
+    this.invalidateBooksCache();
   }
 
   async addTagToMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
@@ -190,7 +222,7 @@ export class NotionAdapter {
     
     // 3. Add new tag
     currentTags.push({ name: tag });
-    
+
     // 4. Update page
     await withRetry(() => this.notion.pages.update({
       page_id: pageId,
@@ -198,6 +230,7 @@ export class NotionAdapter {
         [propertyName]: { multi_select: currentTags }
       }
     }));
+    this.invalidateBooksCache();
   }
 
   async resolveDataSourceId(databaseId: string): Promise<string> {
@@ -225,6 +258,7 @@ export class NotionAdapter {
       page_id: pageId,
       properties
     }));
+    this.invalidateBooksCache();
   }
 
   async addRow(properties: any): Promise<any> {
@@ -240,6 +274,7 @@ export class NotionAdapter {
       parent: parent,
       properties
     } as any), 3, 1000, 2, false);
+    this.invalidateBooksCache();
     return response;
   }
 }

--- a/services/libraryCheckService.ts
+++ b/services/libraryCheckService.ts
@@ -27,7 +27,8 @@ export class LibraryCheckService {
     checkCancellation: () => boolean,
   ) {
     sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-    const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation);
+    // cache: kolejne filie w „Skanuj wszystkie" współdzielą jedno pobranie z Notion.
+    const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
     // Kandydaci: mają polski tytuł i NIE są już przeczytane/posiadane/w bibliotece.
     const candidates = allBooks.filter((b) => {

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -22,7 +22,8 @@ export class VintedSyncService {
   ) {
     try {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-      const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation);
+      // cache: współdziel pobranie z sąsiadującymi skanami (biblioteka/Vinted).
+      const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
       // Filter books:
       // - Have Polish title

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -121,11 +121,11 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
           animate={{ opacity: 1, height: "auto" }}
           className="space-y-3 overflow-hidden"
         >
-          {sortedBooks.map((book: any, idx: number) => {
+          {sortedBooks.map((book: any) => {
             const isExactMatch = book.extractedTitle && book.extractedTitle.toLowerCase() === book.title.toLowerCase();
             const isMarked = markedIds.has(`${library.sourceTag}:${book.id}`);
             return (
-            <div key={idx} className={`flex items-start gap-3 p-3 rounded-xl border transition-colors group/book ${
+            <div key={book.id} className={`flex items-start gap-3 p-3 rounded-xl border transition-colors group/book ${
               isExactMatch 
                 ? "bg-green-500/5 border-green-500/30 hover:border-green-500/50" 
                 : "bg-slate-950/30 border-slate-800/50 hover:border-blue-500/30"


### PR DESCRIPTION
## Propozycja 1 — jedno pobranie z Notion na „Skanuj wszystkie"

**Przedtem:** każdy skan filii (`runLibraryCheck`) na starcie robił pełne `getBooksForStats()` — pełną paginację całej bazy Notion. „Skanuj wszystkie" (2 filie) = **2× pełne pobranie**. Skan Vinted pobierał ją niezależnie jeszcze raz.

**Teraz:** opt-in cache pełnej listy książek w `NotionAdapter`:
- `getBooksForStats(…, { cache: true })` współdzieli **jedno** pobranie między kolejnymi skanami (obie filie + sąsiadujący skan Vinted).
- TTL 5 min to tylko bezpiecznik na edycje spoza aplikacji — każdy **zapis** książki (`mark-as-read`, `addRow`, `updateLp`, `updateBookPublisher`, `updatePage`) unieważnia cache przez `invalidateBooksCache()`.
- **Statystyki czytają bez cache** (`statsService` → `getBooksForStats()` bez flagi), więc „Odśwież" i `/api/stats` pozostają zawsze świeże — zero regresji względem poprzednich zmian.
- Mutujące synchronizacje dalej używają niecache'owanego `queryAllBooks` (bez zmian).

## Propozycja 3 (drobny fix) — stabilny klucz listy React

`IdentifiedLibraryItem`: `key={book.id}` zamiast `key={idx}` na sortowanej liście trafień (indeks jako klucz to antywzorzec — eliminuje ryzyko mignięcia stanu „oznaczone" na złej pozycji). Część z jednoprzebiegowym `getStats` **świadomie pominięta** (niski zysk, realne ryzyko regresji w liczbach).

## Testy

4 nowe przypadki w `notion.adapter.test.ts`: współdzielenie cache między skanami, świeżość ścieżki statystyk (bez cache), inwalidacja po zapisie (`addTagToMultiSelect`), brak cache przy anulowaniu pobierania. Całość zielona (**163**), `tsc --noEmit` czysty, `docs/library-check.md` zaktualizowane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_