### PR TITLE
feat: Regał Archiwum — bookshelf visualization with drag&drop (v1.15.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Każda operacja to osobne, anulowalne zadanie strumieniowane do UI przez SSE.
 | **Sanctity (Integralność)** | `POST /api/sync-integrity` | Porównuje bazę Notion z wiki: liczby per rok/nagroda, unikalność Lp/tytułów. |
 | **Statystyki** | `GET /api/stats` | Agregaty do dashboardu (postęp autorów, roczników, pokrycie nagród, biblioteki). |
 | **Skryptorium** (wyszukiwarka) | `GET /api/books` | Odchudzony indeks rekordów; front filtruje client-side po tytule (PL+oryg) i autorze, diakrytyki-agnostycznie, na żywo („per" → wiele, „pere" → Perelandra). |
+| **Regał** (wizualizacja) | `POST /api/mark-as-read`, `POST /api/unmark-as-read` | Księgozbiór jako fizyczne półki (grzbiety + okładki „Wyróżnione"); dwa regały „Do przeczytania"/„Przeczytane" z drag&drop, który zapisuje/usuwa tag „Przeczytane" w kolumnie „Źródło". |
 | **Skan Biblioteki** | `POST /api/library-check` | Sprawdza dostępność w OPAC MBP Lublin (scraping HTML). |
 | **Skan Vinted** | `POST /api/vinted-check` | Szuka fizycznych egzemplarzy na vinted.pl (scraping HTML). |
 

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.14.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.0** — „Regał Archiwum" (#89): zakładka z wizualizacją księgozbioru jako fizyczne
+  półki (koncept A grzbiety + B półka okładek „Wyróżnione"=read+nagroda). Dwa regały „Do
+  przeczytania"/„Przeczytane" z **drag&drop** (HTML5 DnD); upuszczenie zapisuje/usuwa tag
+  „Przeczytane" w „Źródło" (optymistyczny stan `overrides` + revert przy błędzie). Backend:
+  `removeTagFromMultiSelect` + `syncManager.unmarkRead` + `POST /api/unmark-as-read` (guard
+  `ALLOWED_SOURCE_TAGS`), symetryczne do `markAsRead`; cache książek inwalidowany. Czyste
+  `src/utils/bookshelf.ts` (`spineStyle` deterministyczny, `splitShelves`, `featuredReads`).
+  BUG złapany testem: `h >> 3` (znakowe) → ujemne dla hashów >2^31 → `>>> 3`. +9 testów.
 - **1.14.0** — Paczki Vinted: przełącznik sortowania „Najwięcej książek" / „Najtańsza paczka".
   Czysta `sortBundles(bundles, mode)` (`count`: najwięcej książek → remis najtańsza suma;
   `price`: najtańsza `totalValue` → remis najwięcej książek), zwraca kopię (bez mutacji).

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -188,6 +188,24 @@ export const markAsRead = async (req: Request, res: Response) => {
   }
 };
 
+export const unmarkAsRead = async (req: Request, res: Response) => {
+  try {
+    const { pageId, tag } = req.body;
+    if (!pageId) return res.status(400).json({ error: "Missing pageId parameter" });
+
+    const sourceTag = tag ?? "Przeczytane";
+    if (!ALLOWED_SOURCE_TAGS.has(sourceTag)) {
+      return res.status(400).json({ error: `Niedozwolony znacznik: ${sourceTag}.` });
+    }
+
+    await syncManager.unmarkRead(pageId, sourceTag);
+    res.json({ success: true });
+  } catch (error: any) {
+    console.error("Unmark as Read Error:", error);
+    res.status(500).json({ error: error.message || "Wystąpił błąd podczas usuwania znacznika." });
+  }
+};
+
 export const checkVintedAvailability = async (req: Request, res: Response) => {
   if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
     return res.status(400).json({ error: "Brak kluczy API Notion." });

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,6 @@ Szczegółowe opisy działania poszczególnych rytuałów (jeden dokument na kon
 | [library-check.md](./library-check.md) | Skan dostępności w OPAC MBP Lublin (scraping HTML). |
 | [vinted-scanner.md](./vinted-scanner.md) | Skan ofert na vinted.pl (scraping HTML — bez AI). |
 | [skryptorium-search.md](./skryptorium-search.md) | Wyszukiwarka rekordów archiwum (client-side, fold diakrytyków, highlight). |
+| [bookshelf.md](./bookshelf.md) | Regał: wizualizacja księgozbioru (grzbiety + okładki) z drag&drop przeczytanych. |
 
 Obserwowalność, diagnostyka (`/api/diagnostics`), wdrożenie i rozwiązywanie problemów opisane są w [README](../README.md).

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -1,0 +1,42 @@
+# Regał Archiwum (Bookshelf)
+
+## 1. Overview
+The **Regał** tab renders the tracked library as physical shelves instead of a list: read books
+stand as coloured **spines** (concept A), awarded reads also appear face-out on a **"Wyróżnione"**
+cover row (concept B). Two shelves — **Do przeczytania** and **Przeczytane** — sit side by side, and
+a book is dragged between them; the drop writes the read state back to Notion. **No AI/LLM.**
+
+## 2. Data
+- Reuses **`GET /api/books`** (`BookIndexEntry[]`, see [skryptorium-search.md](./skryptorium-search.md)) —
+  the same slim index the search uses. Read state is derived from the `zrodlo` (Źródło) tag
+  `Przeczytane`; nothing extra is fetched.
+
+## 3. Pure helpers (`src/utils/bookshelf.ts`, unit-tested)
+- **`isRead(book, overrides)`** — read state with optimistic overrides layered over the base tag.
+- **`spineStyle(book)`** — deterministic spine colour (a muted book-cloth palette), width and height
+  from a hash of the title, so a spine looks identical across re-renders. The hash is unsigned
+  (`>>> 0`); the height derivation uses an **unsigned** shift (`>>> 3`) — a signed `>> 3` goes
+  negative for hashes above 2³¹ and produced out-of-range heights (caught by a bounds test).
+- **`splitShelves(books, overrides)`** — partitions into `{ read, toRead }`, each sorted by author
+  then title.
+- **`featuredReads(books, overrides, limit)`** — the cover row: read **and** awarded, newest year
+  first (no read-date exists in the data), capped at `limit`.
+
+## 4. Drag & drop + persistence
+- Native HTML5 DnD: each `BookSpine` is `draggable` and puts its id on the dataTransfer; each `Shelf`
+  is a drop target that highlights while a drag is in progress.
+- On drop onto the opposite shelf, `BookshelfSection` moves the book **optimistically** (sets a
+  `ReadOverrides` entry so `splitShelves` re-partitions immediately) and then persists:
+  - drop on **Przeczytane** → `POST /api/mark-as-read` (adds the `Przeczytane` tag);
+  - drop on **Do przeczytania** → `POST /api/unmark-as-read` (removes it).
+  If the write fails, the override is reverted and an error banner names the book. Dropping onto the
+  same shelf is a no-op.
+- **Backend** mirrors the existing mark path: `NotionAdapter.removeTagFromMultiSelect` (inverse of
+  `addTagToMultiSelect`, both invalidate the books cache) → `SyncManager.unmarkRead` →
+  `POST /api/unmark-as-read`, guarded by the same `ALLOWED_SOURCE_TAGS` allow-list as `mark-as-read`
+  so only known Źródło tags can be written.
+
+## 5. Scope notes
+Concept A (spines) + B (featured covers) shipped; the alternate 40k "Krypta Danych" neon skin (C)
+was a rejected mock. Out of scope for now: virtualization for extreme counts, per-shelf sort/filter,
+and a write-in-progress animation on the dragged spine.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -233,6 +233,32 @@ export class NotionAdapter {
     this.invalidateBooksCache();
   }
 
+  /** Usuwa znacznik z pola multi_select (odwrotność `addTagToMultiSelect`). */
+  async removeTagFromMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
+    await this.init();
+
+    const page = await withRetry(() => this.notion.pages.retrieve({ page_id: pageId })) as any;
+    const prop = page.properties[propertyName];
+
+    if (!prop || prop.type !== "multi_select") {
+      throw new Error(`Property ${propertyName} is not a multi_select`);
+    }
+
+    const currentTags = prop.multi_select.map((t: any) => ({ name: t.name }));
+    const nextTags = currentTags.filter((t: any) => t.name !== tag);
+    if (nextTags.length === currentTags.length) {
+      return; // Nie było tagu — nic do zrobienia
+    }
+
+    await withRetry(() => this.notion.pages.update({
+      page_id: pageId,
+      properties: {
+        [propertyName]: { multi_select: nextTags }
+      }
+    }));
+    this.invalidateBooksCache();
+  }
+
   async resolveDataSourceId(databaseId: string): Promise<string> {
     await this.init();
     return this.actualDataSourceId!;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -32,6 +32,7 @@ router.post("/sync-lp", syncController.runLpSync);
 router.post("/sync-duplicates", syncController.runDuplicateCheck);
 router.post("/sync-integrity", syncController.runIntegrityCheck);
 router.post("/mark-as-read", syncController.markAsRead);
+router.post("/unmark-as-read", syncController.unmarkAsRead);
 router.post("/vinted-check", syncController.checkVintedAvailability);
 router.post("/vinted-check/stop", syncController.stopVintedCheck);
 router.post("/vinted-resolve-sellers", syncController.resolveVintedSellers);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart, ScrollText } from "lucide-react";
+import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart, ScrollText, Library } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { StatsSection } from "./components/StatsSection";
 import { SearchSection } from "./components/SearchSection";
+import { BookshelfSection } from "./components/BookshelfSection";
 import { VintedSection } from "./components/VintedSection";
 import { StatusSection } from "./components/StatusSection";
 import { SyncAwards } from "./components/SyncAwards";
@@ -19,7 +20,7 @@ import { IntegrityCheckResult } from "./types";
 
 export default function App() {
   const { configStatus, schema, schemaLoading, schemaError, fetchSchema } = useConfig();
-  const [activeTab, setActiveTab] = useState<'stats' | 'search' | 'config' | 'vinted'>('stats');
+  const [activeTab, setActiveTab] = useState<'stats' | 'shelf' | 'search' | 'config' | 'vinted'>('stats');
   const [showScrollTop, setShowScrollTop] = useState(false);
 
   const {
@@ -87,6 +88,17 @@ export default function App() {
           >
             <Database className="w-5 h-5" />
             Statystyki Archiwum
+          </button>
+          <button
+            onClick={() => setActiveTab('shelf')}
+            className={`w-full sm:flex-1 px-4 py-4 rounded-2xl border font-bold uppercase tracking-wide text-sm transition-all flex items-center justify-center gap-3 ${
+              activeTab === 'shelf'
+                ? 'bg-amber-500/20 border-amber-500/50 text-amber-300 shadow-[0_0_20px_rgba(251,191,36,0.2)]'
+                : 'bg-slate-900/50 border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
+            }`}
+          >
+            <Library className="w-5 h-5" />
+            Regał
           </button>
           <button
             onClick={() => setActiveTab('search')}
@@ -175,6 +187,16 @@ export default function App() {
               transition={{ duration: 0.3 }}
             >
               <StatsSection />
+            </motion.div>
+          ) : activeTab === 'shelf' ? (
+            <motion.div
+              key="shelf"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <BookshelfSection />
             </motion.div>
           ) : activeTab === 'search' ? (
             <motion.div

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { BookIndexEntry } from "../types";
+import { isRead, spineStyle, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG } from "../utils/bookshelf";
+
+const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
+  id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
+  awards: [], zrodlo: [], series: "", partOfCycle: false, ...over,
+});
+
+describe("bookshelf.isRead", () => {
+  it("reads the Przeczytane tag from zrodlo", () => {
+    expect(isRead(mk({ zrodlo: [READ_TAG] }))).toBe(true);
+    expect(isRead(mk({ zrodlo: ["Posiadam"] }))).toBe(false);
+  });
+  it("lets an override win over the base state", () => {
+    const b = mk({ id: "b1", zrodlo: ["Posiadam"] });
+    expect(isRead(b, { b1: true })).toBe(true);
+    const r = mk({ id: "r1", zrodlo: [READ_TAG] });
+    expect(isRead(r, { r1: false })).toBe(false);
+  });
+});
+
+describe("bookshelf.spineStyle", () => {
+  it("is deterministic for the same title", () => {
+    const a = spineStyle(mk({ plTitle: "Diuna" }));
+    const b = spineStyle(mk({ plTitle: "Diuna", id: "other" }));
+    expect(a).toEqual(b);
+  });
+  it("stays within palette and size bounds", () => {
+    for (const t of ["Diuna", "Hyperion", "Ubik", "Solaris", "Lód"]) {
+      const s = spineStyle(mk({ plTitle: t }));
+      expect(CLOTH_PALETTE).toContain(s.color);
+      expect(s.width).toBeGreaterThanOrEqual(16);
+      expect(s.width).toBeLessThanOrEqual(27);
+      expect(s.height).toBeGreaterThanOrEqual(124);
+      expect(s.height).toBeLessThanOrEqual(171);
+    }
+  });
+});
+
+describe("bookshelf.splitShelves", () => {
+  const books = [
+    mk({ id: "1", plTitle: "B", author: "Lem", zrodlo: [READ_TAG] }),
+    mk({ id: "2", plTitle: "A", author: "Lem", zrodlo: ["Posiadam"] }),
+    mk({ id: "3", plTitle: "C", author: "Dick", zrodlo: [READ_TAG] }),
+  ];
+
+  it("partitions by read state", () => {
+    const { read, toRead } = splitShelves(books);
+    expect(read.map((b) => b.id).sort()).toEqual(["1", "3"]);
+    expect(toRead.map((b) => b.id)).toEqual(["2"]);
+  });
+
+  it("sorts each shelf by author then title", () => {
+    const { read } = splitShelves(books);
+    // Dick/C before Lem/B
+    expect(read.map((b) => b.id)).toEqual(["3", "1"]);
+  });
+
+  it("respects overrides when partitioning (drag&drop move)", () => {
+    const { read, toRead } = splitShelves(books, { "1": false });
+    expect(read.map((b) => b.id)).toEqual(["3"]);
+    expect(toRead.map((b) => b.id).sort()).toEqual(["1", "2"]);
+  });
+});
+
+describe("bookshelf.featuredReads", () => {
+  it("keeps only read + awarded, sorted by year desc, limited", () => {
+    const books = [
+      mk({ id: "1", plTitle: "Old", zrodlo: [READ_TAG], awards: ["Nagroda Hugo"], year: "1990" }),
+      mk({ id: "2", plTitle: "New", zrodlo: [READ_TAG], awards: ["Nagroda Nebula"], year: "2010" }),
+      mk({ id: "3", plTitle: "Unread", zrodlo: ["Posiadam"], awards: ["Nagroda Hugo"], year: "2020" }),
+      mk({ id: "4", plTitle: "ReadNoAward", zrodlo: [READ_TAG], awards: [], year: "2000" }),
+    ];
+    const f = featuredReads(books, {}, 12).map((b) => b.id);
+    expect(f).toEqual(["2", "1"]); // read+award only, newest first
+  });
+
+  it("respects the limit", () => {
+    const many = Array.from({ length: 20 }, (_, i) =>
+      mk({ id: String(i), plTitle: `T${i}`, zrodlo: [READ_TAG], awards: ["Nagroda X"], year: String(2000 + i) }));
+    expect(featuredReads(many, {}, 5)).toHaveLength(5);
+  });
+});

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useMemo, useCallback } from "react";
+import { Library, BookOpen, CheckCircle2, Sparkles, Loader2, AlertCircle, X } from "lucide-react";
+import { BookIndexEntry } from "../types";
+import { useBooks } from "../hooks/useBooks";
+import { useMarkRead } from "../hooks/useMarkRead";
+import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
+import { Shelf } from "./shelf/Shelf";
+import { CoverCard } from "./shelf/CoverCard";
+
+export const BookshelfSection: React.FC = () => {
+  const { books, loading, error, fetchBooks } = useBooks();
+  const { setRead } = useMarkRead();
+
+  const [overrides, setOverrides] = useState<ReadOverrides>({});
+  const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
+  const [moveError, setMoveError] = useState<string | null>(null);
+
+  const all = books ?? [];
+  const { read, toRead } = useMemo(() => splitShelves(all, overrides), [all, overrides]);
+  const featured = useMemo(() => featuredReads(all, overrides), [all, overrides]);
+
+  const handleDrop = useCallback((target: ShelfId) => {
+    const book = dragging;
+    setDragging(null);
+    if (!book) return;
+
+    const targetRead = target === "read";
+    const wasRead = isRead(book, overrides);
+    if (wasRead === targetRead) return; // upuszczono na tę samą półkę — nic
+
+    // Optymistyczny ruch, potem zapis; przy błędzie cofnij i pokaż komunikat.
+    setOverrides((prev) => ({ ...prev, [book.id]: targetRead }));
+    setMoveError(null);
+    setRead(book.id, targetRead).catch((e: any) => {
+      setOverrides((prev) => ({ ...prev, [book.id]: wasRead }));
+      setMoveError(`Nie udało się zapisać „${book.plTitle || book.origTitle}": ${e.message}`);
+    });
+  }, [dragging, overrides, setRead]);
+
+  return (
+    <div className="space-y-8">
+      {/* Nagłówek */}
+      <div className="flex items-center gap-6">
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
+        <div className="flex items-center gap-4">
+          <Library className="w-6 h-6 text-amber-300" />
+          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-amber-100/90 whitespace-nowrap">Regał Archiwum</h2>
+        </div>
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
+      </div>
+      <p className="text-center text-[11px] text-slate-500 uppercase tracking-widest font-bold -mt-4">
+        Przeciągnij wolumin między regałami — zapis trafia do kolumny „Źródło" w Notion
+      </p>
+
+      {moveError && (
+        <div className="glass-card p-4 rounded-2xl border-red-500/30 bg-red-500/5 max-w-2xl mx-auto flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
+          <p className="text-sm text-red-300 flex-1">{moveError}</p>
+          <button onClick={() => setMoveError(null)} className="text-red-400/70 hover:text-red-300" aria-label="Zamknij">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center gap-3 py-16 text-slate-500">
+          <Loader2 className="w-5 h-5 animate-spin" />
+          <span className="text-sm font-bold uppercase tracking-widest">Wczytywanie księgozbioru…</span>
+        </div>
+      ) : error ? (
+        <div className="glass-card p-6 rounded-3xl border-red-500/30 bg-red-500/5 max-w-xl mx-auto flex items-center gap-4">
+          <AlertCircle className="w-6 h-6 text-red-400 shrink-0" />
+          <div className="flex-1">
+            <p className="text-sm text-red-300 font-bold">{error}</p>
+            <button onClick={fetchBooks} className="mt-2 text-[11px] text-red-400/70 hover:text-red-300 uppercase tracking-widest font-bold">Spróbuj ponownie</button>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Półka „Wyróżnione" (okładki twarzą) */}
+          {featured.length > 0 && (
+            <div className="rounded-3xl border border-purple-500/20 bg-gradient-to-b from-purple-950/20 to-black/40 p-4 sm:p-5">
+              <div className="flex items-center gap-2 mb-4">
+                <Sparkles className="w-4 h-4 text-purple-300" />
+                <h3 className="text-sm font-bold uppercase tracking-widest text-purple-200">Wyróżnione — nagrodzone, przeczytane</h3>
+                <span className="px-2 py-0.5 rounded-lg text-[10px] font-bold border bg-purple-500/10 border-purple-500/25 text-purple-300">{featured.length}</span>
+              </div>
+              <div className="flex gap-3.5 overflow-x-auto pb-1 custom-scrollbar">
+                {featured.map((b) => <CoverCard key={b.id} book={b} />)}
+              </div>
+              <div className="h-4 rounded-[3px] mt-1 bg-gradient-to-b from-amber-800/70 via-amber-950/80 to-black shadow-[0_10px_16px_-6px_rgba(0,0,0,.7),inset_0_1px_0_rgba(255,220,170,.12)]" />
+            </div>
+          )}
+
+          {/* Dwa regały */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+            <Shelf
+              shelfId="toRead" title="Do przeczytania" accent="cyan"
+              icon={<BookOpen className="w-4 h-4" />}
+              books={toRead} dragging={!!dragging}
+              onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
+            />
+            <Shelf
+              shelfId="read" title="Przeczytane" accent="emerald"
+              icon={<CheckCircle2 className="w-4 h-4" />}
+              books={read} dragging={!!dragging}
+              onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
+            />
+          </div>
+
+          <p className="text-center text-[10px] text-slate-600 uppercase tracking-widest font-bold">
+            {all.length} woluminów · <span className="text-amber-400/70">●</span> = nagroda · najedź, by wysunąć grzbiet
+          </p>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { BookIndexEntry } from "../../types";
+import { SpineStyle, displayTitle, hasAward } from "../../utils/bookshelf";
+
+interface Props {
+  book: BookIndexEntry;
+  style: SpineStyle;
+  onDragStart: (book: BookIndexEntry) => void;
+  onDragEnd: () => void;
+}
+
+/** Grzbiet książki (koncept A) — przeciągalny element regału. */
+export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd }) => (
+  <div
+    draggable
+    onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
+    onDragEnd={onDragEnd}
+    title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
+    className="group relative shrink-0 flex items-center justify-center cursor-grab active:cursor-grabbing select-none rounded-[3px_3px_1px_1px] transition-transform duration-150 hover:-translate-y-3"
+    style={{
+      width: style.width,
+      height: style.height,
+      background: `linear-gradient(90deg, rgba(0,0,0,.35), ${style.color} 22%, ${style.color} 78%, rgba(0,0,0,.28))`,
+      boxShadow: "inset 1.5px 0 0 rgba(255,255,255,.14), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6)",
+    }}
+  >
+    <span className="absolute left-0 right-0 h-[10px] top-[9px] bg-black/25" aria-hidden />
+    <span
+      className="font-bold text-[10px] text-white/85 whitespace-nowrap overflow-hidden max-h-[80%] py-1.5"
+      style={{ writingMode: "vertical-rl", transform: "rotate(180deg)", textShadow: "0 1px 2px rgba(0,0,0,.5)" }}
+    >
+      {displayTitle(book)}
+    </span>
+    {hasAward(book) && (
+      <span className="absolute bottom-[7px] left-1/2 -translate-x-1/2 w-[9px] h-[9px] rounded-full bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,.85)]" title="Nagroda / nominacja" />
+    )}
+  </div>
+);

--- a/src/components/shelf/CoverCard.tsx
+++ b/src/components/shelf/CoverCard.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { BookIndexEntry } from "../../types";
+import { CLOTH_PALETTE, displayTitle } from "../../utils/bookshelf";
+
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+/** Okładka „twarzą" (koncept B) — półka „Wyróżnione". Widok, bez drag&drop. */
+export const CoverCard: React.FC<{ book: BookIndexEntry }> = ({ book }) => {
+  const h = hash(displayTitle(book));
+  const c1 = CLOTH_PALETTE[h % CLOTH_PALETTE.length];
+  const c2 = CLOTH_PALETTE[(h >>> 3) % CLOTH_PALETTE.length];
+  return (
+    <div
+      title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}`}
+      className="group relative shrink-0 w-[104px] h-[156px] rounded-[6px_3px_3px_6px] overflow-hidden flex flex-col justify-between p-3 pl-4 transition-transform duration-150 hover:-translate-y-2"
+      style={{ background: `linear-gradient(150deg, ${c1}, ${c2})`, boxShadow: "inset -5px 0 8px -6px rgba(0,0,0,.6), 0 10px 16px -8px rgba(0,0,0,.7)" }}
+    >
+      <span className="absolute left-0 top-0 bottom-0 w-1.5 bg-black/25 shadow-[1px_0_2px_rgba(255,255,255,.1)]" aria-hidden />
+      <span className="absolute top-2 right-2 w-4 h-4 rounded-full border-[1.5px] border-amber-300 text-amber-300 text-[9px] flex items-center justify-center">★</span>
+      <div className="text-[12px] font-bold leading-tight text-white text-balance drop-shadow-[0_1px_3px_rgba(0,0,0,.5)]">
+        {displayTitle(book)}
+      </div>
+      <div className="text-[8.5px] uppercase tracking-wider text-white/75 font-bold">
+        {book.author}{book.year ? ` · ${book.year}` : ""}
+      </div>
+    </div>
+  );
+};

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { BookIndexEntry } from "../../types";
+import { ShelfId, spineStyle } from "../../utils/bookshelf";
+import { BookSpine } from "./BookSpine";
+
+interface Props {
+  shelfId: ShelfId;
+  title: string;
+  icon: React.ReactNode;
+  accent: "emerald" | "cyan";
+  books: BookIndexEntry[];
+  onDragStart: (book: BookIndexEntry) => void;
+  onDragEnd: () => void;
+  onDropBook: (target: ShelfId) => void;
+  /** Czy trwa przeciąganie (do podświetlenia stref upuszczenia). */
+  dragging: boolean;
+}
+
+const ACCENT = {
+  emerald: { text: "text-emerald-300", ring: "border-emerald-500/40", glow: "shadow-[0_0_24px_rgba(52,211,153,.18)]", chip: "bg-emerald-500/10 border-emerald-500/25 text-emerald-300" },
+  cyan: { text: "text-cyan-300", ring: "border-cyan-500/40", glow: "shadow-[0_0_24px_rgba(34,211,238,.18)]", chip: "bg-cyan-500/10 border-cyan-500/25 text-cyan-300" },
+};
+
+/** Jeden regał = drop-target z półkami grzbietów (zawijanymi w rzędy). */
+export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, dragging }) => {
+  const [over, setOver] = useState(false);
+  const a = ACCENT[accent];
+
+  return (
+    <div
+      onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true); }}
+      onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setOver(false); }}
+      onDrop={(e) => { e.preventDefault(); setOver(false); onDropBook(shelfId); }}
+      className={`rounded-3xl border p-4 sm:p-5 bg-gradient-to-b from-amber-950/30 to-black/40 transition-colors ${
+        over ? `${a.ring} ${a.glow}` : dragging ? "border-white/15 border-dashed" : "border-amber-900/40"
+      }`}
+    >
+      <div className="flex items-center gap-2 mb-4">
+        <span className={a.text}>{icon}</span>
+        <h3 className="text-sm font-bold uppercase tracking-widest text-slate-200">{title}</h3>
+        <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{books.length}</span>
+        {dragging && <span className="ml-auto text-[10px] uppercase tracking-widest text-slate-500 font-bold">upuść tutaj</span>}
+      </div>
+
+      {books.length === 0 ? (
+        <div className="min-h-[120px] flex items-center justify-center text-xs text-slate-600 italic">
+          {dragging ? "Upuść wolumin, aby przenieść" : "Pusto na tej półce"}
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-end gap-[5px] content-end max-h-[520px] overflow-y-auto pr-1 custom-scrollbar">
+          {books.map((b) => (
+            <BookSpine key={b.id} book={b} style={spineStyle(b)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+          ))}
+        </div>
+      )}
+      {/* Deska półki */}
+      <div className="h-4 rounded-[3px] mt-1 bg-gradient-to-b from-amber-800/70 via-amber-950/80 to-black shadow-[0_10px_16px_-6px_rgba(0,0,0,.7),inset_0_1px_0_rgba(255,220,170,.15)]" />
+    </div>
+  );
+};

--- a/src/hooks/useMarkRead.ts
+++ b/src/hooks/useMarkRead.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react";
+import { READ_TAG } from "../utils/bookshelf";
+
+/**
+ * Zapis stanu „przeczytane" do Notion: `mark-as-read` dodaje tag „Przeczytane"
+ * w kolumnie „Źródło", `unmark-as-read` go usuwa. Rzuca przy błędzie — wołający
+ * (regał) robi optymistyczny ruch i cofa go, jeśli zapis się nie powiedzie.
+ */
+export function useMarkRead() {
+  const setRead = useCallback(async (pageId: string, read: boolean): Promise<void> => {
+    const url = read ? "/api/mark-as-read" : "/api/unmark-as-read";
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageId, tag: READ_TAG }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || "Zapis do Notion nie powiódł się");
+    }
+  }, []);
+
+  return { setRead };
+}

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -1,0 +1,81 @@
+import { BookIndexEntry } from "../types";
+
+/** Znacznik „Źródło" oznaczający pozycję przeczytaną. */
+export const READ_TAG = "Przeczytane";
+
+/** Która półka: przeczytane vs do przeczytania. */
+export type ShelfId = "read" | "toRead";
+
+/** Lokalne nadpisania stanu „przeczytane" (optymistyczny drag&drop przed potwierdzeniem z API). */
+export type ReadOverrides = Record<string, boolean>;
+
+/** Czy książka jest przeczytana — z uwzględnieniem optymistycznego nadpisania. */
+export function isRead(book: BookIndexEntry, overrides: ReadOverrides = {}): boolean {
+  if (Object.prototype.hasOwnProperty.call(overrides, book.id)) return overrides[book.id];
+  return book.zrodlo.includes(READ_TAG);
+}
+
+/** Deterministyczny wygląd grzbietu — stały dla danego tytułu (bez migotania przy re-renderze). */
+export interface SpineStyle {
+  color: string;
+  width: number;  // px
+  height: number; // px
+}
+
+/** Paleta „płótna introligatorskiego" — stonowana, autentyczna. */
+export const CLOTH_PALETTE = [
+  "#7f1d2e", "#0f5132", "#1e3a5f", "#7c5410", "#3f2d52", "#2b2b2b",
+  "#5a2a1e", "#14504f", "#4a3b16", "#5b1f3a", "#243b53", "#6b2737",
+];
+
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+export function spineStyle(book: BookIndexEntry): SpineStyle {
+  const h = hash(book.plTitle || book.origTitle || book.id);
+  return {
+    color: CLOTH_PALETTE[h % CLOTH_PALETTE.length],
+    width: 16 + (h % 12),          // 16–27 px
+    height: 124 + ((h >>> 3) % 48), // 124–171 px (unsigned shift — h bywa >2^31)
+  };
+}
+
+/** Tytuł do pokazania (polski, a gdy brak — oryginalny). */
+export function displayTitle(book: BookIndexEntry): string {
+  return book.plTitle || book.origTitle;
+}
+
+/** Czy pozycja ma nagrodę/nominację (do pieczęci na grzbiecie i półki „Wyróżnione"). */
+export function hasAward(book: BookIndexEntry): boolean {
+  return book.awards.length > 0;
+}
+
+const byAuthorTitle = (a: BookIndexEntry, b: BookIndexEntry) =>
+  (a.author || "").localeCompare(b.author || "", "pl") || displayTitle(a).localeCompare(displayTitle(b), "pl");
+
+/**
+ * Dzieli księgozbiór na dwie półki wg stanu „przeczytane" (z nadpisaniami),
+ * każda posortowana wg autora → tytułu (naturalny porządek biblioteczny).
+ */
+export function splitShelves(books: BookIndexEntry[], overrides: ReadOverrides = {}): Record<ShelfId, BookIndexEntry[]> {
+  const read: BookIndexEntry[] = [];
+  const toRead: BookIndexEntry[] = [];
+  for (const b of books) (isRead(b, overrides) ? read : toRead).push(b);
+  read.sort(byAuthorTitle);
+  toRead.sort(byAuthorTitle);
+  return { read, toRead };
+}
+
+/**
+ * Półka „Wyróżnione" (okładki twarzą): przeczytane pozycje z nagrodą.
+ * Brak daty przeczytania w danych → kolejność wg roku malejąco, potem tytuł.
+ */
+export function featuredReads(books: BookIndexEntry[], overrides: ReadOverrides = {}, limit = 12): BookIndexEntry[] {
+  return books
+    .filter((b) => isRead(b, overrides) && hasAward(b))
+    .sort((a, b) => (Number(b.year) || 0) - (Number(a.year) || 0) || displayTitle(a).localeCompare(displayTitle(b), "pl"))
+    .slice(0, limit);
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -153,6 +153,11 @@ class SyncManager {
     return await this.notion.addTagToMultiSelect(pageId, "Źródło", tag);
   }
 
+  /** Usuwa znacznik „Źródło" (odwrotność `markAsRead`) — drag&drop na regale. */
+  async unmarkRead(pageId: string, tag: string = "Przeczytane") {
+    return await this.notion.removeTagFromMultiSelect(pageId, "Źródło", tag);
+  }
+
   /** Odczyt składowanych wyników Vinted (kafelki/paczki z bazy — bez re-scrape). */
   async getVintedStored() {
     return await vintedSyncService.getStoredData();


### PR DESCRIPTION
Nowa zakładka **„Regał"** — księgozbiór jako fizyczne półki zamiast listy. Closes #89.

## Co jest
- **Koncept A (grzbiety)** — książki stoją grzbietami, deterministyczny kolor/wymiar z tytułu, pieczęć ● przy nagrodzie.
- **Koncept B (okładki)** — górna półka „Wyróżnione" (przeczytane + nagrodzone) twarzą do przodu.
- **Dwa regały** „Do przeczytania" / „Przeczytane" z **drag&drop** (natywne HTML5 DnD): przeciągnięcie przenosi wolumin i **zapisuje stan do Notion** — na „Przeczytane" dodaje tag, na „Do przeczytania" usuwa. Optymistyczny ruch (mapa `overrides`) + **revert i baner błędu**, gdy zapis padnie. Upuszczenie na tę samą półkę = no-op.

## Backend (symetryczny do `markAsRead`)
`NotionAdapter.removeTagFromMultiSelect` (odwrotność `add`, inwaliduje cache) → `SyncManager.unmarkRead` → `POST /api/unmark-as-read`, ten sam guard `ALLOWED_SOURCE_TAGS` (tylko znane tagi „Źródło").

## Frontend
Czyste `src/utils/bookshelf.ts` (`isRead`+overrides, `spineStyle`, `splitShelves`, `featuredReads`); `BookshelfSection` (orkiestracja DnD) + `shelf/BookSpine|Shelf|CoverCard`; reużywa `GET /api/books`.

## Bug złapany testem
Znakowe `h >> 3` schodziło poniżej zera dla hashów >2³¹ → wysokości grzbietów poza zakresem. Naprawione na `>>> 3` (bez znaku).

## Weryfikacja
- `npm run lint` czysty · `npm test` **245/245** (+9: isRead/overrides, determinizm i zakresy `spineStyle`, `splitShelves`, `featuredReads`) · `npm run build` OK.
- Wersja → **1.15.0** (mirror package.json + lock); README + `docs/bookshelf.md` + indeks docs.

## Poza zakresem (backlog)
Wirtualizacja przy ekstremalnej liczbie, sort/filtr półek, animacja „pull" przy zapisie, alternatywna skóra 40k „Krypta Danych" (koncept C — odrzucony w mockupie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_