### PR TITLE
refactor(vinted): extract planner + http helpers from vintedSyncService (v1.15.4)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.4** — God-object krok 4/5 (#91): `vintedSyncService` 409 → 283 linii. Pure logic
+  wyjęta do testowalnych helperów: `vintedScanPlanner` (`selectAndOrderCandidates`/`scannedMs` —
+  filtr kandydatów + okno „Kontynuuj" + sort od najstarszych, `now` wstrzykiwalny), `vintedHttp`
+  (`vintedRequestHeaders`/`memMb`/`throttle`/`classifyVintedError` — dedup 4× jitter-sleep i
+  gałęzi 429/403), `looksEmpty` w parserze (obok `looksBlocked`), `computeChangedAt`+`toStoredBookView`
+  w store. Dedup 2× guard „persist empty tylko gdy nic nie było" → prywatny `persistEmptyIfNew`.
+  Zachowanie (SSE, kolejność, guardy) 1:1, +13 testów. Klasy NIE rozdzielałem (ryzyko DI/registry) —
+  opcjonalny split scan/seller/store-view zostaje jako deferred.
 - **1.15.3** — God-object krok 3/5 (#91): `useSyncManager` (God-Hook). „Wielki Rytuał" opisany
   DANYMI (`FULL_SYNC_STEPS[]` + pętla; 7× copy-paste → 1 pętla, `abortOnFail` per krok).
   `handleAwardChange` przyjmuje `string` (nie `ChangeEvent`) — parsowanie `<select>` zostaje w

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.3",
+      "version": "1.15.4",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.3",
+  "version": "1.15.4",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/vintedHelpers.test.ts
+++ b/services/__tests__/vintedHelpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { looksEmpty } from "../vintedParser";
+import { computeChangedAt, StoredVintedData, OfferDiff } from "../vintedStore";
+import { classifyVintedError } from "../vintedHttp";
+
+describe("vintedParser.looksEmpty", () => {
+  it("detects the no-results markers", () => {
+    expect(looksEmpty("… Brak wyników …")).toBe(true);
+    expect(looksEmpty("Nie znaleźliśmy żadnych przedmiotów")).toBe(true);
+  });
+  it("is false for a normal page or empty input", () => {
+    expect(looksEmpty("<html>oferty</html>")).toBe(false);
+    expect(looksEmpty("")).toBe(false);
+  });
+});
+
+describe("vintedStore.computeChangedAt", () => {
+  const prev: StoredVintedData = { scannedAt: "t0", changedAt: "t0", offers: [] };
+  const changed: OfferDiff = { added: 1, removed: 0, priceDropped: 0, priceRaised: 0 };
+  const same: OfferDiff = { added: 0, removed: 0, priceDropped: 0, priceRaised: 0 };
+
+  it("bumps to scannedAt only with a baseline AND a real change", () => {
+    expect(computeChangedAt(prev, changed, "t1")).toBe("t1");
+  });
+  it("keeps the old changedAt when nothing changed", () => {
+    expect(computeChangedAt(prev, same, "t1")).toBe("t0");
+  });
+  it("is undefined on the first scan (no baseline)", () => {
+    expect(computeChangedAt(null, changed, "t1")).toBeUndefined();
+  });
+});
+
+describe("vintedHttp.classifyVintedError", () => {
+  it("waits 5s on 429", () => {
+    const r = classifyVintedError({ response: { status: 429 } }, "Diuna");
+    expect(r.waitMs).toBe(5000);
+    expect(r.message).toContain("429");
+  });
+  it("does not wait on 403 (Cloudflare)", () => {
+    const r = classifyVintedError({ response: { status: 403 } }, "Diuna");
+    expect(r.waitMs).toBe(0);
+    expect(r.message).toContain("403");
+  });
+  it("falls back to a generic message with the title", () => {
+    const r = classifyVintedError({ message: "socket hang up" }, "Hyperion");
+    expect(r.waitMs).toBe(0);
+    expect(r.message).toContain("Hyperion");
+    expect(r.message).toContain("socket hang up");
+  });
+});

--- a/services/__tests__/vintedScanPlanner.test.ts
+++ b/services/__tests__/vintedScanPlanner.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { selectAndOrderCandidates, scannedMs, EXCLUDED_SOURCES } from "../vintedScanPlanner";
+import { serializeVintedData } from "../vintedStore";
+import { NotionBook } from "../../src/types";
+
+const book = (over: Partial<NotionBook>): NotionBook => ({
+  id: over.id ?? "x", plTitle: "T", origTitle: "", awards: [], zrodlo: [],
+  currentWydawnictwo: "", currentSeria: "", lp: "", plTitleRichText: [], origTitleRichText: [], ...over,
+});
+
+const scannedBook = (id: string, iso: string): NotionBook =>
+  book({ id, plTitle: `B-${id}`, vintedData: serializeVintedData({ scannedAt: iso, offers: [] }) });
+
+describe("vintedScanPlanner.selectAndOrderCandidates", () => {
+  it("excludes owned/read/library sources and title-less rows", () => {
+    const books = [
+      book({ id: "keep", plTitle: "Keep" }),
+      book({ id: "owned", plTitle: "Owned", zrodlo: ["Posiadam"] }),
+      book({ id: "read", plTitle: "Read", zrodlo: ["Przeczytane"] }),
+      book({ id: "notitle", plTitle: "  " }),
+    ];
+    const { candidates } = selectAndOrderCandidates(books);
+    expect(candidates.map((b) => b.id)).toEqual(["keep"]);
+  });
+
+  it("covers every documented excluded source", () => {
+    for (const src of EXCLUDED_SOURCES) {
+      expect(selectAndOrderCandidates([book({ id: "b", plTitle: "B", zrodlo: [src] })]).candidates).toHaveLength(0);
+    }
+  });
+
+  it("orders oldest-scanned first, with never-scanned (-Infinity) at the very front", () => {
+    const books = [
+      scannedBook("new", "2026-03-10T00:00:00.000Z"),
+      book({ id: "never", plTitle: "Never" }),
+      scannedBook("old", "2026-03-01T00:00:00.000Z"),
+    ];
+    expect(selectAndOrderCandidates(books).candidates.map((b) => b.id)).toEqual(["never", "old", "new"]);
+  });
+
+  it("skips books scanned within the resume window and reports the count", () => {
+    const now = Date.parse("2026-03-10T12:00:00.000Z");
+    const books = [
+      scannedBook("fresh", "2026-03-10T06:00:00.000Z"),  // 6h ago → skipped (< 12h)
+      scannedBook("stale", "2026-03-08T00:00:00.000Z"),  // >2d ago → kept
+      book({ id: "never", plTitle: "Never" }),           // never → kept
+    ];
+    const { candidates, skipped } = selectAndOrderCandidates(books, 12, now);
+    expect(skipped).toBe(1);
+    expect(candidates.map((b) => b.id)).toEqual(["never", "stale"]);
+  });
+});
+
+describe("vintedScanPlanner.scannedMs", () => {
+  it("returns -Infinity for never-scanned or invalid", () => {
+    expect(scannedMs(book({}))).toBe(-Infinity);
+    expect(scannedMs(scannedBook("s", "2026-03-01T00:00:00.000Z"))).toBe(Date.parse("2026-03-01T00:00:00.000Z"));
+  });
+});

--- a/services/vintedHttp.ts
+++ b/services/vintedHttp.ts
@@ -1,0 +1,49 @@
+import { getRandomUserAgent } from "../scrapingClient";
+
+/** Nagłówki żądania Vinted (świeży User-Agent na wywołanie). Wspólne dla skanu i grupowania. */
+export function vintedRequestHeaders() {
+  return {
+    'User-Agent': getRandomUserAgent(),
+    'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+    'Referer': 'https://www.vinted.pl/',
+    'Upgrade-Insecure-Requests': '1',
+    'Sec-Fetch-Dest': 'document',
+    'Sec-Fetch-Mode': 'navigate',
+    'Sec-Fetch-Site': 'none',
+    'Sec-Fetch-User': '?1',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Connection': 'keep-alive',
+    'Cache-Control': 'max-age=0',
+  };
+}
+
+/**
+ * Odczyt pamięci procesu (MB). Strony Vinted to ~7 MB HTML każda — na hostingu z
+ * limitem RAM (Render free = 512 MB) powtarzane piki przy parsowaniu mogą wywołać
+ * OOM-kill procesu, co urywa SSE i „ubija" skan przy w miarę stałej liczbie prób.
+ * Dołączamy `rssMb`/`heapMb` do debug każdej próby, żeby to zobaczyć w panelu logów.
+ */
+export function memMb() {
+  const m = process.memoryUsage();
+  return { rssMb: Math.round(m.rss / 1048576), heapMb: Math.round(m.heapUsed / 1048576) };
+}
+
+/**
+ * Odczekanie między żądaniami z jitterem (domyślnie 3–5 s). Stosowane na KAŻDEJ
+ * ścieżce (też przy braku wyników) — burst żądań to prosta droga do bloku Cloudflare.
+ */
+export function throttle(minMs = 3000, jitterMs = 2000): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, minMs + Math.floor(Math.random() * jitterMs)));
+}
+
+/**
+ * Mapuje błąd HTTP Vinted na komunikat dla UI + ewentualne dodatkowe odczekanie.
+ * 429 = rate-limit (odczekaj 5 s), 403 = Cloudflare (leć dalej), reszta = timeout/inne.
+ */
+export function classifyVintedError(err: any, title: string): { message: string; waitMs: number } {
+  const status = err?.response?.status;
+  if (status === 429) return { message: `🛑 Vinted zablokował zapytania (429). Odczekaj chwilę...`, waitMs: 5000 };
+  if (status === 403) return { message: `🛡️ Vinted zablokował dostęp (403 - Cloudflare). Próbuję dalej...`, waitMs: 0 };
+  return { message: `⚠️ Błąd Vinted dla "${title}": ${err?.message || "Timeout"}. Kontynuuję...`, waitMs: 0 };
+}

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -87,6 +87,16 @@ export function looksBlocked(html: string): boolean {
   return h.length < 100_000 && CHALLENGE_RE.test(h);
 }
 
+/**
+ * Marker „brak wyników" na stronie katalogu. UWAGA: to naiwny substring w ~7 MB
+ * markupie i bywa fałszywy na stronie Z ofertami — wołający NIE kasuje wtedy
+ * zapisanych danych (patrz vintedSyncService: persist tylko gdy nic nie było).
+ */
+export function looksEmpty(html: string): boolean {
+  const h = html || "";
+  return h.includes("Brak wyników") || h.includes("Nie znaleźliśmy żadnych przedmiotów");
+}
+
 // Kafelek oferty w siatce katalogu. Vinted hashuje nazwy klas CSS-modules
 // (`Grid-module-scss-module__HmDNda__feed-grid__item`), więc celujemy w stabilny
 // suffiks `feed-grid__item"`. Trailing `"` odcina wariant `feed-grid__item-content`.

--- a/services/vintedScanPlanner.ts
+++ b/services/vintedScanPlanner.ts
@@ -1,0 +1,48 @@
+import { NotionBook } from "../src/types";
+import { parseVintedData } from "./vintedStore";
+
+/** Znaczniki „Źródło" wykluczające książkę ze skanu (już mamy / czytamy). */
+export const EXCLUDED_SOURCES = ["Posiadam", "Przeczytane", "Audioteka", "Biblioteka", "Biblioteka 9"];
+
+/** Czas ostatniego skanu książki w ms; nigdy-skanowane = -Infinity (najstarsze → najwyższy priorytet). */
+export function scannedMs(book: NotionBook): number {
+  const at = parseVintedData(book.vintedData)?.scannedAt;
+  const t = at ? Date.parse(at) : NaN;
+  return isNaN(t) ? -Infinity : t;
+}
+
+export interface ScanPlan {
+  candidates: NotionBook[];
+  /** Ile pominięto przez okno „Kontynuuj" (skanowane < N h). */
+  skipped: number;
+}
+
+/**
+ * Czysty plan skanu: (1) odsiej niekandydatów (wykluczone źródła / brak tytułu PL),
+ * (2) opcjonalnie pomiń skanowane w ostatnich `skipScannedWithinHours` (bieżąca partia),
+ * (3) posortuj OD NAJSTARSZYCH (nigdy-skanowane pierwsze) — przerwany przebieg zawsze
+ * posuwa najbardziej nieaktualne dane, a „Kontynuuj" domyka partię zamiast dublować świeże.
+ * `now` wstrzykiwalny dla testów.
+ */
+export function selectAndOrderCandidates(
+  books: NotionBook[],
+  skipScannedWithinHours?: number,
+  now: number = Date.now(),
+): ScanPlan {
+  const base = books.filter((b) => {
+    const zrodlo = b.zrodlo || [];
+    return !zrodlo.some((z) => EXCLUDED_SOURCES.includes(z)) && !!b.plTitle && b.plTitle.trim() !== "";
+  });
+
+  let withDates = base.map((b) => ({ book: b, at: scannedMs(b) }));
+  let skipped = 0;
+  if (skipScannedWithinHours && skipScannedWithinHours > 0) {
+    const cutoff = now - skipScannedWithinHours * 3_600_000;
+    const before = withDates.length;
+    withDates = withDates.filter((x) => x.at < cutoff); // -Infinity (nigdy) też przechodzi
+    skipped = before - withDates.length;
+  }
+
+  withDates.sort((a, b) => a.at - b.at);
+  return { candidates: withDates.map((x) => x.book), skipped };
+}

--- a/services/vintedStore.ts
+++ b/services/vintedStore.ts
@@ -1,4 +1,5 @@
 import { VintedItem, VintedSeller } from "./vintedParser";
+import { NotionBook } from "../src/types";
 
 /**
  * Trwałe składowanie wyników Vinted w Notion (blob JSON w polu tekstowym książki).
@@ -57,6 +58,29 @@ export const EMPTY_DIFF: OfferDiff = { added: 0, removed: 0, priceDropped: 0, pr
 
 export function hasChanges(d: OfferDiff): boolean {
   return d.added > 0 || d.removed > 0 || d.priceDropped > 0 || d.priceRaised > 0;
+}
+
+/**
+ * Polityka znacznika `changedAt`: bump do `scannedAt` TYLKO gdy istnieje poprzedni
+ * stan (baseline) I faktycznie coś się zmieniło — inaczej pierwszy skan fałszywie
+ * oznaczałby całą książkę jako „zmiana". Bez baseline / bez zmian: zachowaj stary.
+ */
+export function computeChangedAt(prevData: StoredVintedData | null, diff: OfferDiff, scannedAt: string): string | undefined {
+  return prevData && hasChanges(diff) ? scannedAt : prevData?.changedAt;
+}
+
+/** Projekcja wiersza Notion + składowanych danych → widok kafelka/paczki (etap 3). */
+export function toStoredBookView(book: NotionBook, data: StoredVintedData): StoredBookView {
+  return {
+    id: book.id,
+    title: book.plTitle,
+    author: book.author || "",
+    year: book.year,
+    partOfCycle: book.currentCzesccyklu,
+    scannedAt: data.scannedAt,
+    changedAt: data.changedAt,
+    offers: data.offers,
+  };
 }
 
 /** VintedItem (ze skanu) → StoredOffer (do zapisu). */

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -3,46 +3,21 @@ import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent } from "../src/types";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
-import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
-import { parseVintedItems, vintedDiagnostics, looksBlocked, extractVintedSeller, VintedItem } from "./vintedParser";
+import { createScrapingAgent } from "../scrapingClient";
+import { parseVintedItems, vintedDiagnostics, looksBlocked, looksEmpty, extractVintedSeller, VintedItem } from "./vintedParser";
 import { NotionBook } from "../src/types";
-import { offerFromItem, parseVintedData, mergeAndDiff, hasChanges, serializeVintedData, StoredVintedData, StoredOffer, StoredBookView, OfferDiff, EMPTY_DIFF } from "./vintedStore";
+import { offerFromItem, parseVintedData, mergeAndDiff, serializeVintedData, computeChangedAt, toStoredBookView, StoredVintedData, StoredOffer, StoredBookView, OfferDiff, EMPTY_DIFF } from "./vintedStore";
+import { selectAndOrderCandidates } from "./vintedScanPlanner";
+import { vintedRequestHeaders, memMb, throttle, classifyVintedError } from "./vintedHttp";
 
 const log = createLogger("VintedScan");
-
-/** Nagłówki żądania Vinted (świeży User-Agent na wywołanie). Wspólne dla skanu i grupowania. */
-function vintedRequestHeaders() {
-  return {
-    'User-Agent': getRandomUserAgent(),
-    'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
-    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-    'Referer': 'https://www.vinted.pl/',
-    'Upgrade-Insecure-Requests': '1',
-    'Sec-Fetch-Dest': 'document',
-    'Sec-Fetch-Mode': 'navigate',
-    'Sec-Fetch-Site': 'none',
-    'Sec-Fetch-User': '?1',
-    'Accept-Encoding': 'gzip, deflate, br',
-    'Connection': 'keep-alive',
-    'Cache-Control': 'max-age=0',
-  };
-}
-
-/**
- * Odczyt pamięci procesu (MB). Strony Vinted to ~7 MB HTML każda — na hostingu z
- * limitem RAM (Render free = 512 MB) powtarzane piki przy parsowaniu mogą wywołać
- * OOM-kill procesu, co urywa SSE i „ubija" skan przy w miarę stałej liczbie prób.
- * Dołączamy `rssMb`/`heapMb` do debug każdej próby, żeby to zobaczyć w panelu logów.
- */
-function memMb() {
-  const m = process.memoryUsage();
-  return { rssMb: Math.round(m.rss / 1048576), heapMb: Math.round(m.heapUsed / 1048576) };
-}
 
 /**
  * Skaner ofert na Vinted (bezpośredni scraper HTML — NIE AI). Dla każdej książki,
  * której jeszcze nie posiadamy, wyszukuje oferty w katalogu Vinted i emituje
- * trafienia przez SSE. Zob. docs/vinted-scanner.md.
+ * trafienia przez SSE. Cienki orkiestrator — plan skanu (`vintedScanPlanner`),
+ * HTTP/throttling (`vintedHttp`), parsowanie (`vintedParser`) i merge/diff
+ * (`vintedStore`) żyją w czystych helperach. Zob. docs/vinted-scanner.md.
  */
 export class VintedSyncService {
   constructor(private notion: NotionAdapter) {}
@@ -57,7 +32,7 @@ export class VintedSyncService {
     for (const b of allBooks) {
       const data = parseVintedData(b.vintedData);
       if (!data || data.offers.length === 0) continue;
-      books.push({ id: b.id, title: b.plTitle, author: b.author || "", year: b.year, partOfCycle: b.currentCzesccyklu, scannedAt: data.scannedAt, changedAt: data.changedAt, offers: data.offers });
+      books.push(toStoredBookView(b, data));
     }
     return { books, generatedAt: new Date().toISOString() };
   }
@@ -72,14 +47,26 @@ export class VintedSyncService {
       const fresh = items.map(offerFromItem);
       const prevData = parseVintedData(book.vintedData);
       const { offers, diff } = mergeAndDiff(fresh, prevData?.offers, scannedAt);
-      // changedAt bumpujemy tylko, gdy JEST poprzedni stan (baseline) I faktycznie coś się
-      // zmieniło — inaczej pierwszy skan fałszywie oznaczałby całą książkę jako „zmiana".
-      const changedAt = prevData && hasChanges(diff) ? scannedAt : prevData?.changedAt;
+      const changedAt = computeChangedAt(prevData, diff, scannedAt);
       await this.notion.saveVintedData(book.id, serializeVintedData({ scannedAt, changedAt, offers }));
       return diff;
     } catch (e: any) {
       log.warn("Nie udało się zapisać VintedData", { title: book.plTitle, error: e?.message });
       return EMPTY_DIFF;
+    }
+  }
+
+  /**
+   * Utrwala PUSTY rekord tylko dla pierwszego skanu tej książki. Gdy coś już było
+   * zapisane, NIE kasuje ofert/sprzedawców (marker „brak wyników"/0 ofert bywa fałszywy
+   * na stronie z ofertami — zachowanie jak przy cichym missie).
+   */
+  private async persistEmptyIfNew(book: NotionBook, scannedAt: string, persistEnabled: boolean, warnMsg: string): Promise<void> {
+    const hadStored = (parseVintedData(book.vintedData)?.offers.length ?? 0) > 0;
+    if (persistEnabled && !hadStored) {
+      await this.persistBookOffers(book, [], scannedAt);
+    } else if (hadStored) {
+      log.warn(warnMsg, { title: book.plTitle });
     }
   }
 
@@ -93,43 +80,11 @@ export class VintedSyncService {
       // cache: współdziel pobranie z sąsiadującymi skanami (biblioteka/Vinted).
       const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
-      // Filter books:
-      // - Have Polish title
-      // - Exclude from source: Posiadam, Przeczytane, Audioteka, Biblioteka, Biblioteka 9
-      const baseCandidates = allBooks.filter(b => {
-        const zrodlo = b.zrodlo || [];
-        const excluded = ["Posiadam", "Przeczytane", "Audioteka", "Biblioteka", "Biblioteka 9"];
-        return !zrodlo.some(z => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
-      });
-
-      // Czas ostatniego skanu w ms; nigdy-skanowane = -Infinity (najstarsze → najwyższy priorytet).
-      const scannedMs = (b: NotionBook): number => {
-        const at = parseVintedData(b.vintedData)?.scannedAt;
-        const t = at ? Date.parse(at) : NaN;
-        return isNaN(t) ? -Infinity : t;
-      };
-      let withDates = baseCandidates.map(b => ({ book: b, at: scannedMs(b) }));
-
-      // Wznawianie: pomiń tylko książki skanowane w ostatnich N GODZIN (bieżąca partia),
-      // a nie sztywne dni — inaczej „wczorajsze" (< 3 dni) też wypadały i przebieg nic nie
-      // robił. Resztę (starsze + nigdy-skanowane) skanujemy OD NAJSTARSZYCH, więc przerwany
-      // pełny skan kontynuuje się naturalnie na niezrobionych zamiast zaczynać od zera.
       const skipHours = params?.skipScannedWithinHours;
-      if (skipHours && skipHours > 0) {
-        const cutoff = Date.now() - skipHours * 3_600_000;
-        const before = withDates.length;
-        withDates = withDates.filter(x => x.at < cutoff); // -Infinity (nigdy) też przechodzi
-        const skipped = before - withDates.length;
-        if (skipped > 0) {
-          sendEvent({ type: "status", message: `Wznawianie: pominięto ${skipped} skanowanych < ${skipHours} h. Do sprawdzenia: ${withDates.length}.` });
-        }
+      const { candidates, skipped } = selectAndOrderCandidates(allBooks, skipHours);
+      if (skipHours && skipHours > 0 && skipped > 0) {
+        sendEvent({ type: "status", message: `Wznawianie: pominięto ${skipped} skanowanych < ${skipHours} h. Do sprawdzenia: ${candidates.length}.` });
       }
-
-      // Od najstarszych (nigdy-skanowane pierwsze) — przerwany przebieg zawsze posuwa
-      // najbardziej nieaktualne dane, a „Kontynuuj" domyka partię zamiast dublować świeże.
-      withDates.sort((a, b) => a.at - b.at);
-      const candidates = withDates.map(x => x.book);
-
       sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia (od najstarszych) na Vinted...` });
 
       const results: any[] = [];
@@ -154,39 +109,19 @@ export class VintedSyncService {
         const searchText = `${title} ${book.author || ""}`.trim();
         const scannedAt = new Date().toISOString();
 
-        const headers = vintedRequestHeaders();
-
         sendEvent({
           type: "progress",
           message: `Sprawdzanie Vinted: ${searchText} (${i + 1}/${candidates.length})`,
           current: i + 1,
-          total: candidates.length
+          total: candidates.length,
         });
 
-        // Vinted Search URL
         const url = `https://www.vinted.pl/catalog?catalog[]=2319&language_book_ids[]=6440&page=1&order=price_low_to_high&price_from=2&currency=PLN&search_text=${encodeURIComponent(searchText)}`;
 
-        // Initial search attempt event
-        sendEvent({
-          type: "search_attempt",
-          result: {
-            id: book.id,
-            title: book.plTitle,
-            author: book.author,
-            url,
-            status: "pending",
-            itemCount: 0
-          }
-        });
+        sendEvent({ type: "search_attempt", result: { id: book.id, title: book.plTitle, author: book.author, url, status: "pending", itemCount: 0 } });
 
         try {
-          const response = await withRetry(async () => {
-            return await axios.get(url, {
-              httpsAgent,
-              headers,
-              timeout: 30000
-            });
-          }, 3, 4000);
+          const response = await withRetry(async () => axios.get(url, { httpsAgent, headers: vintedRequestHeaders(), timeout: 30000 }), 3, 4000);
 
           const html = response.data;
           log.info(`Odpowiedź Vinted`, { title, chars: html.length, ...memMb() });
@@ -195,36 +130,17 @@ export class VintedSyncService {
           if (looksBlocked(html)) {
             log.warn(`Vinted zablokował żądanie (wykrycie bota)`, { title });
             sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
-            sendEvent({
-              type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } }
-            });
-            // Blok to NIE „brak ofert": NIE zapisujemy pustki (zachowaj składowane oferty
-            // i ustalonych sprzedawców) ani `scannedAt`, by wznowienie ponowiło tę książkę.
-            await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
+            sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } } });
+            // Blok to NIE „brak ofert": nie zapisujemy pustki ani scannedAt, by wznowienie ponowiło tę książkę.
+            await throttle();
             continue;
           }
 
-          if (html.includes("Brak wyników") || html.includes("Nie znaleźliśmy żadnych przedmiotów")) {
-            // If "Title Author" failed, maybe try just "Title" in a real app,
-            // but for now let's just log it.
+          if (looksEmpty(html)) {
             log.info(`Brak wyników na Vinted`, { searchText });
-            sendEvent({
-              type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } }
-            });
-            // Utrwal pustkę tylko, gdy nic wcześniej nie było — „Brak wyników" to naiwny
-            // substring w ~7 MB markupie i bywa fałszywy na stronie Z ofertami; nie kasujemy
-            // wtedy zapisanych ofert/sprzedawców (zachowanie jak przy cichym missie).
-            const hadStored = (parseVintedData(book.vintedData)?.offers.length ?? 0) > 0;
-            if (persistEnabled && !hadStored) {
-              await this.persistBookOffers(book, [], scannedAt);
-            } else if (hadStored) {
-              log.warn("Marker 'Brak wyników' mimo zapisanych ofert — pomijam zapis (możliwy fałszywy marker)", { title });
-            }
-            // Odczekaj jak przy każdym innym zapytaniu — pomijanie opóźnienia
-            // przy braku wyników (częsty przypadek) to prosta droga do blokady
-            await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
+            sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } } });
+            await this.persistEmptyIfNew(book, scannedAt, persistEnabled, "Marker 'Brak wyników' mimo zapisanych ofert — pomijam zapis (możliwy fałszywy marker)");
+            await throttle();
             continue;
           }
 
@@ -234,21 +150,11 @@ export class VintedSyncService {
           if (items.length > 0) {
             // Utrwal (scala ze składowanymi — zachowuje sprzedawców przy niezmienionym URL) + policz diff.
             const diff = persistEnabled ? await this.persistBookOffers(book, items, scannedAt) : EMPTY_DIFF;
-            const matchResult = {
-              id: book.id,
-              title: book.plTitle,
-              author: book.author,
-              searchUrl: url,
-              vintedItems: items
-            };
+            const matchResult = { id: book.id, title: book.plTitle, author: book.author, searchUrl: url, vintedItems: items };
             results.push(matchResult);
             sendEvent({ type: "match", result: matchResult });
-            sendEvent({
-              type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length, debug: { ...debug, changes: diff } }
-            });
-            // Książka istnieje na Vinted → oznacz źródło tagiem „Vinted" (best-effort).
-            // Guard po zrodlo pomija zbędny zapis dla już otagowanych (re-scan).
+            sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length, debug: { ...debug, changes: diff } } });
+            // Książka istnieje na Vinted → oznacz źródło tagiem „Vinted" (best-effort, pomiń jeśli już jest).
             if (!(book.zrodlo || []).includes("Vinted")) {
               try {
                 await this.notion.addTagToMultiSelect(book.id, "Źródło", "Vinted");
@@ -257,49 +163,20 @@ export class VintedSyncService {
               }
             }
           } else {
-            // 0 ofert BEZ markera „brak wyników" i bez blokady: realnie pusto ALBO cichy
-            // miss parsera. Nie kasuj wcześniej zapisanych ofert/sprzedawców — utrwal pustkę
-            // tylko, gdy nic wcześniej nie było (pierwszy skan tej książki).
-            const hadStored = (parseVintedData(book.vintedData)?.offers.length ?? 0) > 0;
-            if (persistEnabled && !hadStored) {
-              await this.persistBookOffers(book, [], scannedAt);
-            } else if (hadStored) {
-              log.warn("0 ofert mimo zapisanych wcześniej — pomijam zapis (możliwy miss/blok), zachowuję dane", { title });
-            }
-            sendEvent({
-              type: "search_attempt",
-              result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug }
-            });
+            // 0 ofert BEZ markera i bez blokady: realnie pusto ALBO cichy miss parsera.
+            await this.persistEmptyIfNew(book, scannedAt, persistEnabled, "0 ofert mimo zapisanych wcześniej — pomijam zapis (możliwy miss/blok), zachowuję dane");
+            sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug } });
           }
         } catch (err: any) {
           log.warn(`Błąd sprawdzania Vinted`, { title, error: err.message || "Nieznany błąd" });
-          sendEvent({
-            type: "search_attempt",
-            result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0, debug: { error: err.message, code: err.code, httpStatus: err.response?.status, ...memMb() } }
-          });
-          if (err.response?.status === 429) {
-            sendEvent({
-              type: "status",
-              message: `🛑 Vinted zablokował zapytania (429). Odczekaj chwilę...`
-            });
-            // Wait longer if blocked
-            await new Promise(resolve => setTimeout(resolve, 5000));
-          } else if (err.response?.status === 403) {
-            sendEvent({
-              type: "status",
-              message: `🛡️ Vinted zablokował dostęp (403 - Cloudflare). Próbuję dalej...`
-            });
-          } else {
-            sendEvent({
-              type: "status",
-              message: `⚠️ Błąd Vinted dla "${title}": ${err.message || "Timeout"}. Kontynuuję...`
-            });
-          }
+          sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "error", itemCount: 0, debug: { error: err.message, code: err.code, httpStatus: err.response?.status, ...memMb() } } });
+          const { message, waitMs } = classifyVintedError(err, title);
+          sendEvent({ type: "status", message });
+          if (waitMs) await new Promise((resolve) => setTimeout(resolve, waitMs));
         }
 
-        // Delay to avoid being blocked (with jitter)
-        const jitter = Math.floor(Math.random() * 2000);
-        await new Promise(resolve => setTimeout(resolve, 3000 + jitter));
+        // Odstęp między żądaniami (z jitterem) — na KAŻDEJ ścieżce, by nie wywołać bloku.
+        await throttle();
       }
 
       const wasCancelled = checkCancellation();
@@ -314,9 +191,8 @@ export class VintedSyncService {
    * Etap 2 (przyrostowo, wznawialnie): dociąga sprzedawcę do SKŁADOWANYCH ofert bez
    * sprzedawcy i zapisuje z powrotem do Notion. Rozpoznani zostają w blobie, więc kolejny
    * przebieg bierze tylko wciąż-`null`. Bez capu domyślnie: przebieg ustala WSZYSTKIE
-   * brakujące (praca jest skończona — ilość nulli w bazie), ile zdąży zanim padnie; że
-   * zapis idzie raz na książkę, przerwany przebieg i tak utrwala postęp. Rate chroni
-   * throttling, nie liczba total. Opcjonalny `cap` ogranicza przebieg (np. z UI).
+   * brakujące, ile zdąży zanim padnie (zapis raz na książkę utrwala postęp). Opcjonalny
+   * `cap` ogranicza przebieg (np. z UI).
    */
   async resolveSellersToStore(
     sendEvent: (data: SyncEvent) => void,
@@ -334,7 +210,7 @@ export class VintedSyncService {
       for (const book of allBooks) {
         const data = parseVintedData(book.vintedData);
         if (!data) continue;
-        const nulls = data.offers.filter(o => o.seller == null && /\/items\//.test(o.url));
+        const nulls = data.offers.filter((o) => o.seller == null && /\/items\//.test(o.url));
         if (nulls.length) { pending.push({ book, data, offers: nulls }); totalPending += nulls.length; }
       }
 
@@ -362,9 +238,7 @@ export class VintedSyncService {
           fetched++;
           sendEvent({ type: "progress", message: `Sprzedawca: ${p.book.plTitle} (${fetched}/${target})`, current: fetched, total: target });
           try {
-            const response = await withRetry(async () => {
-              return await axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(), timeout: 30000 });
-            }, 3, 4000);
+            const response = await withRetry(async () => axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(), timeout: 30000 }), 3, 4000);
             const html = response.data;
             if (looksBlocked(html)) {
               log.warn("Vinted zablokował stronę oferty (sprzedawca, baza)", { url: offer.url });
@@ -380,7 +254,7 @@ export class VintedSyncService {
           } catch (err: any) {
             log.warn("Błąd ustalania sprzedawcy (baza)", { url: offer.url, error: err.message });
           }
-          await new Promise(resolve => setTimeout(resolve, 3000 + Math.floor(Math.random() * 2000)));
+          await throttle();
         }
         // Zapisz książkę raz, po ustaleniu jej ofert (mniej zapisów do Notion).
         if (dirty) {


### PR DESCRIPTION
Dekompozycja przerośniętego orkiestratora `vintedSyncService` — **krok 4/5**. Refs #91.

Plik **409 → 283 linii**; wplecione concerny god-metody `runVintedCheck` żyją teraz w czystych, testowalnych helperach, a dwa zdublowane guardy są scalone.

- **`services/vintedScanPlanner.ts`** — `selectAndOrderCandidates` / `scannedMs`: filtr kandydatów (wykluczone źródła + tytuł), okno „Kontynuuj" i sort od najstarszych; `now` wstrzykiwalny (testy deterministyczne).
- **`services/vintedHttp.ts`** — `vintedRequestHeaders`, `memMb`, `throttle` (jitter-sleep ręcznie pisany 4×), `classifyVintedError` (gałęzie 429/403/inne).
- **`vintedParser`** — `looksEmpty` obok `looksBlocked` (heurystyka „Brak wyników" już nie inline).
- **`vintedStore`** — `computeChangedAt` (polityka baseline `changedAt`) + `toStoredBookView`.
- **`persistEmptyIfNew`** (prywatny) zastępuje 2× copy-paste guard „persist pustki tylko gdy nic nie było".

Refaktor zachowujący zachowanie — komunikaty SSE, kolejność i guardy 1:1. Klasy **nie** rozdzielałem na 3 (ripple w DI/registry) — opcjonalny split scan/seller/store-view zostaje deferred.

## Weryfikacja
- `npm run lint` czysty · `npm test` **266/266** (+13: planner filtr/okno/kolejność, `looksEmpty`, `computeChangedAt`, `classifyVintedError`) · `npm run build` OK.
- Wersja → **1.15.4**; backlog zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_