### PR TITLE
fix(vinted): raise scanner stall-watchdog 30s→120s (self-kill debug step 1)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.0.1** (źródło prawdy: `metadata.json`; mirror w `package.json`).
+- Wersja aplikacji: **1.0.2** (źródło prawdy: `metadata.json`; mirror w `package.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -30,6 +30,16 @@
   sąsiednie tytuły. Potwierdzone jako słuszne 0: „Dzieci nocy" (Simmons; same „…nocy"),
   „Eden w ogniu" (Simmons). `parsed:0` nie oznacza automatycznie buga parsera —
   weryfikuj po `itemLinks` vs faktyczne tytuły.
+- **Vinted „skaner sam się ubija" (#2) — mechanizm** — brak twardego self-kill timera.
+  Skan pada, gdy jedna wolna/blokowana książka daje >watchdog ciszy `data:` (serwer
+  śle tylko keepalive co 5 s). Worst-case ciszy = ~102 s (`withRetry(3, 4000)` × timeout
+  30 s = 30+4+30+8+30). Front resetuje watchdog na każdym chunku (keepalive też) —
+  więc pada TYLKO gdy Render buforuje keepalive. Watchdog fire → abort fetch → serwer
+  widzi `res close` → `stopActiveSync()` → ubity cały skan.
+- **#48 zbundlował 2 zmiany** — watchdog 30→90 s (BEZPIECZNA) + timeout 30→15 s
+  (SZKODLIWA: ucinała wolne, poprawne odpowiedzi Cloudflare → zero trafień). Oba
+  cofnięte (#49). Debuguj po jednej: KROK 1 = tylko watchdog (1.0.2). NIE skracaj
+  timeout/retry scrapera — to zabija trafienia.
 - **Marker debug `grid` vs `html`** — `html` w logach skanera oznacza, że oferty złapał
   tylko fallback (ścieżka 4), a nie siatka. Po wdrożeniu fixu na stronach z siatką ma
   być `grid`. Jeśli po redeployu dalej `html` na stronie z siatką → deploy serwuje
@@ -39,6 +49,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.0.2** — Skaner Vinted: self-kill debug KROK 1. Front-owy stall-watchdog dla Vinted
+  30 s → 120 s (izolowana bezpieczna połowa cofniętego #48; NIE rusza timeout/retry
+  scrapera, więc nie zmniejsza trafień). Pokrywa worst-case ~102 s ciszy na jednej
+  wolnej/blokowanej książce. Zakres: tylko `useVintedCheck`.
 - **1.0.1** — Vinted parser dostrojony do aktualnego DOM Vinted (siatka feed-grid po
   hashowanej klasie, cena strukturalna + miniatury; fix `hasFeedGrid`). Wprowadzenie
   wersjonowania w `metadata.json` i trwałej pamięci `backlog.md`. (PR #52 + workflow rules)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -59,7 +59,12 @@ export function useVintedCheck() {
     setCheckProgress({ current: 0, total: 0, message: "Inicjowanie...", startTime: Date.now() });
     setVintedError(null);
 
-    const watchdog = createStallWatchdog();
+    // Skaner Vinted potrafi milczeć długo na jednej książce: withRetry(3, 4000) przy
+    // timeout 30 s daje worst-case ~102 s ciszy (30+4+30+8+30) na wolnej/blokowanej
+    // pozycji, gdy serwer wysyła tylko keepalive (a Render bywa go buforuje). Domyślne
+    // 30 s ucinało wtedy fetch → serwer widział rozłączenie → self-kill całego skanu.
+    // 120 s pokrywa ten worst-case bez ruszania timingu scrapera (nie zmniejsza trafień).
+    const watchdog = createStallWatchdog(120000);
 
     try {
       watchdog.arm();
@@ -113,7 +118,7 @@ export function useVintedCheck() {
     } catch (err: any) {
       setVintedError(
         watchdog.stalled
-          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
+          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 120 s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie."
           : err.message
       );
     } finally {


### PR DESCRIPTION
## Context

Step-by-step debugging of the intermittent Vinted scanner self-kill (#2), from the known-good baseline restored in #49. **One variable only.**

## Mechanism (measured)

The scan has no self-kill timer. It dies when a single slow/blocked book produces more than the watchdog window of `data:` silence:

- Vinted calls `withRetry(fn, 3, 4000)` at `timeout: 30000`. A fully-hanging book (each attempt hits the 30s timeout, classified transient → retried) yields **~102s of silence**: `30 + 4 (backoff) + 30 + 8 (backoff) + 30`.
- During that window the server emits only `: keepalive` comments (every 5s). The frontend resets its stall-watchdog on **every** chunk — keepalive included — so this only bites when **Render buffers the keepalive**.
- When it does: 30s watchdog → `fetch` abort → server sees `res` close → `stopActiveSync()` → the whole scan dies. This matches the symptom (scan runs fine, then dies on one slow title).

## Change

Raise **only** the frontend stall-watchdog, scoped to `useVintedCheck`: `30s → 120s` (covers the ~102s worst case). Stale "30 s" copy in the error message updated to "120 s".

This is the **isolated, safe half of the reverted #48**. It does **not** touch the scraper `timeout`/`retry`, so it cannot reduce hit-rate the way #48's `30s→15s` timeout cut did (that cut off slow-but-valid Cloudflare responses → zero hits). Other scanners keep the 30s default.

## What to look for on the next run

- Scan should reach the end without self-killing, even when it hits a slow title.
- If it **still** self-kills after 120s of silence, that rules keepalive-buffering out and points to a genuinely dead stream — a different diagnosis for step 2.

## Verification

`npm run lint` clean, full suite **187/187** green, build OK, bundle carries `1.0.2`.

Versioning: `1.0.1 → 1.0.2` (metadata.json source of truth); `backlog.md` updated with the self-kill mechanism and changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_