### PR TITLE
Skaner Vinted: dynamiczne sortowanie kart po najtańszej ofercie (z animacją)

### DIFF
--- a/src/__tests__/vintedOffers.test.ts
+++ b/src/__tests__/vintedOffers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle } from "../utils/vintedOffers";
+import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle, sortResultsByCheapest } from "../utils/vintedOffers";
 
 describe("sortOffersByPrice", () => {
   it("sorts ascending and pushes price-less offers to the end", () => {
@@ -40,6 +40,30 @@ describe("formatVintedPrice", () => {
   it("falls back to a label when the price is unknown", () => {
     expect(formatVintedPrice(null)).toBe("cena w ofercie");
     expect(formatVintedPrice(undefined)).toBe("cena w ofercie");
+  });
+});
+
+describe("sortResultsByCheapest", () => {
+  const book = (id: string, prices: (number | null)[]) => ({
+    id,
+    vintedItems: prices.map((p) => ({ priceValue: p })),
+  });
+
+  it("orders books by their cheapest offer and pushes price-less books last", () => {
+    const results = [
+      book("A", [30, 22]),
+      book("B", [null]),
+      book("C", [8, 40]),
+      book("D", [15]),
+    ];
+    expect(sortResultsByCheapest(results).map((r) => r.id)).toEqual(["C", "D", "A", "B"]);
+  });
+
+  it("does not mutate the input", () => {
+    const results = [book("A", [5]), book("B", [1])];
+    const copy = [...results];
+    sortResultsByCheapest(results);
+    expect(results).toEqual(copy);
   });
 });
 

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle, BookImage } from "lucide-react";
 import { formatETA } from "../../utils/time";
 import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
-import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle } from "../../utils/vintedOffers";
+import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle, sortResultsByCheapest } from "../../utils/vintedOffers";
 
 interface VintedCheckItemProps {
   results: VintedResult[];
@@ -155,13 +155,13 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
           animate={{ opacity: 1, height: "auto" }}
           className="grid grid-cols-1 lg:grid-cols-2 gap-4 overflow-hidden"
         >
-          {results.map((result, idx) => {
+          {sortResultsByCheapest(results).map((result) => {
             const offers = sortOffersByPrice(result.vintedItems);
             const { min, count } = offersPriceSummary(offers);
             // Indeks pierwszej (najtańszej) oferty ze znaną ceną — do wyróżnienia.
             const cheapestIdx = offers.findIndex((o) => o.priceValue !== null && o.priceValue !== undefined);
             return (
-            <div key={idx} className="flex flex-col gap-3 p-5 rounded-3xl border border-rose-500/10 bg-slate-900/40 group/book hover:border-rose-500/30 transition-all hover:shadow-lg hover:shadow-rose-500/5">
+            <motion.div layout key={result.id} transition={{ type: "spring", stiffness: 400, damping: 40 }} className="flex flex-col gap-3 p-5 rounded-3xl border border-rose-500/10 bg-slate-900/40 group/book hover:border-rose-500/30 transition-all hover:shadow-lg hover:shadow-rose-500/5">
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <div className="text-base font-bold text-slate-100 leading-tight mb-1 truncate group-hover/book:text-rose-400 transition-colors">
@@ -234,7 +234,7 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                   </a>
                 )})}
               </div>
-            </div>
+            </motion.div>
           )})}
         </motion.div>
       )}

--- a/src/utils/vintedOffers.ts
+++ b/src/utils/vintedOffers.ts
@@ -59,3 +59,19 @@ export function offersPriceSummary(items: OfferLike[]): { min: number | null; co
     .filter((v): v is number => v !== null && v !== undefined && Number.isFinite(v));
   return { min: prices.length ? Math.min(...prices) : null, count: items.length };
 }
+
+/**
+ * Sortuje KARTY wyników po najtańszej ofercie każdej książki (rosnąco). Książki
+ * bez żadnej znanej ceny lądują na końcu. Zwraca NOWĄ tablicę (nie mutuje).
+ * Używane do dynamicznego układania wyników w trakcie skanu.
+ */
+export function sortResultsByCheapest<T extends { vintedItems: OfferLike[] }>(results: T[]): T[] {
+  return [...results].sort((a, b) => {
+    const am = offersPriceSummary(a.vintedItems).min;
+    const bm = offersPriceSummary(b.vintedItems).min;
+    if (am === null && bm === null) return 0;
+    if (am === null) return 1;
+    if (bm === null) return -1;
+    return am - bm;
+  });
+}


### PR DESCRIPTION
## Cel

Wyniki (karty książek) były w kolejności skanu. Teraz układają się **od najtańszej znalezionej pozycji** — a że trafienia napływają strumieniowo (SSE), sortowanie jest **na żywo**.

## Wyzwanie, które wskazałeś

Pozycje o różnej kwocie pojawiają się w trakcie skanu — więc twarde re-sortowanie powodowałoby „skakanie" kart. Rozwiązanie: karta to `motion.div` z `layout` i **stabilnym `key={result.id}`**, więc przy zmianie kolejności Framer Motion robi płynny **FLIP** (spring) — karty przesuwają się na swoje miejsce, gdy pojawi się tańsza pozycja.

## Zmiany

- **`src/utils/vintedOffers.ts`** — `sortResultsByCheapest()` (czyste, testowalne): sortuje karty po `offersPriceSummary().min` rosnąco; książki bez znanej ceny na końcu; nowa tablica (bez mutacji).
- **`VintedCheckItem`** — mapowanie po `sortResultsByCheapest(results)`; karta jako `motion.div` z `layout` + `key={result.id}` (spring). Wewnątrz karty oferty dalej sortowane od najtańszej.

## Weryfikacja

Test `sortResultsByCheapest` (kolejność wg najtańszej + brak mutacji). Całość zielona (**181**), `tsc` czysty, `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_