### PR TITLE
Revert #48 — przywróć poprzednią konfigurację skanera Vinted

### DIFF
--- a/docs/vinted-scanner.md
+++ b/docs/vinted-scanner.md
@@ -14,16 +14,13 @@ Searches **vinted.pl** for physical, second-hand copies of the tracked books. Th
   - **Per item**: `title`, `price` (raw string), `priceValue` (numeric, for sorting — `null` when only a placeholder like "Sprawdź"/"??" is available), `currency`, `url`, and `photo` (a catalog thumbnail URL; present only on the JSON path). `parseVintedPrice` normalizes `"25,00"` / `"12.90"` / numbers → a number, placeholders → `null`.
 
 ## 3. Reliability & Anti-Bot Pacing
-- **Per-book scan** is factored into `scanBook()` (reused by the main loop and the retry pass), returning a status (`success` / `no_results` / `blocked` / `error`).
-- **Timeout**: 15 000 ms per request, up to 2 attempts (`withRetry`, idempotent GET — retries timeouts/5xx/429, **not** 403). Shorter than before so a hung title yields the loop quickly instead of holding the stream silent.
-- **Throttling**: 3–5 s delay (with jitter) between books — applied on **every** path, including no-results, to avoid the request bursts that trigger Cloudflare blocks.
-- **Retry pass**: titles that came back `blocked` (bot/Cloudflare markers) or `error` are collected and retried **once** after the main loop, with a longer 8–12 s cooldown (Cloudflare blocks are often transient). Capped at `RETRY_PASS_LIMIT` (25) so a hard-flagged IP doesn't stretch the scan indefinitely; the remainder is reported in a status event. From a datacenter/Render IP some titles will stay blocked — the pass improves recovery, it can't guarantee it.
+- **Timeout**: 45 000 ms per request (via a keep-alive `https.Agent`).
+- **Throttling**: 3–5 s delay (with jitter) between books — applied on **every** path, including the no-results case, to avoid the request bursts that trigger Cloudflare blocks.
 - **429 handling**: On HTTP 429 waits ~5 s before continuing; 403 is surfaced as a Cloudflare block.
-- **No hard lifecycle**: there is no self-kill timer. A scan ends only when all candidates are done, the user stops it, or the **client disconnects** (which cancels the task server-side). The client's stall watchdog is what would disconnect on a truly silent stream — see §4.
 - **Cancellation**: Cooperative — checks the cancellation token each iteration and reports `cancelled: true` on the `complete` event when stopped.
 
 ## 4. Frontend Integration
-- **Hook**: `useVintedCheck` opens the SSE stream and renders progress, per-book search attempts, and matched listings. Its stall watchdog is set to **90 s** (vs. the 30 s default) because the scan has long inherent pauses; the server's 5 s keepalive resets it on a healthy connection, so it only fires on a genuinely dead/buffered stream.
+- **Hook**: `useVintedCheck` opens the SSE stream and renders progress, per-book search attempts, and matched listings.
 - **Trigger**: The "Skaner Artefaktów Vinted" section (Vinted tab).
 - **Output**: A `search_attempt` event per book (status + item count) plus `match` events with the found listings.
 - **Offer display** (`VintedCheckItem`): per book the offers are sorted cheapest → dearest via `sortOffersByPrice` (price-less offers sink to the end); the card header shows `od {min} zł · {count}` (`offersPriceSummary`), the cheapest offer is badged "najtańsza", and each row renders the offer thumbnail (falling back to a placeholder icon), the formatted price (`formatVintedPrice`, Polish style), and the offer title. Helpers live in `src/utils/vintedOffers.ts` (pure, unit-tested).

--- a/services/__tests__/vintedSyncService.test.ts
+++ b/services/__tests__/vintedSyncService.test.ts
@@ -83,27 +83,6 @@ describe('VintedSyncService', () => {
     expect(complete.result.results).toHaveLength(0);
   });
 
-  it('retries a bot-blocked title in a second pass and can recover a match', async () => {
-    const notion = makeNotion([{ id: '1', plTitle: 'Solaris', author: 'Lem', zrodlo: [] }]);
-    // 1st pass: Cloudflare block; 2nd pass: real catalog with a match.
-    mockedGet
-      .mockResolvedValueOnce({ data: '<html>cloudflare captcha robot</html>' })
-      .mockResolvedValueOnce({
-        data: CATALOG_HTML({ items: { list: [{ id: 9, title: 'Solaris Lem', price: { amount: '10', currency_code: 'PLN' }, url: '/items/9' }] } }),
-      });
-
-    const svc = new VintedSyncService(notion);
-    await svc.runVintedCheck(sendEvent, never);
-
-    const events = sendEvent.mock.calls.map((c: any) => c[0]);
-    expect(events.some((e: any) => e.type === 'search_attempt' && e.result.status === 'blocked')).toBe(true);
-    expect(mockedGet).toHaveBeenCalledTimes(2); // main pass + retry pass
-    const match = events.find((e: any) => e.type === 'match');
-    expect(match?.result.id).toBe('1');
-    const complete = events.find((e: any) => e.type === 'complete');
-    expect(complete.result.results).toHaveLength(1);
-  });
-
   it('excludes owned/read books from the candidate set', async () => {
     const notion = makeNotion([
       { id: '1', plTitle: 'Solaris', author: 'Lem', zrodlo: ['Posiadam'] },

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -8,14 +8,6 @@ import { parseVintedItems } from "./vintedParser";
 
 const log = createLogger("VintedScan");
 
-const REQUEST_TIMEOUT = 15000;
-const MAX_RETRIES = 2;
-// Ile zablokowanych/błędnych pozycji ponawiamy w drugim przejściu (żeby nie
-// wydłużać skanu w nieskończoność, gdy IP zostało twardo oflagowane).
-const RETRY_PASS_LIMIT = 25;
-
-const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
 /**
  * Skaner ofert na Vinted (bezpośredni scraper HTML — NIE AI). Dla każdej książki,
  * której jeszcze nie posiadamy, wyszukuje oferty w katalogu Vinted i emituje
@@ -46,9 +38,6 @@ export class VintedSyncService {
 
       const results: any[] = [];
       const httpsAgent = createScrapingAgent();
-      // Pozycje, które padły blokadą bota / błędem — bloki Cloudflare bywają
-      // przejściowe, więc próbujemy je jeszcze raz po głównym przejściu.
-      const retryQueue: any[] = [];
 
       for (let i = 0; i < candidates.length; i++) {
         if (checkCancellation()) {
@@ -56,43 +45,134 @@ export class VintedSyncService {
           break;
         }
         const book = candidates[i];
+        const title = book.plTitle;
+        const searchText = `${title} ${book.author || ""}`.trim();
+
+        const headers = {
+          'User-Agent': getRandomUserAgent(),
+          'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+          'Referer': 'https://www.vinted.pl/',
+          'Upgrade-Insecure-Requests': '1',
+          'Sec-Fetch-Dest': 'document',
+          'Sec-Fetch-Mode': 'navigate',
+          'Sec-Fetch-Site': 'none',
+          'Sec-Fetch-User': '?1',
+          'Accept-Encoding': 'gzip, deflate, br',
+          'Connection': 'keep-alive',
+          'Cache-Control': 'max-age=0',
+        };
+
         sendEvent({
           type: "progress",
-          message: `Sprawdzanie Vinted: ${book.plTitle} ${book.author || ""}`.trim() + ` (${i + 1}/${candidates.length})`,
+          message: `Sprawdzanie Vinted: ${searchText} (${i + 1}/${candidates.length})`,
           current: i + 1,
-          total: candidates.length,
+          total: candidates.length
         });
 
-        const status = await this.scanBook(book, httpsAgent, results, sendEvent);
-        if (status === "blocked" || status === "error") retryQueue.push(book);
+        // Vinted Search URL
+        const url = `https://www.vinted.pl/catalog?catalog[]=2319&language_book_ids[]=6440&page=1&order=price_low_to_high&price_from=2&currency=PLN&search_text=${encodeURIComponent(searchText)}`;
 
-        // Odstęp z jitterem na każdej ścieżce — pomijanie go (np. przy braku
-        // wyników) to prosta droga do blokady.
-        await delay(3000 + Math.floor(Math.random() * 2000));
-      }
+        // Initial search attempt event
+        sendEvent({
+          type: "search_attempt",
+          result: {
+            id: book.id,
+            title: book.plTitle,
+            author: book.author,
+            url,
+            status: "pending",
+            itemCount: 0
+          }
+        });
 
-      // Druga próba dla zablokowanych/błędnych — dłuższy cooldown, tylko raz,
-      // z limitem, żeby przy twardo oflagowanym IP nie ciągnąć skanu bez końca.
-      const toRetry = retryQueue.slice(0, RETRY_PASS_LIMIT);
-      if (!checkCancellation() && toRetry.length > 0) {
-        if (retryQueue.length > RETRY_PASS_LIMIT) {
-          sendEvent({ type: "status", message: `Druga próba dla ${toRetry.length} z ${retryQueue.length} zablokowanych pozycji (limit)...` });
-        } else {
-          sendEvent({ type: "status", message: `Druga próba dla ${toRetry.length} zablokowanych pozycji...` });
-        }
-        for (let i = 0; i < toRetry.length; i++) {
-          if (checkCancellation()) break;
-          const book = toRetry[i];
-          // Dłuższy, losowy cooldown przed ponowieniem zablokowanej pozycji.
-          await delay(8000 + Math.floor(Math.random() * 4000));
+        try {
+          const response = await withRetry(async () => {
+            return await axios.get(url, {
+              httpsAgent,
+              headers,
+              timeout: 30000
+            });
+          }, 3, 4000);
+
+          const html = response.data;
+          log.info(`Odpowiedź Vinted`, { title, chars: html.length });
+
+          // Debug logging for empty results
+          if (html.includes("cloudflare") || html.includes("captcha") || html.includes("robot")) {
+            log.warn(`Vinted zablokował żądanie (wykrycie bota)`, { title });
+            sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0 }
+            });
+          }
+
+          if (html.includes("Brak wyników") || html.includes("Nie znaleźliśmy żadnych przedmiotów")) {
+            // If "Title Author" failed, maybe try just "Title" in a real app,
+            // but for now let's just log it.
+            log.info(`Brak wyników na Vinted`, { searchText });
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
+            });
+            // Odczekaj jak przy każdym innym zapytaniu — pomijanie opóźnienia
+            // przy braku wyników (częsty przypadek) to prosta droga do blokady
+            await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
+            continue;
+          }
+
+          const items = parseVintedItems(html, title, book.author || "");
+
+          if (items.length > 0) {
+            const matchResult = {
+              id: book.id,
+              title: book.plTitle,
+              author: book.author,
+              searchUrl: url,
+              vintedItems: items
+            };
+            results.push(matchResult);
+            sendEvent({ type: "match", result: matchResult });
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length }
+            });
+          } else {
+            sendEvent({
+              type: "search_attempt",
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
+            });
+          }
+        } catch (err: any) {
+          log.warn(`Błąd sprawdzania Vinted`, { title, error: err.message || "Nieznany błąd" });
           sendEvent({
-            type: "progress",
-            message: `Ponawiam (blokada): ${book.plTitle} (${i + 1}/${toRetry.length})`,
-            current: candidates.length,
-            total: candidates.length,
+            type: "search_attempt",
+            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0 }
           });
-          await this.scanBook(book, httpsAgent, results, sendEvent);
+          if (err.response?.status === 429) {
+            sendEvent({
+              type: "status",
+              message: `🛑 Vinted zablokował zapytania (429). Odczekaj chwilę...`
+            });
+            // Wait longer if blocked
+            await new Promise(resolve => setTimeout(resolve, 5000));
+          } else if (err.response?.status === 403) {
+            sendEvent({
+              type: "status",
+              message: `🛡️ Vinted zablokował dostęp (403 - Cloudflare). Próbuję dalej...`
+            });
+          } else {
+            sendEvent({
+              type: "status",
+              message: `⚠️ Błąd Vinted dla "${title}": ${err.message || "Timeout"}. Kontynuuję...`
+            });
+          }
         }
+
+        // Delay to avoid being blocked (with jitter)
+        const jitter = Math.floor(Math.random() * 2000);
+        await new Promise(resolve => setTimeout(resolve, 3000 + jitter));
       }
 
       const wasCancelled = checkCancellation();
@@ -100,91 +180,6 @@ export class VintedSyncService {
     } catch (error: any) {
       log.error("Błąd inicjalizacji Vinted", { message: error.message });
       sendEvent({ type: "error", error: `Błąd inicjalizacji Vinted: ${error.message}` });
-    }
-  }
-
-  /**
-   * Sprawdza pojedynczą książkę na Vinted i emituje zdarzenia (search_attempt,
-   * ewentualny match). Dokłada trafienie do `results`. Zwraca status wyniku, by
-   * wołający mógł dołożyć pozycję do kolejki ponowień (blocked/error).
-   */
-  private async scanBook(
-    book: any,
-    httpsAgent: any,
-    results: any[],
-    sendEvent: (data: SyncEvent) => void,
-  ): Promise<"success" | "no_results" | "blocked" | "error"> {
-    const title = book.plTitle;
-    const searchText = `${title} ${book.author || ""}`.trim();
-    const url = `https://www.vinted.pl/catalog?catalog[]=2319&language_book_ids[]=6440&page=1&order=price_low_to_high&price_from=2&currency=PLN&search_text=${encodeURIComponent(searchText)}`;
-    const headers = {
-      'User-Agent': getRandomUserAgent(),
-      'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
-      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-      'Referer': 'https://www.vinted.pl/',
-      'Upgrade-Insecure-Requests': '1',
-      'Sec-Fetch-Dest': 'document',
-      'Sec-Fetch-Mode': 'navigate',
-      'Sec-Fetch-Site': 'none',
-      'Sec-Fetch-User': '?1',
-      'Accept-Encoding': 'gzip, deflate, br',
-      'Connection': 'keep-alive',
-      'Cache-Control': 'max-age=0',
-    };
-
-    const attempt = (status: "pending" | "success" | "no_results" | "blocked" | "error", itemCount = 0) =>
-      sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status, itemCount } });
-
-    attempt("pending");
-
-    try {
-      const response = await withRetry(
-        () => axios.get(url, { httpsAgent, headers, timeout: REQUEST_TIMEOUT }),
-        MAX_RETRIES,
-        4000,
-      );
-
-      const html = response.data;
-      log.info(`Odpowiedź Vinted`, { title, chars: html.length });
-
-      if (html.includes("cloudflare") || html.includes("captcha") || html.includes("robot")) {
-        log.warn(`Vinted zablokował żądanie (wykrycie bota)`, { title });
-        sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Ponowię później...` });
-        attempt("blocked");
-        return "blocked";
-      }
-
-      if (html.includes("Brak wyników") || html.includes("Nie znaleźliśmy żadnych przedmiotów")) {
-        log.info(`Brak wyników na Vinted`, { searchText });
-        attempt("no_results");
-        return "no_results";
-      }
-
-      const items = parseVintedItems(html, title, book.author || "");
-      if (items.length > 0) {
-        // Deduplikacja (druga próba może trafić już dodaną książkę).
-        if (!results.some((r) => r.id === book.id)) {
-          results.push({ id: book.id, title, author: book.author, searchUrl: url, vintedItems: items });
-        }
-        sendEvent({ type: "match", result: { id: book.id, title, author: book.author, searchUrl: url, vintedItems: items } });
-        attempt("success", items.length);
-        return "success";
-      }
-
-      attempt("no_results");
-      return "no_results";
-    } catch (err: any) {
-      log.warn(`Błąd sprawdzania Vinted`, { title, error: err.message || "Nieznany błąd" });
-      attempt("error");
-      if (err.response?.status === 429) {
-        sendEvent({ type: "status", message: `🛑 Vinted zablokował zapytania (429). Odczekaj chwilę...` });
-        await delay(5000);
-      } else if (err.response?.status === 403) {
-        sendEvent({ type: "status", message: `🛡️ Vinted zablokował dostęp (403 - Cloudflare). Ponowię później...` });
-      } else {
-        sendEvent({ type: "status", message: `⚠️ Błąd Vinted dla "${title}": ${err.message || "Timeout"}. Kontynuuję...` });
-      }
-      return "error";
     }
   }
 }

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -22,9 +22,7 @@ export function useLibraryCheck() {
     setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
     setLibraryError(null);
     
-    // Skaner biblioteki bywa długi (setki tytułów, retry/timeout OPAC) — 90 s
-    // ciszy zamiast 30 s; keepalive co 5 s resetuje odliczanie na żywym łączu.
-    const watchdog = createStallWatchdog(90000);
+    const watchdog = createStallWatchdog();
 
     return new Promise<void>(async (resolve) => {
       try {
@@ -76,7 +74,7 @@ export function useLibraryCheck() {
       } catch (err: any) {
         setLibraryError(
           watchdog.stalled
-            ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 90 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
+            ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
             : err.message
         );
         resolve(); // Resolve anyway so the next library can be checked

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -45,10 +45,7 @@ export function useVintedCheck() {
     setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
     setVintedError(null);
 
-    // Skaner ma z natury długie pauzy (odstępy anty-blokadowe + timeouty na
-    // pojedynczej ofercie), więc dajemy watchdogowi 90 s ciszy zamiast 30 s —
-    // keepalive co 5 s i tak resetuje odliczanie na zdrowym połączeniu.
-    const watchdog = createStallWatchdog(90000);
+    const watchdog = createStallWatchdog();
 
     try {
       watchdog.arm();
@@ -102,7 +99,7 @@ export function useVintedCheck() {
     } catch (err: any) {
       setVintedError(
         watchdog.stalled
-          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 90 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
+          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
           : err.message
       );
     } finally {


### PR DESCRIPTION
Po #48 skaner przestał wrzucać jakiekolwiek książki na listę. Dla bezpieczeństwa cofamy całą tę zmianę i wracamy do znanego, działającego stanu, żeby debugować krok po kroku.

Przywrócone:
- Timeout żądania Vinted **15 s → 30 s**, retry **2 → 3**.
- Stall-watchdog skanerów (Vinted + biblioteka) **90 s → 30 s**.
- Usunięty refaktor `scanBook()` oraz druga próba dla zablokowanych — powrót do jednego przejścia pętli jak przed #48.

To czysty `git revert` commitu z #48. `tsc` czysty, testy zielone (**181**), `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_