### PR TITLE
feat(vinted): per-book memory readout in scan debug (self-kill step 2)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.0.2** (źródło prawdy: `metadata.json`; mirror w `package.json`).
+- Wersja aplikacji: **1.0.3** (źródło prawdy: `metadata.json`; mirror w `package.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -49,6 +49,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.0.3** — Skaner Vinted: self-kill debug KROK 2 (obserwowalność pamięci). `rssMb`/
+  `heapMb` w debug każdej próby + log serwera. KROK 1 (watchdog 120 s) NIE pomógł —
+  skan padł nawet wcześniej (26 vs 28), co wyklucza front-owy watchdog. Nowa hipoteza:
+  OOM-kill na Render (strony ~7 MB × ~27 → piki pamięci > 512 MB). Zero zmian w timingu.
 - **1.0.2** — Skaner Vinted: self-kill debug KROK 1. Front-owy stall-watchdog dla Vinted
   30 s → 120 s (izolowana bezpieczna połowa cofniętego #48; NIE rusza timeout/retry
   scrapera, więc nie zmniejsza trafień). Pokrywa worst-case ~102 s ciszy na jednej

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -9,6 +9,17 @@ import { parseVintedItems, vintedDiagnostics, looksBlocked } from "./vintedParse
 const log = createLogger("VintedScan");
 
 /**
+ * Odczyt pamięci procesu (MB). Strony Vinted to ~7 MB HTML każda — na hostingu z
+ * limitem RAM (Render free = 512 MB) powtarzane piki przy parsowaniu mogą wywołać
+ * OOM-kill procesu, co urywa SSE i „ubija" skan przy w miarę stałej liczbie prób.
+ * Dołączamy `rssMb`/`heapMb` do debug każdej próby, żeby to zobaczyć w panelu logów.
+ */
+function memMb() {
+  const m = process.memoryUsage();
+  return { rssMb: Math.round(m.rss / 1048576), heapMb: Math.round(m.heapUsed / 1048576) };
+}
+
+/**
  * Skaner ofert na Vinted (bezpośredni scraper HTML — NIE AI). Dla każdej książki,
  * której jeszcze nie posiadamy, wyszukuje oferty w katalogu Vinted i emituje
  * trafienia przez SSE. Zob. docs/vinted-scanner.md.
@@ -96,7 +107,7 @@ export class VintedSyncService {
           }, 3, 4000);
 
           const html = response.data;
-          log.info(`Odpowiedź Vinted`, { title, chars: html.length });
+          log.info(`Odpowiedź Vinted`, { title, chars: html.length, ...memMb() });
 
           // Blokada = MAŁA strona challenge, nie samo słowo w wielkim HTML.
           if (looksBlocked(html)) {
@@ -104,7 +115,7 @@ export class VintedSyncService {
             sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
             sendEvent({
               type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: vintedDiagnostics(html, 0) }
+              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } }
             });
           }
 
@@ -114,7 +125,7 @@ export class VintedSyncService {
             log.info(`Brak wyników na Vinted`, { searchText });
             sendEvent({
               type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: vintedDiagnostics(html, 0) }
+              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } }
             });
             // Odczekaj jak przy każdym innym zapytaniu — pomijanie opóźnienia
             // przy braku wyników (częsty przypadek) to prosta droga do blokady
@@ -123,7 +134,7 @@ export class VintedSyncService {
           }
 
           const items = parseVintedItems(html, title, book.author || "");
-          const debug = vintedDiagnostics(html, items.length);
+          const debug = { ...vintedDiagnostics(html, items.length), ...memMb() };
 
           if (items.length > 0) {
             const matchResult = {
@@ -149,7 +160,7 @@ export class VintedSyncService {
           log.warn(`Błąd sprawdzania Vinted`, { title, error: err.message || "Nieznany błąd" });
           sendEvent({
             type: "search_attempt",
-            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0, debug: { error: err.message, code: err.code, httpStatus: err.response?.status } }
+            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0, debug: { error: err.message, code: err.code, httpStatus: err.response?.status, ...memMb() } }
           });
           if (err.response?.status === 429) {
             sendEvent({

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -25,6 +25,8 @@ function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
   if (d.parsed !== undefined) parts.push(`parsed:${d.parsed}`);
   if (d.blockedMarker) parts.push("BLOCK");
   if (d.noResultsMarker) parts.push("noRes");
+  // Pamięć procesu — rosnące rssMb ku limitowi hostingu tuż przed śmiercią = OOM.
+  if (d.rssMb !== undefined) parts.push(`mem:${d.rssMb}MB`);
   return parts.join(" · ");
 }
 

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -38,6 +38,10 @@ export interface VintedSearchAttempt {
     error?: string;
     code?: string;
     httpStatus?: number;
+    // Diagnostyka OOM (Krok 2): pamięć procesu po każdej próbie. Rosnące rssMb ku
+    // limitowi hostingu (Render free = 512 MB) tuż przed śmiercią skanu = OOM-kill.
+    rssMb?: number;
+    heapMb?: number;
   };
 }
 


### PR DESCRIPTION
## Step 1 result (watchdog) — negative, and informative

Raising the Vinted stall-watchdog to 120s (#54) **did not help** — the scan self-killed even **earlier** (26 vs ~28 books). If the frontend watchdog were the cause, a longer window would push the run **further**, not less. **This rules the watchdog out.**

## New hypothesis: OOM-kill on Render (512 MB)

The scan dies at a roughly **constant book count** (~26–28) regardless of the watchdog — a signature of a **resource limit**, not timing. Vinted result pages are **~7 MB of HTML each** (the captured view-source was 7.25 MB). In V8, strings are UTF-16 (~2× in memory), and `parseVintedItems` does `html.split(regex)` → ~96 substrings per page. Across ~27 pages on Render's 512 MB free tier, repeated parse-time spikes are a strong OOM-kill candidate: the process dies, the SSE stream drops, and the scan "ends" at a consistent count.

## This step: observability only (no timing change)

- Emit `process.memoryUsage()` RSS/heap (MB) in each `search_attempt` debug object and the server log.
- Surface it in the debug panel as `mem:NNNMB` (extended `formatDebug` + the debug type).

Zero changes to scraper timeout/retry/delays, so it cannot affect hit-rate.

## What to look for on the next run

- Open the debug panel (bug icon) and watch `mem:NNNMB` per book.
- **If RSS climbs toward ~512 MB right before the scan dies → OOM confirmed** → step 3 mitigates (free the 7 MB HTML aggressively, cap retained data, or raise the instance memory).
- If memory stays flat and it still dies at ~27 → OOM is out; we look at Render request/response limits or Cloudflare hard-blocking next.

**Also worth a 30-second check now:** Render dashboard → this service → Events/Logs around when the scan died. Render logs an explicit "Ran out of memory (used over 512MB)" + restart on OOM — that would confirm the hypothesis immediately, before the next run.

## Verification

`npm run lint` clean, full suite **187/187** green, build OK. v1.0.3 (metadata.json); backlog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_