### PR TITLE
refactor(vinted): extract pure formatters from VintedCheckItem (v1.15.1)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.1** — God-object audyt + krok 1/5 (#91): ekstrakcja czystych helperów z God-Component
+  `VintedCheckItem` (528 l.) do `src/utils/vintedFormat.ts` (`shortDate`, `formatDebug`,
+  `isBookChanged`, `offerBadges`) — ~40 linii logiki-w-JSX out, +8 testów. Audyt SRP wykazał
+  4 winowajców: VintedCheckItem (God-Component), `useSyncManager` (God-Hook: rejestr+polityka+
+  7-krokowa saga+parsing DOM), `vintedSyncService` (`runVintedCheck` god-metoda 225 l. + 3
+  concerny/klasa), `notion.adapter` (God-Adapter: literały domeny + dup metody). Oczyszczone:
+  `syncController` (płaski), `useSync` (wzorzec). Dekompozycja w krokach 2–5.
 - **1.15.0** — „Regał Archiwum" (#89): zakładka z wizualizacją księgozbioru jako fizyczne
   półki (koncept A grzbiety + B półka okładek „Wyróżnione"=read+nagroda). Dwa regały „Do
   przeczytania"/„Przeczytane" z **drag&drop** (HTML5 DnD); upuszczenie zapisuje/usuwa tag

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.15.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/vintedFormat.test.ts
+++ b/src/__tests__/vintedFormat.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { shortDate, formatDebug, isBookChanged, offerBadges } from "../utils/vintedFormat";
+import { VintedResult } from "../hooks/useVintedCheck";
+
+const result = (over: Partial<VintedResult>): VintedResult =>
+  ({ id: "1", title: "T", author: "A", vintedItems: [], ...over });
+
+const offer = (over: any = {}) => ({ title: "o", price: "10", priceValue: 10, currency: "zł", url: "u", ...over });
+
+describe("vintedFormat.shortDate", () => {
+  it("formats ISO to DD.MM", () => {
+    expect(shortDate("2026-03-07T12:00:00.000Z")).toBe("07.03");
+  });
+  it("returns empty for missing/invalid", () => {
+    expect(shortDate(null)).toBe("");
+    expect(shortDate("not-a-date")).toBe("");
+  });
+});
+
+describe("vintedFormat.formatDebug", () => {
+  it("renders an error line with status", () => {
+    expect(formatDebug({ error: "boom", httpStatus: 403 })).toBe("⚠ boom (403)");
+  });
+  it("summarizes a grid parse with links/parsed and a delta", () => {
+    const s = formatDebug({ chars: 7000, hasFeedGrid: true, itemLinks: 5, parsed: 3, changes: { added: 2, priceDropped: 1 } as any });
+    expect(s).toContain("7k");
+    expect(s).toContain("grid");
+    expect(s).toContain("links:5");
+    expect(s).toContain("parsed:3");
+    expect(s).toContain("Δ +2 ↓1");
+  });
+  it("marks block and memory", () => {
+    const s = formatDebug({ blockedMarker: true, rssMb: 240 });
+    expect(s).toContain("BLOCK");
+    expect(s).toContain("mem:240MB");
+  });
+});
+
+describe("vintedFormat.isBookChanged", () => {
+  it("is true only with a baseline changedAt equal to scannedAt", () => {
+    expect(isBookChanged(result({ scannedAt: "t1", changedAt: "t1" }))).toBe(true);
+    expect(isBookChanged(result({ scannedAt: "t1", changedAt: "t0" }))).toBe(false);
+    expect(isBookChanged(result({ scannedAt: "t1" }))).toBe(false); // pierwszy skan
+  });
+});
+
+describe("vintedFormat.offerBadges", () => {
+  it("flags a new offer only when the scan detected a change", () => {
+    const r = result({ scannedAt: "t1", changedAt: "t1" });
+    expect(offerBadges(offer({ firstSeenAt: "t1" }), r).isNew).toBe(true);
+    // pierwszy skan (bez changedAt baseline) → nie „nowa"
+    expect(offerBadges(offer({ firstSeenAt: "t1" }), result({ scannedAt: "t1" })).isNew).toBe(false);
+    // stara oferta
+    expect(offerBadges(offer({ firstSeenAt: "t0" }), r).isNew).toBe(false);
+  });
+  it("computes a price drop vs the previous scan", () => {
+    expect(offerBadges(offer({ prevPrice: 30, priceValue: 22 }), result({})).drop).toBe(8);
+    expect(offerBadges(offer({ prevPrice: 20, priceValue: 25 }), result({})).drop).toBeNull();
+    expect(offerBadges(offer({ priceValue: 25 }), result({})).drop).toBeNull();
+  });
+});

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -7,15 +7,8 @@ import { sortOffersByPrice, offersPriceSummary, formatVintedPrice, cleanOfferTit
 import { useVintedResolveSellers } from "../../hooks/useVintedResolveSellers";
 import { useVintedStored } from "../../hooks/useVintedStored";
 import { groupBySeller, sortBundles, BundleSortMode } from "../../utils/vintedSellers";
+import { shortDate, formatDebug, isBookChanged, offerBadges } from "../../utils/vintedFormat";
 import { RitualButton } from "./RitualButton";
-
-/** Krótka data „DD.MM" ze znacznika ISO (świeżość danych z bazy). */
-function shortDate(iso?: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return "";
-  return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}`;
-}
 
 interface VintedCheckItemProps {
   results: VintedResult[];
@@ -24,32 +17,6 @@ interface VintedCheckItemProps {
   onStop: () => void;
   isChecking: boolean;
   progress: any;
-}
-
-// Zwięzła jednolinijkowa diagnostyka próby (Krok 2). Kluczowy sygnał:
-// itemLinks>0 przy parsed:0 i bez markerów = parser zgubił oferty.
-function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
-  if (d.error) return `⚠ ${d.error}${d.httpStatus ? ` (${d.httpStatus})` : d.code ? ` (${d.code})` : ""}`;
-  const parts: string[] = [];
-  if (d.chars !== undefined) parts.push(`${(d.chars / 1000).toFixed(0)}k`);
-  parts.push(d.hasCatalogJson ? "json" : d.hasFeedGrid ? "grid" : "html");
-  if (d.itemLinks !== undefined) parts.push(`links:${d.itemLinks}`);
-  if (d.parsed !== undefined) parts.push(`parsed:${d.parsed}`);
-  if (d.blockedMarker) parts.push("BLOCK");
-  if (d.noResultsMarker) parts.push("noRes");
-  // Pamięć procesu — rosnące rssMb ku limitowi hostingu tuż przed śmiercią = OOM.
-  if (d.rssMb !== undefined) parts.push(`mem:${d.rssMb}MB`);
-  // Zmiany względem poprzedniego skanu (nowe/zniknięte/spadek/wzrost ceny).
-  if (d.changes) {
-    const c = d.changes;
-    const delta: string[] = [];
-    if (c.added) delta.push(`+${c.added}`);
-    if (c.removed) delta.push(`−${c.removed}`);
-    if (c.priceDropped) delta.push(`↓${c.priceDropped}`);
-    if (c.priceRaised) delta.push(`↑${c.priceRaised}`);
-    if (delta.length) parts.push(`Δ ${delta.join(" ")}`);
-  }
-  return parts.join(" · ");
 }
 
 const RESUME_HOURS = 12;
@@ -421,7 +388,7 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                   {result.scannedAt && (
                     <div className="text-[9px] text-indigo-400/60 font-bold tracking-widest mt-0.5 flex items-center gap-1">
                       <Clock className="w-2.5 h-2.5" /> skan {shortDate(result.scannedAt)}
-                      {result.changedAt && result.changedAt === result.scannedAt && (
+                      {isBookChanged(result) && (
                         <span className="ml-1 flex items-center gap-0.5 text-amber-400"><Sparkles className="w-2.5 h-2.5" /> zmiana</span>
                       )}
                     </div>
@@ -449,15 +416,7 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
                   const isCheapest = i === cheapestIdx;
                   const hasPrice = item.priceValue !== null && item.priceValue !== undefined;
                   const offerTitle = cleanOfferTitle(item.title);
-                  // Znaczniki zmian (dane z bazy): „nowa" = pojawiła się w ostatnim skanie,
-                  // ale tylko gdy ten skan W OGÓLE wykrył zmianę (changedAt===scannedAt) —
-                  // inaczej pierwszy skan oznaczałby wszystkie oferty jako nowe.
-                  const isNew = !!item.firstSeenAt
-                    && item.firstSeenAt === result.scannedAt
-                    && result.changedAt === result.scannedAt;
-                  const drop = (item.prevPrice != null && item.priceValue != null && item.priceValue < item.prevPrice)
-                    ? item.prevPrice - item.priceValue
-                    : null;
+                  const { isNew, drop } = offerBadges(item, result);
                   return (
                   <a
                     key={item.url ?? i}

--- a/src/utils/vintedFormat.ts
+++ b/src/utils/vintedFormat.ts
@@ -1,0 +1,64 @@
+import { VintedResult, VintedSearchAttempt } from "../hooks/useVintedCheck";
+
+type Offer = VintedResult["vintedItems"][number];
+
+/** Krótka data „DD.MM" ze znacznika ISO (świeżość danych z bazy). */
+export function shortDate(iso?: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * Zwięzła jednolinijkowa diagnostyka próby skanu (Krok 2). Kluczowy sygnał:
+ * itemLinks>0 przy parsed:0 i bez markerów = parser zgubił oferty. Rosnące
+ * rssMb ku limitowi hostingu = zbliżający się OOM.
+ */
+export function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
+  if (d.error) return `⚠ ${d.error}${d.httpStatus ? ` (${d.httpStatus})` : d.code ? ` (${d.code})` : ""}`;
+  const parts: string[] = [];
+  if (d.chars !== undefined) parts.push(`${(d.chars / 1000).toFixed(0)}k`);
+  parts.push(d.hasCatalogJson ? "json" : d.hasFeedGrid ? "grid" : "html");
+  if (d.itemLinks !== undefined) parts.push(`links:${d.itemLinks}`);
+  if (d.parsed !== undefined) parts.push(`parsed:${d.parsed}`);
+  if (d.blockedMarker) parts.push("BLOCK");
+  if (d.noResultsMarker) parts.push("noRes");
+  if (d.rssMb !== undefined) parts.push(`mem:${d.rssMb}MB`);
+  if (d.changes) {
+    const c = d.changes;
+    const delta: string[] = [];
+    if (c.added) delta.push(`+${c.added}`);
+    if (c.removed) delta.push(`−${c.removed}`);
+    if (c.priceDropped) delta.push(`↓${c.priceDropped}`);
+    if (c.priceRaised) delta.push(`↑${c.priceRaised}`);
+    if (delta.length) parts.push(`Δ ${delta.join(" ")}`);
+  }
+  return parts.join(" · ");
+}
+
+/**
+ * Czy kafelek książki zmienił się w OSTATNIM skanie (`changedAt === scannedAt`).
+ * Wymaga baseline — pierwszy skan (bez `changedAt`) nie liczy się jako zmiana.
+ */
+export function isBookChanged(result: VintedResult): boolean {
+  return !!result.changedAt && result.changedAt === result.scannedAt;
+}
+
+export interface OfferBadges {
+  /** „nowa" — oferta pojawiła się w ostatnim skanie, ale tylko gdy ten skan w ogóle
+   * wykrył zmianę (inaczej pierwszy skan oznaczałby wszystkie oferty jako nowe). */
+  isNew: boolean;
+  /** Spadek ceny vs poprzedni skan (zł), lub null. */
+  drop: number | null;
+}
+
+export function offerBadges(item: Offer, result: VintedResult): OfferBadges {
+  const isNew = !!item.firstSeenAt
+    && item.firstSeenAt === result.scannedAt
+    && result.changedAt === result.scannedAt;
+  const drop = (item.prevPrice != null && item.priceValue != null && item.priceValue < item.prevPrice)
+    ? item.prevPrice - item.priceValue
+    : null;
+  return { isNew, drop };
+}


### PR DESCRIPTION
Dekompozycja God-Component `VintedCheckItem` — **krok 1/5** (najniższe ryzyko). Refs #91.

Wyciąga logikę-w-JSX do czystego, testowalnego helpera `src/utils/vintedFormat.ts`:
- `shortDate` (ISO→„DD.MM"), `formatDebug` (diagnostyka próby skanu, 23 linie),
- `isBookChanged(result)` — reguła „zmiana tylko z baseline `changedAt===scannedAt`",
- `offerBadges(item, result)` — `{ isNew, drop }`; subtelna reguła „`isNew` wymaga wykrytej zmiany" (inaczej pierwszy skan oznaczałby wszystko jako nowe) jest teraz nazwana i przetestowana.

`VintedCheckItem` importuje helpery i traci ~40 linii inline. Zachowanie bez zmian.

## Weryfikacja
- `npm run lint` czysty · `npm test` **253/253** (+8) · `npm run build` OK.
- Wersja → **1.15.1** (mirror package.json + lock); backlog zaktualizowany o audyt + plan 2–5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_