### PR TITLE
fix(skryptorium): include untranslated books, split badges, equal tabs (v1.12.1)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.12.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.12.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.12.1** — Skryptorium fixy (#80): (1) indeks dopuszcza rekordy z tytułem PL **lub**
+  oryginalnym (nieprzetłumaczone książki wypadały — 684 pokazywało ~389); karta/ranking
+  używają tytułu efektywnego `plTitle || origTitle`. (2) badge nagród i tagi źródła w dwóch
+  osobnych wierszach (ikony `Award`/`Tag`). (3) zakładki równej szerokości (`sm:flex-1` +
+  `items-stretch`, `tracking-wide`, `px-4`). +1 test (origTitle-only).
 - **1.12.0** — „Skryptorium": wyszukiwarka rekordów archiwum (4. zakładka). Nowy
   `GET /api/books` zwraca odchudzony `BookIndexEntry[]` (mapper `services/bookSearchIndex.ts`,
   reużywa `getBooksForStats({cache})`). Front filtruje CAŁOŚĆ client-side (`useBooks` fetch raz,

--- a/docs/skryptorium-search.md
+++ b/docs/skryptorium-search.md
@@ -10,7 +10,9 @@ is diacritics-insensitive and spans the Polish title, original title, and author
   returns a slim `BookIndexEntry[]` (`src/types.ts`): `id, plTitle, origTitle, author, year,
   awards[], zrodlo[], series, partOfCycle`. The pure mapper `toSearchIndex`
   (`services/bookSearchIndex.ts`) projects the full `NotionBook[]` down to this — deliberately
-  dropping the heavy `vintedData` blob and `*RichText`, and skipping title-less skeleton rows.
+  dropping the heavy `vintedData` blob and `*RichText`. A record is kept when it has **any**
+  title (Polish **or** original) — untranslated books that only carry an original title are
+  searchable too; only rows with no title at all (skeletons) are dropped.
 - It reuses `getBooksForStats({ cache: true })`, so it rides the existing `booksCache`
   (invalidated on writes) — the endpoint is effectively free.
 - **`useBooks`** (`src/hooks/useBooks.ts`) fetches the index **once** into state. With ~214

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -3,12 +3,13 @@ import { NotionBook, BookIndexEntry } from "../src/types";
 /**
  * Czysta projekcja pełnych rekordów Notion → odchudzony indeks wyszukiwarki.
  * Odcina ciężkie pola (`vintedData` blob, `*RichText`), zostawia tylko to, po
- * czym filtruje/renderuje „Skryptorium". Filtruje książki bez tytułu polskiego
- * (tak jak statystyki) — pusty tytuł to rekord-szkielet, nie do przeszukiwania.
+ * czym filtruje/renderuje „Skryptorium". Zostawia rekord mający JAKIKOLWIEK
+ * tytuł — polski LUB oryginalny; nieprzetłumaczone książki (tylko tytuł oryg.)
+ * też mają być wyszukiwalne. Odpada dopiero rekord bez żadnego tytułu (szkielet).
  */
 export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
   return books
-    .filter((b) => b.plTitle && b.plTitle.trim().length > 0)
+    .filter((b) => (b.plTitle && b.plTitle.trim().length > 0) || (b.origTitle && b.origTitle.trim().length > 0))
     .map((b) => ({
       id: b.id,
       plTitle: b.plTitle,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,10 +76,10 @@ export default function App() {
         </motion.header>
 
         {/* Tab Navigation */}
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-8">
+        <div className="flex flex-col sm:flex-row sm:items-stretch justify-center gap-4 mt-8">
           <button
             onClick={() => setActiveTab('stats')}
-            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+            className={`w-full sm:flex-1 px-4 py-4 rounded-2xl border font-bold uppercase tracking-wide text-sm transition-all flex items-center justify-center gap-3 ${
               activeTab === 'stats' 
                 ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]' 
                 : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
@@ -90,7 +90,7 @@ export default function App() {
           </button>
           <button
             onClick={() => setActiveTab('search')}
-            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+            className={`w-full sm:flex-1 px-4 py-4 rounded-2xl border font-bold uppercase tracking-wide text-sm transition-all flex items-center justify-center gap-3 ${
               activeTab === 'search'
                 ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]'
                 : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
@@ -101,7 +101,7 @@ export default function App() {
           </button>
           <button
             onClick={() => setActiveTab('config')}
-            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+            className={`w-full sm:flex-1 px-4 py-4 rounded-2xl border font-bold uppercase tracking-wide text-sm transition-all flex items-center justify-center gap-3 ${
               activeTab === 'config' 
                 ? 'bg-purple-500/20 border-purple-500/50 text-purple-400 shadow-[0_0_20px_rgba(168,85,247,0.2)]' 
                 : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
@@ -112,7 +112,7 @@ export default function App() {
           </button>
           <button
             onClick={() => setActiveTab('vinted')}
-            className={`w-full sm:w-auto px-8 py-4 rounded-2xl border font-bold uppercase tracking-widest text-sm transition-all flex items-center justify-center gap-3 ${
+            className={`w-full sm:flex-1 px-4 py-4 rounded-2xl border font-bold uppercase tracking-wide text-sm transition-all flex items-center justify-center gap-3 ${
               activeTab === 'vinted' 
                 ? 'bg-rose-500/20 border-rose-500/50 text-rose-400 shadow-[0_0_20px_rgba(244,63,94,0.2)]' 
                 : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'

--- a/src/__tests__/bookSearch.test.ts
+++ b/src/__tests__/bookSearch.test.ts
@@ -56,6 +56,17 @@ describe("bookSearch.matchBooks", () => {
     expect(r[0]).toBe("Hyperion"); // prefix beats "Upadek Hyperiona"
   });
 
+  it("finds and ranks untranslated books by original title when plTitle is empty", () => {
+    const idx = [
+      mk({ id: "u", plTitle: "", origTitle: "Childe", author: "Gordon Dickson" }),
+      mk({ id: "s", plTitle: "Solaris", origTitle: "Solaris", author: "Stanisław Lem" }),
+    ];
+    const r = matchBooks("childe", idx);
+    expect(r.map((b) => b.id)).toEqual(["u"]);
+    // prefiks tytułu efektywnego (origTitle) rankuje jak prefiks tytułu
+    expect(matchBooks("chi", idx)[0].id).toBe("u");
+  });
+
   it("empty query returns the whole set sorted by title", () => {
     const r = matchBooks("", INDEX).map((b) => b.plTitle);
     expect(r).toHaveLength(INDEX.length);

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "motion/react";
-import { Layers, BookMarked } from "lucide-react";
+import { Layers, BookMarked, Award, Tag } from "lucide-react";
 import { BookIndexEntry } from "../../types";
 import { HighlightedText } from "./HighlightedText";
 
@@ -27,7 +27,9 @@ interface Props {
 }
 
 export const BookResultCard: React.FC<Props> = ({ book, query }) => {
-  const showOrig = book.origTitle && book.origTitle.trim() && book.origTitle !== book.plTitle;
+  // Tytuł główny = polski, a gdy go brak — oryginalny (książki nieprzetłumaczone).
+  const primaryTitle = book.plTitle?.trim() ? book.plTitle : book.origTitle;
+  const showOrig = book.origTitle && book.origTitle.trim() && book.origTitle !== primaryTitle;
 
   return (
     <motion.div
@@ -45,7 +47,7 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <HighlightedText
-              text={book.plTitle}
+              text={primaryTitle}
               query={query}
               className="text-base font-bold text-slate-100 leading-tight"
             />
@@ -73,18 +75,29 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
             {book.series ? <span className="text-slate-600 normal-case tracking-normal italic"> · {book.series}</span> : null}
           </div>
 
-          {(book.awards.length > 0 || book.zrodlo.length > 0) && (
-            <div className="flex flex-wrap gap-1.5 mt-3">
-              {book.awards.map((a, i) => (
-                <span key={`a${i}`} className={`px-2 py-0.5 rounded-full border text-[9px] font-bold uppercase tracking-wider ${awardTheme(a)}`}>
-                  {a}
-                </span>
-              ))}
-              {book.zrodlo.map((z, i) => (
-                <span key={`z${i}`} className={`px-2 py-0.5 rounded-full border text-[9px] font-bold uppercase tracking-wider ${zrodloTheme(z)}`}>
-                  {z}
-                </span>
-              ))}
+          {book.awards.length > 0 && (
+            <div className="flex items-center gap-1.5 mt-3">
+              <Award className="w-3 h-3 text-amber-400/60 shrink-0" />
+              <div className="flex flex-wrap gap-1.5">
+                {book.awards.map((a, i) => (
+                  <span key={`a${i}`} className={`px-2 py-0.5 rounded-full border text-[9px] font-bold uppercase tracking-wider ${awardTheme(a)}`}>
+                    {a}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {book.zrodlo.length > 0 && (
+            <div className="flex items-center gap-1.5 mt-2">
+              <Tag className="w-3 h-3 text-slate-500 shrink-0" />
+              <div className="flex flex-wrap gap-1.5">
+                {book.zrodlo.map((z, i) => (
+                  <span key={`z${i}`} className={`px-2 py-0.5 rounded-full border text-[9px] font-bold uppercase tracking-wider ${zrodloTheme(z)}`}>
+                    {z}
+                  </span>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/src/utils/bookSearch.ts
+++ b/src/utils/bookSearch.ts
@@ -29,13 +29,15 @@ function tokenize(query: string): string[] {
  */
 export function matchBooks(query: string, index: BookIndexEntry[]): BookIndexEntry[] {
   const tokens = tokenize(query);
-  const byTitle = (a: BookIndexEntry, b: BookIndexEntry) => a.plTitle.localeCompare(b.plTitle, "pl");
+  // Tytuł efektywny = polski, a gdy go brak — oryginalny (rekordy nieprzetłumaczone).
+  const displayTitle = (b: BookIndexEntry) => b.plTitle || b.origTitle;
+  const byTitle = (a: BookIndexEntry, b: BookIndexEntry) => displayTitle(a).localeCompare(displayTitle(b), "pl");
 
   if (!tokens.length) return [...index].sort(byTitle);
 
   const scored: { book: BookIndexEntry; score: number }[] = [];
   for (const b of index) {
-    const title = fold(b.plTitle);
+    const title = fold(displayTitle(b));
     const orig = fold(b.origTitle);
     const author = fold(b.author);
     const matchesAll = tokens.every((t) => title.includes(t) || orig.includes(t) || author.includes(t));


### PR DESCRIPTION
Poprawki do „Skryptorium" zgłoszone po pierwszym uruchomieniu. Closes #80.

## 1. Za mało rekordów (684 → pokazywało ~389)
Indeks filtrował po niepustym `plTitle`, więc książki **nieprzetłumaczone** (mające tylko tytuł oryginalny) wypadały. Teraz `toSearchIndex` zostawia rekord z tytułem PL **lub** oryginalnym; `matchBooks` i `BookResultCard` używają tytułu efektywnego `plTitle || origTitle` do wyświetlania, rankingu i sortowania. (Odpadają już tylko rekordy bez żadnego tytułu.)

## 2. Nagrody sklejone ze źródłem
Badge nagród i tagi źródła były w jednym wierszu. Rozdzielone na **dwa osobne rzędy** z ikonami `Award` (nagrody) i `Tag` (źródło).

## 3. Nierówna szerokość zakładki „Skryptorium"
Taby były `sm:w-auto` (szerokość = treść). Ujednolicone do równej szerokości (`sm:flex-1` + `sm:items-stretch`, `tracking-wide`, `px-4`).

## Weryfikacja
- `npm run lint` czysty · `npm test` **223/223** (+1: rekord tylko z tytułem oryginalnym znaleziony i porankowany) · `npm run build` OK.
- Wersja → **1.12.1** (mirror package.json + lock); backlog + docs zaktualizowane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_