### PR TITLE
UI: mały znacznik wersji aplikacji przy tytule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,9 +56,15 @@ export default function App() {
             <Database className="w-12 h-12 text-cyan-400" />
           </motion.div>
           <div className="flex-1">
-            <h1 className="text-4xl md:text-5xl font-bold tracking-tighter font-display mb-2">
+            <h1 className="text-4xl md:text-5xl font-bold tracking-tighter font-display mb-2 flex items-center justify-center md:justify-start gap-3 flex-wrap">
               <span className="bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]">
                 COGITATOR OMNISSIAH
+              </span>
+              <span
+                className="text-[10px] font-mono font-bold tracking-widest text-cyan-400/70 bg-cyan-500/10 border border-cyan-500/20 rounded-full px-2 py-0.5 self-center"
+                title="Wersja rytuału"
+              >
+                v{__APP_VERSION__}
               </span>
             </h1>
             <p className="text-slate-400 text-lg font-medium tracking-wide uppercase flex items-center justify-center md:justify-start gap-2">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// Wersja aplikacji wstrzykiwana przez Vite `define` (z package.json).
+declare const __APP_VERSION__: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "skipLibCheck": true,
     "strict": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "jsx": "react-jsx",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,14 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import {defineConfig} from 'vite';
+import {version} from './package.json';
 
 export default defineConfig(() => {
   return {
+    // Wersja aplikacji (z package.json) dostępna w kodzie klienta jako __APP_VERSION__.
+    define: {
+      __APP_VERSION__: JSON.stringify(version),
+    },
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {


### PR DESCRIPTION
## Cel

Dodanie dyskretnego oznaczenia numeru wersji aplikacji obok tytułu **„Cogitator Omnissiah"**.

## Rozwiązanie

- **Plakietka `v{wersja}`** w nagłówku (`App.tsx`) — mono, pill, akcent cyan, zawija się na wąskich ekranach.
- **Jedno źródło prawdy:** wersja pochodzi z `package.json` i jest wstrzykiwana do kodu klienta przez Vite `define` jako `__APP_VERSION__` — aktualizuje się automatycznie przy bumpie wersji, bez duplikowania stałej.
- `package.json`: `version` `0.0.0` → `1.0.0` (pierwsza oznaczona wersja).
- `tsconfig.json`: `resolveJsonModule: true` (import wersji w configu Vite); deklaracja globala w `src/vite-env.d.ts`.

## Weryfikacja

`tsc --noEmit` czysty, testy zielone (163), `npm run build` OK (frontend + `dist/server.cjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_