### PR TITLE
feat(skryptorium): „Czy chodziło Ci o…" typo suggestions (v1.13.0)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.12.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.13.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.13.0** — Skryptorium „Czy chodziło Ci o…" (#82): fuzzy-podpowiedzi na literówki. Gdy
+  `matchBooks`=0, `didYouMean` liczy Levenshteina między OSTATNIM tokenem zapytania a słownikiem
+  `buildSearchVocab` (słowa tytułów PL+oryg + autorów, dedupe po foldzie, display z wielką literą);
+  próg wg długości (≤4→1, ≤7→2, dłuższe→3), odsiew po |Δlen|, pomija dystans 0. UI: klikalne
+  „Perelandra?" ustawia query. +6 testów. Wszystko client-side.
 - **1.12.1** — Skryptorium fixy (#80): (1) indeks dopuszcza rekordy z tytułem PL **lub**
   oryginalnym (nieprzetłumaczone książki wypadały — 684 pokazywało ~389); karta/ranking
   używają tytułu efektywnego `plTitle || origTitle`. (2) badge nagród i tagi źródła w dwóch

--- a/docs/skryptorium-search.md
+++ b/docs/skryptorium-search.md
@@ -31,6 +31,12 @@ is diacritics-insensitive and spans the Polish title, original title, and author
 - **`highlight(text, query)`** — splits a string into hit / non-hit segments using the 1:1 fold,
   merging overlapping ranges; falls back to a single non-hit segment if a rare lowercase length
   change would misalign indices.
+- **`buildSearchVocab(index)` + `didYouMean(query, vocab)`** — "Czy chodziło Ci o…". The vocab is
+  the deduped set of folded words from titles (PL + original) and authors (display keeps a
+  capitalized variant), built once per set. `didYouMean` takes the **last** query token (a typo
+  usually sits in one word) and returns up to 3 vocab terms within a length-scaled Levenshtein
+  threshold (≤4→1, ≤7→2, else 3), pre-filtering on `|Δlen|` and skipping exact (distance-0) hits.
+  The UI shows the suggestions only when `matchBooks` returned nothing; clicking one sets the query.
 
 ## 4. UI (`src/components/SearchSection.tsx` + `search/`)
 - Autofocused input (styled like `SchemaEditor`), a live count, and a responsive grid of

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.12.1",
+      "version": "1.13.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.13.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookSearch.test.ts
+++ b/src/__tests__/bookSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fold, matchBooks, highlight } from "../utils/bookSearch";
+import { fold, matchBooks, highlight, buildSearchVocab, didYouMean } from "../utils/bookSearch";
 import { BookIndexEntry } from "../types";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
@@ -71,6 +71,34 @@ describe("bookSearch.matchBooks", () => {
     const r = matchBooks("", INDEX).map((b) => b.plTitle);
     expect(r).toHaveLength(INDEX.length);
     expect(r).toEqual([...r].sort((a, b) => a.localeCompare(b, "pl")));
+  });
+});
+
+describe("bookSearch.didYouMean", () => {
+  const vocab = buildSearchVocab(INDEX);
+
+  it("suggests the closest title word for a one-off typo", () => {
+    expect(didYouMean("perelanda", vocab)).toContain("Perelandra");
+  });
+
+  it("suggests the closest author surname for a typo", () => {
+    expect(didYouMean("simnons", vocab)).toContain("Simmons");
+  });
+
+  it("uses the last token (typo usually sits in one word)", () => {
+    expect(didYouMean("dan simnons", vocab)).toContain("Simmons");
+  });
+
+  it("returns nothing when the query is far from everything", () => {
+    expect(didYouMean("qwerty", vocab)).toEqual([]);
+  });
+
+  it("does not suggest an exact vocabulary hit (distance 0)", () => {
+    expect(didYouMean("hyperion", vocab)).not.toContain("Hyperion");
+  });
+
+  it("ignores too-short queries", () => {
+    expect(didYouMean("pe", vocab)).toEqual([]);
   });
 });
 

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useDeferredValue, useRef, useEffect } from "r
 import { motion, AnimatePresence } from "motion/react";
 import { Search, X, Loader2, ScrollText, AlertCircle } from "lucide-react";
 import { useBooks } from "../hooks/useBooks";
-import { matchBooks } from "../utils/bookSearch";
+import { matchBooks, buildSearchVocab, didYouMean } from "../utils/bookSearch";
 import { BookResultCard } from "./search/BookResultCard";
 
 /** Ile kart maksymalnie rysujemy (ochrona DOM przy „pustym" zapytaniu = cały zbiór). */
@@ -21,6 +21,13 @@ export const SearchSection: React.FC = () => {
   const results = useMemo(() => matchBooks(deferredQuery, books ?? []), [deferredQuery, books]);
   const shown = results.slice(0, RENDER_CAP);
   const total = books?.length ?? 0;
+
+  // „Czy chodziło Ci o…" — słownik liczony raz na zbiór; podpowiedzi tylko przy 0 trafień.
+  const vocab = useMemo(() => buildSearchVocab(books ?? []), [books]);
+  const suggestions = useMemo(
+    () => (results.length === 0 && deferredQuery.trim() ? didYouMean(deferredQuery, vocab) : []),
+    [results.length, deferredQuery, vocab]
+  );
 
   return (
     <div className="space-y-8">
@@ -94,9 +101,27 @@ export const SearchSection: React.FC = () => {
           </div>
         </div>
       ) : results.length === 0 ? (
-        <p className="text-center text-sm text-slate-600 italic py-16">
-          Archiwum milczy — żaden wolumin nie pasuje do „{query}".
-        </p>
+        <div className="text-center py-16 space-y-4">
+          <p className="text-sm text-slate-600 italic">
+            Archiwum milczy — żaden wolumin nie pasuje do „{query}".
+          </p>
+          {suggestions.length > 0 && (
+            <p className="text-sm text-slate-400">
+              Czy chodziło Ci o:{" "}
+              {suggestions.map((s, i) => (
+                <React.Fragment key={s}>
+                  <button
+                    onClick={() => setQuery(s)}
+                    className="text-cyan-300 hover:text-cyan-200 font-semibold underline decoration-dotted underline-offset-4 decoration-cyan-500/50"
+                  >
+                    {s}
+                  </button>
+                  {i < suggestions.length - 1 ? <span className="text-slate-600">, </span> : <span className="text-slate-500">?</span>}
+                </React.Fragment>
+              ))}
+            </p>
+          )}
+        </div>
       ) : (
         <motion.div layout className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <AnimatePresence mode="popLayout">

--- a/src/utils/bookSearch.ts
+++ b/src/utils/bookSearch.ts
@@ -106,3 +106,92 @@ export function highlight(text: string, query: string): HighlightSegment[] {
   if (cur < text.length) segs.push({ text: text.slice(cur), hit: false });
   return segs;
 }
+
+// ── „Czy chodziło Ci o…" — fuzzy podpowiedzi na literówki ──────────────────
+
+export interface VocabTerm {
+  /** Znormalizowane (fold) słowo — po tym liczymy dystans. */
+  folded: string;
+  /** Wariant do pokazania użytkownikowi (oryginalna pisownia). */
+  display: string;
+}
+
+/** Słowa (≥3 znaki) z tekstu, rozbite na granicach nie-liter/cyfr. */
+function wordsOf(s: string): string[] {
+  return s.split(/[^\p{L}\p{N}]+/u).filter((w) => w.length >= 3);
+}
+
+/**
+ * Buduje słownik terminów (słowa tytułów PL+oryg i autorów) do fuzzy-podpowiedzi.
+ * Dedupe po foldzie; jako `display` preferuje wariant z wielką literą. Liczony raz
+ * na zbiór (memoizowany w komponencie), nie na każdy znak.
+ */
+export function buildSearchVocab(index: BookIndexEntry[]): VocabTerm[] {
+  const map = new Map<string, string>();
+  const hasUpper = (w: string) => w !== w.toLowerCase();
+  const add = (s: string) => {
+    for (const w of wordsOf(s)) {
+      const f = fold(w);
+      if (f.length < 3) continue;
+      const prev = map.get(f);
+      if (!prev || (hasUpper(w) && !hasUpper(prev))) map.set(f, w);
+    }
+  };
+  for (const b of index) {
+    add(b.plTitle);
+    add(b.origTitle);
+    add(b.author);
+  }
+  return [...map.entries()].map(([folded, display]) => ({ folded, display }));
+}
+
+/** Dystans Levenshteina (dwa bufory wierszy — O(min·max) pamięci liniowej). */
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (!m) return n;
+  if (!n) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let cur = new Array<number>(n + 1);
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[n];
+}
+
+/**
+ * „Czy chodziło Ci o…" — dla (zwykle zerowego) zapytania zwraca do `limit`
+ * najbliższych terminów ze słownika. Porównuje OSTATNI token zapytania (tam
+ * zwykle siedzi literówka), z progiem zależnym od długości. Odsiew po różnicy
+ * długości (Levenshtein ≥ |Δlen|) tnie koszt. Pomija trafienie dokładne.
+ */
+export function didYouMean(query: string, vocab: VocabTerm[], limit = 3): string[] {
+  const qWord = fold(query).split(/\s+/).filter(Boolean).pop() ?? "";
+  if (qWord.length < 3) return [];
+  const maxDist = qWord.length <= 4 ? 1 : qWord.length <= 7 ? 2 : 3;
+
+  const scored: { display: string; dist: number; len: number; folded: string }[] = [];
+  for (const v of vocab) {
+    if (Math.abs(v.folded.length - qWord.length) > maxDist) continue;
+    if (v.folded === qWord) continue;
+    const d = levenshtein(qWord, v.folded);
+    if (d <= maxDist) scored.push({ display: v.display, dist: d, len: v.folded.length, folded: v.folded });
+  }
+  scored.sort((a, b) => a.dist - b.dist || a.len - b.len || a.display.localeCompare(b.display, "pl"));
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const s of scored) {
+    const key = s.display.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(s.display);
+    if (out.length >= limit) break;
+  }
+  return out;
+}


### PR DESCRIPTION
Gdy zapytanie w „Skryptorium" nie daje trafień (prawdopodobna literówka), pokazujemy klikalne podpowiedzi „Czy chodziło Ci o…". Closes #82.

## Jak działa
- **`buildSearchVocab(index)`** — słownik terminów: słowa tytułów (PL+oryg) i autorów, dedupe po foldzie, `display` z wielką literą. Liczony **raz** na zbiór (memoizowany).
- **`didYouMean(query, vocab)`** — bierze **ostatni token** zapytania (tam zwykle siedzi literówka), liczy Levenshteina względem słownika z progiem zależnym od długości (≤4→1, ≤7→2, dłuższe→3), odsiewa po |Δlen| (Levenshtein ≥ różnica długości) i pomija trafienie dokładne. Zwraca do 3 unikatów wg dystansu.
- **UI**: podpowiedzi renderują się tylko przy 0 trafień, pod „Archiwum milczy"; klik ustawia zapytanie. Wszystko client-side.

Przykłady: `perelanda` → „Perelandra?", `simnons` → „Simmons?", `dan simnons` → „Simmons?".

## Weryfikacja
- `npm run lint` czysty · `npm test` **229/229** (+6: literówka tytułu/autora, ostatni token, dalekie zapytanie, pominięcie dokładnego, za krótkie) · `npm run build` OK.
- Wersja → **1.13.0** (mirror package.json + lock); `docs/skryptorium-search.md` + backlog zaktualizowane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_