### PR TITLE
refactor(schema): rozbij SchemaEditor 296→88 linii (Refs #102, krok 3/4)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.9** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.10** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.10** — Audyt #2 krok 3/4 (#102): `SchemaEditor` (mild God-Component) **296 → 88 linii**
+  (cienki orkiestrator). Inline PATCH ×2 + walidacja duplikatu → hook `useSchemaMutations`
+  (`patchOptions` wspólny, `addOption`/`deleteOption`); inline modal usuwania → generyczny
+  `ConfirmDialog`; wielka karta kolumny → `SchemaColumnCard` (`key!=='Autor'` skonsolidowane w
+  `isEditable`). Zachowanie 1:1, 270 testów.
 - **1.15.9** — Audyt #2 krok 2/4 (#102): App.tsx (God-Component) **332 → 149 linii** (czysta
   powłoka). Wyciągnięte `LiturgySection` (blok zakładki config + własny `useConfig`, `useSyncManager`
   propem `sm`) i `TabNav` (5× copy-paste przycisków → mapa). Error-card ZOSTAJE w App (globalny,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.9",
+  "version": "1.15.10",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.9",
+  "version": "1.15.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.9",
+      "version": "1.15.10",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.9",
+  "version": "1.15.10",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { AlertCircle, X } from "lucide-react";
+
+interface Props {
+  open: boolean;
+  title: string;
+  subtitle?: string;
+  body: React.ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/** Generyczny modal potwierdzenia operacji destrukcyjnej. */
+export const ConfirmDialog: React.FC<Props> = ({ open, title, subtitle = "Operacja nieodwracalna", body, confirmLabel, cancelLabel = "Anuluj", onConfirm, onCancel }) => (
+  <AnimatePresence>
+    {open && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onCancel} className="absolute inset-0 bg-slate-950/80 backdrop-blur-md" />
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9, y: 20 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.9, y: 20 }}
+          className="relative w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl shadow-[0_0_50px_rgba(0,0,0,0.8)] overflow-hidden"
+        >
+          <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-cyan-500 to-transparent opacity-50" />
+
+          <div className="p-8">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="p-3 bg-rose-500/10 rounded-full border border-rose-500/20">
+                <AlertCircle className="w-8 h-8 text-rose-400" />
+              </div>
+              <div>
+                <h3 className="text-xl font-display font-bold text-slate-100 uppercase tracking-wider">{title}</h3>
+                <p className="text-sm text-slate-500 font-medium">{subtitle}</p>
+              </div>
+            </div>
+
+            <p className="text-lg text-slate-300 mb-8 font-medium leading-relaxed">{body}</p>
+
+            <div className="flex gap-4">
+              <button onClick={onCancel} className="flex-1 px-6 py-3 text-sm font-bold text-slate-300 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl transition-all active:scale-95">
+                {cancelLabel}
+              </button>
+              <button onClick={onConfirm} className="flex-1 px-6 py-3 text-sm font-bold bg-gradient-to-br from-rose-600 to-rose-900 hover:from-rose-500 hover:to-rose-800 text-white rounded-xl shadow-lg shadow-rose-500/20 transition-all active:scale-95 border border-rose-500/30">
+                {confirmLabel}
+              </button>
+            </div>
+          </div>
+
+          <button onClick={onCancel} className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-200 transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </motion.div>
+      </div>
+    )}
+  </AnimatePresence>
+);

--- a/src/components/SchemaColumnCard.tsx
+++ b/src/components/SchemaColumnCard.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Plus, Loader2, X, AlertCircle } from "lucide-react";
+
+interface Props {
+  name: string;
+  value: any;
+  isSelectType: boolean;
+  options: any[];        // posortowane opcje (dla select/multi_select)
+  isOverLimit: boolean;
+  limit: number;
+  index: number;         // do animacji wejścia (delay)
+  updating: boolean;     // czy trwa mutacja tej kolumny
+  newOptionValue: string;
+  onNewOptionChange: (v: string) => void;
+  onAdd: () => void;
+  onDeleteRequest: (optionName: string) => void;
+}
+
+/** Karta jednej kolumny schematu: nazwa, licznik limitu, opcje + dodawanie/usuwanie. */
+export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, options, isOverLimit, limit, index, updating, newOptionValue, onNewOptionChange, onAdd, onDeleteRequest }) => {
+  // „Autor" jest tylko do odczytu — nie pokazujemy licznika, przycisków usuwania ani warnu.
+  const isEditable = name !== "Autor";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.05 }}
+      className="bg-slate-900/20 border border-white/5 rounded-3xl p-6 backdrop-blur-md hover:border-cyan-500/20 transition-all duration-500 group relative overflow-hidden"
+    >
+      <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-br from-cyan-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
+
+      <div className="flex items-center justify-between mb-5 relative z-10">
+        <div className="flex flex-col gap-1">
+          <span className="font-display font-bold text-xl text-slate-200 tracking-tight group-hover:text-cyan-400 transition-colors duration-300">{name}</span>
+          {isSelectType && isEditable && (
+            <div className="flex items-center gap-2">
+              <div className="h-1 w-24 bg-slate-800 rounded-full overflow-hidden">
+                <div className={`h-full transition-all duration-1000 ${isOverLimit ? 'bg-rose-500' : 'bg-cyan-500'}`} style={{ width: `${Math.min(100, (options.length / limit) * 100)}%` }} />
+              </div>
+              <span className={`text-[9px] font-display font-bold uppercase tracking-widest ${isOverLimit ? 'text-rose-400' : 'text-slate-500'}`}>
+                {options.length} / {limit}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 rounded-full text-[9px] font-display border border-cyan-500/20 uppercase tracking-[0.15em] font-black shadow-[0_0_15px_rgba(6,182,212,0.1)]">
+            {value.type}
+          </span>
+        </div>
+      </div>
+
+      {isSelectType && (
+        <div className="mt-6 pt-6 border-t border-white/5 relative z-10">
+          {isOverLimit && isEditable && (
+            <div className="mb-6 p-4 bg-rose-500/5 border border-rose-500/10 rounded-2xl flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 text-rose-500 mt-0.5 shrink-0" />
+              <div className="text-[11px] text-rose-300/80 font-display font-medium leading-relaxed">
+                <span className="font-bold block mb-1 uppercase tracking-wider text-rose-400">Krytyczny Limit API</span>
+                Wykryto {options.length} wpisów. Notion blokuje edycję powyżej {limit}.
+                Zalecana konwersja na <span className="text-cyan-400 font-bold">Plain Text</span> w panelu sterowania Notion.
+              </div>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-[10px] text-slate-500 uppercase tracking-[0.2em] font-bold">Zasoby Opcji</p>
+            {options.length === 0 && <span className="text-[10px] text-slate-600 italic font-display">Baza pusta</span>}
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-6">
+            {options.map((opt: any) => (
+              <motion.span
+                layout
+                key={opt.id || opt.name}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-slate-950/40 border border-white/5 text-slate-400 rounded-2xl text-xs font-display font-medium group/opt hover:border-cyan-500/40 hover:text-cyan-300 transition-all duration-300 shadow-sm"
+              >
+                {opt.name}
+                {isEditable && (
+                  <button
+                    onClick={() => onDeleteRequest(opt.name)}
+                    disabled={updating}
+                    className="text-slate-600 hover:text-rose-500 disabled:opacity-50 transition-colors p-0.5 rounded-md hover:bg-rose-500/10"
+                    title="Usuń opcję"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                )}
+              </motion.span>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-3">
+            <div className="relative flex-1 group/input">
+              <input
+                type="text"
+                placeholder="Wprowadź nową desygnację..."
+                className="w-full pl-4 pr-4 py-3 text-xs bg-slate-950/60 border border-white/5 text-slate-300 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-700 transition-all duration-300 font-display font-medium"
+                value={newOptionValue}
+                onChange={(e) => onNewOptionChange(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') onAdd(); }}
+              />
+            </div>
+            <button
+              onClick={onAdd}
+              disabled={!newOptionValue.trim() || updating || isOverLimit}
+              className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-cyan-600 to-cyan-500 text-white rounded-2xl text-xs font-display font-bold hover:from-cyan-500 hover:to-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-300 active:scale-95 shadow-lg shadow-cyan-500/20 uppercase tracking-widest"
+            >
+              {updating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+              Inicjuj
+            </button>
+          </div>
+        </div>
+      )}
+    </motion.div>
+  );
+};

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -1,98 +1,28 @@
 import React, { useState } from 'react';
-import { Plus, Loader2, X, AlertCircle, Settings } from 'lucide-react';
+import { X, AlertCircle, Settings } from 'lucide-react';
 import { motion, AnimatePresence } from "motion/react";
+import { useSchemaMutations } from "../hooks/useSchemaMutations";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { SchemaColumnCard } from "./SchemaColumnCard";
 
 interface SchemaEditorProps {
   schema: any;
   onSchemaUpdated: () => void;
 }
 
+const NOTION_OPTION_LIMIT = 100;
+
 export function SchemaEditor({ schema, onSchemaUpdated }: SchemaEditorProps) {
-  const [updatingProperty, setUpdatingProperty] = useState<string | null>(null);
-  const [newOptionNames, setNewOptionNames] = useState<Record<string, string>>({});
-  const [error, setError] = useState<string | null>(null);
-  const [confirmDelete, setConfirmDelete] = useState<{ propertyName: string, propertyType: string, optionName: string } | null>(null);
+  const { updatingProperty, error, setError, newOptionNames, setNewOptionNames, addOption, deleteOption } = useSchemaMutations(schema, onSchemaUpdated);
+  const [confirmDelete, setConfirmDelete] = useState<{ propertyName: string; propertyType: string; optionName: string } | null>(null);
 
-  const NOTION_OPTION_LIMIT = 100;
-
-  const handleAddOption = async (propertyName: string, propertyType: string) => {
-    const newOptionName = newOptionNames[propertyName]?.trim();
-    if (!newOptionName) return;
-
-    setError(null);
-    setUpdatingProperty(propertyName);
-    try {
-      const existingOptions = schema[propertyName][propertyType]?.options || [];
-      
-      if (existingOptions.some((opt: any) => opt.name.toLowerCase() === newOptionName.toLowerCase())) {
-        throw new Error("Taka opcja już istnieje.");
-      }
-
-      const newOptions = [...existingOptions, { name: newOptionName }];
-
-      const res = await fetch("/api/notion/schema", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          propertyName,
-          propertyType,
-          newOptions
-        })
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || "Błąd aktualizacji schematu");
-      }
-
-      setNewOptionNames(prev => ({ ...prev, [propertyName]: "" }));
-      onSchemaUpdated();
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setUpdatingProperty(null);
-    }
-  };
-
-  const handleDeleteOption = async () => {
-    if (!confirmDelete) return;
-    const { propertyName, propertyType, optionName } = confirmDelete;
-
-    setError(null);
-    setUpdatingProperty(propertyName);
-    setConfirmDelete(null);
-    try {
-      const existingOptions = schema[propertyName][propertyType]?.options || [];
-      const newOptions = existingOptions.filter((opt: any) => opt.name !== optionName);
-
-      const res = await fetch("/api/notion/schema", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          propertyName,
-          propertyType,
-          newOptions
-        })
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || "Błąd aktualizacji schematu");
-      }
-
-      onSchemaUpdated();
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setUpdatingProperty(null);
-    }
-  };
+  const columns = Object.entries(schema).filter(([key]) => key !== "_empty").sort((a, b) => a[0].localeCompare(b[0]));
 
   return (
     <div className="mt-4 space-y-6">
       <AnimatePresence>
         {error && (
-          <motion.div 
+          <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -107,65 +37,18 @@ export function SchemaEditor({ schema, onSchemaUpdated }: SchemaEditorProps) {
         )}
       </AnimatePresence>
 
-      <AnimatePresence>
-        {confirmDelete && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <motion.div 
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setConfirmDelete(null)}
-              className="absolute inset-0 bg-slate-950/80 backdrop-blur-md"
-            />
-            <motion.div 
-              initial={{ opacity: 0, scale: 0.9, y: 20 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.9, y: 20 }}
-              className="relative w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl shadow-[0_0_50px_rgba(0,0,0,0.8)] overflow-hidden"
-            >
-              <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-cyan-500 to-transparent opacity-50" />
-              
-              <div className="p-8">
-                <div className="flex items-center gap-4 mb-6">
-                  <div className="p-3 bg-rose-500/10 rounded-full border border-rose-500/20">
-                    <AlertCircle className="w-8 h-8 text-rose-400" />
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-display font-bold text-slate-100 uppercase tracking-wider">Potwierdź usunięcie</h3>
-                    <p className="text-sm text-slate-500 font-medium">Operacja nieodwracalna</p>
-                  </div>
-                </div>
-
-                <p className="text-lg text-slate-300 mb-8 font-medium leading-relaxed">
-                  Czy na pewno chcesz usunąć opcję <span className="text-cyan-400 font-bold underline decoration-cyan-400/30 underline-offset-4">"{confirmDelete.optionName}"</span> z bazy danych?
-                </p>
-
-                <div className="flex gap-4">
-                  <button 
-                    onClick={() => setConfirmDelete(null)}
-                    className="flex-1 px-6 py-3 text-sm font-bold text-slate-300 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl transition-all active:scale-95"
-                  >
-                    Anuluj
-                  </button>
-                  <button 
-                    onClick={handleDeleteOption}
-                    className="flex-1 px-6 py-3 text-sm font-bold bg-gradient-to-br from-rose-600 to-rose-900 hover:from-rose-500 hover:to-rose-800 text-white rounded-xl shadow-lg shadow-rose-500/20 transition-all active:scale-95 border border-rose-500/30"
-                  >
-                    Usuń na zawsze
-                  </button>
-                </div>
-              </div>
-              
-              <button 
-                onClick={() => setConfirmDelete(null)}
-                className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-200 transition-colors"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
+      <ConfirmDialog
+        open={!!confirmDelete}
+        title="Potwierdź usunięcie"
+        body={<>Czy na pewno chcesz usunąć opcję <span className="text-cyan-400 font-bold underline decoration-cyan-400/30 underline-offset-4">"{confirmDelete?.optionName}"</span> z bazy danych?</>}
+        confirmLabel="Usuń na zawsze"
+        onConfirm={() => {
+          const c = confirmDelete;
+          setConfirmDelete(null);
+          if (c) deleteOption(c.propertyName, c.propertyType, c.optionName);
+        }}
+        onCancel={() => setConfirmDelete(null)}
+      />
 
       <h3 className="text-sm font-display font-bold mb-6 text-slate-500 uppercase tracking-[0.2em] flex items-center gap-3">
         <div className="w-8 h-[1px] bg-gradient-to-r from-cyan-500 to-transparent" />
@@ -176,118 +59,27 @@ export function SchemaEditor({ schema, onSchemaUpdated }: SchemaEditorProps) {
         {schema._empty && (
           <p className="text-xs text-slate-500 font-mono">{(schema._empty as any).type}</p>
         )}
-        {Object.entries(schema).filter(([key]) => key !== "_empty").sort((a, b) => a[0].localeCompare(b[0])).map(([key, value]: [string, any], index) => {
+        {columns.map(([key, value]: [string, any], index) => {
           const isSelectType = value.type === 'multi_select' || value.type === 'select';
           const options = isSelectType ? [...(value[value.type]?.options || [])].sort((a, b) => a.name.localeCompare(b.name)) : [];
           const isOverLimit = options.length >= NOTION_OPTION_LIMIT;
 
           return (
-            <motion.div 
-              initial={{ opacity: 0, y: 10 }} 
-              animate={{ opacity: 1, y: 0 }} 
-              transition={{ delay: index * 0.05 }}
-              key={key} 
-              className="bg-slate-900/20 border border-white/5 rounded-3xl p-6 backdrop-blur-md hover:border-cyan-500/20 transition-all duration-500 group relative overflow-hidden"
-            >
-              <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-br from-cyan-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
-              
-              <div className="flex items-center justify-between mb-5 relative z-10">
-                <div className="flex flex-col gap-1">
-                  <span className="font-display font-bold text-xl text-slate-200 tracking-tight group-hover:text-cyan-400 transition-colors duration-300">{key}</span>
-                  {isSelectType && key !== 'Autor' && (
-                    <div className="flex items-center gap-2">
-                      <div className="h-1 w-24 bg-slate-800 rounded-full overflow-hidden">
-                        <div 
-                          className={`h-full transition-all duration-1000 ${isOverLimit ? 'bg-rose-500' : 'bg-cyan-500'}`}
-                          style={{ width: `${Math.min(100, (options.length / NOTION_OPTION_LIMIT) * 100)}%` }}
-                        />
-                      </div>
-                      <span className={`text-[9px] font-display font-bold uppercase tracking-widest ${isOverLimit ? 'text-rose-400' : 'text-slate-500'}`}>
-                        {options.length} / {NOTION_OPTION_LIMIT}
-                      </span>
-                    </div>
-                  )}
-                </div>
-                <div className="flex flex-col items-end gap-1">
-                  <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 rounded-full text-[9px] font-display border border-cyan-500/20 uppercase tracking-[0.15em] font-black shadow-[0_0_15px_rgba(6,182,212,0.1)]">
-                    {value.type}
-                  </span>
-                </div>
-              </div>
-              
-              {isSelectType && (
-                <div className="mt-6 pt-6 border-t border-white/5 relative z-10">
-                  {isOverLimit && key !== 'Autor' && (
-                    <div className="mb-6 p-4 bg-rose-500/5 border border-rose-500/10 rounded-2xl flex items-start gap-3">
-                      <AlertCircle className="w-5 h-5 text-rose-500 mt-0.5 shrink-0" />
-                      <div className="text-[11px] text-rose-300/80 font-display font-medium leading-relaxed">
-                        <span className="font-bold block mb-1 uppercase tracking-wider text-rose-400">Krytyczny Limit API</span>
-                        Wykryto {options.length} wpisów. Notion blokuje edycję powyżej {NOTION_OPTION_LIMIT}. 
-                        Zalecana konwersja na <span className="text-cyan-400 font-bold">Plain Text</span> w panelu sterowania Notion.
-                      </div>
-                    </div>
-                  )}
-                  
-                  <div className="flex items-center justify-between mb-4">
-                    <p className="text-[10px] text-slate-500 uppercase tracking-[0.2em] font-bold">Zasoby Opcji</p>
-                    {options.length === 0 && (
-                      <span className="text-[10px] text-slate-600 italic font-display">Baza pusta</span>
-                    )}
-                  </div>
-
-                  <div className="flex flex-wrap gap-2 mb-6">
-                    {options.map((opt: any) => (
-                      <motion.span 
-                        layout
-                        key={opt.id || opt.name} 
-                        className="inline-flex items-center gap-2 px-4 py-2 bg-slate-950/40 border border-white/5 text-slate-400 rounded-2xl text-xs font-display font-medium group/opt hover:border-cyan-500/40 hover:text-cyan-300 transition-all duration-300 shadow-sm"
-                      >
-                        {opt.name}
-                        {key !== 'Autor' && (
-                          <button
-                            onClick={() => setConfirmDelete({ propertyName: key, propertyType: value.type, optionName: opt.name })}
-                            disabled={updatingProperty === key}
-                            className="text-slate-600 hover:text-rose-500 disabled:opacity-50 transition-colors p-0.5 rounded-md hover:bg-rose-500/10"
-                            title="Usuń opcję"
-                          >
-                            <X className="w-3 h-3" />
-                          </button>
-                        )}
-                      </motion.span>
-                    ))}
-                  </div>
-                  
-                  <div className="flex items-center gap-3">
-                    <div className="relative flex-1 group/input">
-                      <input
-                        type="text"
-                        placeholder="Wprowadź nową desygnację..."
-                        className="w-full pl-4 pr-4 py-3 text-xs bg-slate-950/60 border border-white/5 text-slate-300 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-700 transition-all duration-300 font-display font-medium"
-                        value={newOptionNames[key] || ""}
-                        onChange={(e) => setNewOptionNames(prev => ({ ...prev, [key]: e.target.value }))}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') {
-                            handleAddOption(key, value.type);
-                          }
-                        }}
-                      />
-                    </div>
-                    <button
-                      onClick={() => handleAddOption(key, value.type)}
-                      disabled={!newOptionNames[key]?.trim() || updatingProperty === key || isOverLimit}
-                      className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-cyan-600 to-cyan-500 text-white rounded-2xl text-xs font-display font-bold hover:from-cyan-500 hover:to-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-300 active:scale-95 shadow-lg shadow-cyan-500/20 uppercase tracking-widest"
-                    >
-                      {updatingProperty === key ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <Plus className="w-4 h-4" />
-                      )}
-                      Inicjuj
-                    </button>
-                  </div>
-                </div>
-              )}
-            </motion.div>
+            <SchemaColumnCard
+              key={key}
+              name={key}
+              value={value}
+              isSelectType={isSelectType}
+              options={options}
+              isOverLimit={isOverLimit}
+              limit={NOTION_OPTION_LIMIT}
+              index={index}
+              updating={updatingProperty === key}
+              newOptionValue={newOptionNames[key] || ""}
+              onNewOptionChange={(v) => setNewOptionNames(prev => ({ ...prev, [key]: v }))}
+              onAdd={() => addOption(key, value.type)}
+              onDeleteRequest={(optionName) => setConfirmDelete({ propertyName: key, propertyType: value.type, optionName })}
+            />
           );
         })}
       </div>

--- a/src/hooks/useSchemaMutations.ts
+++ b/src/hooks/useSchemaMutations.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from "react";
+
+/**
+ * Mutacje opcji schematu Notion (dodanie/usunięcie w kolumnie select/multi_select).
+ * Trzyma stan operacji (`updatingProperty`, `error`, wpisywane nazwy) i wspólny
+ * `PATCH /api/notion/schema` — add/delete to cienkie przypadki na jednym zapisie.
+ */
+export function useSchemaMutations(schema: any, onSchemaUpdated: () => void) {
+  const [updatingProperty, setUpdatingProperty] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [newOptionNames, setNewOptionNames] = useState<Record<string, string>>({});
+
+  const patchOptions = async (propertyName: string, propertyType: string, newOptions: { name: string }[]) => {
+    const res = await fetch("/api/notion/schema", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ propertyName, propertyType, newOptions }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Błąd aktualizacji schematu");
+    }
+    onSchemaUpdated();
+  };
+
+  const addOption = useCallback(async (propertyName: string, propertyType: string) => {
+    const newOptionName = newOptionNames[propertyName]?.trim();
+    if (!newOptionName) return;
+
+    setError(null);
+    setUpdatingProperty(propertyName);
+    try {
+      const existing = schema[propertyName][propertyType]?.options || [];
+      if (existing.some((opt: any) => opt.name.toLowerCase() === newOptionName.toLowerCase())) {
+        throw new Error("Taka opcja już istnieje.");
+      }
+      await patchOptions(propertyName, propertyType, [...existing, { name: newOptionName }]);
+      setNewOptionNames(prev => ({ ...prev, [propertyName]: "" }));
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setUpdatingProperty(null);
+    }
+  }, [schema, newOptionNames, onSchemaUpdated]);
+
+  const deleteOption = useCallback(async (propertyName: string, propertyType: string, optionName: string) => {
+    setError(null);
+    setUpdatingProperty(propertyName);
+    try {
+      const existing = schema[propertyName][propertyType]?.options || [];
+      await patchOptions(propertyName, propertyType, existing.filter((opt: any) => opt.name !== optionName));
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setUpdatingProperty(null);
+    }
+  }, [schema, onSchemaUpdated]);
+
+  return { updatingProperty, error, setError, newOptionNames, setNewOptionNames, addOption, deleteOption };
+}


### PR DESCRIPTION
## Audyt #2 — krok 3/4 (Refs #102)

`SchemaEditor.tsx` był mild God-Component: dwukrotnie zaszyty `PATCH /api/notion/schema`, inline modal potwierdzenia usunięcia oraz duża karta kolumny — wszystko w jednym pliku (296 linii). Rozbicie na cienki orkiestrator + trzy jednostki o jednej odpowiedzialności.

### Zmiany
- **`src/hooks/useSchemaMutations.ts`** (nowy) — stan operacji (`updatingProperty` / `error` / `newOptionNames`) + wspólny `patchOptions`; `addOption`/`deleteOption` jako cienkie przypadki na jednym zapisie (walidacja duplikatu case-insensitive w `addOption`).
- **`src/components/ConfirmDialog.tsx`** (nowy) — generyczny modal operacji destrukcyjnej (`AnimatePresence`).
- **`src/components/SchemaColumnCard.tsx`** (nowy) — karta jednej kolumny: licznik limitu, ostrzeżenie o limicie API, chipy opcji, dodawanie/usuwanie. Special-case „Autor" skonsolidowany w `isEditable`.
- **`src/components/SchemaEditor.tsx`** — **296 → 88 linii**, cienki orkiestrator (error-banner + `ConfirmDialog` + mapowanie kolumn na `SchemaColumnCard`).

### Weryfikacja
- Zachowanie 1:1 (bez zmian w API/UX).
- `npm run lint` czysty, **270/270** testów zielonych.
- Bump `metadata.json` → **1.15.10** (mirror w `package.json` + `package-lock.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_