### PR TITLE
fix(vinted): bug-hunt round 2 — data-loss guard, change-badge accuracy, UI races

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.10.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.10.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.10.1** — Bughunting runda 2 (3 agenty). NAPRAWIONE: (dane) gałąź „Brak wyników"
+  kasowała oferty bez guardu `hadStored` (fałszywy substring w 7 MB) → teraz nie nadpisuje;
+  (change-detect) pierwszy skan/migracja fałszywie oznaczały „zmiana"/„nowa" → `changedAt`
+  tylko przy baseline, survivor zachowuje oryginalny `firstSeenAt` (undefined dla starych
+  blobów), „nowa" wymaga changedAt===scannedAt; dedupe URL w `mergeAndDiff`; (UI) wyścig
+  wczytania z bazy porywał widok po starcie skanu/resolucji → pokolenie+abort w
+  `useVintedStored` + `clearStored` na starcie resolucji; stabilny klucz miniatur;
+  brak podwójnej notki pustego stanu; (infra) `res.on('error')` w SSE (koniec uncaughtException),
+  guard kluczy Notion na resolve/stored. Reszta infra: czyste (lock, cache, agent, chunking).
 - **1.10.0** — Wykrywanie zmian przy odświeżaniu. `mergeAndDiff` (zamiast `mergeOffers`):
   liczy nowe/zniknięte/spadek/wzrost ceny, zachowuje sprzedawcę + `firstSeenAt`, zapisuje
   `prevPrice`; `changedAt` w blobie (kiedy ostatnio się zmieniło). Widok z bazy: badge

--- a/controllers/sseStream.ts
+++ b/controllers/sseStream.ts
@@ -73,6 +73,13 @@ export const executeSyncTask = async (
     }
   });
 
+  // Zapis do strumienia (sendEvent/keepalive) ma wyścig check-then-write: reset TCP między
+  // guardem `!writableEnded` a `res.write` emituje 'error'. Bez listenera stałby się to
+  // nieobsłużony uncaughtException. Połknij i zaloguj — `res.on('close')` i tak sprząta.
+  res.on("error", (err: any) => {
+    log.warn("Błąd strumienia SSE (klient prawdopodobnie się rozłączył).", { endpoint: req.path, error: err?.message });
+  });
+
   try {
     await task(sendEvent);
     clearInterval(keepAlive);

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -198,6 +198,9 @@ export const checkVintedAvailability = async (req: Request, res: Response) => {
 export const stopVintedCheck = makeStopHandler("Zatrzymywanie skanowania Vinted...");
 
 export const resolveVintedSellers = async (req: Request, res: Response) => {
+  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+    return res.status(400).json({ error: "Brak kluczy API Notion." });
+  }
   // Bez capu domyślnie — resolucja jest przyrostowa i wznawialna, więc jeden przebieg
   // ustala wszystkie brakujące, ile zdąży. Opcjonalny `cap` z body ogranicza przebieg.
   const capRaw = req.body?.cap;
@@ -214,6 +217,9 @@ export const resolveVintedSellers = async (req: Request, res: Response) => {
 export const stopVintedResolveSellers = makeStopHandler("Zatrzymywanie ustalania sprzedawców...");
 
 export const getVintedStored = async (_req: Request, res: Response) => {
+  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+    return res.status(400).json({ error: "Brak kluczy API Notion." });
+  }
   try {
     res.json(await syncManager.getVintedStored());
   } catch (error: any) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/vintedStore.test.ts
+++ b/services/__tests__/vintedStore.test.ts
@@ -58,6 +58,30 @@ describe("vintedStore", () => {
     expect(hasChanges(diff)).toBe(false); // same url, same price
   });
 
+  it("mergeAndDiff dedupes duplicate URLs in fresh (counts once, stores once)", () => {
+    const { offers, diff } = mergeAndDiff(
+      [
+        { url: "a", price: 5, currency: "zł" },
+        { url: "a", price: 5, currency: "zł" }, // duplikat z parsera
+        { url: "b", price: 6, currency: "zł" },
+      ],
+      undefined,
+      "2026-02-01T00:00:00.000Z",
+    );
+    expect(offers).toHaveLength(2);
+    expect(offers.map(o => o.url)).toEqual(["a", "b"]);
+    expect(diff.added).toBe(2);
+  });
+
+  it("mergeAndDiff leaves a legacy survivor (no firstSeenAt) undefined so it isn't marked 'nowa'", () => {
+    const { offers } = mergeAndDiff(
+      [{ url: "a", price: 10, currency: "zł" }],
+      [{ url: "a", price: 10, currency: "zł" }], // stary blob: brak firstSeenAt
+      "2026-02-01T00:00:00.000Z",
+    );
+    expect(offers[0].firstSeenAt).toBeUndefined();
+  });
+
   it("mergeAndDiff counts a price rise separately from a drop", () => {
     const { diff } = mergeAndDiff(
       [{ url: "a", price: 12, currency: "zł" }],

--- a/services/vintedStore.ts
+++ b/services/vintedStore.ts
@@ -101,18 +101,29 @@ export function mergeAndDiff(
   scannedAt: string,
 ): { offers: StoredOffer[]; diff: OfferDiff } {
   const prevByUrl = new Map((prev ?? []).map(o => [o.url, o]));
-  const freshUrls = new Set(fresh.map(o => o.url));
-  let added = 0, priceDropped = 0, priceRaised = 0;
 
-  const offers: StoredOffer[] = fresh.map(o => {
+  // Dedupe świeżych po URL — parser potrafi zwrócić tę samą ofertę dwa razy; bez tego
+  // `added` i lista ofert puchną (duplikat renderowany 2× i liczony jako 2 „nowe").
+  const uniqueFresh: StoredOffer[] = [];
+  const freshUrls = new Set<string>();
+  for (const o of fresh) {
+    if (freshUrls.has(o.url)) continue;
+    freshUrls.add(o.url);
+    uniqueFresh.push(o);
+  }
+
+  let added = 0, priceDropped = 0, priceRaised = 0;
+  const offers: StoredOffer[] = uniqueFresh.map(o => {
     const old = prevByUrl.get(o.url);
     if (!old) {
       added++;
       return { ...o, seller: o.seller ?? null, firstSeenAt: scannedAt };
     }
-    // Oferta przetrwała: zachowaj sprzedawcę i firstSeenAt, zapisz cenę poprzednią.
+    // Oferta przetrwała: zachowaj sprzedawcę i ORYGINALNY firstSeenAt (może być undefined
+    // dla starych blobów sprzed tej funkcji — wtedy NIE oznaczamy jej jako „nowa"), zapisz
+    // poprzednią cenę do wykrycia spadku.
     const seller = o.seller ?? old.seller ?? null;
-    const firstSeenAt = old.firstSeenAt ?? scannedAt;
+    const firstSeenAt = old.firstSeenAt;
     const prevPrice = typeof old.price === "number" ? old.price : null;
     if (typeof o.price === "number" && typeof old.price === "number" && o.price !== old.price) {
       if (o.price < old.price) priceDropped++; else priceRaised++;

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -72,8 +72,9 @@ export class VintedSyncService {
       const fresh = items.map(offerFromItem);
       const prevData = parseVintedData(book.vintedData);
       const { offers, diff } = mergeAndDiff(fresh, prevData?.offers, scannedAt);
-      // changedAt aktualizujemy tylko, gdy faktycznie coś się zmieniło (inaczej zachowaj poprzedni).
-      const changedAt = hasChanges(diff) ? scannedAt : prevData?.changedAt;
+      // changedAt bumpujemy tylko, gdy JEST poprzedni stan (baseline) I faktycznie coś się
+      // zmieniło — inaczej pierwszy skan fałszywie oznaczałby całą książkę jako „zmiana".
+      const changedAt = prevData && hasChanges(diff) ? scannedAt : prevData?.changedAt;
       await this.notion.saveVintedData(book.id, serializeVintedData({ scannedAt, changedAt, offers }));
       return diff;
     } catch (e: any) {
@@ -202,8 +203,15 @@ export class VintedSyncService {
               type: "search_attempt",
               result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } }
             });
-            // Zapisz „przeskanowano, brak ofert" — utrwala pokrycie skanu (wznawialność).
-            if (persistEnabled) await this.persistBookOffers(book, [], scannedAt);
+            // Utrwal pustkę tylko, gdy nic wcześniej nie było — „Brak wyników" to naiwny
+            // substring w ~7 MB markupie i bywa fałszywy na stronie Z ofertami; nie kasujemy
+            // wtedy zapisanych ofert/sprzedawców (zachowanie jak przy cichym missie).
+            const hadStored = (parseVintedData(book.vintedData)?.offers.length ?? 0) > 0;
+            if (persistEnabled && !hadStored) {
+              await this.persistBookOffers(book, [], scannedAt);
+            } else if (hadStored) {
+              log.warn("Marker 'Brak wyników' mimo zapisanych ofert — pomijam zapis (możliwy fałszywy marker)", { title });
+            }
             // Odczekaj jak przy każdym innym zapytaniu — pomijanie opóźnienia
             // przy braku wyników (częsty przypadek) to prosta droga do blokady
             await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -134,7 +134,7 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
             animate={isResolving ? "spin" : undefined}
             title={isResolving ? "Przerwij Identyfikację" : "Rytuał Identyfikacji Handlarzy"}
             subtitle={isResolving ? "Zatrzymanie dociągania sprzedawców" : "Dociągnięcie sprzedawców do bazy — wznawialny"}
-            onClick={() => { if (isResolving) stopResolve(); else runResolve(); }}
+            onClick={() => { if (isResolving) { stopResolve(); return; } clearStored(); runResolve(); }}
           />
         )}
 
@@ -406,15 +406,18 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                   const isCheapest = i === cheapestIdx;
                   const hasPrice = item.priceValue !== null && item.priceValue !== undefined;
                   const offerTitle = cleanOfferTitle(item.title);
-                  // Znaczniki zmian (dane z bazy): „nowa" = pojawiła się w ostatnim skanie;
-                  // „spadek" = cena niższa niż w poprzednim skanie.
-                  const isNew = !!item.firstSeenAt && item.firstSeenAt === result.scannedAt;
+                  // Znaczniki zmian (dane z bazy): „nowa" = pojawiła się w ostatnim skanie,
+                  // ale tylko gdy ten skan W OGÓLE wykrył zmianę (changedAt===scannedAt) —
+                  // inaczej pierwszy skan oznaczałby wszystkie oferty jako nowe.
+                  const isNew = !!item.firstSeenAt
+                    && item.firstSeenAt === result.scannedAt
+                    && result.changedAt === result.scannedAt;
                   const drop = (item.prevPrice != null && item.priceValue != null && item.priceValue < item.prevPrice)
                     ? item.prevPrice - item.priceValue
                     : null;
                   return (
                   <a
-                    key={i}
+                    key={item.url ?? i}
                     href={item.url}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -474,7 +477,7 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
         </motion.div>
       )}
       
-      {displayResults.length === 0 && !isChecking && !isLoadingStored && (
+      {displayResults.length === 0 && !isChecking && !isLoadingStored && !stored && (
         <p className="text-xs text-slate-500 italic text-center py-4">Brak wyników z Vinted. Uruchom skanowanie albo wczytaj z bazy.</p>
       )}
     </div>

--- a/src/hooks/useVintedStored.ts
+++ b/src/hooks/useVintedStored.ts
@@ -1,35 +1,55 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { storedToView, StoredView } from "../utils/vintedSellers";
 
 /**
  * Etap 3: wczytuje SKŁADOWANE wyniki Vinted z Notion (`GET /api/vinted-stored`) i mapuje
  * na widok renderowalny tym samym UI co skan live — kafelki i paczki lecą z bazy, bez
  * re-scrape. Zwykły GET (odczyt Notion, nie Cloudflare), więc bez SSE/watchdoga.
+ *
+ * Ochrona przed wyścigiem: `genRef` + AbortController — gdy w trakcie wolnego GET-a
+ * użytkownik ruszy skan/resolucję (które wołają `clearStored`), przestarzała odpowiedź
+ * jest porzucana i nie „porywa" widoku (nie ustawia `stored` po fakcie).
  */
 export function useVintedStored() {
   const [stored, setStored] = useState<StoredView | null>(null);
   const [isLoadingStored, setIsLoadingStored] = useState(false);
   const [storedError, setStoredError] = useState<string | null>(null);
+  const genRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
 
   const loadStored = useCallback(async () => {
+    const gen = ++genRef.current;
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
     setIsLoadingStored(true);
     setStoredError(null);
     try {
-      const res = await fetch("/api/vinted-stored");
+      const res = await fetch("/api/vinted-stored", { signal: ac.signal });
+      if (gen !== genRef.current) return; // unieważnione (clear/nowe żądanie)
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({}));
         throw new Error(errorData.error || `Błąd serwera: ${res.status}`);
       }
       const data = await res.json();
+      if (gen !== genRef.current) return; // sprawdź ponownie po await
       setStored(storedToView(data.books || []));
     } catch (err: any) {
+      if (err?.name === "AbortError" || gen !== genRef.current) return;
       setStoredError(err.message);
     } finally {
-      setIsLoadingStored(false);
+      if (gen === genRef.current) setIsLoadingStored(false);
     }
   }, []);
 
-  const clearStored = useCallback(() => setStored(null), []);
+  const clearStored = useCallback(() => {
+    // Unieważnij każdy load w locie (bump pokolenia + abort) i wyjdź z widoku bazy.
+    genRef.current++;
+    abortRef.current?.abort();
+    setIsLoadingStored(false);
+    setStored(null);
+  }, []);
 
   return { stored, isLoadingStored, storedError, loadStored, clearStored };
 }


### PR DESCRIPTION
Second 3-agent bug hunt (change-detection / infra / frontend-state), each finding verified by hand before fixing.

## Data integrity
- **"Brak wyników" branch could still wipe stored data.** The #67 fix guarded the silent-miss path but this branch persisted `offers=[]` unconditionally — a false-positive of that substring in the ~7 MB page (possible on a page that *has* offers) destroyed stored offers + resolved sellers. Now guarded by `hadStored` like the miss path: it only writes empty on a book's first scan.

## Change-detection accuracy
- **First scan / legacy blobs falsely flagged everything "zmiana"/"nowa".** `changedAt` is now bumped only when a prior baseline existed **and** something changed; `mergeAndDiff` keeps a survivor's **original** `firstSeenAt` (undefined for pre-feature blobs, so they don't light up "nowa"); the "nowa" badge additionally requires `changedAt === scannedAt`.
- **Duplicate URLs.** `mergeAndDiff` now dedupes duplicate URLs in `fresh` (the parser can emit the same offer twice) so counts and the stored list don't double up.

## Frontend races / keys
- **Slow "Wczytaj z bazy" could hijack the view.** A load GET resolving after the user started a scan/resolution flipped `usingStored`, hiding fresh results and unmounting the resolution's only Stop control. `useVintedStored` now uses a **generation counter + AbortController**; `clearStored` invalidates in-flight loads; starting a resolution also clears a pending load.
- **Offer rows keyed by `item.url`** (was index) so a broken-image `display:none` can't stick to a reused DOM node after reorder/replace.
- Suppressed the double empty-state note.

## Infra
- `executeSyncTask` adds **`res.on('error')`** so the SSE write check-then-write race (client reset between the `writableEnded` guard and `res.write`) is swallowed instead of becoming an `uncaughtException`.
- `resolveVintedSellers` / `getVintedStored` return the same clean **400** on missing Notion keys as their peers.

Everything else infra (single-active-task lock, cache coherence during a live scan, keep-alive agent over a 200-book scan, 2000-char chunking) was reviewed and **found clean**.

## Verification
207 tests green (+2: dedupe, legacy-survivor firstSeenAt), `npm run lint` clean, `npm run build` OK. v1.10.1; backlog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_