### PR TITLE
Skaner Vinted: napraw fałszywy marker BLOCK (mała strona challenge, nie samo słowo)

### DIFF
--- a/services/__tests__/vintedParser.test.ts
+++ b/services/__tests__/vintedParser.test.ts
@@ -87,12 +87,18 @@ describe("vintedDiagnostics", () => {
     expect(d.noResultsMarker).toBe(false);
   });
 
-  it("detects the catalog JSON path and a bot block", () => {
-    const html = `<div data-component-name="Catalog"></div> cloudflare captcha`;
-    const d = vintedDiagnostics(html, 3);
+  it("detects the catalog JSON path", () => {
+    const d = vintedDiagnostics(`<div data-component-name="Catalog"></div>`, 3);
     expect(d.hasCatalogJson).toBe(true);
-    expect(d.blockedMarker).toBe(true);
     expect(d.parsed).toBe(3);
+  });
+
+  it("flags a block only for a small challenge page, not a huge normal page", () => {
+    // Mała strona challenge → blokada.
+    expect(vintedDiagnostics(`<html>Just a moment... checking your browser</html>`, 0).blockedMarker).toBe(true);
+    // Wielka normalna strona zawierająca słowo „cloudflare" (analytics) → NIE blokada.
+    const huge = `<html>${"x".repeat(200000)} cloudflare robot captcha</html>`;
+    expect(vintedDiagnostics(huge, 5).blockedMarker).toBe(false);
   });
 
   it("detects the no-results marker", () => {

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -53,6 +53,17 @@ export interface VintedDebug {
   parsed: number;
 }
 
+// Realna strona wyników Vinted to megabajty HTML. Strona challenge/blokady
+// Cloudflare jest MAŁA i niesie konkretny marker. Samo słowo „cloudflare"/
+// „robot" występuje w normalnym HTML (analytics, meta), więc było fałszywym
+// alarmem na każdej stronie — dlatego bramkujemy rozmiarem i frazą challenge.
+const CHALLENGE_RE = /just a moment|attention required|cf-mitigated|checking your browser|verify you are human|enable javascript and cookies|please complete the security check/i;
+
+export function looksBlocked(html: string): boolean {
+  const h = html || "";
+  return h.length < 100_000 && CHALLENGE_RE.test(h);
+}
+
 /**
  * Lekka diagnostyka odpowiedzi Vinted (bez I/O) — pomaga odróżnić realny brak
  * ofert od cichej blokady lub gubienia ofert przez parser. `itemLinks > 0` przy
@@ -65,7 +76,7 @@ export function vintedDiagnostics(html: string, parsed: number): VintedDebug {
     hasCatalogJson: h.includes('data-component-name="Catalog"'),
     hasFeedGrid: h.includes('class="feed-grid__item"'),
     itemLinks: (h.match(/\/items\//g) || []).length,
-    blockedMarker: /cloudflare|captcha|robot/i.test(h),
+    blockedMarker: looksBlocked(h),
     noResultsMarker: h.includes("Brak wyników") || h.includes("Nie znaleźliśmy żadnych przedmiotów"),
     parsed,
   };

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -4,7 +4,7 @@ import { SyncEvent } from "../src/types";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
 import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
-import { parseVintedItems, vintedDiagnostics } from "./vintedParser";
+import { parseVintedItems, vintedDiagnostics, looksBlocked } from "./vintedParser";
 
 const log = createLogger("VintedScan");
 
@@ -98,8 +98,8 @@ export class VintedSyncService {
           const html = response.data;
           log.info(`Odpowiedź Vinted`, { title, chars: html.length });
 
-          // Debug logging for empty results
-          if (html.includes("cloudflare") || html.includes("captcha") || html.includes("robot")) {
+          // Blokada = MAŁA strona challenge, nie samo słowo w wielkim HTML.
+          if (looksBlocked(html)) {
             log.warn(`Vinted zablokował żądanie (wykrycie bota)`, { title });
             sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
             sendEvent({


### PR DESCRIPTION
Diagnostyka z Kroku 2 pokazała `BLOCK` na **każdej** pozycji — także trafionych (`parsed:5`, strony **~6 MB**, `links:32/54`). To fałszywy alarm: marker `/cloudflare|captcha|robot/` łapał te słowa w normalnym HTML Vinted (analytics/meta). Realna strona wyników ma megabajty; challenge Cloudflare jest **mała** i niesie konkretną frazę.

## Zmiana

- **`looksBlocked(html)`**: blokada = rozmiar `< 100 KB` **ORAZ** marker challenge (`„Just a moment"`, `„Checking your browser"`, `„cf-mitigated"`, `„Verify you are human"` itd.).
- `vintedDiagnostics.blockedMarker` i gałąź `blocked` w serwisie używają `looksBlocked` — koniec fałszywych `BLOCK`. Pole `chars` w debug i tak jest najsilniejszym sygnałem blokady (tiny = challenge).

Zachowanie skanu bez zmian (gałąź `blocked` i tak parsowała dalej). Testy zaktualizowane, całość zielona (**185**).

## Uwaga — właściwy problem recall (osobny, wymaga próbki)

Diagnostyka odsłoniła sedno: wszystkie odpowiedzi idą ścieżką **`html`** (nie `json`, nie `grid`) → marker `data-component-name="Catalog"` **już nie istnieje** w aktualnym HTML Vinted, więc lecimy najsłabszym fallbackiem. Stąd np. **Dzieci nocy: links:192, parsed:0** — oferty są w HTML, ale parser ich nie łapie. Naprawa (przepisanie parsera pod aktualną strukturę + odzysk cen/miniatur) będzie osobnym PR-em, gdy dostanę próbkę `view-source` jednego wyszukiwania z wynikami.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_