### PR TITLE
fix(bughunt): serialize shelf writes + fix search empty-state flash (v1.15.7)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.6** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.7** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.7** — Bughunt po zmianach (#100). 4 audyty (useSSEStream, vintedSyncService, rozbicie
+  VintedCheckItem = FAITHFUL/czyste). 2 realne bugi w nowych featurach naprawione:
+  (1) Regał: wyścig drag&drop — zapisy per-książka SERIALIZOWANE (latest-wins, `pendingRef`/
+  `runningRef`), koniec nakładających się nieatomowych RMW rozjeżdżających Notion z UI.
+  (2) Skryptorium/Regał: `useBooks` startuje `loading=true` (fetch w useEffect po paint dawał
+  mignięcie pustego stanu); SearchSection rozróżnia pusty-query („Archiwum jest puste") od braku
+  trafień. Minor „overrides nie czyszczone" — poprawne przy single-fetch, zostawione.
 - **1.15.6** — `useSSEStream` (deferred z audytu god-object): wspólny transport SSE
   (POST → `res.ok` → `consumeSSE` + watchdog + derywacja komunikatu błędu/stall). Trzy hooki
   streamowe zbudowane na nim, różnią się tylko routingiem zdarzeń: `useSync` 154→100 (koniec

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.6",
+      "version": "1.15.7",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.6",
+  "version": "1.15.7",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback, useRef } from "react";
 import { Library, BookOpen, CheckCircle2, Sparkles, Loader2, AlertCircle, X } from "lucide-react";
 import { BookIndexEntry } from "../types";
 import { useBooks } from "../hooks/useBooks";
@@ -15,6 +15,13 @@ export const BookshelfSection: React.FC = () => {
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
 
+  // Zapis stanu „przeczytane" jest SERIALIZOWANY per książka (latest-wins). Backend
+  // `mutateMultiSelect` to nieatomowy retrieve→modify→update, więc dwa nakładające się
+  // zapisy tej samej książki mogłyby przeczytać ten sam stan i rozjechać Notion z UI.
+  // `pendingRef` trzyma najświeższy żądany stan, `runningRef` — książki z aktywnym runnerem.
+  const pendingRef = useRef<Record<string, boolean>>({});
+  const runningRef = useRef<Set<string>>(new Set());
+
   const all = books ?? [];
   const { read, toRead } = useMemo(() => splitShelves(all, overrides), [all, overrides]);
   const featured = useMemo(() => featuredReads(all, overrides), [all, overrides]);
@@ -28,13 +35,30 @@ export const BookshelfSection: React.FC = () => {
     const wasRead = isRead(book, overrides);
     if (wasRead === targetRead) return; // upuszczono na tę samą półkę — nic
 
-    // Optymistyczny ruch, potem zapis; przy błędzie cofnij i pokaż komunikat.
+    // Optymistyczny ruch od razu.
     setOverrides((prev) => ({ ...prev, [book.id]: targetRead }));
     setMoveError(null);
-    setRead(book.id, targetRead).catch((e: any) => {
-      setOverrides((prev) => ({ ...prev, [book.id]: wasRead }));
-      setMoveError(`Nie udało się zapisać „${book.plTitle || book.origTitle}": ${e.message}`);
-    });
+
+    // Zapisz najświeższy żądany stan; jeśli runner tej książki już działa, weźmie go sam.
+    pendingRef.current[book.id] = targetRead;
+    if (runningRef.current.has(book.id)) return;
+    runningRef.current.add(book.id);
+    void (async () => {
+      try {
+        while (book.id in pendingRef.current) {
+          const desired = pendingRef.current[book.id];
+          delete pendingRef.current[book.id];
+          await setRead(book.id, desired);
+        }
+      } catch (e: any) {
+        // Zapis nie doszedł — wróć do stanu z bazy i pokaż błąd.
+        delete pendingRef.current[book.id];
+        setOverrides((prev) => { const next = { ...prev }; delete next[book.id]; return next; });
+        setMoveError(`Nie udało się zapisać „${book.plTitle || book.origTitle}": ${e.message}`);
+      } finally {
+        runningRef.current.delete(book.id);
+      }
+    })();
   }, [dragging, overrides, setRead]);
 
   return (

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -103,9 +103,11 @@ export const SearchSection: React.FC = () => {
       ) : results.length === 0 ? (
         <div className="text-center py-16 space-y-4">
           <p className="text-sm text-slate-600 italic">
-            Archiwum milczy — żaden wolumin nie pasuje do „{query}".
+            {query.trim()
+              ? `Archiwum milczy — żaden wolumin nie pasuje do „${query}".`
+              : "Archiwum jest puste — brak rekordów do przeszukania."}
           </p>
-          {suggestions.length > 0 && (
+          {query.trim() && suggestions.length > 0 && (
             <p className="text-sm text-slate-400">
               Czy chodziło Ci o:{" "}
               {suggestions.map((s, i) => (

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -8,7 +8,9 @@ import { BookIndexEntry } from "../types";
  */
 export function useBooks() {
   const [books, setBooks] = useState<BookIndexEntry[] | null>(null);
-  const [loading, setLoading] = useState(false);
+  // Startujemy w stanie ładowania — fetch leci od razu w useEffect (po paint), więc
+  // bez tego pierwsza klatka pokazywałaby pusty stan zamiast spinnera.
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchBooks = useCallback(async () => {


### PR DESCRIPTION
Bughunt po serii zmian (4 obszary sprawdzone równolegle, z porównaniem do stanu sprzed refaktoru). Closes #100.

**Refaktory czyste** (faithful, zero regresji): `useSSEStream`, `vintedSyncService` (planner/http/guardy), rozbicie `VintedCheckItem`.

## Naprawione 2 realne bugi w nowych featurach

**1. Regał — wyścig drag&drop (medium).** `setRead` szło bez serializacji, a backend `mutateMultiSelect` to nieatomowy retrieve→modify→update. Dwa szybkie przeciwne upuszczenia tej samej książki mogły się przepleść i zostawić Notion rozjechane z optymistycznym UI (po reloadzie książka „wraca"). Teraz zapisy są **serializowane per książka, latest-wins** (`pendingRef`/`runningRef`): gdy runner książki działa, nowe upuszczenia aktualizują żądany stan, a runner zapisuje najświeższy — zero nakładających się RMW.

**2. Skryptorium/Regał — mignięcie pustego stanu (low).** `useBooks` startował `loading=false`, a fetch leci w `useEffect` (po paint) → pierwsza klatka pokazywała pusty stan. Teraz `loading=true` startowo. `SearchSection` dodatkowo rozróżnia **pusty query** (pusta baza → „Archiwum jest puste") od realnego **braku trafień**.

Minor „`overrides` nigdy nie czyszczone" — przy modelu single-fetch to poprawne (override jest źródłem prawdy po zapisie), zostawione.

## Weryfikacja
- `npm run lint` czysty · `npm test` **270/270** · `npm run build` OK.
- Wersja → **1.15.7**; backlog zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_