### PR TITLE
Skaner Vinted (debug krok 2): diagnostyka per próba w panelu logów

### DIFF
--- a/services/__tests__/vintedParser.test.ts
+++ b/services/__tests__/vintedParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseVintedItems, parseVintedPrice, extractPriceFromText } from "../vintedParser";
+import { parseVintedItems, parseVintedPrice, extractPriceFromText, vintedDiagnostics } from "../vintedParser";
 
 // Catalog blob with &quot;-escaped JSON, as in the real page
 const catalogHtml = (json: object) =>
@@ -74,6 +74,29 @@ describe("parseVintedItems", () => {
     const html = `<div class="feed-grid__item"><a href="/items/5" title="Solaris"></a></div>`;
     const items = parseVintedItems(html, "Solaris", "Lem");
     expect(items[0].priceValue).toBeNull();
+  });
+});
+
+describe("vintedDiagnostics", () => {
+  it("flags a likely parser miss: item links present but nothing parsed and no markers", () => {
+    const html = `<html><body><a href="/items/1"></a><a href="/items/2"></a></body></html>`;
+    const d = vintedDiagnostics(html, 0);
+    expect(d.itemLinks).toBe(2);
+    expect(d.parsed).toBe(0);
+    expect(d.blockedMarker).toBe(false);
+    expect(d.noResultsMarker).toBe(false);
+  });
+
+  it("detects the catalog JSON path and a bot block", () => {
+    const html = `<div data-component-name="Catalog"></div> cloudflare captcha`;
+    const d = vintedDiagnostics(html, 3);
+    expect(d.hasCatalogJson).toBe(true);
+    expect(d.blockedMarker).toBe(true);
+    expect(d.parsed).toBe(3);
+  });
+
+  it("detects the no-results marker", () => {
+    expect(vintedDiagnostics("Nie znaleźliśmy żadnych przedmiotów", 0).noResultsMarker).toBe(true);
   });
 });
 

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -36,6 +36,41 @@ export function parseVintedPrice(raw: string | number | null | undefined): numbe
  * `feed-grid__item`, (4) globalny regex `href=/items/…`. Wyodrębnione, by tę
  * kruchą logikę dało się testować jednostkowo na utrwalonym HTML.
  */
+export interface VintedDebug {
+  /** Długość odpowiedzi HTML (znaki). Bardzo mała = możliwy blok/challenge. */
+  chars: number;
+  /** Czy strona zawiera blob JSON katalogu (ścieżka „bogata"). */
+  hasCatalogJson: boolean;
+  /** Czy są bloki feed-grid (ścieżka fallback). */
+  hasFeedGrid: boolean;
+  /** Ile linków /items/ jest w HTML (są oferty, nawet jeśli parser ich nie złapał). */
+  itemLinks: number;
+  /** Markery blokady bota (cloudflare/captcha/robot). */
+  blockedMarker: boolean;
+  /** Markery „brak wyników" Vinted. */
+  noResultsMarker: boolean;
+  /** Ile ofert faktycznie wyłuskał parser. */
+  parsed: number;
+}
+
+/**
+ * Lekka diagnostyka odpowiedzi Vinted (bez I/O) — pomaga odróżnić realny brak
+ * ofert od cichej blokady lub gubienia ofert przez parser. `itemLinks > 0` przy
+ * `parsed === 0` i braku markerów = mocny sygnał, że parser coś przeoczył.
+ */
+export function vintedDiagnostics(html: string, parsed: number): VintedDebug {
+  const h = html || "";
+  return {
+    chars: h.length,
+    hasCatalogJson: h.includes('data-component-name="Catalog"'),
+    hasFeedGrid: h.includes('class="feed-grid__item"'),
+    itemLinks: (h.match(/\/items\//g) || []).length,
+    blockedMarker: /cloudflare|captcha|robot/i.test(h),
+    noResultsMarker: h.includes("Brak wyników") || h.includes("Nie znaleźliśmy żadnych przedmiotów"),
+    parsed,
+  };
+}
+
 export function parseVintedItems(html: string, title: string, author: string): VintedItem[] {
   const items: VintedItem[] = [];
   let rawItems: any[] = [];

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -4,7 +4,7 @@ import { SyncEvent } from "../src/types";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
 import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
-import { parseVintedItems } from "./vintedParser";
+import { parseVintedItems, vintedDiagnostics } from "./vintedParser";
 
 const log = createLogger("VintedScan");
 
@@ -104,7 +104,7 @@ export class VintedSyncService {
             sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
             sendEvent({
               type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0 }
+              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: vintedDiagnostics(html, 0) }
             });
           }
 
@@ -114,7 +114,7 @@ export class VintedSyncService {
             log.info(`Brak wyników na Vinted`, { searchText });
             sendEvent({
               type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: vintedDiagnostics(html, 0) }
             });
             // Odczekaj jak przy każdym innym zapytaniu — pomijanie opóźnienia
             // przy braku wyników (częsty przypadek) to prosta droga do blokady
@@ -123,6 +123,7 @@ export class VintedSyncService {
           }
 
           const items = parseVintedItems(html, title, book.author || "");
+          const debug = vintedDiagnostics(html, items.length);
 
           if (items.length > 0) {
             const matchResult = {
@@ -136,19 +137,19 @@ export class VintedSyncService {
             sendEvent({ type: "match", result: matchResult });
             sendEvent({
               type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length }
+              result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length, debug }
             });
           } else {
             sendEvent({
               type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0 }
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug }
             });
           }
         } catch (err: any) {
           log.warn(`Błąd sprawdzania Vinted`, { title, error: err.message || "Nieznany błąd" });
           sendEvent({
             type: "search_attempt",
-            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0 }
+            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0, debug: { error: err.message, code: err.code, httpStatus: err.response?.status } }
           });
           if (err.response?.status === 429) {
             sendEvent({

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -14,6 +14,20 @@ interface VintedCheckItemProps {
   progress: any;
 }
 
+// Zwięzła jednolinijkowa diagnostyka próby (Krok 2). Kluczowy sygnał:
+// itemLinks>0 przy parsed:0 i bez markerów = parser zgubił oferty.
+function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
+  if (d.error) return `⚠ ${d.error}${d.httpStatus ? ` (${d.httpStatus})` : d.code ? ` (${d.code})` : ""}`;
+  const parts: string[] = [];
+  if (d.chars !== undefined) parts.push(`${(d.chars / 1000).toFixed(0)}k`);
+  parts.push(d.hasCatalogJson ? "json" : d.hasFeedGrid ? "grid" : "html");
+  if (d.itemLinks !== undefined) parts.push(`links:${d.itemLinks}`);
+  if (d.parsed !== undefined) parts.push(`parsed:${d.parsed}`);
+  if (d.blockedMarker) parts.push("BLOCK");
+  if (d.noResultsMarker) parts.push("noRes");
+  return parts.join(" · ");
+}
+
 export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
   const [showLogs, setShowLogs] = React.useState(false);
 
@@ -122,6 +136,9 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                       <div className="flex flex-col min-w-0">
                         <span className="text-slate-200 font-bold truncate group-hover/log:text-slate-100 transition-colors">{attempt.title}</span>
                         <span className="text-slate-500 text-[9px] uppercase tracking-widest font-bold">{attempt.author}</span>
+                        {attempt.debug && (
+                          <span className="text-[9px] font-mono text-slate-500 truncate mt-0.5">{formatDebug(attempt.debug)}</span>
+                        )}
                       </div>
                     </div>
                     

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -25,6 +25,20 @@ export interface VintedSearchAttempt {
   url: string;
   status: "pending" | "success" | "no_results" | "blocked" | "error";
   itemCount: number;
+  // Diagnostyka (Krok 2) — pomaga odróżnić realny brak ofert od bloku / gubienia
+  // ofert przez parser. Kształt zależny od ścieżki (HTML vs błąd sieci).
+  debug?: {
+    chars?: number;
+    hasCatalogJson?: boolean;
+    hasFeedGrid?: boolean;
+    itemLinks?: number;
+    blockedMarker?: boolean;
+    noResultsMarker?: boolean;
+    parsed?: number;
+    error?: string;
+    code?: string;
+    httpStatus?: number;
+  };
 }
 
 export function useVintedCheck() {


### PR DESCRIPTION
Krok 2 debugowania. Panel logów pokazywał tylko status (`success`/`no_results`/`blocked`/`error`) — za mało, by odróżnić **realny brak ofert** od **cichej blokady** lub **gubienia ofert przez parser**. Dokładam nieinwazyjną diagnostykę — **zero zmian w zachowaniu skanera**.

## Zmiany

- **`vintedParser.vintedDiagnostics(html, parsed)`** (czysta, testowalna): długość HTML, obecność blobu `Catalog` JSON / bloków `feed-grid`, liczba linków `/items/` w HTML, markery blokady (`cloudflare/captcha/robot`) i „brak wyników", liczba wyłuskanych ofert.
- **`vintedSyncService`**: dołącza `debug` do każdego `search_attempt` (dla błędu: `message`/`code`/`httpStatus`).
- **`VintedCheckItem`**: jednolinijkowa diagnostyka pod tytułem próby, np. `12k · json · links:5 · parsed:0 · noRes`.

## Jak to czytać

- `links:>0` przy `parsed:0` i **bez** markerów → **parser gubi oferty** (fix po stronie parsera).
- `BLOCK` / bardzo małe `Nk` → **blokada bota** (temat IP/proxy, nie kodu).
- `noRes` → Vinted faktycznie nic nie ma.
- `json` vs `grid` vs `html` → którą ścieżką poszła odpowiedź.

## Weryfikacja

Testy `vintedDiagnostics` (parser-miss, blok+JSON, marker braku wyników). Całość zielona (**184**), `tsc` czysty, `npm run build` OK.

Po zmergowaniu odpal skaner i podeślij zrzut panelu 🐞 — z linijek diagnostycznych wyczytamy, czy `no_results` to realny brak, blok, czy przeoczenie parsera, i wtedy celujemy w konkretną naprawę.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_