### PR TITLE
feat(vinted): tag books found on Vinted with a "Vinted" source tag

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.6.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.7.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,9 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.7.0** — Skan taguje źródło: książka z ofertami na Vinted (match) dostaje tag
+  „Vinted" w kolumnie Źródło (`addTagToMultiSelect`, best-effort, guard po `zrodlo` by
+  nie pisać zbędnie przy re-scanie). Tylko dodaje; nie usuwa gdy oferta zniknie.
 - **1.6.0** — Vinted skan wznawialny: checkbox „Kontynuuj" (dom. ON) pomija książki
   skanowane < 3 dni (`skipScannedWithinDays` z `scannedAt` w blobie) → skan rusza od
   niezrobionych zamiast od zera. Łagodzi limit ~160/kontener i drop połączenia na mobile

--- a/docs/vinted-scanner.md
+++ b/docs/vinted-scanner.md
@@ -34,6 +34,7 @@ Scraping is rate-limited and unreliable (Cloudflare); analysis (grouping) is che
 - **Throttling**: 3–5 s delay (with jitter) between books — applied on **every** path, including the no-results case, to avoid the request bursts that trigger Cloudflare blocks.
 - **429 handling**: On HTTP 429 waits ~5 s before continuing; 403 is surfaced as a Cloudflare block.
 - **Cancellation**: Cooperative — checks the cancellation token each iteration and reports `cancelled: true` on the `complete` event when stopped.
+- **Source tagging**: a book that has offers on Vinted (a match) gets a `Vinted` tag added to its `Źródło` multi-select in Notion (`addTagToMultiSelect`, best-effort, skipped when the book already carries the tag). It only adds the tag; it isn't removed if the offers later disappear. `Vinted` is not in the scan's exclusion list, so tagged books keep being re-scanned.
 - **Resumable scan**: with the `skipScannedWithinDays` param (frontend "Kontynuuj" checkbox, default on → 3 days), candidates whose stored `scannedAt` is within the window are skipped, so an interrupted run (the ~160-books-per-container limit, or a mobile connection drop when the browser is backgrounded) continues from the un-scanned books instead of restarting. Uncheck it to force a full re-scan (which also refreshes offers, keeping resolved sellers via `mergeOffers`).
 
 ## 4. Frontend Integration

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -222,6 +222,15 @@ export class VintedSyncService {
               type: "search_attempt",
               result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length, debug }
             });
+            // Książka istnieje na Vinted → oznacz źródło tagiem „Vinted" (best-effort).
+            // Guard po zrodlo pomija zbędny zapis dla już otagowanych (re-scan).
+            if (!(book.zrodlo || []).includes("Vinted")) {
+              try {
+                await this.notion.addTagToMultiSelect(book.id, "Źródło", "Vinted");
+              } catch (e: any) {
+                log.warn("Nie udało się dodać tagu Vinted", { title: book.plTitle, error: e?.message });
+              }
+            }
           } else {
             sendEvent({
               type: "search_attempt",


### PR DESCRIPTION
## What

When the scan finds offers for a book (a match), it adds a **`Vinted`** tag to that book's **`Źródło`** multi_select in Notion — so the Source column reflects that the book currently exists on Vinted.

## How

- Uses the existing `addTagToMultiSelect(pageId, "Źródło", "Vinted")`, which reads the page fresh, **dedupes** (no-ops if the tag is already there) and **preserves** other tags.
- A guard on the book's already-loaded `zrodlo` skips the call entirely when the tag is already present, so re-scans don't churn Notion with redundant reads/writes.
- **Best-effort**: a tagging failure is logged and never fails the scan.
- Applied **only to matches** (books with ≥1 offer). Books with no offers aren't tagged.

## Behaviour notes

- It **only adds** the tag; it isn't removed if the offers later disappear (sold/delisted). Say the word if you'd like removal-on-empty on a full re-scan — easy to add, but it means a re-scan that gets 403'd wouldn't wrongly strip the tag, so it needs a "confirmed empty" signal to be safe.
- `Vinted` is **not** in the scan's exclusion list (`Posiadam`, `Przeczytane`, `Audioteka`, `Biblioteka`, `Biblioteka 9`), so tagged books keep being re-scanned as normal.

## Verification

204 tests green, `npm run lint` clean, `npm run build` OK. v1.7.0 (metadata + package + lockfile synced); backlog + `docs/vinted-scanner.md` updated.

On Render: run a scan; books with offers should gain the `Vinted` tag in their Źródło column, and re-running shouldn't re-write already-tagged books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_