### PR TITLE
fix(skryptorium): did-you-mean replaces only the last token (v1.13.1)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.13.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.13.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,9 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.13.1** — Skryptorium (#84): klik podpowiedzi podmienia TYLKO ostatni token (czysta
+  `replaceLastToken`), nie całe pole. „Greg Vear" + „Bear" → „Greg Bear" (nie samo „Bear").
+  Fokus wraca do inputu. +4 testy.
 - **1.13.0** — Skryptorium „Czy chodziło Ci o…" (#82): fuzzy-podpowiedzi na literówki. Gdy
   `matchBooks`=0, `didYouMean` liczy Levenshteina między OSTATNIM tokenem zapytania a słownikiem
   `buildSearchVocab` (słowa tytułów PL+oryg + autorów, dedupe po foldzie, display z wielką literą);

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookSearch.test.ts
+++ b/src/__tests__/bookSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fold, matchBooks, highlight, buildSearchVocab, didYouMean } from "../utils/bookSearch";
+import { fold, matchBooks, highlight, buildSearchVocab, didYouMean, replaceLastToken } from "../utils/bookSearch";
 import { BookIndexEntry } from "../types";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
@@ -99,6 +99,26 @@ describe("bookSearch.didYouMean", () => {
 
   it("ignores too-short queries", () => {
     expect(didYouMean("pe", vocab)).toEqual([]);
+  });
+});
+
+describe("bookSearch.replaceLastToken", () => {
+  it("replaces only the last token, keeping earlier words", () => {
+    expect(replaceLastToken("Greg Vear", "Bear")).toBe("Greg Bear");
+    expect(replaceLastToken("dan simnons", "Simmons")).toBe("dan Simmons");
+  });
+
+  it("replaces a single token wholesale", () => {
+    expect(replaceLastToken("simnons", "Simmons")).toBe("Simmons");
+  });
+
+  it("drops trailing whitespace around the last token", () => {
+    expect(replaceLastToken("Greg Vear  ", "Bear")).toBe("Greg Bear");
+  });
+
+  it("returns the term for an empty / whitespace query", () => {
+    expect(replaceLastToken("", "Bear")).toBe("Bear");
+    expect(replaceLastToken("   ", "Bear")).toBe("Bear");
   });
 });
 

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useDeferredValue, useRef, useEffect } from "r
 import { motion, AnimatePresence } from "motion/react";
 import { Search, X, Loader2, ScrollText, AlertCircle } from "lucide-react";
 import { useBooks } from "../hooks/useBooks";
-import { matchBooks, buildSearchVocab, didYouMean } from "../utils/bookSearch";
+import { matchBooks, buildSearchVocab, didYouMean, replaceLastToken } from "../utils/bookSearch";
 import { BookResultCard } from "./search/BookResultCard";
 
 /** Ile kart maksymalnie rysujemy (ochrona DOM przy „pustym" zapytaniu = cały zbiór). */
@@ -111,7 +111,7 @@ export const SearchSection: React.FC = () => {
               {suggestions.map((s, i) => (
                 <React.Fragment key={s}>
                   <button
-                    onClick={() => setQuery(s)}
+                    onClick={() => { setQuery(replaceLastToken(query, s)); inputRef.current?.focus(); }}
                     className="text-cyan-300 hover:text-cyan-200 font-semibold underline decoration-dotted underline-offset-4 decoration-cyan-500/50"
                   >
                     {s}

--- a/src/utils/bookSearch.ts
+++ b/src/utils/bookSearch.ts
@@ -195,3 +195,14 @@ export function didYouMean(query: string, vocab: VocabTerm[], limit = 3): string
   }
   return out;
 }
+
+/**
+ * Podmienia OSTATNI token zapytania na `term`, zachowując wcześniejsze słowa —
+ * bo `didYouMean` poprawia właśnie ostatni token. „Greg Vear" + „Bear" →
+ * „Greg Bear". Puste / same spacje → zwraca sam `term`.
+ */
+export function replaceLastToken(query: string, term: string): string {
+  const m = query.match(/^(.*?)(\S+)\s*$/);
+  if (!m) return term;
+  return `${m[1]}${term}`;
+}


### PR DESCRIPTION
Kliknięcie podpowiedzi „Czy chodziło Ci o" nadpisywało całe pole. Teraz podmienia tylko ostatni (literówkowy) token, zachowując wcześniejsze słowa. Closes #84.

Przykład: „Greg Vear" + klik „Bear" → **„Greg Bear"** (wcześniej: samo „Bear"). Fokus wraca do inputu.

## Zmiana
- Czysta `replaceLastToken(query, term)` w `src/utils/bookSearch.ts` (regex podmieniający ostatni token; puste/same spacje → sam `term`).
- `SearchSection` używa jej zamiast `setQuery(term)`.

## Weryfikacja
- `npm run lint` czysty · `npm test` **233/233** (+4: ostatni token, pojedynczy token, spacje na końcu, puste zapytanie) · `npm run build` OK.
- Wersja → **1.13.1** (mirror package.json + lock); backlog zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_