### PR TITLE
Skaner Vinted (UX A): oferty sortowane po cenie, kwoty + miniatury per pozycja

### DIFF
--- a/docs/vinted-scanner.md
+++ b/docs/vinted-scanner.md
@@ -10,7 +10,8 @@ Searches **vinted.pl** for physical, second-hand copies of the tracked books. Th
 - **Result parsing**: the scanner inspects the HTML for status markers and delegates item extraction to the pure `parseVintedItems(html, title, author)` in `services/vintedParser.ts` (unit-tested on captured HTML/JSON).
   - Bot/anti-scrape markers (`cloudflare`, `captcha`, "robot") → reported as `blocked`.
   - "Brak wyników" / "Nie znaleźliśmy żadnych przedmiotów" → `no_results`.
-  - Otherwise `parseVintedItems` extracts up to 5 relevant listing items (title, price, currency, url) via four cascading paths: the `data-component-name="Catalog"` JSON blob, an `"items":[…]` regex with bracket matching, `feed-grid__item` blocks, then a global `href=/items/…` regex.
+  - Otherwise `parseVintedItems` extracts up to 5 relevant listing items via four cascading paths: the `data-component-name="Catalog"` JSON blob, an `"items":[…]` regex with bracket matching, `feed-grid__item` blocks, then a global `href=/items/…` regex.
+  - **Per item**: `title`, `price` (raw string), `priceValue` (numeric, for sorting — `null` when only a placeholder like "Sprawdź"/"??" is available), `currency`, `url`, and `photo` (a catalog thumbnail URL; present only on the JSON path). `parseVintedPrice` normalizes `"25,00"` / `"12.90"` / numbers → a number, placeholders → `null`.
 
 ## 3. Reliability & Anti-Bot Pacing
 - **Timeout**: 45 000 ms per request (via a keep-alive `https.Agent`).
@@ -22,6 +23,7 @@ Searches **vinted.pl** for physical, second-hand copies of the tracked books. Th
 - **Hook**: `useVintedCheck` opens the SSE stream and renders progress, per-book search attempts, and matched listings.
 - **Trigger**: The "Skaner Artefaktów Vinted" section (Vinted tab).
 - **Output**: A `search_attempt` event per book (status + item count) plus `match` events with the found listings.
+- **Offer display** (`VintedCheckItem`): per book the offers are sorted cheapest → dearest via `sortOffersByPrice` (price-less offers sink to the end); the card header shows `od {min} zł · {count}` (`offersPriceSummary`), the cheapest offer is badged "najtańsza", and each row renders the offer thumbnail (falling back to a placeholder icon), the formatted price (`formatVintedPrice`, Polish style), and the offer title. Helpers live in `src/utils/vintedOffers.ts` (pure, unit-tested).
 
 ## 5. Notes
 - Vinted's markup and anti-bot behaviour change over time; treat the HTML parsing as best-effort and expect occasional `blocked` results from a datacenter IP.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/services/__tests__/vintedParser.test.ts
+++ b/services/__tests__/vintedParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseVintedItems } from "../vintedParser";
+import { parseVintedItems, parseVintedPrice } from "../vintedParser";
 
 // Catalog blob with &quot;-escaped JSON, as in the real page
 const catalogHtml = (json: object) =>
@@ -50,5 +50,39 @@ describe("parseVintedItems", () => {
 
   it("returns [] when nothing matches any path", () => {
     expect(parseVintedItems("<html><body>nic</body></html>", "Solaris", "Lem")).toEqual([]);
+  });
+
+  it("exposes a numeric priceValue and a photo from the catalog JSON", () => {
+    const html = catalogHtml({
+      items: { list: [{ id: 1, title: "Solaris Lem", price: { amount: "12,50", currency_code: "PLN" }, url: "/items/1", photo: { url: "https://img/1.jpg" } }] },
+    });
+    const items = parseVintedItems(html, "Solaris", "Lem");
+    expect(items[0].priceValue).toBe(12.5);
+    expect(items[0].photo).toBe("https://img/1.jpg");
+  });
+
+  it("sets priceValue to null when the price is a placeholder", () => {
+    const html = `<div class="feed-grid__item"><a href="/items/5" title="Solaris"></a></div>`;
+    const items = parseVintedItems(html, "Solaris", "Lem");
+    expect(items[0].price).toBe("Sprawdź");
+    expect(items[0].priceValue).toBeNull();
+  });
+});
+
+describe("parseVintedPrice", () => {
+  it("parses integers, decimals and comma decimals", () => {
+    expect(parseVintedPrice("15")).toBe(15);
+    expect(parseVintedPrice("12.90")).toBe(12.9);
+    expect(parseVintedPrice("25,00")).toBe(25);
+    expect(parseVintedPrice("1 200,50")).toBe(1200.5);
+    expect(parseVintedPrice(30)).toBe(30);
+  });
+
+  it("returns null for placeholders and non-numeric input", () => {
+    expect(parseVintedPrice("Sprawdź")).toBeNull();
+    expect(parseVintedPrice("??")).toBeNull();
+    expect(parseVintedPrice("")).toBeNull();
+    expect(parseVintedPrice(null)).toBeNull();
+    expect(parseVintedPrice(undefined)).toBeNull();
   });
 });

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -6,8 +6,26 @@ export interface VintedItem {
   id?: string | number;
   title: string;
   price: string | number;
+  /** Cena jako liczba (do sortowania). null, gdy nieznana (placeholder „Sprawdź"/„??"). */
+  priceValue: number | null;
   currency: string;
   url: string;
+  /** Miniatura oferty z katalogu Vinted (tylko ścieżka JSON — fallbacki HTML jej nie mają). */
+  photo?: string | null;
+}
+
+/**
+ * Normalizuje surową cenę Vinted do liczby: „15" → 15, „25,00" → 25, „12.90" → 12.9,
+ * liczba → liczba. Placeholdery („??", „Sprawdź", puste) i wartości nieliczbowe → null,
+ * żeby oferty bez ceny dało się posortować na koniec zamiast psuć porównania.
+ */
+export function parseVintedPrice(raw: string | number | null | undefined): number | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  const cleaned = raw.replace(/\s/g, "").replace(",", ".").replace(/[^0-9.]/g, "");
+  if (!cleaned) return null;
+  const n = parseFloat(cleaned);
+  return Number.isFinite(n) ? n : null;
 }
 
 /**
@@ -89,12 +107,16 @@ export function parseVintedItems(html: string, title: string, author: string): V
       const hasAuthor = searchAuthor && itemTitle.includes(searchAuthor);
 
       if (hasTitle || hasAuthor) {
+        const rawPrice = item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || "??";
+        const photo = item.photo?.url || item.photo?.thumbnails?.[0]?.url || item.photos?.[0]?.url || null;
         items.push({
           id: item.id,
           title: item.title || itemTitle,
-          price: item.price?.amount || item.total_item_price?.amount || item.price?.amount_decimal || "??",
+          price: rawPrice,
+          priceValue: parseVintedPrice(rawPrice),
           currency: item.price?.currency_code || item.currency || "PLN",
-          url: item.url ? (item.url.startsWith('http') ? item.url : `https://www.vinted.pl${item.url}`) : `https://www.vinted.pl/items/${item.id}`
+          url: item.url ? (item.url.startsWith('http') ? item.url : `https://www.vinted.pl${item.url}`) : `https://www.vinted.pl/items/${item.id}`,
+          photo
         });
       }
     }
@@ -115,10 +137,12 @@ export function parseVintedItems(html: string, title: string, author: string): V
         if (urlMatch && titleMatch) {
           const itemTitle = titleMatch[1];
           if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
+            const rawPrice = priceMatch ? priceMatch[1] : "Sprawdź";
             items.push({
               title: itemTitle,
               url: `https://www.vinted.pl${urlMatch[1]}`,
-              price: priceMatch ? priceMatch[1] : "Sprawdź",
+              price: rawPrice,
+              priceValue: parseVintedPrice(rawPrice),
               currency: priceMatch ? priceMatch[2] : "PLN"
             });
           }
@@ -135,7 +159,7 @@ export function parseVintedItems(html: string, title: string, author: string): V
       const itemUrl = `https://www.vinted.pl${match[1]}`;
       const itemTitle = match[2];
       if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
-        items.push({ title: itemTitle, url: itemUrl, price: "Sprawdź", currency: "PLN" });
+        items.push({ title: itemTitle, url: itemUrl, price: "Sprawdź", priceValue: null, currency: "PLN" });
       }
     }
   }

--- a/src/__tests__/vintedOffers.test.ts
+++ b/src/__tests__/vintedOffers.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { sortOffersByPrice, offersPriceSummary, formatVintedPrice } from "../utils/vintedOffers";
+
+describe("sortOffersByPrice", () => {
+  it("sorts ascending and pushes price-less offers to the end", () => {
+    const offers = [
+      { priceValue: 18, id: "a" },
+      { priceValue: null, id: "b" },
+      { priceValue: 5, id: "c" },
+      { priceValue: 12, id: "d" },
+    ];
+    expect(sortOffersByPrice(offers).map((o) => o.id)).toEqual(["c", "d", "a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const offers = [{ priceValue: 3 }, { priceValue: 1 }];
+    const copy = [...offers];
+    sortOffersByPrice(offers);
+    expect(offers).toEqual(copy);
+  });
+});
+
+describe("offersPriceSummary", () => {
+  it("returns the minimum known price and the total count", () => {
+    expect(offersPriceSummary([{ priceValue: 18 }, { priceValue: 5 }, { priceValue: null }]))
+      .toEqual({ min: 5, count: 3 });
+  });
+
+  it("returns min=null when no offer has a price", () => {
+    expect(offersPriceSummary([{ priceValue: null }, {}])).toEqual({ min: null, count: 2 });
+  });
+});
+
+describe("formatVintedPrice", () => {
+  it("formats a known price in the Polish style", () => {
+    expect(formatVintedPrice(12.5, "PLN")).toBe("12,50 zł");
+    expect(formatVintedPrice(30, "zł")).toBe("30,00 zł");
+  });
+
+  it("falls back to a label when the price is unknown", () => {
+    expect(formatVintedPrice(null)).toBe("cena w ofercie");
+    expect(formatVintedPrice(undefined)).toBe("cena w ofercie");
+  });
+});

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle } from "lucide-react";
+import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle, BookImage } from "lucide-react";
 import { formatETA } from "../../utils/time";
 import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
+import { sortOffersByPrice, offersPriceSummary, formatVintedPrice } from "../../utils/vintedOffers";
 
 interface VintedCheckItemProps {
   results: VintedResult[];
@@ -154,7 +155,12 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
           animate={{ opacity: 1, height: "auto" }}
           className="grid grid-cols-1 lg:grid-cols-2 gap-4 overflow-hidden"
         >
-          {results.map((result, idx) => (
+          {results.map((result, idx) => {
+            const offers = sortOffersByPrice(result.vintedItems);
+            const { min, count } = offersPriceSummary(offers);
+            // Indeks pierwszej (najtańszej) oferty ze znaną ceną — do wyróżnienia.
+            const cheapestIdx = offers.findIndex((o) => o.priceValue !== null && o.priceValue !== undefined);
+            return (
             <div key={idx} className="flex flex-col gap-3 p-5 rounded-3xl border border-rose-500/10 bg-slate-900/40 group/book hover:border-rose-500/30 transition-all hover:shadow-lg hover:shadow-rose-500/5">
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
@@ -163,33 +169,70 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                   </div>
                   <div className="text-[10px] text-slate-500 uppercase font-bold tracking-[0.2em]">{result.author}</div>
                 </div>
-                <a 
-                  href={result.searchUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="p-2 rounded-xl bg-slate-800/50 text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 transition-all"
-                  title="Otwórz wyszukiwanie Vinted"
-                >
-                  <ExternalLink className="w-4 h-4" />
-                </a>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="px-2.5 py-1 rounded-full bg-rose-500/10 border border-rose-500/20 text-[11px] font-bold text-rose-300 whitespace-nowrap">
+                    {min !== null ? `od ${formatVintedPrice(min)}` : `${count} ${count === 1 ? "oferta" : "ofert"}`}
+                    {min !== null && <span className="text-rose-400/50"> · {count}</span>}
+                  </span>
+                  <a
+                    href={result.searchUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-2 rounded-xl bg-slate-800/50 text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 transition-all"
+                    title="Otwórz wyszukiwanie Vinted"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                </div>
               </div>
-              
-              <div className="flex flex-wrap gap-2 mt-2">
-                {result.vintedItems.map((item, i) => (
-                  <a 
+
+              <div className="flex flex-col gap-1.5 mt-1">
+                {offers.map((item, i) => {
+                  const isCheapest = i === cheapestIdx;
+                  return (
+                  <a
                     key={i}
                     href={item.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-2 px-3 py-2 rounded-xl bg-rose-500/5 border border-rose-500/10 text-xs font-bold text-rose-400 hover:bg-rose-500/20 hover:border-rose-500/30 transition-all group/item"
+                    className={`flex items-center gap-3 px-3 py-2 rounded-xl border transition-all group/item ${
+                      isCheapest
+                        ? "bg-emerald-500/10 border-emerald-500/30 hover:bg-emerald-500/15"
+                        : "bg-rose-500/5 border-rose-500/10 hover:bg-rose-500/15 hover:border-rose-500/30"
+                    }`}
                   >
-                    <span className="group-hover/item:scale-110 transition-transform">{item.price} {item.currency}</span>
-                    <ShoppingCart className="w-3 h-3 opacity-50 group-hover/item:opacity-100" />
+                    {item.photo ? (
+                      <img
+                        src={item.photo}
+                        alt=""
+                        loading="lazy"
+                        onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+                        className="w-9 h-9 rounded-lg object-cover border border-slate-700/50 shrink-0"
+                      />
+                    ) : (
+                      <div className="w-9 h-9 rounded-lg bg-slate-800/50 border border-slate-700/40 flex items-center justify-center shrink-0">
+                        <BookImage className="w-4 h-4 text-slate-600" />
+                      </div>
+                    )}
+
+                    <div className="flex-1 min-w-0">
+                      <div className={`text-sm font-bold ${isCheapest ? "text-emerald-300" : "text-rose-300"}`}>
+                        {formatVintedPrice(item.priceValue, item.currency)}
+                      </div>
+                      <div className="text-[10px] text-slate-500 truncate">{item.title}</div>
+                    </div>
+
+                    {isCheapest && (
+                      <span className="px-2 py-0.5 rounded-md bg-emerald-500/20 text-emerald-400 text-[9px] font-bold uppercase tracking-widest shrink-0">
+                        najtańsza
+                      </span>
+                    )}
+                    <ShoppingCart className={`w-3.5 h-3.5 shrink-0 opacity-50 group-hover/item:opacity-100 ${isCheapest ? "text-emerald-400" : "text-rose-400"}`} />
                   </a>
-                ))}
+                )})}
               </div>
             </div>
-          ))}
+          )})}
         </motion.div>
       )}
       

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -11,8 +11,10 @@ export interface VintedResult {
     id?: string;
     title: string;
     price: string | number;
+    priceValue?: number | null;
     currency: string;
     url: string;
+    photo?: string | null;
   }[];
 }
 

--- a/src/utils/vintedOffers.ts
+++ b/src/utils/vintedOffers.ts
@@ -1,0 +1,44 @@
+// Pomocniki prezentacji ofert Vinted (czyste, testowalne): sortowanie po cenie
+// rosnąco (oferty bez ceny na końcu), zakres cen do nagłówka karty i formatowanie
+// kwoty w polskim stylu.
+
+export interface OfferLike {
+  priceValue?: number | null;
+  currency?: string;
+}
+
+/** Waluta do wyświetlenia: PLN → „zł", w innym wypadku kod bez zmian. */
+function currencyLabel(currency?: string): string {
+  if (!currency) return "zł";
+  const c = currency.trim().toUpperCase();
+  return c === "PLN" || c === "ZŁ" ? "zł" : currency;
+}
+
+/** „12,00 zł" dla znanej ceny; „cena w ofercie", gdy nieznana (placeholder). */
+export function formatVintedPrice(value: number | null | undefined, currency?: string): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "cena w ofercie";
+  return `${value.toFixed(2).replace(".", ",")} ${currencyLabel(currency)}`;
+}
+
+/**
+ * Sortuje oferty rosnąco po cenie; oferty bez ceny (priceValue == null) lądują na
+ * końcu. Zwraca NOWĄ tablicę (nie mutuje wejścia).
+ */
+export function sortOffersByPrice<T extends OfferLike>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const av = a.priceValue ?? null;
+    const bv = b.priceValue ?? null;
+    if (av === null && bv === null) return 0;
+    if (av === null) return 1;
+    if (bv === null) return -1;
+    return av - bv;
+  });
+}
+
+/** Minimalna cena (lub null, gdy żadna oferta nie ma ceny) i liczba ofert. */
+export function offersPriceSummary(items: OfferLike[]): { min: number | null; count: number } {
+  const prices = items
+    .map((i) => i.priceValue)
+    .filter((v): v is number => v !== null && v !== undefined && Number.isFinite(v));
+  return { min: prices.length ? Math.min(...prices) : null, count: items.length };
+}


### PR DESCRIPTION
## Cel

Zamiast rzędu identycznych pigułek „Sprawdź PLN", karta książki w skanerze Vinted pokazuje teraz czytelną, **posortowaną po cenie** listę ofert z kwotami i miniaturami (opcja A z propozycji).

## Parser (`services/vintedParser.ts`)

- **`parseVintedPrice()`** — normalizuje cenę do liczby: `"25,00"` → `25`, `"12.90"` → `12.9`, liczba → liczba; placeholdery (`"Sprawdź"`, `"??"`, puste) → `null` (żeby oferty bez ceny dało się posortować na koniec, nie psując porównań).
- **`VintedItem`** zyskuje `priceValue` (do sortowania) oraz **`photo`** — miniatura z katalogowego JSON Vinted (bez dodatkowych żądań; fallbacki HTML jej nie mają → ikona zastępcza).

## Front

- **`src/utils/vintedOffers.ts`** (czyste, testowalne): `sortOffersByPrice` (rosnąco, oferty bez ceny na końcu), `offersPriceSummary` (min + liczba), `formatVintedPrice` (polski styl `„12,00 zł"` / `„cena w ofercie"`).
- **`VintedCheckItem`**: nagłówek karty **`od {min} zł · {n}`**, oferty **od najtańszej**, najtańsza wyróżniona (badge „najtańsza" + zielony akcent); każdy wiersz: **miniatura** (lub ikona) + **kwota** + tytuł oferty, linkuje do aukcji.

## Uwaga o danych

Sortowanie/kwoty działają tam, gdzie parser trafia ścieżką JSON (obecnie częsta — mniej blokad bota). Gdy Vinted odda uboższy HTML (ścieżka fallback), oferta nie ma ceny ani miniatury — wtedy wyświetla się „cena w ofercie" i ikona zastępcza, i taka oferta ląduje na końcu listy.

## Pozostałe

Zawiera też drobny chore: synchronizację `version` w `package-lock.json` (`0.0.0` → `1.0.0`) po bumpie z PR #44.

## Weryfikacja

`tsc --noEmit` czysty, testy zielone (**173**, +10: normalizacja ceny, `priceValue`/`photo` w parserze, util sort/summary/format), `npm run build` OK. Docs `vinted-scanner.md` zaktualizowane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_