### PR TITLE
refactor(sync): data-drive full-sync saga in useSyncManager (v1.15.3)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.3** — God-object krok 3/5 (#91): `useSyncManager` (God-Hook). „Wielki Rytuał" opisany
+  DANYMI (`FULL_SYNC_STEPS[]` + pętla; 7× copy-paste → 1 pętla, `abortOnFail` per krok).
+  `handleAwardChange` przyjmuje `string` (nie `ChangeEvent`) — parsowanie `<select>` zostaje w
+  `SyncAwards` (manager niezależny od prezentacji, zgodnie z GUIDELINES §2). Zachowanie bez zmian.
 - **1.15.2** — God-object krok 2/5 (#91): rozbicie God-Component `VintedCheckItem` **528 → 75
   linii**. 6 komponentów w `src/components/stats/vinted/`: `VintedScanControls`, `VintedScanProgress`,
   `VintedDebugLog`, `VintedResolveStatus`, `VintedBundleList` (własny `bundleSort`), `VintedBookResultList`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.2",
+  "version": "1.15.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/SyncAwards.tsx
+++ b/src/components/SyncAwards.tsx
@@ -8,7 +8,7 @@ import { IntegrityCheckCard } from "./IntegrityCheckCard";
 interface SyncAwardsProps {
   sync: ReturnType<typeof useSync>;
   integritySync: ReturnType<typeof useSync>;
-  handleAwardChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleAwardChange: (name: string) => void;
   handleSync: () => void;
   handleFullSync: () => void;
   isAnySyncLoading: boolean;
@@ -42,7 +42,7 @@ export const SyncAwards: React.FC<SyncAwardsProps> = ({
           <select 
             id="award-select"
             value={syncState.awardName || ""} 
-            onChange={handleAwardChange}
+            onChange={(e) => handleAwardChange(e.target.value)}
             disabled={syncState.loading}
             className="w-full bg-slate-950 border border-slate-800 rounded-2xl px-4 py-3 text-slate-200 focus:ring-2 focus:ring-cyan-500/50 focus:border-cyan-500/50 outline-none transition-all disabled:opacity-50 font-medium"
           >

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useSync } from "./useSync";
 import { PREDEFINED_AWARDS } from "../constants";
 
@@ -45,8 +45,9 @@ export function useSyncManager() {
     return await syncService.startSync(params, undefined, statusMessage);
   };
 
-  const handleAwardChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedName = e.target.value;
+  // Przyjmuje samą NAZWĘ nagrody (nie zdarzenie DOM) — manager pozostaje
+  // niezależny od prezentacji (parsowanie <select> zostaje w komponencie).
+  const handleAwardChange = (selectedName: string) => {
     const predefined = PREDEFINED_AWARDS.find(a => a.name === selectedName);
 
     sync.setState(prev => ({
@@ -72,54 +73,32 @@ export function useSyncManager() {
     });
   };
 
+  // „Wielki Rytuał" — sekwencja kroków opisana danymi (nie 7× copy-paste).
+  // Kroki `abortOnFail` przerywają całość przy błędzie i porzucają wyniki; ostatni
+  // (Lp) tylko dopisuje wynik, jeśli jest, i zawsze domyka podsumowanie.
+  const FULL_SYNC_STEPS: { sync: any; name: string; color: string; label: string; params?: any; abortOnFail: boolean }[] = [
+    { sync: schemaSync, name: "Schemat", color: "emerald", label: "Krok 1/7: Rytuał Inicjacji Schematu...", abortOnFail: true },
+    { sync: purifySync, name: "Puryfikacja", color: "amber", label: "Krok 2/7: Rytuał Puryfikacji...", abortOnFail: true },
+    { sync, name: "Nagrody", color: "cyan", label: "Krok 3/7: Synchronizacja Nagród...", params: { awardName: "Wszystkie Nagrody", syncAll: true }, abortOnFail: true },
+    { sync: cyclesSync, name: "Cykle", color: "blue", label: "Krok 4/7: Rytuał Oznaczania Cykli...", abortOnFail: true },
+    { sync: publisherSync, name: "Wydawcy", color: "rose", label: "Krok 5/7: Rytuał Wydania...", abortOnFail: true },
+    { sync: seriesSync, name: "Serie", color: "indigo", label: "Krok 6/7: Rytuał Seryjny...", abortOnFail: true },
+    { sync: lpSync, name: "Lubimy Czytać", color: "purple", label: "Krok 7/7: Rytuał Rekonstrukcji Liczb...", abortOnFail: false },
+  ];
+
   const handleFullSync = async () => {
     setFullSyncResults(null);
     const results: any[] = [];
 
-    // 1. Schema Initiation
-    clearOthers(schemaSync);
-    const res1 = await schemaSync.startSync({}, undefined, "Krok 1/7: Rytuał Inicjacji Schematu...");
-    if (!res1 || res1.success === false) return;
-    results.push({ name: "Schemat", result: res1, color: "emerald" });
-
-    // 2. Purification
-    clearOthers(purifySync);
-    const res2 = await purifySync.startSync({}, undefined, "Krok 2/7: Rytuał Puryfikacji...");
-    if (!res2 || res2.success === false) return;
-    results.push({ name: "Puryfikacja", result: res2, color: "amber" });
-
-    // 3. Sync Awards (Wszystkie)
-    clearOthers(sync);
-    const res3 = await sync.startSync({
-      awardName: "Wszystkie Nagrody",
-      syncAll: true
-    }, undefined, "Krok 3/7: Synchronizacja Nagród...");
-    if (!res3 || res3.success === false) return;
-    results.push({ name: "Nagrody", result: res3, color: "cyan" });
-
-    // 4. Cycles Marking
-    clearOthers(cyclesSync);
-    const res4 = await cyclesSync.startSync({}, undefined, "Krok 4/7: Rytuał Oznaczania Cykli...");
-    if (!res4 || res4.success === false) return;
-    results.push({ name: "Cykle", result: res4, color: "blue" });
-
-    // 5. Publisher Sync
-    clearOthers(publisherSync);
-    const res5 = await publisherSync.startSync({}, undefined, "Krok 5/7: Rytuał Wydania...");
-    if (!res5 || res5.success === false) return;
-    results.push({ name: "Wydawcy", result: res5, color: "rose" });
-
-    // 6. Series Sync
-    clearOthers(seriesSync);
-    const res6 = await seriesSync.startSync({}, undefined, "Krok 6/7: Rytuał Seryjny...");
-    if (!res6 || res6.success === false) return;
-    results.push({ name: "Serie", result: res6, color: "indigo" });
-
-    // 7. Numbers Reconstruction (Lp)
-    clearOthers(lpSync);
-    const res7 = await lpSync.startSync({}, undefined, "Krok 7/7: Rytuał Rekonstrukcji Liczb...");
-    if (res7) {
-      results.push({ name: "Lubimy Czytać", result: res7, color: "purple" });
+    for (const step of FULL_SYNC_STEPS) {
+      clearOthers(step.sync);
+      const res = await step.sync.startSync(step.params ?? {}, undefined, step.label);
+      if (step.abortOnFail) {
+        if (!res || res.success === false) return; // przerwij i porzuć częściowe wyniki
+        results.push({ name: step.name, result: res, color: step.color });
+      } else if (res) {
+        results.push({ name: step.name, result: res, color: step.color });
+      }
     }
 
     setFullSyncResults(results);


### PR DESCRIPTION
Dekompozycja God-Hook `useSyncManager` — **krok 3/5**. Refs #91.

- **`handleFullSync`**: „Wielki Rytuał" opisany **danymi** — `FULL_SYNC_STEPS[]` + jedna pętla, zamiast 7 niemal identycznych bloków copy-paste. Flaga `abortOnFail` per krok; zachowanie zachowane 1:1 (w tym semantyka ostatniego kroku Lp: „dopisz jeśli jest", bez przerwania).
- **`handleAwardChange`** przyjmuje teraz `string` (nazwę nagrody), nie `ChangeEvent` DOM; `SyncAwards` parsuje `<select>` i podaje `e.target.value`. Manager pozostaje niezależny od prezentacji (GUIDELINES §2 „Logic Isolation").

Refaktor zachowujący zachowanie.

## Weryfikacja
- `npm run lint` czysty · `npm test` **253/253** · `npm run build` OK.
- Wersja → **1.15.3**; backlog zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_