### PR TITLE
refactor(notion): dedupe multi-select mutation in adapter (v1.15.5)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.5** — God-object krok 5/5 (#91, DOMKNIĘTE): `notion.adapter` — dedup
+  `add`/`removeTagFromMultiSelect` → prywatny `mutateMultiSelect(pageId, prop, transform)`
+  (retrieve→mutate→update w jednym miejscu; `transform` zwraca `null` = no-op). Zachowanie 1:1.
+  DEFERRED (opcjonalne, medium): pełny split adaptera na Source/SchemaAdmin/BookRepository,
+  ewikcja literałów domeny (`VintedData`/`Wydawnictwo`/`Lp`) i `useSSEStream` (3 hooki streamowe
+  duplikują szkielet fetch+watchdog+routing). Cały audyt god-object zamknięty (kroki 1–5).
 - **1.15.4** — God-object krok 4/5 (#91): `vintedSyncService` 409 → 283 linii. Pure logic
   wyjęta do testowalnych helperów: `vintedScanPlanner` (`selectAndOrderCandidates`/`scannedMs` —
   filtr kandydatów + okno „Kontynuuj" + sort od najstarszych, `now` wstrzykiwalny), `vintedHttp`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -202,61 +202,48 @@ export class NotionAdapter {
     this.invalidateBooksCache();
   }
 
-  async addTagToMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
+  /**
+   * Wspólny rdzeń mutacji pola multi_select: pobiera aktualne tagi, przepuszcza je
+   * przez `transform` i zapisuje wynik. `transform` zwraca nową listę tagów albo
+   * `null` = brak zmiany (pomiń zapis i inwalidację cache). Add/remove to cienkie
+   * przypadki na tym rdzeniu — jedno miejsce na retrieve→mutate→update.
+   */
+  private async mutateMultiSelect(
+    pageId: string,
+    propertyName: string,
+    transform: (current: { name: string }[]) => { name: string }[] | null,
+  ): Promise<void> {
     await this.init();
-    
-    // 1. Get current tags
+
     const page = await withRetry(() => this.notion.pages.retrieve({ page_id: pageId })) as any;
     const prop = page.properties[propertyName];
-    
     if (!prop || prop.type !== "multi_select") {
       throw new Error(`Property ${propertyName} is not a multi_select`);
     }
-    
-    const currentTags = prop.multi_select.map((t: any) => ({ name: t.name }));
-    
-    // 2. Check if tag already exists
-    if (currentTags.some((t: any) => t.name === tag)) {
-      return; // Already has the tag
-    }
-    
-    // 3. Add new tag
-    currentTags.push({ name: tag });
 
-    // 4. Update page
+    const currentTags = prop.multi_select.map((t: any) => ({ name: t.name }));
+    const nextTags = transform(currentTags);
+    if (nextTags === null) return; // no-op: tag już jest / nie było
+
     await withRetry(() => this.notion.pages.update({
       page_id: pageId,
-      properties: {
-        [propertyName]: { multi_select: currentTags }
-      }
+      properties: { [propertyName]: { multi_select: nextTags } },
     }));
     this.invalidateBooksCache();
   }
 
+  /** Dopisuje znacznik do pola multi_select (pomija, jeśli już jest). */
+  async addTagToMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
+    return this.mutateMultiSelect(pageId, propertyName, (tags) =>
+      tags.some((t) => t.name === tag) ? null : [...tags, { name: tag }]);
+  }
+
   /** Usuwa znacznik z pola multi_select (odwrotność `addTagToMultiSelect`). */
   async removeTagFromMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
-    await this.init();
-
-    const page = await withRetry(() => this.notion.pages.retrieve({ page_id: pageId })) as any;
-    const prop = page.properties[propertyName];
-
-    if (!prop || prop.type !== "multi_select") {
-      throw new Error(`Property ${propertyName} is not a multi_select`);
-    }
-
-    const currentTags = prop.multi_select.map((t: any) => ({ name: t.name }));
-    const nextTags = currentTags.filter((t: any) => t.name !== tag);
-    if (nextTags.length === currentTags.length) {
-      return; // Nie było tagu — nic do zrobienia
-    }
-
-    await withRetry(() => this.notion.pages.update({
-      page_id: pageId,
-      properties: {
-        [propertyName]: { multi_select: nextTags }
-      }
-    }));
-    this.invalidateBooksCache();
+    return this.mutateMultiSelect(pageId, propertyName, (tags) => {
+      const next = tags.filter((t) => t.name !== tag);
+      return next.length === tags.length ? null : next;
+    });
   }
 
   async resolveDataSourceId(databaseId: string): Promise<string> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.4",
+      "version": "1.15.5",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.4",
+  "version": "1.15.5",
   "type": "module",
   "engines": {
     "node": ">=18 <21"


### PR DESCRIPTION
Dekompozycja God-Adapter — **krok 5/5 (finalny)**. Closes #91.

`addTagToMultiSelect` i `removeTagFromMultiSelect` były niemal lustrzanymi kopiami (retrieve → mutate → update). Wspólny rdzeń:
- prywatny **`mutateMultiSelect(pageId, prop, transform)`** — `transform` zwraca nową listę tagów albo `null` = brak zmiany (pomiń zapis i inwalidację cache). Add/remove to cienkie przypadki na tym rdzeniu.

Refaktor zachowujący zachowanie 1:1.

## Deferred (opcjonalne, medium)
Świadomie NIE w tym PR (większy ripple, niska korzyść): pełny split adaptera na `NotionSource`/`SchemaAdmin`/`BookRepository`, ewikcja literałów domeny (`VintedData`/`Wydawnictwo`/`Lp`), oraz `useSSEStream` (3 hooki streamowe duplikują szkielet fetch+watchdog+routing). Zapisane w backlogu.

## Weryfikacja
- `npm run lint` czysty · `npm test` **266/266** · `npm run build` OK.
- Wersja → **1.15.5**; backlog zaktualizowany. Domyka cały audyt god-object (kroki 1–5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_