### PR TITLE
style(vinted): restyle scanner actions as synchronization-liturgy rituals

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.7.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.8.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.8.0** — Przyciski skanera w stylu rytuałów liturgii synchronizacji. Nowy reużywalny
+  `RitualButton` (ciemna baza slate-950 + kolorowy hover-glow/scale + ikona w boxie +
+  „Rytuał X" + uppercase podtytuł); motyw rozszerzony o `ritualButtonTheme` (literały klas).
+  Akcje skanera przeniesione z „głośnych" pilli do siatki rytuałów (Skanowania /
+  Identyfikacji Handlarzy / Przywołania z Archiwum / Kartelu). Checkbox „Kontynuuj" i
+  logi zostają w nagłówku. Test App zaktualizowany do nowych etykiet.
 - **1.7.1** — „Ustal sprzedawców (baza)": zdjęty cap 150 (domyślnie bez limitu — jeden
   przebieg ustala wszystkie brakujące). Bezpieczne dzięki wznawialności (zapis raz/książkę)
   i throttlingowi (to on chroni rate, nie liczba total). `cap` z body wciąż opcjonalny.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.8.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -357,7 +357,7 @@ describe('App Main Flows', () => {
       expect(screen.getByText(/Katalog Beletrystyka/i)).toBeInTheDocument();
     });
     
-    const searchButton = screen.getByText(/Uruchom Skaner Vinted/i);
+    const searchButton = screen.getByText(/Rytuał Skanowania Vinted/i);
     
     await act(async () => {
       fireEvent.click(searchButton);
@@ -365,7 +365,7 @@ describe('App Main Flows', () => {
     
     // Use waitFor because state update might not be immediate
     await waitFor(() => {
-      expect(screen.getByText(/Zatrzymaj Skanowanie/i)).toBeInTheDocument();
+      expect(screen.getByText(/Przerwij Rytuał Skanowania/i)).toBeInTheDocument();
     });
   });
 

--- a/src/components/stats/RitualButton.tsx
+++ b/src/components/stats/RitualButton.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { LucideIcon } from "lucide-react";
+import { RitualColor, getRitualButtonTheme } from "../../theme/ritualColors";
+
+interface RitualButtonProps {
+  color: RitualColor;
+  icon: LucideIcon;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+  /** Animuj ikonę: „spin" (loader) lub „pulse" (aktywny rytuał). */
+  animate?: "spin" | "pulse";
+  disabled?: boolean;
+  /** Dodatkowe klasy układu, np. `sm:col-span-2`. */
+  className?: string;
+}
+
+/**
+ * Przycisk w stylu rytuału z liturgii synchronizacji (zob. OtherToolsCard): ciemna baza
+ * slate-950, ikona w boxie, kolorowy akcent border/glow/scale na hover, tytuł „Rytuał X"
+ * + uppercase podtytuł. Kolor bierze z centralnego motywu `ritualButtonTheme`. Stan
+ * (bieg/stop/loader) ustala wołający, podając odpowiedni kolor/ikonę/tytuł.
+ */
+export const RitualButton: React.FC<RitualButtonProps> = ({
+  color, icon: Icon, title, subtitle, onClick, animate, disabled, className,
+}) => {
+  const t = getRitualButtonTheme(color);
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl text-left transition-all duration-200 group hover:bg-slate-900/50 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg ${t.hoverBorder} ${t.hoverShadow} disabled:opacity-50 disabled:hover:scale-100 disabled:cursor-not-allowed ${className ?? ""}`}
+    >
+      <div className={`p-3 rounded-xl ${t.iconBg} ${t.iconText} group-hover:scale-110 transition-transform shrink-0`}>
+        <Icon className={`w-5 h-5 ${animate === "spin" ? "animate-spin" : animate === "pulse" ? "animate-pulse" : ""}`} />
+      </div>
+      <div className="min-w-0">
+        <div className={`font-bold text-slate-200 ${t.hoverText} transition-colors`}>{title}</div>
+        <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">{subtitle}</div>
+      </div>
+    </button>
+  );
+};

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -8,6 +8,7 @@ import { useVintedGrouping } from "../../hooks/useVintedGrouping";
 import { useVintedResolveSellers } from "../../hooks/useVintedResolveSellers";
 import { useVintedStored } from "../../hooks/useVintedStored";
 import { groupBySeller } from "../../utils/vintedSellers";
+import { RitualButton } from "./RitualButton";
 
 /** Krótka data „DD.MM" ze znacznika ISO (świeżość danych z bazy). */
 function shortDate(iso?: string | null): string {
@@ -91,89 +92,6 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
         </div>
         
         <div className="flex items-center gap-3">
-          {searchAttempts.length > 0 && (
-            <button
-              onClick={() => setShowLogs(!showLogs)}
-              className={`p-3 rounded-2xl transition-all border ${
-                showLogs 
-                  ? "bg-amber-500/20 border-amber-500/50 text-amber-400" 
-                  : "bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300"
-              }`}
-              title="Pokaż logi skanowania"
-            >
-              <Bug className="w-5 h-5" />
-            </button>
-          )}
-
-          {results.length > 0 && !isChecking && isGrouping && (
-            <button
-              onClick={() => stopGrouping()}
-              className="flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border bg-red-600/90 border-red-500/50 text-white hover:bg-red-500"
-            >
-              <Loader2 className="w-4 h-4 animate-spin" />
-              <span>Zatrzymaj grupowanie</span>
-            </button>
-          )}
-
-          {results.length > 0 && !isChecking && !isGrouping && !isResolving && (
-            <div className="flex items-center gap-2">
-              <button
-                onClick={handleGroupCheapest}
-                className="flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border bg-purple-600/90 border-purple-500/50 text-white hover:bg-purple-500 shadow-lg shadow-purple-500/20"
-                title="Grupuj po sprzedawcy — po najtańszej ofercie z każdej książki (1 zapytanie/książkę, szybkie)"
-              >
-                <Users className="w-4 h-4" />
-                <span>Najtańsze</span>
-              </button>
-              <button
-                onClick={handleGroupAll}
-                className="flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border bg-amber-600/90 border-amber-500/50 text-white hover:bg-amber-500 shadow-lg shadow-amber-500/20"
-                title="Grupuj po sprzedawcy — WSZYSTKIE oferty (ujawnia many-to-many; wolniejsze, cap 150 zapytań)"
-              >
-                <Package className="w-4 h-4" />
-                <span>Wszystkie oferty</span>
-              </button>
-            </div>
-          )}
-
-          {!isChecking && !isGrouping && !isResolving && (
-            usingStored ? (
-              <button
-                onClick={clearStored}
-                className="flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border bg-slate-800/80 border-slate-600/50 text-slate-300 hover:bg-slate-700"
-                title="Wyczyść widok z bazy (wróć do wyników bieżącego skanu)"
-              >
-                <Trash2 className="w-4 h-4" />
-                <span>Wyczyść bazę</span>
-              </button>
-            ) : (
-              <button
-                onClick={loadStored}
-                disabled={isLoadingStored}
-                className="flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border bg-indigo-600/90 border-indigo-500/50 text-white hover:bg-indigo-500 shadow-lg shadow-indigo-500/20 disabled:opacity-60"
-                title="Wczytaj kafelki i paczki ze składowanych danych w Notion (bez skanowania)"
-              >
-                {isLoadingStored ? <Loader2 className="w-4 h-4 animate-spin" /> : <HardDriveDownload className="w-4 h-4" />}
-                <span>Wczytaj z bazy</span>
-              </button>
-            )
-          )}
-
-          {!isChecking && !isGrouping && !usingStored && (
-            <button
-              onClick={() => { if (isResolving) stopResolve(); else runResolve(); }}
-              className={`flex items-center gap-2 px-4 py-3 rounded-2xl transition-all text-sm font-bold border ${
-                isResolving
-                  ? "bg-red-600/90 border-red-500/50 text-white hover:bg-red-500"
-                  : "bg-teal-600/90 border-teal-500/50 text-white hover:bg-teal-500 shadow-lg shadow-teal-500/20"
-              }`}
-              title="Dociągnij sprzedawców do składowanych ofert w Notion (przyrostowo i wznawialnie — jeden przebieg ustala wszystkie brakujące, ile zdąży)"
-            >
-              {isResolving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Database className="w-4 h-4" />}
-              <span>{isResolving ? "Zatrzymaj" : "Ustal sprzedawców (baza)"}</span>
-            </button>
-          )}
-
           {!isChecking && (
             <label
               className="flex items-center gap-1.5 text-[11px] font-bold text-slate-400 cursor-pointer select-none"
@@ -188,31 +106,99 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
               Kontynuuj
             </label>
           )}
-
-          <button
-            onClick={() => {
-              if (isChecking) onStop();
-              else onCheck(resumeScan ? { skipScannedWithinDays: RESUME_DAYS } : undefined);
-            }}
-            className={`flex items-center gap-3 px-6 py-3 rounded-2xl transition-all text-sm font-bold text-white shadow-xl ${
-              isChecking
-                ? "bg-red-600 hover:bg-red-500 shadow-red-500/20"
-                : "bg-cyan-600 hover:bg-cyan-500 shadow-cyan-500/20"
-            }`}
-          >
-            {isChecking ? (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin" />
-                <span>Zatrzymaj Skanowanie</span>
-              </>
-            ) : (
-              <>
-                <Search className="w-4 h-4" />
-                <span>Uruchom Skaner Vinted</span>
-              </>
-            )}
-          </button>
+          {searchAttempts.length > 0 && (
+            <button
+              onClick={() => setShowLogs(!showLogs)}
+              className={`p-3 rounded-2xl transition-all border ${
+                showLogs
+                  ? "bg-amber-500/20 border-amber-500/50 text-amber-400"
+                  : "bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300"
+              }`}
+              title="Pokaż logi skanowania"
+            >
+              <Bug className="w-5 h-5" />
+            </button>
+          )}
         </div>
+      </div>
+
+      {/* Rytuały skanera — w stylu liturgii synchronizacji */}
+      <div className="grid sm:grid-cols-2 gap-3">
+        <RitualButton
+          className="sm:col-span-2"
+          color={isChecking ? "rose" : "cyan"}
+          icon={isChecking ? Loader2 : Search}
+          animate={isChecking ? "spin" : undefined}
+          title={isChecking ? "Przerwij Rytuał Skanowania" : "Rytuał Skanowania Vinted"}
+          subtitle={isChecking ? "Zatrzymanie aktywnego przeszukania katalogu" : "Przeszukanie katalogu Vinted — język polski, od 2 PLN"}
+          onClick={() => {
+            if (isChecking) onStop();
+            else onCheck(resumeScan ? { skipScannedWithinDays: RESUME_DAYS } : undefined);
+          }}
+        />
+
+        {!isChecking && !isGrouping && !usingStored && (
+          <RitualButton
+            color={isResolving ? "rose" : "emerald"}
+            icon={isResolving ? Loader2 : Database}
+            animate={isResolving ? "spin" : undefined}
+            title={isResolving ? "Przerwij Identyfikację" : "Rytuał Identyfikacji Handlarzy"}
+            subtitle={isResolving ? "Zatrzymanie dociągania sprzedawców" : "Dociągnięcie sprzedawców do bazy — wznawialny"}
+            onClick={() => { if (isResolving) stopResolve(); else runResolve(); }}
+          />
+        )}
+
+        {!isChecking && !isGrouping && !isResolving && (
+          usingStored ? (
+            <RitualButton
+              color="indigo"
+              icon={Trash2}
+              title="Rozwiej Przywołanie"
+              subtitle="Powrót do wyników bieżącego skanu"
+              onClick={clearStored}
+            />
+          ) : (
+            <RitualButton
+              color="indigo"
+              icon={isLoadingStored ? Loader2 : HardDriveDownload}
+              animate={isLoadingStored ? "spin" : undefined}
+              disabled={isLoadingStored}
+              title="Rytuał Przywołania z Archiwum"
+              subtitle="Kafelki i paczki ze składowanych danych — bez skanu"
+              onClick={loadStored}
+            />
+          )
+        )}
+
+        {results.length > 0 && !isChecking && isGrouping && (
+          <RitualButton
+            color="rose"
+            icon={Loader2}
+            animate="spin"
+            title="Przerwij Rytuał Kartelu"
+            subtitle="Zatrzymanie grupowania per sprzedawca"
+            onClick={() => stopGrouping()}
+          />
+        )}
+
+        {results.length > 0 && !isChecking && !isGrouping && !isResolving && !usingStored && (
+          <>
+            <RitualButton
+              color="purple"
+              icon={Users}
+              title="Rytuał Kartelu — Najtańsze"
+              subtitle="Grupowanie po najtańszej ofercie z książki"
+              onClick={handleGroupCheapest}
+            />
+            <RitualButton
+              color="amber"
+              icon={Package}
+              title="Rytuał Kartelu — Wszystkie"
+              subtitle="Grupowanie po wszystkich ofertach — many-to-many"
+              onClick={handleGroupAll}
+            />
+          </>
+        )}
       </div>
 
       {isChecking && progress && (

--- a/src/theme/ritualColors.ts
+++ b/src/theme/ritualColors.ts
@@ -50,6 +50,33 @@ export const ritualTheme: Record<RitualColor, RitualTheme> = {
 export const getRitualTheme = (color?: string | null): RitualTheme =>
   ritualTheme[(color as RitualColor)] ?? ritualTheme.cyan;
 
+/**
+ * Klasy przycisku-rytuału (styl „liturgii synchronizacji": ciemna baza slate-950,
+ * kolorowy akcent border/glow na hover, ikona w boxie). Pełne literały — patrz uwaga
+ * o skanerze JIT Tailwinda na górze pliku. Używane przez komponent `RitualButton`.
+ */
+export interface RitualButtonTheme {
+  hoverBorder: string;
+  hoverShadow: string;
+  iconBg: string;
+  iconText: string;
+  hoverText: string;
+}
+
+export const ritualButtonTheme: Record<RitualColor, RitualButtonTheme> = {
+  cyan:    { hoverBorder: "hover:border-cyan-500/50",    hoverShadow: "hover:shadow-cyan-500/10",    iconBg: "bg-cyan-500/10",    iconText: "text-cyan-400",    hoverText: "group-hover:text-cyan-400" },
+  rose:    { hoverBorder: "hover:border-rose-500/50",    hoverShadow: "hover:shadow-rose-500/10",    iconBg: "bg-rose-500/10",    iconText: "text-rose-400",    hoverText: "group-hover:text-rose-400" },
+  indigo:  { hoverBorder: "hover:border-indigo-500/50",  hoverShadow: "hover:shadow-indigo-500/10",  iconBg: "bg-indigo-500/10",  iconText: "text-indigo-400",  hoverText: "group-hover:text-indigo-400" },
+  blue:    { hoverBorder: "hover:border-blue-500/50",    hoverShadow: "hover:shadow-blue-500/10",    iconBg: "bg-blue-500/10",    iconText: "text-blue-400",    hoverText: "group-hover:text-blue-400" },
+  purple:  { hoverBorder: "hover:border-purple-500/50",  hoverShadow: "hover:shadow-purple-500/10",  iconBg: "bg-purple-500/10",  iconText: "text-purple-400",  hoverText: "group-hover:text-purple-400" },
+  orange:  { hoverBorder: "hover:border-orange-500/50",  hoverShadow: "hover:shadow-orange-500/10",  iconBg: "bg-orange-500/10",  iconText: "text-orange-400",  hoverText: "group-hover:text-orange-400" },
+  amber:   { hoverBorder: "hover:border-amber-500/50",   hoverShadow: "hover:shadow-amber-500/10",   iconBg: "bg-amber-500/10",   iconText: "text-amber-400",   hoverText: "group-hover:text-amber-400" },
+  emerald: { hoverBorder: "hover:border-emerald-500/50", hoverShadow: "hover:shadow-emerald-500/10", iconBg: "bg-emerald-500/10", iconText: "text-emerald-400", hoverText: "group-hover:text-emerald-400" },
+};
+
+export const getRitualButtonTheme = (color?: string | null): RitualButtonTheme =>
+  ritualButtonTheme[(color as RitualColor)] ?? ritualButtonTheme.cyan;
+
 /** Sama kropka kroku (z fallbackiem do cyan). */
 export const getRitualDot = (color?: string | null): string => getRitualTheme(color).dot;
 


### PR DESCRIPTION
## What

The scanner's action buttons were loud solid-colour pills — out of step with the **synchronization-liturgy rituals** (`OtherToolsCard`): dark `slate-950` base, coloured hover border/glow/scale, icon-in-a-box, "Rytuał X" title + uppercase subtitle. Reworked them to match that design language.

## How

- **New reusable `RitualButton`** (`src/components/stats/RitualButton.tsx`) capturing the ritual design, coloured from the central theme. State (run / stop / loader) is driven by the caller passing the right colour/icon/animation.
- **`ritualColors.ts`** gains `ritualButtonTheme` — full-literal Tailwind classes per ritual colour (respecting the JIT-scanner note in that file) + `getRitualButtonTheme`.
- **`VintedCheckItem`** actions moved from a crowded horizontal pill row into a **ritual grid**:
  - **Rytuał Skanowania Vinted** (cyan; rose "Przerwij" while running) — full width.
  - **Rytuał Identyfikacji Handlarzy** (emerald) — the store seller resolution.
  - **Rytuał Przywołania z Archiwum** (indigo) — load from store / "Rozwiej Przywołanie" to clear.
  - **Rytuał Kartelu — Najtańsze / Wszystkie** (purple / amber) — the live grouping.
  - The **"Kontynuuj"** checkbox and the debug-logs toggle stay as compact header controls.

Behaviour is unchanged — same handlers, same conditional visibility, same states; only the presentation.

## Verification

204 tests green (the App flow test updated to the new "Rytuał Skanowania Vinted" / "Przerwij Rytuał Skanowania" labels), `npm run lint` clean, `npm run build` OK. v1.8.0; backlog updated.

## Note

The two **Rytuał Kartelu** buttons (Najtańsze/Wszystkie) are the live-grouping ones we flagged for removal earlier — I restyled them for now so nothing looks half-finished, but they can go when we do that cleanup, and `RitualButton` is ready to be reused if any survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_