### PR TITLE
feat(vinted): incremental seller resolution into the store (persistence stage 2)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.3.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.4.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.4.0** — Vinted persystencja ETAP 2: przyrostowe dociąganie sprzedawców DO BAZY.
+  `resolveSellersToStore` czyta składowane oferty bez sprzedawcy, dociąga (throttled,
+  cap 150/przebieg, wznawialne — rozpoznani zostają w blobie), zapisuje raz/książkę.
+  Task `vinted-resolve-sellers`, endpoint `POST /api/vinted-resolve-sellers`, hook
+  `useVintedResolveSellers`, przycisk „Ustal sprzedawców (baza)" + postęp/wynik.
 - **1.3.0** — Vinted persystencja ETAP 1 (fundament): wyniki skanu zapisywane do Notion
   (blob JSON w polu `VintedData`, chunk ≤2000 zn., mapper skleja). `vintedStore` (pure:
   serialize/parse/merge — merge ZACHOWUJE sprzedawcę dla ofert z niezmienionym URL).
@@ -96,9 +101,6 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 
 ## Otwarte pozycje
 
-- **Vinted persystencja ETAP 2** — przyrostowe dociąganie sprzedawcy do bazy: task czyta
-  składowane oferty bez sprzedawcy, dociąga (throttled, cap, wznawialny między
-  przebiegami), zapisuje z powrotem do blobu. Bazuje na `vintedStore` + `saveVintedData`.
 - **Vinted persystencja ETAP 3** — grupowanie i kafelki Z BAZY (bez re-scrape): endpoint
   czyta `VintedData` wszystkich książek → buduje wyniki + `sellersByUrl` → `groupBySeller`.
   Front renderuje kafelki i paczki ze składowanych danych + znacznik świeżości (`scannedAt`).

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -218,6 +218,17 @@ export const groupVintedBySeller = async (req: Request, res: Response) => {
 
 export const stopVintedGroup = makeStopHandler("Zatrzymywanie grupowania per sprzedawca...");
 
+export const resolveVintedSellers = async (req: Request, res: Response) => {
+  await executeSyncTask(
+    req,
+    res,
+    (sendEvent) => syncManager.run("vinted-resolve-sellers", sendEvent, { cap: 150 }),
+    "Vinted Resolve Sellers Error:"
+  );
+};
+
+export const stopVintedResolveSellers = makeStopHandler("Zatrzymywanie ustalania sprzedawców...");
+
 export const checkLibraryAvailability = async (req: Request, res: Response) => {
   const { libraryCode } = req.body;
   if (!libraryCode) return res.status(400).json({ error: "Missing libraryCode parameter" });

--- a/docs/vinted-scanner.md
+++ b/docs/vinted-scanner.md
@@ -26,7 +26,8 @@ Scraping is rate-limited and unreliable (Cloudflare); analysis (grouping) is che
 - **Store**: a compact JSON blob in a `VintedData` rich_text property on each book row (`services/vintedStore.ts`: `StoredVintedData = { scannedAt, offers[] }`). The adapter chunks it into ≤2000-char rich_text segments (`saveVintedData`); the mapper rejoins them (`getPlainText` → `NotionBook.vintedData`).
 - **Write path** (stage 1): the scan persists per book best-effort (`persistBookOffers`) after each response — matches, or an empty-offers record that still stamps `scannedAt` (scan coverage). `createColumnIfNeeded("VintedData")` ensures the property once per run; a failure disables persistence without failing the scan.
 - **Merge**: `mergeOffers` keeps a previously-resolved **seller** for any offer whose URL still exists, so a re-scan doesn't wipe seller data captured separately; vanished offers drop, new ones enter without a seller.
-- **Stages 2–3** (planned): an incremental job resolves sellers for stored offers lacking one (resumable, capped), then grouping and the tile view read straight from the blob (no re-scrape) with a `scannedAt` freshness marker.
+- **Seller resolution** (stage 2): `resolveSellersToStore` walks stored offers whose `seller` is `null`, fetches each offer page, and writes the seller back into the blob (one Notion write per book). It's **incremental and resumable** — resolved sellers persist, so each run (capped, default 150 fetches) only tackles remaining `null`s; re-run until `remaining` is 0. Task `vinted-resolve-sellers` / `POST /api/vinted-resolve-sellers`; UI button "Ustal sprzedawców (baza)".
+- **Stage 3** (planned): grouping and the tile view read straight from the blob (no re-scrape) with a `scannedAt` freshness marker.
 
 ## 3. Reliability & Anti-Bot Pacing
 - **Timeout**: 45 000 ms per request (via a keep-alive `https.Agent`).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -35,6 +35,8 @@ router.post("/vinted-check", syncController.checkVintedAvailability);
 router.post("/vinted-check/stop", syncController.stopVintedCheck);
 router.post("/vinted-group", syncController.groupVintedBySeller);
 router.post("/vinted-group/stop", syncController.stopVintedGroup);
+router.post("/vinted-resolve-sellers", syncController.resolveVintedSellers);
+router.post("/vinted-resolve-sellers/stop", syncController.stopVintedResolveSellers);
 router.post("/library-check", syncController.checkLibraryAvailability);
 
 export default router;

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -6,7 +6,7 @@ import { createLogger } from "../logger";
 import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
 import { parseVintedItems, vintedDiagnostics, looksBlocked, extractVintedSeller, VintedItem } from "./vintedParser";
 import { NotionBook } from "../src/types";
-import { offerFromItem, parseVintedData, mergeOffers, serializeVintedData } from "./vintedStore";
+import { offerFromItem, parseVintedData, mergeOffers, serializeVintedData, StoredVintedData, StoredOffer } from "./vintedStore";
 
 const log = createLogger("VintedScan");
 
@@ -287,5 +287,95 @@ export class VintedSyncService {
 
     const wasCancelled = checkCancellation();
     sendEvent({ type: "complete", result: { success: !wasCancelled, cancelled: wasCancelled } });
+  }
+
+  /**
+   * Etap 2 (przyrostowo, wznawialnie): dociąga sprzedawcę do SKŁADOWANYCH ofert bez
+   * sprzedawcy i zapisuje z powrotem do Notion. Rozpoznani zostają w blobie, więc kolejny
+   * przebieg bierze tylko wciąż-`null` — dzięki temu można rozłożyć pracę na wiele przebiegów
+   * pod limitem Cloudflare (cap/przebieg). Zapis raz na książkę (mniej zapisów do Notion).
+   */
+  async resolveSellersToStore(
+    sendEvent: (data: SyncEvent) => void,
+    checkCancellation: () => boolean,
+    params?: { cap?: number },
+  ) {
+    const CAP = Math.max(1, Math.min(300, params?.cap ?? 150));
+    try {
+      sendEvent({ type: "status", message: "Wczytywanie składowanych ofert z Notion..." });
+      const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
+
+      // Książki z ofertami bez sprzedawcy (offer to referencja do data.offers — mutacja wraca do blobu).
+      const pending: { book: NotionBook; data: StoredVintedData; offers: StoredOffer[] }[] = [];
+      let totalPending = 0;
+      for (const book of allBooks) {
+        const data = parseVintedData(book.vintedData);
+        if (!data) continue;
+        const nulls = data.offers.filter(o => o.seller == null && /\/items\//.test(o.url));
+        if (nulls.length) { pending.push({ book, data, offers: nulls }); totalPending += nulls.length; }
+      }
+
+      if (totalPending === 0) {
+        sendEvent({ type: "complete", result: { success: true, resolved: 0, remaining: 0, message: "Wszyscy sprzedawcy już ustaleni w bazie." } });
+        return;
+      }
+
+      const target = Math.min(totalPending, CAP);
+      sendEvent({ type: "status", message: `Ofert bez sprzedawcy: ${totalPending}. Ten przebieg: ${target} (limit ${CAP}).` });
+
+      const httpsAgent = createScrapingAgent();
+      let fetched = 0, resolved = 0;
+
+      for (const p of pending) {
+        if (fetched >= CAP || checkCancellation()) break;
+        let dirty = false;
+        for (const offer of p.offers) {
+          if (fetched >= CAP || checkCancellation()) break;
+          fetched++;
+          sendEvent({ type: "progress", message: `Sprzedawca: ${p.book.plTitle} (${fetched}/${target})`, current: fetched, total: target });
+          try {
+            const response = await withRetry(async () => {
+              return await axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(), timeout: 30000 });
+            }, 3, 4000);
+            const html = response.data;
+            if (looksBlocked(html)) {
+              log.warn("Vinted zablokował stronę oferty (sprzedawca, baza)", { url: offer.url });
+            } else {
+              const seller = extractVintedSeller(html);
+              if (seller) {
+                offer.seller = seller;
+                dirty = true;
+                resolved++;
+                sendEvent({ type: "seller_resolved", result: { url: offer.url, seller, ...memMb() } });
+              }
+            }
+          } catch (err: any) {
+            log.warn("Błąd ustalania sprzedawcy (baza)", { url: offer.url, error: err.message });
+          }
+          await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
+        }
+        // Zapisz książkę raz, po ustaleniu jej ofert (mniej zapisów do Notion).
+        if (dirty) {
+          try {
+            await this.notion.saveVintedData(p.book.id, serializeVintedData(p.data));
+          } catch (e: any) {
+            log.warn("Nie udało się zapisać sprzedawców do VintedData", { title: p.book.plTitle, error: e?.message });
+          }
+        }
+      }
+
+      const wasCancelled = checkCancellation();
+      const remaining = totalPending - resolved;
+      sendEvent({
+        type: "complete",
+        result: {
+          success: !wasCancelled, cancelled: wasCancelled, resolved, remaining,
+          message: `${wasCancelled ? "Przerwano. " : ""}Ustalono sprzedawców: ${resolved}. Pozostało bez sprzedawcy: ${remaining}${remaining > 0 ? " — uruchom ponownie, by dokończyć." : "."}`,
+        },
+      });
+    } catch (error: any) {
+      log.error("Błąd ustalania sprzedawców z bazy", { message: error.message });
+      sendEvent({ type: "error", error: `Błąd ustalania sprzedawców: ${error.message}` });
+    }
   }
 }

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle, BookImage, Users, Package } from "lucide-react";
+import { ShoppingCart, ExternalLink, Loader2, Search, Bug, CheckCircle2, XCircle, AlertCircle, BookImage, Users, Package, Database } from "lucide-react";
 import { formatETA } from "../../utils/time";
 import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
 import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTitle, sortResultsByCheapest } from "../../utils/vintedOffers";
 import { useVintedGrouping } from "../../hooks/useVintedGrouping";
+import { useVintedResolveSellers } from "../../hooks/useVintedResolveSellers";
 import { groupBySeller } from "../../utils/vintedSellers";
 
 interface VintedCheckItemProps {
@@ -35,6 +36,7 @@ function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
 export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
   const [showLogs, setShowLogs] = React.useState(false);
   const { sellersByUrl, isGrouping, groupProgress, groupError, runGrouping, stopGrouping } = useVintedGrouping();
+  const { isResolving, resolveProgress, resolveResult, resolveError, runResolve, stopResolve } = useVintedResolveSellers();
 
   const [groupSkipped, setGroupSkipped] = React.useState(0);
   const GROUP_CAP = 150;
@@ -94,7 +96,7 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
             </button>
           )}
 
-          {results.length > 0 && !isChecking && !isGrouping && (
+          {results.length > 0 && !isChecking && !isGrouping && !isResolving && (
             <div className="flex items-center gap-2">
               <button
                 onClick={handleGroupCheapest}
@@ -113,6 +115,21 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                 <span>Wszystkie oferty</span>
               </button>
             </div>
+          )}
+
+          {!isChecking && !isGrouping && (
+            <button
+              onClick={() => { if (isResolving) stopResolve(); else runResolve(); }}
+              className={`flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border ${
+                isResolving
+                  ? "bg-red-600/90 border-red-500/50 text-white hover:bg-red-500"
+                  : "bg-teal-600/90 border-teal-500/50 text-white hover:bg-teal-500 shadow-lg shadow-teal-500/20"
+              }`}
+              title="Dociągnij sprzedawców do składowanych ofert w Notion (przyrostowo, wznawialnie, cap 150/przebieg)"
+            >
+              {isResolving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Database className="w-4 h-4" />}
+              <span>{isResolving ? "Zatrzymaj" : "Ustal sprzedawców (baza)"}</span>
+            </button>
           )}
 
           <button
@@ -245,6 +262,30 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
         </div>
       )}
       {groupError && <p className="text-xs text-red-400 italic px-2">{groupError}</p>}
+
+      {isResolving && resolveProgress && (
+        <div className="px-2 space-y-1">
+          <div className="flex justify-between text-xs text-teal-300 uppercase font-bold">
+            <span className="break-words">{resolveProgress.message}</span>
+            {resolveProgress.total > 0 && <span>{resolveProgress.current} / {resolveProgress.total}</span>}
+          </div>
+          {resolveProgress.total > 0 && (
+            <div className="h-1 bg-slate-900 rounded-full overflow-hidden">
+              <motion.div
+                initial={{ width: 0 }}
+                animate={{ width: `${(resolveProgress.current / resolveProgress.total) * 100}%` }}
+                className="h-full bg-teal-500"
+              />
+            </div>
+          )}
+        </div>
+      )}
+      {resolveError && <p className="text-xs text-red-400 italic px-2">{resolveError}</p>}
+      {!isResolving && resolveResult && (
+        <p className="text-xs text-teal-300/80 px-2">
+          {resolveResult.message}
+        </p>
+      )}
 
       {bundles.length > 0 && (
         <div className="space-y-3">

--- a/src/hooks/useVintedResolveSellers.ts
+++ b/src/hooks/useVintedResolveSellers.ts
@@ -1,0 +1,78 @@
+import { useState, useCallback, useRef } from "react";
+import { consumeSSE } from "../utils/sse";
+import { createStallWatchdog } from "../utils/stallWatchdog";
+
+/**
+ * Etap 2: przyrostowe dociąganie sprzedawców do SKŁADOWANYCH ofert (Notion), wznawialne
+ * między przebiegami. Nie zależy od bieżącego skanu — działa na bazie. Wzorzec SSE jak
+ * w useVintedCheck (watchdog 120 s). Zwraca postęp i podsumowanie (resolved/remaining).
+ */
+export function useVintedResolveSellers() {
+  const [isResolving, setIsResolving] = useState(false);
+  const [resolveProgress, setResolveProgress] = useState<{ current: number; total: number; message: string } | null>(null);
+  const [resolveResult, setResolveResult] = useState<{ resolved: number; remaining: number; message: string } | null>(null);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const runningRef = useRef(false);
+
+  const runResolve = useCallback(async () => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setIsResolving(true);
+    setResolveProgress({ current: 0, total: 0, message: "Inicjowanie..." });
+    setResolveResult(null);
+    setResolveError(null);
+
+    const watchdog = createStallWatchdog(120000);
+    try {
+      watchdog.arm();
+      const response = await fetch("/api/vinted-resolve-sellers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: watchdog.signal,
+      });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || `Błąd serwera: ${response.status}`);
+      }
+
+      await consumeSSE(response.body, (data) => {
+        if (data.type === "progress" || data.type === "status") {
+          setResolveProgress(prev => ({
+            current: data.current ?? prev?.current ?? 0,
+            total: data.total ?? prev?.total ?? 0,
+            message: data.message ?? "",
+          }));
+        } else if (data.type === "complete") {
+          setResolveResult({
+            resolved: data.result?.resolved ?? 0,
+            remaining: data.result?.remaining ?? 0,
+            message: data.result?.message ?? "",
+          });
+        } else if (data.type === "error") {
+          throw new Error(data.error);
+        }
+      }, watchdog.arm);
+    } catch (err: any) {
+      setResolveError(
+        watchdog.stalled
+          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 120 s). Odśwież i spróbuj ponownie."
+          : err.message
+      );
+    } finally {
+      watchdog.clear();
+      runningRef.current = false;
+      setIsResolving(false);
+      setResolveProgress(null);
+    }
+  }, []);
+
+  const stopResolve = useCallback(async () => {
+    try {
+      await fetch("/api/vinted-resolve-sellers/stop", { method: "POST" });
+    } catch (err) {
+      console.error("Error stopping seller resolution:", err);
+    }
+  }, []);
+
+  return { isResolving, resolveProgress, resolveResult, resolveError, runResolve, stopResolve };
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -57,7 +57,8 @@ export type SyncTaskName =
   | "integrity"
   | "library"
   | "vinted"
-  | "vinted-group";
+  | "vinted-group"
+  | "vinted-resolve-sellers";
 
 type TaskFn = (checkCancellation: () => boolean) => Promise<void>;
 
@@ -81,6 +82,7 @@ const TASK_REGISTRY: Record<SyncTaskName, (sendEvent: (data: SyncEvent) => void,
   library:    (s, p) => (cc) => libraryCheckService.runLibraryCheck(p.libraryCode, s, cc),
   vinted:     (s) => (cc) => vintedSyncService.runVintedCheck(s, cc),
   "vinted-group": (s, p) => (cc) => vintedSyncService.resolveSellers(p.items, s, cc),
+  "vinted-resolve-sellers": (s, p) => (cc) => vintedSyncService.resolveSellersToStore(s, cc, p),
 };
 
 class SyncManager {


### PR DESCRIPTION
## Stage 2 of the persistence pipeline

Builds on stage 1's Notion blob (#59). `resolveSellersToStore` walks stored offers whose `seller` is `null`, fetches each offer page, extracts the seller, and writes it back into the blob (**one Notion write per book**).

The key property is **incremental + resumable**: resolved sellers persist, so each run is **capped** (default 150 fetches, reusing the scanner's throttling / `withRetry` / block detection) and only tackles the remaining `null`s. That's exactly how persistence defeats the caps — the seller work spreads across runs under Cloudflare's tolerance. Re-run until `remaining` hits 0.

## What's wired

- Service: `VintedSyncService.resolveSellersToStore(sendEvent, checkCancellation, { cap })` — collects books with `null`-seller offers, resolves up to the cap, mutates offers in place, saves each dirty book once, reports `resolved` / `remaining`.
- Task `vinted-resolve-sellers`; `POST /api/vinted-resolve-sellers` (+ `/stop`).
- Frontend: `useVintedResolveSellers` (SSE, 120 s watchdog) + a **"Ustal sprzedawców (baza)"** button (teal) with a progress bar and a resolved/remaining summary. It operates on stored data **independently of the current scan** — no re-scan needed.

## Verification

- On Notion: offers' `"seller":null` flip to `{ id, login, url }` as the job runs; re-running continues from where it stopped.
- **201 tests green**, `npm run lint` clean, `npm run build` OK. v1.4.0 (metadata + package + lockfile synced); backlog + docs updated.

## Note

A full pass is still bounded by Cloudflare — with ~hundreds of offers and cap 150, expect to run it a couple of times across a while to fill everything in. That's the intended incremental tradeoff; the point is progress is now durable between runs. **Stage 3 next**: grouping + tiles rendered straight from the store (no re-scrape), with a `scannedAt` freshness marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_