### PR TITLE
fix: honest reporting + broader template match in cycle detection (v1.11.2)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.11.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.11.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - Suite: 187+ testów zielonych; `npm run lint` (tsc) czysty.
@@ -59,6 +59,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.11.2** — Oznaczanie cykli: naprawa „czasem nie łapie". Root cause = CICHE pominięcia:
+  gdy nie znaleziono strony wiki (niedopasowany tytuł) lub autor się nie zgadza, książka była
+  `return`-owana bez śladu, a `complete` raportował sam sukces. Teraz `syncSummary.skipped`
+  zbiera pominięte z powodem (nie znaleziono strony / autor się nie zgadza), a wynik niesie
+  `cyclesDetected` + `skipped`; `SyncSummaryResult` pokazuje listę „Pominięte — nie oceniono".
+  Regex szablonu poszerzony `\{\{Cykl\s*\|` → `\{\{\s*cykl[\s|}]` (łapie `{{Cykl}}` i
+  `{{Cykl nawigacja|…}}`, wciąż odrzuca `{{Cyklista}}`). Zweryfikowane na realnym rawie
+  „Inny"/Dickson: `|cykl = Childe` JEST łapane (regex pola OK), pusty `|cykl=` = false,
+  `|seria=` świadomie pomijane (imprint wydawcy). +5 testów.
 - **1.11.1** — Metadane (rok + ikonka „cykl") także w PACZKACH sprzedawców, nie tylko na
   kafelkach. `SellerBundleEntry` niesie `bookYear`/`bookPartOfCycle` (z `VintedResult`),
   `groupBySeller` je przepisuje, a wpis paczki pokazuje rok przy autorze i badge „cykl".
@@ -170,6 +179,11 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
     ale zapisuje TYLKO boolean „Część cyklu" (linie 41–131) — nazwę cyklu i listę tomów
     z szablonu `{{Cykl}}` wyrzucamy. Tu jest źródło danych: rozszerzyć ten sam rytuał,
     nie dokładać nowego fetchu.
+  - **NOWY finding (1.11.2, realny raw „Inny"/Dickson)**: infobox `{{Książka}}` ma pola
+    `|poprzednia=` i `|następna=` z tytułami SĄSIEDNICH tomów (np. poprzednia „Młody Bleys",
+    następna „Gildia Orędowników") + `|cykl=` z nazwą cyklu. To gotowy łańcuch prev/next —
+    dużo prostszy niż parsowanie `{{Cykl}}`: krok 1 persystencji może zapisać
+    `{cykl, poprzednia, następna}` wprost z tych pól.
   - **Zasada nadrzędna**: NIE fetchować na żywo w widoku „Wczytaj z bazy" — to łamie
     „scrapuj raz, analizuj wiele" i wskrzesza rate-limit/Cloudflare + fetch wiki przy renderze.
   - **Projekt (3 warstwy, każda w istniejącym flow)**:

--- a/backlog.md
+++ b/backlog.md
@@ -164,9 +164,32 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 - **Ewentualnie później**: odświeżanie pojedynczej książki/oferty z bazy (re-check
   świeżości), natywna baza „Vinted Offers" (jeśli blob przestanie wystarczać), proxy
   rezydencjalne dla ominięcia 403.
-- **Cykle: sąsiednie tomy** (pomysł) — dla książek „Część cyklu" pokazywać/szukać
-  wcześniejszych/późniejszych tomów. Tricky: mogą NIE być w bazie (brak nagród/nominacji),
-  więc trzeba by je pozyskać z zewnątrz (Encyklopedia/wiki po serii) — osobny research.
+- **Cykle: sąsiednie tomy** (pomysł, analiza 1.11.1) — dla książek „Część cyklu"
+  pokazywać/szukać wcześniejszych/późniejszych tomów; sąsiednie tomy mogą NIE być w bazie.
+  - **Kluczowy finding**: `cyclesSyncService` już parsuje `|cykl=` / `{{Cykl|…}}` z wikitekstu,
+    ale zapisuje TYLKO boolean „Część cyklu" (linie 41–131) — nazwę cyklu i listę tomów
+    z szablonu `{{Cykl}}` wyrzucamy. Tu jest źródło danych: rozszerzyć ten sam rytuał,
+    nie dokładać nowego fetchu.
+  - **Zasada nadrzędna**: NIE fetchować na żywo w widoku „Wczytaj z bazy" — to łamie
+    „scrapuj raz, analizuj wiele" i wskrzesza rate-limit/Cloudflare + fetch wiki przy renderze.
+  - **Projekt (3 warstwy, każda w istniejącym flow)**:
+    1. Persystencja struktury: `cyclesSyncService` zapisuje nazwę cyklu + uporządkowaną listę
+       tomów do bloba `CycleData` (wzorzec `VintedData`). Wtedy „sąsiednie tomy" = lookup z bazy.
+    2. Render bez scrapowania: kafelek czyta listę z bloba, krzyżuje z wierszami Notion →
+       oznacza tom `masz` / `w bazie` / `brak`. Czysto ze store.
+    3. Dostępność brakujących na Vinted = osobny opt-in rytuał („Skan sąsiednich tomów", jak
+       „Ustal sprzedawców"): traktuje brakujące tomy jak tymczasowe cele, dopisuje oferty do
+       `CycleData` rodzica. NIGDY w ścieżce renderu.
+  - **Otwarta decyzja produktowa — jak trzymać brakujące tomy**:
+    - Wariant B: realne wiersze Notion (tag np. `Cykl-Discovered`) → pełny pipeline
+      (kandydat→skan→kafelek→paczki→dedup), ale baza puchnie + trzeba wykluczyć ze
+      statystyk/nagród + ryzyko dubli.
+    - Wariant C (rekomendowany na start): kontekst w blobie `CycleData` rodzica → zero
+      zaśmiecania bazy, pasuje 1:1 do `VintedData`; koszt: dane Vinted „drugiej kategorii"
+      (poza głównym flow kafelków/paczek), tom wspólny dla 2 cykli zapisany 2× (brak cross-dedup).
+      Furtka: promocja tomu do realnego wiersza (→ wariant B) jednym klikiem, gdy user zdecyduje.
+  - **Kolejność startu**: najpierw sam krok 1 (persystencja struktury cyklu), żeby zobaczyć
+    dane, zanim dołożymy skan dostępności.
 
 ## Zrobione (skrót)
 

--- a/docs/cycles-sync.md
+++ b/docs/cycles-sync.md
@@ -11,12 +11,14 @@ Automatically identifies and marks books that belong to a literary cycle in the 
   3. **Multi-Search (Orig)**: Same for the original title.
   4. **Direct Fetch**: Last-resort exact-title fetch of the Polish title.
 - **Author verification**: Every candidate page is validated with `isWikiAuthorMatch` (shared helper in `dataNormalizer`) — normalized author comparison with substring and similarity (> 0.6) matching — to avoid reading data from a same-titled page about a different work. Pages are accepted when either side lacks an author.
-- **Cycle criteria** (`checkCycleInWikitext`): the wikitext contains a non-empty `|cykl=` / `|cykle=` parameter or a `{{Cykl|...}}` template. `|seria=` is deliberately ignored to avoid false positives.
+- **Cycle criteria** (`checkCycleInWikitext`): the wikitext contains a non-empty `|cykl=` / `|cykle=` parameter (confirmed against a real `{{Książka}}` infobox raw: `| cykl = Childe`) or a cycle navigation template. The template regex is `\{\{\s*cykl[\s|}]` — it matches `{{Cykl|...}}`, a bare `{{Cykl}}`, and `{{Cykl nawigacja|...}}`, while still rejecting unrelated names like `{{Cyklista}}` (a boundary char — whitespace, pipe or `}` — must follow "cykl"). `|seria=` is deliberately ignored: on the Encyclopedia it's the publisher imprint (e.g. "Kanon science fiction"), not a story cycle, so counting it would produce false positives.
 - **Action**: Sets the **"Część cyklu"** checkbox to match the detection result (both directions).
 
 ## 3. Implementation Details
 - **Comparison**: Only updates the Notion record if the current checkbox value differs from the expected one.
 - **Concurrency**: Uses `p-limit(3)` to throttle Notion API calls.
+- **Honest skip reporting**: A book is only *evaluated* when a page passes the author gate. Previously, a book whose page couldn't be found (title mismatch) or whose author didn't match was `return`-ed silently — the run reported success and the user had no idea it wasn't checked (the root cause behind "cycle marking sometimes misses"). Now every un-evaluated book is recorded in `summary.skipped` with a reason (`nie znaleziono strony` vs `autor się nie zgadza — strona pominięta`), and the `complete` result carries `cyclesDetected` (how many books were positively detected) and `skipped` (count). The UI renders the skipped list in `SyncSummaryResult` so the gaps are visible and diagnosable — a book missing from `skipped` but still unmarked points at the marker/wikitext, not at coverage.
 - **Failure reporting**: Titles that failed to fetch in bulk are listed in the result's `errors`; per-book fetch failures are recorded per title.
+- **Neighbor-volume hint**: the same `{{Książka}}` infobox also carries `|poprzednia=` / `|następna=` (previous/next volume titles) alongside `|cykl=` — a ready-made prev/next chain for the future "cykl: sąsiednie tomy" feature (see `backlog.md`).
 - **Progress Reporting**: Sends SSE events for each batch of books being processed.
 - **Output**: Returns a summary of how many books were updated and any errors encountered, with `success: false` when the run was cancelled.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/cyclesSyncService.test.ts
+++ b/services/__tests__/cyclesSyncService.test.ts
@@ -63,4 +63,69 @@ describe('CyclesSyncService', () => {
     });
     expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
   });
+
+  const bookOf = (over: Partial<NotionBook>): NotionBook => ({
+    id: 'p', plTitle: 'T', origTitle: 'T', author: 'A', year: '2000',
+    currentCzesccyklu: false, awards: [], zrodlo: [], currentWydawnictwo: '',
+    currentSeria: '', lp: '1', plTitleRichText: [], origTitleRichText: [], ...over,
+  });
+
+  it('marks cycle from real {{Książka}} raw with |cykl= filled (Inny / Childe)', async () => {
+    const raw = `{{Książka\n | tytuł = Inny\n | autor = Gordon R. Dickson\n | seria = Kanon science fiction\n | cykl = Childe\n | poprzednia = Młody Bleys\n | następna = Gildia Orędowników\n}}`;
+    mockNotion.queryAllBooks.mockResolvedValue([bookOf({ id: 'inny', plTitle: 'Inny', origTitle: 'Other', author: 'Gordon R. Dickson' })]);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({ contents: { 'inny': raw }, failedTitles: [] });
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('inny', { 'Część cyklu': { checkbox: true } });
+  });
+
+  it('does NOT mark cycle when only |seria= is present (publisher imprint, no |cykl=)', async () => {
+    const raw = `{{Książka\n | autor = Jan Kowalski\n | seria = Uczta Wyobraźni\n | cykl = \n}}`;
+    mockNotion.queryAllBooks.mockResolvedValue([bookOf({ id: 'p1', plTitle: 'Solo', author: 'Jan Kowalski' })]);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({ contents: { 'solo': raw }, failedTitles: [] });
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).not.toHaveBeenCalled();
+  });
+
+  it('detects cycle from a bare {{Cykl}} navigation template (no |cykl= field)', async () => {
+    const raw = `{{Książka\n | autor = Anna Nowak\n}}\nTekst.\n{{Cykl nawigacja|Saga X}}`;
+    mockNotion.queryAllBooks.mockResolvedValue([bookOf({ id: 'p2', plTitle: 'Tom I', author: 'Anna Nowak' })]);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({ contents: { 'tom i': raw }, failedTitles: [] });
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('p2', { 'Część cyklu': { checkbox: true } });
+  });
+
+  it('reports a book as skipped (not silently) when no wiki page is found', async () => {
+    mockNotion.queryAllBooks.mockResolvedValue([bookOf({ id: 'p3', plTitle: 'Widmo', author: 'Zenon Test' })]);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({ contents: {}, failedTitles: [] });
+    mockWiki.searchPage.mockResolvedValue([]);
+    mockWiki.fetchPageContent.mockResolvedValue('');
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).not.toHaveBeenCalled();
+    const complete = mockSendEvent.mock.calls.map((c: any[]) => c[0]).find((e: any) => e.type === 'complete');
+    expect(complete.result.skipped).toBe(1);
+    expect(complete.result.summary.skipped[0]).toContain('Widmo');
+    expect(complete.result.summary.skipped[0]).toContain('nie znaleziono strony');
+  });
+
+  it('reports a book as skipped with author-mismatch reason when the page exists but author differs', async () => {
+    const raw = `{{Książka\n | autor = Zupełnie Inny Autor\n | cykl = Jakiś\n}}`;
+    mockNotion.queryAllBooks.mockResolvedValue([bookOf({ id: 'p4', plTitle: 'Kolizja', author: 'Prawdziwy Pisarz' })]);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({ contents: { 'kolizja': raw }, failedTitles: [] });
+    mockWiki.searchPage.mockResolvedValue([]);
+    mockWiki.fetchPageContent.mockResolvedValue('');
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    expect(mockNotion.updatePage).not.toHaveBeenCalled();
+    const complete = mockSendEvent.mock.calls.map((c: any[]) => c[0]).find((e: any) => e.type === 'complete');
+    expect(complete.result.summary.skipped[0]).toContain('autor się nie zgadza');
+  });
 });

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -28,8 +28,8 @@ export class CyclesSyncService {
       sendEvent({ type: "status", message: `Pobieranie treści ${titlesToFetch.length} stron z Encyklopedii (Bulk API)...` });
       const { contents: wikiContents, failedTitles } = await this.wiki.fetchPagesContentBulk(titlesToFetch);
 
-      let processedCount = 0, updatedCount = 0;
-      const syncSummary = { added: [] as string[], updated: [] as string[] };
+      let processedCount = 0, updatedCount = 0, cyclesDetected = 0;
+      const syncSummary = { added: [] as string[], updated: [] as string[], skipped: [] as string[] };
       const errors: any[] = [];
       if (failedTitles.length > 0) {
         errors.push({ book: `${failedTitles.length} stron`, error: `Nie udało się pobrać treści z encyklopedii (fallback przez wyszukiwarkę): ${failedTitles.slice(0, 5).join(", ")}${failedTitles.length > 5 ? "…" : ""}` });
@@ -40,10 +40,15 @@ export class CyclesSyncService {
 
       const checkCycleInWikitext = (wikitext: string): boolean => {
         if (!wikitext) return false;
-        // Extended cycle detection: |cykl=, |cykle=, {{Cykl}}, {{cykl}}
-        // Exclude |seria= to avoid false positives
+        // Wykrywanie cyklu: NIEPUSTE pole |cykl= / |cykle= w infoboksie {{Książka}}
+        // (potwierdzone na realnym rawie: „| cykl = Childe"). Świadomie WYKLUCZAMY
+        // |seria= — na Encyklopedii to imprint wydawcy (np. „Kanon science fiction"),
+        // nie cykl fabularny → inaczej byłyby false-positive.
         const hasCycleParam = /\|\s*cykl(e)?\s*=\s*[^\s|}]/i.test(wikitext);
-        const hasCycleTemplate = /\{\{(C|c)ykl\s*\|/i.test(wikitext);
+        // Szablon nawigacyjny cyklu. Poszerzone vs stare `\{\{Cykl\s*\|` — łapie też
+        // `{{Cykl}}` (bez parametrów) i `{{Cykl nawigacja|…}}`, a wciąż odrzuca np.
+        // `{{Cyklista}}` (po „cykl" musi iść spacja / pipe / zamknięcie).
+        const hasCycleTemplate = /\{\{\s*cykl[\s|}]/i.test(wikitext);
         return hasCycleParam || hasCycleTemplate;
       };
 
@@ -64,12 +69,18 @@ export class CyclesSyncService {
         try {
           let wikitext = "";
           let foundSource = "";
+          // Czy w OGÓLE natrafiliśmy na treść strony (choćby odrzuconą przez bramkę
+          // autora). Rozróżnia dwie przyczyny pominięcia: „strony nie ma" vs „strona
+          // jest, ale autor się nie zgadza" — inaczej pominięcie było niewidoczne i
+          // wyglądało jak „książka nie należy do cyklu".
+          let sawPage = false;
 
           // 1. Try Bulk Fetch results (Polish title first, then Original)
           wikitext = (plTitle ? wikiContents[plTitle.toLowerCase()] : null) ||
                      (origTitle ? wikiContents[origTitle.toLowerCase()] : null) || "";
 
           if (wikitext) {
+            sawPage = true;
             const wikiAuthor = WikiParser.extractAuthor(wikitext);
             if (!isAuthorMatch(wikiAuthor, notionAuthor)) {
               wikitext = "";
@@ -83,6 +94,7 @@ export class CyclesSyncService {
             const searchedTitles = await this.wiki.searchPage(`${plTitle} ${notionAuthor}`, 3);
             for (const title of searchedTitles) {
               const content = await this.wiki.fetchPageContent(title);
+              if (content) sawPage = true;
               const wikiAuthor = WikiParser.extractAuthor(content);
               if (isAuthorMatch(wikiAuthor, notionAuthor)) {
                 wikitext = content;
@@ -97,6 +109,7 @@ export class CyclesSyncService {
             const searchedTitles = await this.wiki.searchPage(`${origTitle} ${notionAuthor}`, 3);
             for (const title of searchedTitles) {
               const content = await this.wiki.fetchPageContent(title);
+              if (content) sawPage = true;
               const wikiAuthor = WikiParser.extractAuthor(content);
               if (isAuthorMatch(wikiAuthor, notionAuthor)) {
                 wikitext = content;
@@ -114,6 +127,7 @@ export class CyclesSyncService {
           // propaguje do per-book catch niżej i trafia do errors[].
           if (!wikitext && plTitle) {
             const content = await this.wiki.fetchPageContent(plTitle);
+            if (content) sawPage = true;
             const wikiAuthor = WikiParser.extractAuthor(content);
             if (isAuthorMatch(wikiAuthor, notionAuthor)) {
               wikitext = content;
@@ -121,9 +135,18 @@ export class CyclesSyncService {
             }
           }
 
-          if (!wikitext) return;
+          if (!wikitext) {
+            // Honest reporting: książka pominięta, cykl NIE oceniony. Bez tego
+            // „complete" raportował sam sukces i user nie wiedział, że część
+            // pozycji w ogóle nie sprawdzono (root cause „czasem nie łapie cykli").
+            syncSummary.skipped.push(
+              `${plTitle || origTitle}${sawPage ? " (autor się nie zgadza — strona pominięta)" : " (nie znaleziono strony w encyklopedii)"}`
+            );
+            return;
+          }
 
           const hasCycle = checkCycleInWikitext(wikitext);
+          if (hasCycle) cyclesDetected++;
           if (hasCycle !== book.currentCzesccyklu) {
             await this.notion.updatePage(book.id, { "Część cyklu": { checkbox: hasCycle } });
             updatedCount++;
@@ -134,7 +157,7 @@ export class CyclesSyncService {
 
       await Promise.all(syncTasks);
 
-      sendEvent({ type: "complete", result: { success: !checkCancellation(), found: allBooks.length, updated: updatedCount, summary: syncSummary, errors: errors.length > 0 ? errors : undefined } });
+      sendEvent({ type: "complete", result: { success: !checkCancellation(), found: allBooks.length, updated: updatedCount, cyclesDetected, skipped: syncSummary.skipped.length, summary: syncSummary, errors: errors.length > 0 ? errors : undefined } });
     } catch (error: any) { sendEvent({ type: "error", error: error.message }); }
   }
 }

--- a/src/components/SyncSummaryResult.tsx
+++ b/src/components/SyncSummaryResult.tsx
@@ -180,7 +180,7 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
           </div>
         )}
 
-        {summary && (summary.added?.length > 0 || summary.updated?.length > 0 || summary.duplicates?.length > 0) && (
+        {summary && (summary.added?.length > 0 || summary.updated?.length > 0 || summary.duplicates?.length > 0 || summary.skipped?.length > 0) && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {summary.added?.length > 0 && (
               <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
@@ -204,6 +204,20 @@ export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({
                 <div className="max-h-64 overflow-y-auto pr-2 custom-scrollbar space-y-2">
                   {summary.updated.map((item: string, i: number) => (
                     <div key={i} className="text-xs text-slate-300 font-medium border-l-2 border-cyan-500/30 pl-3 py-1 bg-cyan-500/5 rounded-r-lg">
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {summary.skipped?.length > 0 && (
+              <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
+                <h4 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-4 flex items-center gap-2">
+                  <AlertCircle className="w-4 h-4" /> Pominięte — nie oceniono ({summary.skipped.length})
+                </h4>
+                <div className="max-h-64 overflow-y-auto pr-2 custom-scrollbar space-y-2">
+                  {summary.skipped.map((item: string, i: number) => (
+                    <div key={i} className="text-xs text-slate-400 font-medium border-l-2 border-slate-600/40 pl-3 py-1 bg-slate-500/5 rounded-r-lg">
                       {item}
                     </div>
                   ))}


### PR DESCRIPTION
## Problem

„Oznaczanie cykli czasem nie łapie" książek będących częścią cyklu.

## Diagnoza (root cause)

**Ciche pominięcia.** Gdy dla książki nie znaleziono strony wiki (niedopasowany tytuł) **albo** autor nie przeszedł bramki `isWikiAuthorMatch`, książka była `return`-owana bez śladu — a event `complete` raportował sam sukces („N zaktualizowanych"). User nie miał żadnej informacji, że część pozycji w ogóle nie została sprawdzona. To wprost tłumaczy wrażenie „czasem nie łapie".

Sam regex pola `|cykl=` jest **poprawny** — zweryfikowane na realnym rawie `{{Książka}}` („Inny" / Dickson): `| cykl = Childe` jest łapane, pusty `|cykl=` daje `false`, a `|seria=` (imprint wydawcy, np. „Kanon science fiction") jest świadomie pomijane, by nie tworzyć false-positive.

## Zmiany

- **`cyclesSyncService`**: pominięte książki trafiają do `summary.skipped` z powodem (`nie znaleziono strony` / `autor się nie zgadza — strona pominięta`); wynik niesie też `cyclesDetected` i `skipped` (liczniki).
- **Regex szablonu** poszerzony `\{\{Cykl\s*\|` → `\{\{\s*cykl[\s|}]` — łapie `{{Cykl}}` (bez parametrów) i `{{Cykl nawigacja|…}}`, a wciąż odrzuca np. `{{Cyklista}}` (po „cykl" musi wystąpić granica: spacja / `|` / `}`).
- **`SyncSummaryResult`**: renderuje listę „Pominięte — nie oceniono" (licznik „Pominięto" był już wcześniej) — pominięcia są teraz widoczne i diagnozowalne.
- **+5 testów**: realny raw „Inny"/Childe, brak detekcji przy samym `|seria=`, wykrycie z gołego `{{Cykl}}`, oba powody pominięcia.

## Weryfikacja

- `npm run lint` czysty · `npm test` **212/212** (+5) · `npm run build` OK.
- Wersja `metadata.json` → **1.11.2** (mirror w `package.json` + `package-lock.json`); `docs/cycles-sync.md` i `backlog.md` zaktualizowane.

## Bonus

Realny raw ujawnił pola `|poprzednia=` / `|następna=` (tytuły sąsiednich tomów) obok `|cykl=` — gotowy łańcuch prev/next dla przyszłej funkcji „cykl: sąsiednie tomy" (zapisane w `backlog.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_