### PR TITLE
Skaner Vinted: odzysk ceny z opisu oferty + mocniejsza ekspozycja ceny

### DIFF
--- a/services/__tests__/vintedParser.test.ts
+++ b/services/__tests__/vintedParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseVintedItems, parseVintedPrice } from "../vintedParser";
+import { parseVintedItems, parseVintedPrice, extractPriceFromText } from "../vintedParser";
 
 // Catalog blob with &quot;-escaped JSON, as in the real page
 const catalogHtml = (json: object) =>
@@ -61,11 +61,31 @@ describe("parseVintedItems", () => {
     expect(items[0].photo).toBe("https://img/1.jpg");
   });
 
-  it("sets priceValue to null when the price is a placeholder", () => {
+  it("recovers the item price from the offer title attribute when structural price is missing", () => {
+    // Realny przypadek: fallback HTML łapie title aukcji z ceną w opisie.
+    const html = `<a href="/items/5" title="Pokrzywa i kość, T. Kingfisher, Stan: Bardzo dobry, 12,00 zł, 18,65 zł"></a>`;
+    const items = parseVintedItems(html, "Pokrzywa i kość", "Kingfisher");
+    expect(items).toHaveLength(1);
+    expect(items[0].priceValue).toBe(12); // niższa z pary = cena przedmiotu
+    expect(items[0].currency).toBe("zł");
+  });
+
+  it("keeps priceValue null when no price is present anywhere", () => {
     const html = `<div class="feed-grid__item"><a href="/items/5" title="Solaris"></a></div>`;
     const items = parseVintedItems(html, "Solaris", "Lem");
-    expect(items[0].price).toBe("Sprawdź");
     expect(items[0].priceValue).toBeNull();
+  });
+});
+
+describe("extractPriceFromText", () => {
+  it("returns the lowest zł/PLN amount found in the text", () => {
+    expect(extractPriceFromText("Stan: Bardzo dobry, 15.00 zł, 18.65 zł")).toBe(15);
+    expect(extractPriceFromText("cena 9,90 PLN")).toBe(9.9);
+  });
+
+  it("returns null when no price token is present", () => {
+    expect(extractPriceFromText("Pokrzywa i kość, T. Kingfisher")).toBeNull();
+    expect(extractPriceFromText("")).toBeNull();
   });
 });
 

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -164,5 +164,36 @@ export function parseVintedItems(html: string, title: string, author: string): V
     }
   }
 
+  // Ostatnia deska ratunku dla ceny: ścieżki HTML łapią atrybut title aukcji,
+  // który Vinted buduje jako „Tytuł, Marka, Stan: …, {cena} zł, {cena z ochroną} zł".
+  // Gdy nie mamy ceny strukturalnej, wyłuskujemy ją z tego tekstu (niższa z dwóch
+  // = cena przedmiotu, wyższa = z ochroną kupującego).
+  for (const item of items) {
+    if (item.priceValue === null) {
+      const fromText = extractPriceFromText(item.title);
+      if (fromText !== null) {
+        item.priceValue = fromText;
+        item.currency = "zł";
+      }
+    }
+  }
+
   return items;
+}
+
+/**
+ * Wyłuskuje najniższą kwotę „NN[.,]NN zł/PLN" z tekstu (np. z atrybutu title
+ * oferty). Zwraca cenę przedmiotu (niższą z pary cena/total) albo null.
+ */
+export function extractPriceFromText(text: string): number | null {
+  if (!text) return null;
+  // Uwaga: bez \b po „zł" — „ł" to nie-słowny znak, więc granica słowa nie zachodzi.
+  const re = /(\d+(?:[.,]\d+)?)\s*(?:zł|PLN)/gi;
+  const values: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const v = parseVintedPrice(m[1]);
+    if (v !== null) values.push(v);
+  }
+  return values.length ? Math.min(...values) : null;
 }

--- a/src/__tests__/vintedOffers.test.ts
+++ b/src/__tests__/vintedOffers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sortOffersByPrice, offersPriceSummary, formatVintedPrice } from "../utils/vintedOffers";
+import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle } from "../utils/vintedOffers";
 
 describe("sortOffersByPrice", () => {
   it("sorts ascending and pushes price-less offers to the end", () => {
@@ -40,5 +40,20 @@ describe("formatVintedPrice", () => {
   it("falls back to a label when the price is unknown", () => {
     expect(formatVintedPrice(null)).toBe("cena w ofercie");
     expect(formatVintedPrice(undefined)).toBe("cena w ofercie");
+  });
+});
+
+describe("cleanOfferTitle", () => {
+  it("decodes entities and strips the condition/price tail", () => {
+    expect(cleanOfferTitle('&quot;Pokrzywa i Kość&quot;, T. Kingfisher, Stan: Bardzo dobry, 12,00 zł, 18,65 zł'))
+      .toBe('"Pokrzywa i Kość", T. Kingfisher');
+  });
+
+  it("strips a trailing price even without a condition marker", () => {
+    expect(cleanOfferTitle("Solaris - Lem, 15.00 zł")).toBe("Solaris - Lem");
+  });
+
+  it("leaves a clean title untouched", () => {
+    expect(cleanOfferTitle("Pokrzywa i kość")).toBe("Pokrzywa i kość");
   });
 });

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle, BookImage } from "lucide-react";
 import { formatETA } from "../../utils/time";
 import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
-import { sortOffersByPrice, offersPriceSummary, formatVintedPrice } from "../../utils/vintedOffers";
+import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle } from "../../utils/vintedOffers";
 
 interface VintedCheckItemProps {
   results: VintedResult[];
@@ -189,6 +189,8 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
               <div className="flex flex-col gap-1.5 mt-1">
                 {offers.map((item, i) => {
                   const isCheapest = i === cheapestIdx;
+                  const hasPrice = item.priceValue !== null && item.priceValue !== undefined;
+                  const offerTitle = cleanOfferTitle(item.title);
                   return (
                   <a
                     key={i}
@@ -216,18 +218,19 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                     )}
 
                     <div className="flex-1 min-w-0">
-                      <div className={`text-sm font-bold ${isCheapest ? "text-emerald-300" : "text-rose-300"}`}>
-                        {formatVintedPrice(item.priceValue, item.currency)}
-                      </div>
-                      <div className="text-[10px] text-slate-500 truncate">{item.title}</div>
+                      <div className="text-[11px] text-slate-400 truncate">{offerTitle || item.title}</div>
                     </div>
 
-                    {isCheapest && (
-                      <span className="px-2 py-0.5 rounded-md bg-emerald-500/20 text-emerald-400 text-[9px] font-bold uppercase tracking-widest shrink-0">
-                        najtańsza
-                      </span>
-                    )}
-                    <ShoppingCart className={`w-3.5 h-3.5 shrink-0 opacity-50 group-hover/item:opacity-100 ${isCheapest ? "text-emerald-400" : "text-rose-400"}`} />
+                    {/* Cena — najmocniej eksponowana, stała szerokość, nie zawija się */}
+                    <div className={`shrink-0 text-right tabular-nums font-bold leading-none ${
+                      hasPrice ? (isCheapest ? "text-emerald-300 text-lg" : "text-rose-300 text-base") : "text-slate-500 text-[11px] font-medium italic"
+                    }`}>
+                      {hasPrice ? formatVintedPrice(item.priceValue, item.currency) : "cena w ofercie"}
+                      {isCheapest && hasPrice && (
+                        <div className="text-[8px] text-emerald-400/80 uppercase tracking-widest font-bold mt-0.5">najtańsza</div>
+                      )}
+                    </div>
+                    <ShoppingCart className={`w-3.5 h-3.5 shrink-0 opacity-40 group-hover/item:opacity-100 ${isCheapest ? "text-emerald-400" : "text-rose-400"}`} />
                   </a>
                 )})}
               </div>

--- a/src/utils/vintedOffers.ts
+++ b/src/utils/vintedOffers.ts
@@ -35,6 +35,23 @@ export function sortOffersByPrice<T extends OfferLike>(items: T[]): T[] {
   });
 }
 
+/**
+ * Czyści tytuł oferty do wyświetlenia: rozkodowuje encje HTML i odcina „ogon"
+ * z opisu Vinted (kondycja „, Stan: …" oraz doklejone kwoty), bo ścieżki HTML
+ * parsera biorą atrybut title aukcji z całym opisem i ceną w środku.
+ */
+export function cleanOfferTitle(title: string): string {
+  let t = (title || "")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+  t = t.replace(/,\s*Stan:.*$/i, "");                 // odetnij kondycję i wszystko po niej
+  t = t.replace(/,?\s*\d+[.,]\d+\s*(?:zł|PLN).*$/i, ""); // awaryjnie: doklejony ogon cenowy
+  return t.trim();
+}
+
 /** Minimalna cena (lub null, gdy żadna oferta nie ma ceny) i liczba ofert. */
 export function offersPriceSummary(items: OfferLike[]): { min: number | null; count: number } {
   const prices = items


### PR DESCRIPTION
## Problem (z produkcji)

Na zrzucie widać, że skaner trafia **ścieżką fallback HTML** (nie JSON): cena strukturalna jest niedostępna, więc `priceValue` = `null` → nagłówek pokazuje „cena w ofercie", a realna cena tkwi w **atrybucie `title` aukcji** (`„…, Stan: Bardzo dobry, 12,00 zł, 18,65 zł"`), który leciał jako długi, ucinany podtytuł. Brak też miniatur (ta ścieżka ich nie ma).

## Parser (`services/vintedParser.ts`)

- **`extractPriceFromText()`** — wyłuskuje najniższą kwotę `„NN[.,]NN zł/PLN"` z tekstu (niższa z pary = **cena przedmiotu**, wyższa = z ochroną kupującego). Po wszystkich ścieżkach: gdy `priceValue == null`, uzupełniamy je z `title` oferty → cena znów jest liczbą (działa sortowanie i `od {min} zł`).
- **Fix regexu:** usunięty `\b` po `„zł"` — `ł` to znak nie-słowny, więc granica słowa po „zł" nigdy nie zachodziła (`„PLN"` łapało, `„zł"` nie).

## Front

- **`cleanOfferTitle()`** (`vintedOffers.ts`) — rozkodowuje encje (`&quot;` → `"` itd.) i odcina ogon `„, Stan: …"` oraz doklejone kwoty, więc podtytuł to czysta nazwa oferty.
- **`VintedCheckItem`** — **cena najmocniej wyeksponowana**: duża, wyrównana do prawej, `tabular-nums`, nie zawija się; tytuł oferty jako drobny podtytuł; „najtańsza" pod ceną. `„cena w ofercie"` tylko gdy naprawdę brak jakiejkolwiek kwoty.

## Miniatury

Na ścieżce fallback Vinted nie podaje URL-a zdjęcia, więc miniatura zostaje placeholderem (ikona). Realne miniatury pojawiają się, gdy parser trafi ścieżką JSON (wcześniejszy PR).

## Weryfikacja

6 nowych testów (`extractPriceFromText`, odzysk ceny w parserze, `cleanOfferTitle`). Całość zielona (**179**), `tsc` czysty, `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_