### PR TITLE
fix(vinted): stop re-scan wiping stored data on block/parser-miss (+ UX fixes)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.9.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.9.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.9.1** — Bughunting (3 agenty). NAPRAWIONE: (KRYTYCZNE) re-scan z blokadą/missem parsera
+  kasował składowane oferty i sprzedawców — `looksBlocked` teraz `continue` (nie kasuje,
+  nie stempluje scannedAt → wznowienie ponawia), a „0 ofert bez markera" nie nadpisuje,
+  gdy wcześniej coś było. (UX) skan z widoku bazy chował świeże wyniki → `clearStored` na
+  starcie; start skanu zablokowany w trakcie resolucji (nieanulowalność); pusty odczyt bazy
+  ma notkę. Odrzucone jako nie-bug po weryfikacji na realnym HTML: /member regex (seller to
+  jedyny numeryczny link), aria-label ceny (ochrona na początku, wygrywa węzeł tekstowy).
 - **1.9.0** — Usunięto live-grupowanie (przyciski „Najtańsze"/„Wszystkie oferty" — Rytuały
   Kartelu) zastąpione ścieżką bazodanową (Ustal sprzedawców → Wczytaj z bazy). Wycięty
   martwy kod: hook `useVintedGrouping`, endpoint `/api/vinted-group` (+task, controller),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -184,6 +184,10 @@ export class VintedSyncService {
               type: "search_attempt",
               result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } }
             });
+            // Blok to NIE „brak ofert": NIE zapisujemy pustki (zachowaj składowane oferty
+            // i ustalonych sprzedawców) ani `scannedAt`, by wznowienie ponowiło tę książkę.
+            await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
+            continue;
           }
 
           if (html.includes("Brak wyników") || html.includes("Nie znaleźliśmy żadnych przedmiotów")) {
@@ -205,10 +209,9 @@ export class VintedSyncService {
           const items = parseVintedItems(html, title, book.author || "");
           const debug = { ...vintedDiagnostics(html, items.length), ...memMb() };
 
-          // Utrwal wynik (match lub 0 ofert) — scala ze składowanymi, zachowuje sprzedawców.
-          if (persistEnabled) await this.persistBookOffers(book, items, scannedAt);
-
           if (items.length > 0) {
+            // Utrwal (scala ze składowanymi — zachowuje sprzedawców przy niezmienionym URL).
+            if (persistEnabled) await this.persistBookOffers(book, items, scannedAt);
             const matchResult = {
               id: book.id,
               title: book.plTitle,
@@ -232,6 +235,15 @@ export class VintedSyncService {
               }
             }
           } else {
+            // 0 ofert BEZ markera „brak wyników" i bez blokady: realnie pusto ALBO cichy
+            // miss parsera. Nie kasuj wcześniej zapisanych ofert/sprzedawców — utrwal pustkę
+            // tylko, gdy nic wcześniej nie było (pierwszy skan tej książki).
+            const hadStored = (parseVintedData(book.vintedData)?.offers.length ?? 0) > 0;
+            if (persistEnabled && !hadStored) {
+              await this.persistBookOffers(book, [], scannedAt);
+            } else if (hadStored) {
+              log.warn("0 ofert mimo zapisanych wcześniej — pomijam zapis (możliwy miss/blok), zachowuję dane", { title });
+            }
             sendEvent({
               type: "search_attempt",
               result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug }

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -106,11 +106,14 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
           color={isChecking ? "rose" : "cyan"}
           icon={isChecking ? Loader2 : Search}
           animate={isChecking ? "spin" : undefined}
+          disabled={!isChecking && isResolving}
           title={isChecking ? "Przerwij Rytuał Skanowania" : "Rytuał Skanowania Vinted"}
           subtitle={isChecking ? "Zatrzymanie aktywnego przeszukania katalogu" : "Przeszukanie katalogu Vinted — język polski, od 2 PLN"}
           onClick={() => {
-            if (isChecking) onStop();
-            else onCheck(resumeScan ? { skipScannedWithinDays: RESUME_DAYS } : undefined);
+            if (isChecking) { onStop(); return; }
+            // Wyjdź z widoku bazy, żeby świeże wyniki skanu były widoczne (nie pinowane do stored).
+            clearStored();
+            onCheck(resumeScan ? { skipScannedWithinDays: RESUME_DAYS } : undefined);
           }}
         />
 
@@ -258,6 +261,9 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
         </p>
       )}
       {storedError && <p className="text-xs text-red-400 italic px-2">{storedError}</p>}
+      {stored && stored.results.length === 0 && !isLoadingStored && (
+        <p className="text-xs text-slate-500 italic px-2">Baza Vinted jest pusta — najpierw uruchom skan (i „Ustal sprzedawców (baza)").</p>
+      )}
 
       {usingStored && (
         <div className="flex items-center gap-2 px-4 py-2.5 rounded-2xl bg-indigo-500/10 border border-indigo-500/20 text-[11px] text-indigo-200 font-medium">


### PR DESCRIPTION
Results of a 3-agent bug hunt over the recent Vinted persistence work, verified by hand before fixing.

## Critical: re-scan could wipe stored offers + resolved sellers

On a re-scan, a soft Cloudflare block (a **200** "just a moment" page) or a **parser miss** yields 0 parsed items. The scan then called `persistBookOffers(book, [], now)` unconditionally, overwriting the book's blob with an **empty** offer list — destroying previously-stored offers **and** the sellers resolved into them — and stamping `scannedAt=now`, so a resumed run skipped the book instead of retrying it. This made "refresh" actively dangerous.

**Fix:**
- `looksBlocked` now `continue`s (after the normal delay): a block is not "no offers", so nothing is persisted and `scannedAt` is left stale → the book is retried on the next run.
- The persist call moved out of the unconditional pre-branch spot: matches persist as before; a 0-offer result **without** an explicit "Brak wyników" marker only writes an empty blob when nothing was stored before (first scan) — otherwise it **preserves** the existing data.

## Frontend UX fixes (same hunt)

- **Scan from the stored view was invisible**: `clearStored()` on scan start, so fresh results aren't pinned behind the "Dane z bazy" view.
- **Seller resolution could become uncancellable**: the scan ritual is now disabled while a resolution runs, so its only Stop control can't unmount.
- **Empty "Wczytaj z bazy" was a silent no-op**: now shows a "baza pusta" note.

## Verified and rejected (non-bugs)

Two parser findings were checked against the captured real HTML and dismissed: the seller `/member/{id}` link is the only **numeric** one (the four before it are `/member/signup/...`, which the `\d+` requirement skips), and catalog `aria-label`s carry the **protection** price at the *start* (`"6,05 zł zawiera Ochronę Kupujących"`), so the trailing-`"` regex doesn't match them and the correct `>NN zł<` text-node price wins.

## Verification

204 tests green, `npm run lint` clean, `npm run build` OK. v1.9.1; backlog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_