### PR TITLE
feat(vinted): resumable scan — skip recently-scanned books ("Kontynuuj")

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.5.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.6.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.6.0** — Vinted skan wznawialny: checkbox „Kontynuuj" (dom. ON) pomija książki
+  skanowane < 3 dni (`skipScannedWithinDays` z `scannedAt` w blobie) → skan rusza od
+  niezrobionych zamiast od zera. Łagodzi limit ~160/kontener i drop połączenia na mobile
+  (przełączenie apki usypia kartę → SSE pada → serwer anuluje; teraz po prostu wznawiasz).
 - **1.5.0** — Vinted persystencja ETAP 3 (domknięcie): grupowanie i kafelki Z BAZY bez
   re-scrape. `getStoredData` (`GET /api/vinted-stored`) czyta bloby wszystkich książek;
   czysty `storedToView` mapuje na VintedResult[] + sellersByUrl + zakres świeżości.

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -183,10 +183,14 @@ export const checkVintedAvailability = async (req: Request, res: Response) => {
     return res.status(400).json({ error: "Brak kluczy API Notion." });
   }
 
+  // Wznawianie: front może poprosić o pominięcie świeżo skanowanych książek.
+  const skipRaw = req.body?.skipScannedWithinDays;
+  const skipScannedWithinDays = typeof skipRaw === "number" && skipRaw > 0 ? Math.min(skipRaw, 365) : undefined;
+
   await executeSyncTask(
     req,
     res,
-    (sendEvent) => syncManager.run("vinted", sendEvent),
+    (sendEvent) => syncManager.run("vinted", sendEvent, { skipScannedWithinDays }),
     "Vinted Check Error:"
   );
 };

--- a/docs/vinted-scanner.md
+++ b/docs/vinted-scanner.md
@@ -34,6 +34,7 @@ Scraping is rate-limited and unreliable (Cloudflare); analysis (grouping) is che
 - **Throttling**: 3–5 s delay (with jitter) between books — applied on **every** path, including the no-results case, to avoid the request bursts that trigger Cloudflare blocks.
 - **429 handling**: On HTTP 429 waits ~5 s before continuing; 403 is surfaced as a Cloudflare block.
 - **Cancellation**: Cooperative — checks the cancellation token each iteration and reports `cancelled: true` on the `complete` event when stopped.
+- **Resumable scan**: with the `skipScannedWithinDays` param (frontend "Kontynuuj" checkbox, default on → 3 days), candidates whose stored `scannedAt` is within the window are skipped, so an interrupted run (the ~160-books-per-container limit, or a mobile connection drop when the browser is backgrounded) continues from the un-scanned books instead of restarting. Uncheck it to force a full re-scan (which also refreshes offers, keeping resolved sellers via `mergeOffers`).
 
 ## 4. Frontend Integration
 - **Hook**: `useVintedCheck` opens the SSE stream and renders progress, per-book search attempts, and matched listings.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -81,6 +81,7 @@ export class VintedSyncService {
   async runVintedCheck(
     sendEvent: (data: SyncEvent) => void,
     checkCancellation: () => boolean,
+    params?: { skipScannedWithinDays?: number },
   ) {
     try {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
@@ -90,11 +91,29 @@ export class VintedSyncService {
       // Filter books:
       // - Have Polish title
       // - Exclude from source: Posiadam, Przeczytane, Audioteka, Biblioteka, Biblioteka 9
-      const candidates = allBooks.filter(b => {
+      let candidates = allBooks.filter(b => {
         const zrodlo = b.zrodlo || [];
         const excluded = ["Posiadam", "Przeczytane", "Audioteka", "Biblioteka", "Biblioteka 9"];
         return !zrodlo.some(z => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
       });
+
+      // Wznawianie: pomiń książki skanowane w ostatnich N dniach — skan rusza od tych
+      // jeszcze niezrobionych (albo starszych niż okno). Dzięki temu przerwany przebieg
+      // (limit ~160/kontener, drop na mobile) kontynuuje się zamiast zaczynać od zera.
+      const skipDays = params?.skipScannedWithinDays;
+      if (skipDays && skipDays > 0) {
+        const cutoff = Date.now() - skipDays * 86_400_000;
+        const before = candidates.length;
+        candidates = candidates.filter(b => {
+          const at = parseVintedData(b.vintedData)?.scannedAt;
+          const t = at ? Date.parse(at) : NaN;
+          return isNaN(t) || t < cutoff; // nigdy nieskanowana lub stara → skanuj
+        });
+        const skipped = before - candidates.length;
+        if (skipped > 0) {
+          sendEvent({ type: "status", message: `Wznawianie: pominięto ${skipped} świeżo skanowanych (< ${skipDays} dni). Do sprawdzenia: ${candidates.length}.` });
+        }
+      }
 
       sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia na Vinted...` });
 

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -20,7 +20,7 @@ function shortDate(iso?: string | null): string {
 interface VintedCheckItemProps {
   results: VintedResult[];
   searchAttempts: VintedSearchAttempt[];
-  onCheck: () => void;
+  onCheck: (opts?: { skipScannedWithinDays?: number }) => void;
   onStop: () => void;
   isChecking: boolean;
   progress: any;
@@ -42,8 +42,12 @@ function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
   return parts.join(" · ");
 }
 
+const RESUME_DAYS = 3;
+
 export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
   const [showLogs, setShowLogs] = React.useState(false);
+  // Wznawianie: domyślnie pomijamy książki skanowane < RESUME_DAYS dni (kontynuuj, nie od zera).
+  const [resumeScan, setResumeScan] = React.useState(true);
   const { sellersByUrl, isGrouping, groupProgress, groupError, runGrouping, stopGrouping } = useVintedGrouping();
   const { isResolving, resolveProgress, resolveResult, resolveError, runResolve, stopResolve } = useVintedResolveSellers();
   const { stored, isLoadingStored, storedError, loadStored, clearStored } = useVintedStored();
@@ -170,14 +174,29 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
             </button>
           )}
 
+          {!isChecking && (
+            <label
+              className="flex items-center gap-1.5 text-[11px] font-bold text-slate-400 cursor-pointer select-none"
+              title={`Pomiń książki skanowane w ostatnich ${RESUME_DAYS} dniach — skan rusza od niezrobionych (kontynuacja po przerwaniu). Odznacz, by skanować wszystko od nowa.`}
+            >
+              <input
+                type="checkbox"
+                checked={resumeScan}
+                onChange={(e) => setResumeScan(e.target.checked)}
+                className="accent-cyan-500 w-3.5 h-3.5"
+              />
+              Kontynuuj
+            </label>
+          )}
+
           <button
             onClick={() => {
               if (isChecking) onStop();
-              else onCheck(); 
+              else onCheck(resumeScan ? { skipScannedWithinDays: RESUME_DAYS } : undefined);
             }}
             className={`flex items-center gap-3 px-6 py-3 rounded-2xl transition-all text-sm font-bold text-white shadow-xl ${
-              isChecking 
-                ? "bg-red-600 hover:bg-red-500 shadow-red-500/20" 
+              isChecking
+                ? "bg-red-600 hover:bg-red-500 shadow-red-500/20"
                 : "bg-cyan-600 hover:bg-cyan-500 shadow-cyan-500/20"
             }`}
           >

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -56,7 +56,7 @@ export function useVintedCheck() {
   // Ref zamiast stanu w strażniku — stan w domknięciu bywa nieaktualny
   const isCheckingRef = useRef(false);
 
-  const runVintedCheck = useCallback(async () => {
+  const runVintedCheck = useCallback(async (opts?: { skipScannedWithinDays?: number }) => {
     if (isCheckingRef.current) return;
     isCheckingRef.current = true;
     setIsChecking(true);
@@ -77,6 +77,7 @@ export function useVintedCheck() {
       const response = await fetch("/api/vinted-check", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skipScannedWithinDays: opts?.skipScannedWithinDays }),
         signal: watchdog.signal
       });
 

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -80,7 +80,7 @@ const TASK_REGISTRY: Record<SyncTaskName, (sendEvent: (data: SyncEvent) => void,
   cycles:     (s) => (cc) => cyclesSyncService.runCyclesSync(s, cc),
   integrity:  (s) => (cc) => integrityService.runIntegrityCheck(s, cc),
   library:    (s, p) => (cc) => libraryCheckService.runLibraryCheck(p.libraryCode, s, cc),
-  vinted:     (s) => (cc) => vintedSyncService.runVintedCheck(s, cc),
+  vinted:     (s, p) => (cc) => vintedSyncService.runVintedCheck(s, cc, p),
   "vinted-group": (s, p) => (cc) => vintedSyncService.resolveSellers(p.items, s, cc),
   "vinted-resolve-sellers": (s, p) => (cc) => vintedSyncService.resolveSellersToStore(s, cc, p),
 };


### PR DESCRIPTION
## Why

The scan always restarted from the first candidate, so an interrupted run — the ~160-books-per-container Render limit, or a **mobile connection drop when the browser is backgrounded** (switching apps suspends the tab → SSE drops → server cancels) — re-did the same books and often never reached the tail. Persistence's `scannedAt` (stages 1–3) makes resuming possible.

## What

- **Service**: `runVintedCheck` takes `{ skipScannedWithinDays }`; candidates whose stored `scannedAt` is within the window are filtered out (never-scanned or stale books still run), and the skipped count is reported in a status event.
- **Wiring**: the `vinted` task passes params; the controller reads `skipScannedWithinDays` from the body (clamped 1–365); `useVintedCheck.runVintedCheck(opts)` sends it.
- **UI**: a **"Kontynuuj"** checkbox next to the scan button (default **on** → 3 days). Unchecking forces a full re-scan — which also refreshes offers while keeping resolved sellers via `mergeOffers`.

## Answers to the other two questions

- **Null sellers in the blob**: expected, not a bug — a seller stays `null` when the per-run cap (150) was hit, the offer page 403'd, or the offer is **gone** (sold → page has no `/member/`). Re-running "Ustal sprzedawców (baza)" fills the first two; gone offers can't resolve and drop on the book's next scan.
- **Mobile network error on app switch**: it's the mobile browser suspending the backgrounded tab and dropping the connection — the same client-disconnect mechanism, not a code bug. This resumable scan is the pragmatic fix: if it drops, just re-run and it continues.

## Verification

204 tests green, `npm run lint` clean, `npm run build` OK. v1.6.0 (metadata + package + lockfile synced); backlog + `docs/vinted-scanner.md` updated.

## What to check on Render

Run a scan, stop it partway (or let it drop), then run again with "Kontynuuj" checked — it should report "pominięto N świeżo skanowanych" and only work through the remaining books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_