### PR TITLE
feat: Skryptorium — live client-side archive search (v1.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Każda operacja to osobne, anulowalne zadanie strumieniowane do UI przez SSE.
 | **Duplikaty** | `POST /api/sync-duplicates` | Wykrywa potencjalne duplikaty (tytuł + podobieństwo autora). |
 | **Sanctity (Integralność)** | `POST /api/sync-integrity` | Porównuje bazę Notion z wiki: liczby per rok/nagroda, unikalność Lp/tytułów. |
 | **Statystyki** | `GET /api/stats` | Agregaty do dashboardu (postęp autorów, roczników, pokrycie nagród, biblioteki). |
+| **Skryptorium** (wyszukiwarka) | `GET /api/books` | Odchudzony indeks rekordów; front filtruje client-side po tytule (PL+oryg) i autorze, diakrytyki-agnostycznie, na żywo („per" → wiele, „pere" → Perelandra). |
 | **Skan Biblioteki** | `POST /api/library-check` | Sprawdza dostępność w OPAC MBP Lublin (scraping HTML). |
 | **Skan Vinted** | `POST /api/vinted-check` | Szuka fizycznych egzemplarzy na vinted.pl (scraping HTML). |
 

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.11.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.12.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.12.0** — „Skryptorium": wyszukiwarka rekordów archiwum (4. zakładka). Nowy
+  `GET /api/books` zwraca odchudzony `BookIndexEntry[]` (mapper `services/bookSearchIndex.ts`,
+  reużywa `getBooksForStats({cache})`). Front filtruje CAŁOŚĆ client-side (`useBooks` fetch raz,
+  `src/utils/bookSearch.ts`: fold diakrytyków per-znak — 1:1 na długość → highlight; `matchBooks`
+  AND-po-tokenach po tytule PL+oryg+autor; ranking prefiks>substring). `useDeferredValue` (React 19)
+  trzyma input płynny. `per`→wiele, `pere`→Perelandra. UI: `SearchSection` + `search/BookResultCard`
+  (badge nagród/źródła/cykl) + `HighlightedText`. +10 testów matchera. RENDER_CAP=150.
 - **1.11.2** — Oznaczanie cykli: naprawa „czasem nie łapie". Root cause = CICHE pominięcia:
   gdy nie znaleziono strony wiki (niedopasowany tytuł) lub autor się nie zgadza, książka była
   `return`-owana bez śladu, a `complete` raportował sam sukces. Teraz `syncSummary.skipped`

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -16,6 +16,16 @@ export const getStats = async (req: Request, res: Response) => {
   }
 };
 
+export const getBooks = async (req: Request, res: Response) => {
+  try {
+    const books = await syncManager.getBooks();
+    res.json(books);
+  } catch (error: any) {
+    console.error("Books Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania rekordów." });
+  }
+};
+
 export const getWikiLastUpdate = async (req: Request, res: Response) => {
   try {
     const { title } = req.query;

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,5 +15,6 @@ Szczegółowe opisy działania poszczególnych rytuałów (jeden dokument na kon
 | [stats-service.md](./stats-service.md) | Agregacja statystyk do dashboardu. |
 | [library-check.md](./library-check.md) | Skan dostępności w OPAC MBP Lublin (scraping HTML). |
 | [vinted-scanner.md](./vinted-scanner.md) | Skan ofert na vinted.pl (scraping HTML — bez AI). |
+| [skryptorium-search.md](./skryptorium-search.md) | Wyszukiwarka rekordów archiwum (client-side, fold diakrytyków, highlight). |
 
 Obserwowalność, diagnostyka (`/api/diagnostics`), wdrożenie i rozwiązywanie problemów opisane są w [README](../README.md).

--- a/docs/skryptorium-search.md
+++ b/docs/skryptorium-search.md
@@ -1,0 +1,43 @@
+# Skryptorium — Archive Search
+
+## 1. Overview
+A live, client-side search over the book records ("Skryptorium" tab). Typing filters the
+archive as you go — `per` shows several titles, `pere` narrows to just *Perelandra*. Matching
+is diacritics-insensitive and spans the Polish title, original title, and author. **No AI/LLM.**
+
+## 2. Data flow
+- **`GET /api/books`** (`routes/syncRoutes.ts` → `syncController.getBooks` → `syncManager.getBooks`)
+  returns a slim `BookIndexEntry[]` (`src/types.ts`): `id, plTitle, origTitle, author, year,
+  awards[], zrodlo[], series, partOfCycle`. The pure mapper `toSearchIndex`
+  (`services/bookSearchIndex.ts`) projects the full `NotionBook[]` down to this — deliberately
+  dropping the heavy `vintedData` blob and `*RichText`, and skipping title-less skeleton rows.
+- It reuses `getBooksForStats({ cache: true })`, so it rides the existing `booksCache`
+  (invalidated on writes) — the endpoint is effectively free.
+- **`useBooks`** (`src/hooks/useBooks.ts`) fetches the index **once** into state. With ~214
+  records the entire search runs in memory: no keystroke ever hits the network or Notion.
+
+## 3. Matching (`src/utils/bookSearch.ts`, pure + unit-tested)
+- **`fold(s)`** — per-character diacritic fold (`ą→a … ł→l … ź→z`) + lowercase. Deliberately
+  **not** `normalize('NFD')`: NFD does not decompose `ł` (U+0142), and a per-char fold stays
+  **1:1 in length**, so a match index in the folded string maps straight back onto the original
+  — which is what makes highlighting correct under diacritics.
+- **`matchBooks(query, index)`** — tokenizes the folded query on whitespace; a record matches
+  when **every** token is a substring of the title, original title, **or** author (AND across
+  tokens, OR across fields — so `simmons upadek` = author ∧ title). Ranking: title-prefix (0) >
+  title-substring (1) > original-title (2) > author (3), tie-broken by Polish `localeCompare`.
+  An empty query returns the whole set sorted by title (browse mode).
+- **`highlight(text, query)`** — splits a string into hit / non-hit segments using the 1:1 fold,
+  merging overlapping ranges; falls back to a single non-hit segment if a rare lowercase length
+  change would misalign indices.
+
+## 4. UI (`src/components/SearchSection.tsx` + `search/`)
+- Autofocused input (styled like `SchemaEditor`), a live count, and a responsive grid of
+  glassmorphism `BookResultCard`s with `motion` `layout` reflow. Each card shows the highlighted
+  title, original title, `author · year · series`, and award / źródło / „cykl" badges.
+- The query is passed through **`useDeferredValue`** (React 19) so the input stays snappy while
+  the grid re-renders. `RENDER_CAP = 150` bounds the DOM for the empty-query "whole archive"
+  case (a hint tells the user to narrow when exceeded).
+
+## 5. Scope notes
+Search fields are title (PL + original) + author by design. Faceted filters (source / award /
+cycle) and a Cmd+K palette are intentionally out of scope for now (see `backlog.md`).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.11.2",
+  "version": "1.12.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -4,6 +4,7 @@ import * as syncController from "../controllers/syncController";
 const router = express.Router();
 
 router.get("/stats", syncController.getStats);
+router.get("/books", syncController.getBooks);
 router.get("/wiki/last-update", syncController.getWikiLastUpdate);
 router.get("/health", syncController.getHealth);
 router.get("/diagnostics", syncController.getDiagnostics);

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -1,0 +1,23 @@
+import { NotionBook, BookIndexEntry } from "../src/types";
+
+/**
+ * Czysta projekcja pełnych rekordów Notion → odchudzony indeks wyszukiwarki.
+ * Odcina ciężkie pola (`vintedData` blob, `*RichText`), zostawia tylko to, po
+ * czym filtruje/renderuje „Skryptorium". Filtruje książki bez tytułu polskiego
+ * (tak jak statystyki) — pusty tytuł to rekord-szkielet, nie do przeszukiwania.
+ */
+export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
+  return books
+    .filter((b) => b.plTitle && b.plTitle.trim().length > 0)
+    .map((b) => ({
+      id: b.id,
+      plTitle: b.plTitle,
+      origTitle: b.origTitle || "",
+      author: b.author || "",
+      year: b.year || "",
+      awards: b.awards || [],
+      zrodlo: b.zrodlo || [],
+      series: b.currentSeria || "",
+      partOfCycle: b.currentCzesccyklu ?? false,
+    }));
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart } from "lucide-react";
+import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart, ScrollText } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { StatsSection } from "./components/StatsSection";
+import { SearchSection } from "./components/SearchSection";
 import { VintedSection } from "./components/VintedSection";
 import { StatusSection } from "./components/StatusSection";
 import { SyncAwards } from "./components/SyncAwards";
@@ -18,7 +19,7 @@ import { IntegrityCheckResult } from "./types";
 
 export default function App() {
   const { configStatus, schema, schemaLoading, schemaError, fetchSchema } = useConfig();
-  const [activeTab, setActiveTab] = useState<'stats' | 'config' | 'vinted'>('stats');
+  const [activeTab, setActiveTab] = useState<'stats' | 'search' | 'config' | 'vinted'>('stats');
   const [showScrollTop, setShowScrollTop] = useState(false);
 
   const {
@@ -86,6 +87,17 @@ export default function App() {
           >
             <Database className="w-5 h-5" />
             Statystyki Archiwum
+          </button>
+          <button
+            onClick={() => setActiveTab('search')}
+            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+              activeTab === 'search'
+                ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]'
+                : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
+            }`}
+          >
+            <ScrollText className="w-5 h-5" />
+            Skryptorium
           </button>
           <button
             onClick={() => setActiveTab('config')}
@@ -163,6 +175,16 @@ export default function App() {
               transition={{ duration: 0.3 }}
             >
               <StatsSection />
+            </motion.div>
+          ) : activeTab === 'search' ? (
+            <motion.div
+              key="search"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <SearchSection />
             </motion.div>
           ) : activeTab === 'config' ? (
             <motion.div

--- a/src/__tests__/bookSearch.test.ts
+++ b/src/__tests__/bookSearch.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { fold, matchBooks, highlight } from "../utils/bookSearch";
+import { BookIndexEntry } from "../types";
+
+const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
+  id: over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
+  awards: [], zrodlo: [], series: "", partOfCycle: false, ...over,
+});
+
+const INDEX: BookIndexEntry[] = [
+  mk({ plTitle: "Perelandra", author: "C.S. Lewis" }),
+  mk({ plTitle: "Peryferal", author: "William Gibson" }),
+  mk({ plTitle: "Hyperion", author: "Dan Simmons" }),
+  mk({ plTitle: "Upadek Hyperiona", author: "Dan Simmons" }),
+  mk({ plTitle: "Żółw", author: "Autor Testowy" }),
+  mk({ plTitle: "Solaris", origTitle: "Solaris", author: "Stanisław Lem" }),
+];
+
+describe("bookSearch.fold", () => {
+  it("folds Polish diacritics per-char (incl. ł which NFD does not decompose)", () => {
+    expect(fold("Żółw")).toBe("zolw");
+    expect(fold("Miłość")).toBe("milosc");
+    expect(fold("PERELANDRA")).toBe("perelandra");
+  });
+});
+
+describe("bookSearch.matchBooks", () => {
+  it("narrows as more characters are typed: 'per' → several, 'pere' → only Perelandra", () => {
+    const per = matchBooks("per", INDEX).map((b) => b.plTitle);
+    expect(per).toContain("Perelandra");
+    expect(per).toContain("Peryferal");
+    expect(per.length).toBeGreaterThan(1);
+
+    const pere = matchBooks("pere", INDEX).map((b) => b.plTitle);
+    expect(pere).toEqual(["Perelandra"]);
+  });
+
+  it("matches diacritics-insensitively ('zolw' → 'Żółw')", () => {
+    expect(matchBooks("zolw", INDEX).map((b) => b.plTitle)).toEqual(["Żółw"]);
+  });
+
+  it("matches by author across the whole set", () => {
+    const simmons = matchBooks("simmons", INDEX).map((b) => b.plTitle);
+    expect(simmons).toContain("Hyperion");
+    expect(simmons).toContain("Upadek Hyperiona");
+    expect(simmons).toHaveLength(2);
+  });
+
+  it("AND-combines tokens across fields (author + title)", () => {
+    const r = matchBooks("simmons upadek", INDEX).map((b) => b.plTitle);
+    expect(r).toEqual(["Upadek Hyperiona"]);
+  });
+
+  it("ranks a title-prefix hit above a mid-title hit", () => {
+    const r = matchBooks("hyperion", INDEX).map((b) => b.plTitle);
+    expect(r[0]).toBe("Hyperion"); // prefix beats "Upadek Hyperiona"
+  });
+
+  it("empty query returns the whole set sorted by title", () => {
+    const r = matchBooks("", INDEX).map((b) => b.plTitle);
+    expect(r).toHaveLength(INDEX.length);
+    expect(r).toEqual([...r].sort((a, b) => a.localeCompare(b, "pl")));
+  });
+});
+
+describe("bookSearch.highlight", () => {
+  it("splits into hit/non-hit segments at the matched substring", () => {
+    const segs = highlight("Perelandra", "pere");
+    expect(segs.filter((s) => s.hit).map((s) => s.text)).toEqual(["Pere"]);
+    expect(segs.map((s) => s.text).join("")).toBe("Perelandra");
+  });
+
+  it("highlights the correct slice despite diacritics (1:1 fold)", () => {
+    const segs = highlight("Żółw", "zol");
+    expect(segs.map((s) => s.text).join("")).toBe("Żółw"); // original preserved
+    expect(segs.find((s) => s.hit)?.text).toBe("Żół");
+  });
+
+  it("returns a single non-hit segment when nothing matches", () => {
+    const segs = highlight("Solaris", "xyz");
+    expect(segs).toEqual([{ text: "Solaris", hit: false }]);
+  });
+});

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useMemo, useDeferredValue, useRef, useEffect } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Search, X, Loader2, ScrollText, AlertCircle } from "lucide-react";
+import { useBooks } from "../hooks/useBooks";
+import { matchBooks } from "../utils/bookSearch";
+import { BookResultCard } from "./search/BookResultCard";
+
+/** Ile kart maksymalnie rysujemy (ochrona DOM przy „pustym" zapytaniu = cały zbiór). */
+const RENDER_CAP = 150;
+
+export const SearchSection: React.FC = () => {
+  const { books, loading, error, fetchBooks } = useBooks();
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const results = useMemo(() => matchBooks(deferredQuery, books ?? []), [deferredQuery, books]);
+  const shown = results.slice(0, RENDER_CAP);
+  const total = books?.length ?? 0;
+
+  return (
+    <div className="space-y-8">
+      {/* Nagłówek sekcji */}
+      <div className="flex items-center gap-6">
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent" />
+        <div className="flex items-center gap-4">
+          <ScrollText className="w-6 h-6 text-cyan-400" />
+          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-cyan-100/90 whitespace-nowrap">
+            Skryptorium
+          </h2>
+        </div>
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent" />
+      </div>
+
+      <p className="text-center text-[11px] text-slate-500 uppercase tracking-widest font-bold -mt-4">
+        Przeszukiwanie zapisów archiwum — tytuł, tytuł oryginalny, autor
+      </p>
+
+      {/* Pole wyszukiwania */}
+      <div className="relative max-w-2xl mx-auto">
+        <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-cyan-400/50 pointer-events-none" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Wpisz fragment tytułu lub nazwisko autora…"
+          aria-label="Przeszukaj archiwum"
+          className="w-full pl-14 pr-12 py-4 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-600 transition-all"
+        />
+        {query && (
+          <button
+            onClick={() => setQuery("")}
+            className="absolute right-4 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-slate-500 hover:text-slate-200 hover:bg-white/5 transition-colors"
+            title="Wyczyść"
+            aria-label="Wyczyść zapytanie"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Licznik */}
+      {books && !loading && (
+        <p className="text-center text-xs text-slate-500 font-bold tracking-widest uppercase">
+          {query.trim()
+            ? `Znaleziono ${results.length} ${results.length === 1 ? "wolumin" : "woluminów"} z ${total}`
+            : `${total} woluminów w archiwum`}
+          {results.length > RENDER_CAP && ` · pokazano ${RENDER_CAP} — zawęź zapytanie`}
+        </p>
+      )}
+
+      {/* Stany: ładowanie / błąd / brak trafień / siatka */}
+      {loading ? (
+        <div className="flex items-center justify-center gap-3 py-16 text-slate-500">
+          <Loader2 className="w-5 h-5 animate-spin" />
+          <span className="text-sm font-bold uppercase tracking-widest">Wczytywanie zapisów…</span>
+        </div>
+      ) : error ? (
+        <div className="glass-card p-6 rounded-3xl border-red-500/30 bg-red-500/5 max-w-xl mx-auto flex items-center gap-4">
+          <AlertCircle className="w-6 h-6 text-red-400 shrink-0" />
+          <div className="flex-1">
+            <p className="text-sm text-red-300 font-bold">{error}</p>
+            <button
+              onClick={fetchBooks}
+              className="mt-2 text-[11px] text-red-400/70 hover:text-red-300 uppercase tracking-widest font-bold"
+            >
+              Spróbuj ponownie
+            </button>
+          </div>
+        </div>
+      ) : results.length === 0 ? (
+        <p className="text-center text-sm text-slate-600 italic py-16">
+          Archiwum milczy — żaden wolumin nie pasuje do „{query}".
+        </p>
+      ) : (
+        <motion.div layout className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <AnimatePresence mode="popLayout">
+            {shown.map((book) => (
+              <BookResultCard key={book.id} book={book} query={deferredQuery} />
+            ))}
+          </AnimatePresence>
+        </motion.div>
+      )}
+    </div>
+  );
+};

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Layers, BookMarked } from "lucide-react";
+import { BookIndexEntry } from "../../types";
+import { HighlightedText } from "./HighlightedText";
+
+/** Kolor tagu źródła — spójny język wizualny z resztą aplikacji. */
+function zrodloTheme(tag: string): string {
+  const t = tag.toLowerCase();
+  if (t.includes("posiadam")) return "bg-emerald-500/10 border-emerald-500/25 text-emerald-300";
+  if (t.includes("przeczytane")) return "bg-cyan-500/10 border-cyan-500/25 text-cyan-300";
+  if (t.includes("biblioteka")) return "bg-indigo-500/10 border-indigo-500/25 text-indigo-300";
+  if (t.includes("vinted")) return "bg-rose-500/10 border-rose-500/25 text-rose-300";
+  return "bg-slate-500/10 border-slate-500/25 text-slate-400";
+}
+
+/** Nagroda vs Nominacja — złoto dla zwycięstwa, chłodniej dla nominacji. */
+function awardTheme(award: string): string {
+  return award.toLowerCase().startsWith("nagroda")
+    ? "bg-amber-500/10 border-amber-500/25 text-amber-300"
+    : "bg-violet-500/10 border-violet-500/25 text-violet-300";
+}
+
+interface Props {
+  book: BookIndexEntry;
+  query: string;
+}
+
+export const BookResultCard: React.FC<Props> = ({ book, query }) => {
+  const showOrig = book.origTitle && book.origTitle.trim() && book.origTitle !== book.plTitle;
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, scale: 0.97 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.97 }}
+      transition={{ duration: 0.18 }}
+      className="glass-card rounded-3xl p-5 border-cyan-500/10 hover:border-cyan-500/25 transition-colors group"
+    >
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 mt-0.5 p-2 rounded-xl bg-cyan-500/10 border border-cyan-500/15 text-cyan-400/80 group-hover:text-cyan-300 transition-colors">
+          <BookMarked className="w-4 h-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <HighlightedText
+              text={book.plTitle}
+              query={query}
+              className="text-base font-bold text-slate-100 leading-tight"
+            />
+            {book.partOfCycle && (
+              <span
+                className="shrink-0 flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-amber-500/15 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-wider"
+                title="Część cyklu — może być kolejnym tomem w kolekcji"
+              >
+                <Layers className="w-2.5 h-2.5" /> cykl
+              </span>
+            )}
+          </div>
+
+          {showOrig && (
+            <HighlightedText
+              text={book.origTitle}
+              query={query}
+              className="block text-xs text-slate-500 italic mt-0.5"
+            />
+          )}
+
+          <div className="text-[11px] text-slate-400 uppercase font-bold tracking-[0.15em] mt-1.5">
+            <HighlightedText text={book.author || "—"} query={query} />
+            {book.year ? <span className="text-slate-600"> · {book.year}</span> : null}
+            {book.series ? <span className="text-slate-600 normal-case tracking-normal italic"> · {book.series}</span> : null}
+          </div>
+
+          {(book.awards.length > 0 || book.zrodlo.length > 0) && (
+            <div className="flex flex-wrap gap-1.5 mt-3">
+              {book.awards.map((a, i) => (
+                <span key={`a${i}`} className={`px-2 py-0.5 rounded-full border text-[9px] font-bold uppercase tracking-wider ${awardTheme(a)}`}>
+                  {a}
+                </span>
+              ))}
+              {book.zrodlo.map((z, i) => (
+                <span key={`z${i}`} className={`px-2 py-0.5 rounded-full border text-[9px] font-bold uppercase tracking-wider ${zrodloTheme(z)}`}>
+                  {z}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/search/HighlightedText.tsx
+++ b/src/components/search/HighlightedText.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { highlight } from "../../utils/bookSearch";
+
+/** Renderuje tekst z podświetlonymi fragmentami trafionymi zapytaniem. */
+export const HighlightedText: React.FC<{ text: string; query: string; className?: string }> = ({ text, query, className }) => {
+  const segments = highlight(text, query);
+  return (
+    <span className={className}>
+      {segments.map((seg, i) =>
+        seg.hit ? (
+          <mark key={i} className="bg-cyan-500/25 text-cyan-200 rounded-[3px] px-0.5">{seg.text}</mark>
+        ) : (
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        )
+      )}
+    </span>
+  );
+};

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from "react";
+import { BookIndexEntry } from "../types";
+
+/**
+ * Pobiera odchudzony indeks książek z `GET /api/books` RAZ i trzyma w stanie.
+ * Cała wyszukiwarka „Skryptorium" filtruje ten indeks w pamięci (client-side),
+ * więc żaden znak w polu wyszukiwania nie uderza do sieci ani do Notion.
+ */
+export function useBooks() {
+  const [books, setBooks] = useState<BookIndexEntry[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBooks = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/books?t=${Date.now()}`);
+      if (!res.ok) throw new Error("Błąd podczas pobierania rekordów archiwum");
+      const data = await res.json();
+      setBooks(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBooks();
+  }, [fetchBooks]);
+
+  return { books, loading, error, fetchBooks };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,23 @@ export interface NotionBook {
   vintedData?: string;
 }
 
+/**
+ * Odchudzony rekord książki dla wyszukiwarki „Skryptorium" (`GET /api/books`).
+ * Świadomie BEZ ciężkich pól (`vintedData` blob, `*RichText`) — to indeks do
+ * filtrowania client-side, nie pełny model. Współdzielony przez serwer i front.
+ */
+export interface BookIndexEntry {
+  id: string;
+  plTitle: string;
+  origTitle: string;
+  author: string;
+  year: string;
+  awards: string[];
+  zrodlo: string[];
+  series: string;
+  partOfCycle: boolean;
+}
+
 export interface SyncState {
   loading: boolean;
   result: any | null;

--- a/src/utils/bookSearch.ts
+++ b/src/utils/bookSearch.ts
@@ -1,0 +1,106 @@
+import { BookIndexEntry } from "../types";
+
+/**
+ * Fold diakrytyków PER ZNAK (nie NFD): mapuje polskie litery na łacińskie
+ * odpowiedniki i lowercase'uje. Świadomie NIE używamy `normalize('NFD')` —
+ * NFD nie rozkłada „ł" (U+0142), a fold per-znak jest 1:1 na długość, dzięki
+ * czemu indeksy trafień mapują wprost na oryginalny tekst (podświetlanie).
+ */
+const FOLD: Record<string, string> = {
+  ą: "a", ć: "c", ę: "e", ł: "l", ń: "n", ó: "o", ś: "s", ż: "z", ź: "z",
+};
+
+export function fold(s: string): string {
+  let out = "";
+  for (const ch of s.toLowerCase()) out += FOLD[ch] ?? ch;
+  return out;
+}
+
+/** Rozbija zapytanie na tokeny (spacje) po foldzie. */
+function tokenize(query: string): string[] {
+  return fold(query).split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Filtruje + rankuje indeks po tytule (PL + oryginalny) i autorze. Każdy token
+ * musi trafić (AND) jako substring w KTÓRYMKOLWIEK z pól — dzięki temu „simmons
+ * hyperion" łączy autora z tytułu. Puste zapytanie → cały zbiór (tryb przeglądu).
+ * Ranking: prefiks tytułu > substring tytułu > tytuł oryginalny > autor.
+ */
+export function matchBooks(query: string, index: BookIndexEntry[]): BookIndexEntry[] {
+  const tokens = tokenize(query);
+  const byTitle = (a: BookIndexEntry, b: BookIndexEntry) => a.plTitle.localeCompare(b.plTitle, "pl");
+
+  if (!tokens.length) return [...index].sort(byTitle);
+
+  const scored: { book: BookIndexEntry; score: number }[] = [];
+  for (const b of index) {
+    const title = fold(b.plTitle);
+    const orig = fold(b.origTitle);
+    const author = fold(b.author);
+    const matchesAll = tokens.every((t) => title.includes(t) || orig.includes(t) || author.includes(t));
+    if (!matchesAll) continue;
+
+    const t0 = tokens[0];
+    const score = title.startsWith(t0) ? 0
+      : title.includes(t0) ? 1
+      : orig.includes(t0) ? 2
+      : 3;
+    scored.push({ book: b, score });
+  }
+
+  return scored
+    .sort((a, b) => a.score - b.score || byTitle(a.book, b.book))
+    .map((s) => s.book);
+}
+
+export interface HighlightSegment {
+  text: string;
+  hit: boolean;
+}
+
+/**
+ * Dzieli tekst na segmenty trafione/nietrafione względem zapytania. Bazuje na
+ * foldzie 1:1 (indeks w folded == indeks w oryginale), więc podświetla we
+ * właściwym miejscu mimo diakrytyków. Podświetla tylko tokeny obecne w TYM
+ * tekście (token trafiony w innym polu tu nie da zakresu).
+ */
+export function highlight(text: string, query: string): HighlightSegment[] {
+  const tokens = tokenize(query);
+  if (!tokens.length || !text) return [{ text, hit: false }];
+
+  const folded = fold(text);
+  // Zabezpieczenie: gdyby lowercase zmienił długość (rzadkie unicode), fallback
+  // bez podświetlenia zamiast rozjechanych indeksów.
+  if (folded.length !== text.length) return [{ text, hit: false }];
+
+  const ranges: [number, number][] = [];
+  for (const t of tokens) {
+    let from = 0;
+    let i = folded.indexOf(t, from);
+    while (i !== -1) {
+      ranges.push([i, i + t.length]);
+      from = i + t.length;
+      i = folded.indexOf(t, from);
+    }
+  }
+  if (!ranges.length) return [{ text, hit: false }];
+
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged: [number, number][] = [];
+  for (const [s, e] of ranges) {
+    const last = merged[merged.length - 1];
+    if (last && s <= last[1]) last[1] = Math.max(last[1], e);
+    else merged.push([s, e]);
+  }
+
+  const segs: HighlightSegment[] = [];
+  let cur = 0;
+  for (const [s, e] of merged) {
+    if (s > cur) segs.push({ text: text.slice(cur, s), hit: false });
+    segs.push({ text: text.slice(s, e), hit: true });
+    cur = e;
+  }
+  if (cur < text.length) segs.push({ text: text.slice(cur), hit: false });
+  return segs;
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -12,6 +12,7 @@ import { SchemaValidationService } from "./services/schemaValidationService";
 import { IntegrityService } from "./services/integrityService";
 import { LibraryCheckService } from "./services/libraryCheckService";
 import { VintedSyncService } from "./services/vintedSyncService";
+import { toSearchIndex } from "./services/bookSearchIndex";
 import { createLogger, classifyHttpError } from "./logger";
 import { SyncEvent } from "./src/types";
 
@@ -98,6 +99,12 @@ class SyncManager {
 
   async getStats() {
     return await statsService.getStats();
+  }
+
+  /** Odchudzony indeks książek dla wyszukiwarki „Skryptorium" (client-side). */
+  async getBooks() {
+    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
+    return toSearchIndex(books);
   }
 
   async getNotionSchema() {


### PR DESCRIPTION
## Cel
Nowa zakładka **„Skryptorium"** — dynamiczna wyszukiwarka rekordów archiwum, filtrująca na żywo w miarę pisania. `per` → kilka tytułów, `pere` → już tylko „Perelandra". Diakrytyki-agnostycznie, po tytule polskim + oryginalnym + autorze.

Closes #78.

## Architektura
- **Backend**: nowy `GET /api/books` → odchudzony `BookIndexEntry[]` przez czysty mapper `services/bookSearchIndex.ts` (reużywa cache'owanego `getBooksForStats`; wycina ciężki blob `VintedData` i `*RichText`). Wiring: `routes` → `syncController.getBooks` → `syncManager.getBooks`.
- **Frontend (100% client-side)**: `useBooks` pobiera indeks **raz**; całe filtrowanie leci w pamięci — żaden znak nie uderza do sieci/Notion (przy ~214 rekordach to idealne).
- **Rdzeń** `src/utils/bookSearch.ts`:
  - `fold` — fold diakrytyków **per-znak** (nie NFD, bo NFD nie rozkłada `ł`); 1:1 na długość → poprawne podświetlanie.
  - `matchBooks` — AND po tokenach, OR po polach (`simmons upadek` = autor ∧ tytuł); ranking prefiks > substring > oryg > autor; puste zapytanie = cały zbiór (przegląd).
  - `highlight` — segmentacja trafień z fallbackiem.
- **UI**: `SearchSection` + `search/BookResultCard` (badge nagród/źródła/„cykl") + `HighlightedText`; query przez `useDeferredValue` (React 19) → input zostaje płynny; `RENDER_CAP=150` ogranicza DOM przy pustym zapytaniu.

## Weryfikacja
- `npm run lint` czysty · `npm test` **222/222** (+10 testów matchera: `per`→wiele/`pere`→Perelandra, fold `zolw`=`żółw`, autor, AND, ranking, highlight) · `npm run build` OK.
- Wersja `metadata.json` → **1.12.0** (mirror w `package.json` + `package-lock.json`); README + `docs/skryptorium-search.md` + indeks docs zaktualizowane.

## Poza zakresem (backlog)
Klikane filtry (źródło/nagroda/cykl), Cmd+K palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_