### PR TITLE
refactor(stats): StatsSection — useMarkAsRead + OwnedUnreadItem + AwardCoverageGrid (Refs #102, krok 4/4)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.10** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.15.11** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.15.11** — Audyt #2 krok 4/4 (#102): `StatsSection` (NIE god — spójny dashboard, ale
+  pod-wyekstrahowany). Logika oznaczania → hook `useMarkAsRead` (stan `markingId`/`markedIds`
+  + optymistyczny update filii / pełny refetch „Przeczytane"); wiersz posiadane-nieprzeczytane
+  → `stats/OwnedUnreadItem`; siatka pokrycia nagród (`Math.round(count/total)`) → `stats/AwardCoverageGrid`.
+  Zachowanie 1:1, 270 testów. **Audyt #2 zamknięty (kroki 1–4).**
 - **1.15.10** — Audyt #2 krok 3/4 (#102): `SchemaEditor` (mild God-Component) **296 → 88 linii**
   (cienki orkiestrator). Inline PATCH ×2 + walidacja duplikatu → hook `useSchemaMutations`
   (`patchOptions` wspólny, `addOption`/`deleteOption`); inline modal usuwania → generyczny

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.10",
+  "version": "1.15.11",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.10",
+  "version": "1.15.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.10",
+      "version": "1.15.11",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.10",
+  "version": "1.15.11",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,59 +1,22 @@
-import React, { useState } from "react";
+import React from "react";
 import { motion } from "motion/react";
-import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search, CheckCircle2, Loader2 } from "lucide-react";
+import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search } from "lucide-react";
 import { useStats } from "../hooks/useStats";
 import { useLibraryCheck } from "../hooks/useLibraryCheck";
+import { useMarkAsRead } from "../hooks/useMarkAsRead";
 import { ProgressBar } from "./stats/ProgressBar";
 import { YearlyProgressItem } from "./stats/YearlyProgressItem";
 import { LibraryProgressItem } from "./stats/LibraryProgressItem";
 import { AuthorProgressItem } from "./stats/AuthorProgressItem";
 import { IdentifiedLibraryItem } from "./stats/IdentifiedLibraryItem";
+import { OwnedUnreadItem } from "./stats/OwnedUnreadItem";
+import { AwardCoverageGrid } from "./stats/AwardCoverageGrid";
 import { LIBRARY_BRANCHES } from "../constants";
 
 export const StatsSection: React.FC = () => {
   const { stats, loading, error, fetchStats, addBookToLibrarySection } = useStats();
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
-
-  const LIBRARY_TAGS = ["Biblioteka", "Biblioteka 9"];
-  const [markingId, setMarkingId] = useState<string | null>(null);
-  // Pozycje oznaczone w tej sesji — klucz „{tag}:{pageId}". Skan biblioteki
-  // wyklucza już otagowane książki, więc pozycja z listy skanera trafia tu
-  // dopiero po kliknięciu; wtedy ma zostać widoczna, lecz z wyłączonym haczykiem.
-  const [markedIds, setMarkedIds] = useState<Set<string>>(new Set());
-
-  // tag domyślnie „Przeczytane" (zasoby posiadane / statystyki biblioteczne);
-  // skaner filii przekazuje znacznik filii („Biblioteka" / „Biblioteka 9").
-  const handleMarkAsRead = async (pageId: string, tag?: string) => {
-    if (markingId) return;
-    setMarkingId(pageId);
-    try {
-      const res = await fetch("/api/mark-as-read", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pageId, tag })
-      });
-      if (!res.ok) throw new Error("Błąd podczas oznaczania pozycji");
-      const sourceTag = tag ?? "Przeczytane";
-      setMarkedIds(prev => new Set(prev).add(`${sourceTag}:${pageId}`));
-
-      // Tag filii dopisuje pozycję wyłącznie do sekcji „Książki dostępne w
-      // bibliotekach" — aktualizujemy ją optymistycznie (natychmiast, odporne na
-      // opóźnienie odczytu Notiona). „Przeczytane" zmienia wiele przekrojów
-      // (autorzy, chronologia, posiadane), więc tam robimy pełny refetch.
-      if (LIBRARY_TAGS.includes(sourceTag)) {
-        const book = Object.values(identifiedBooks).flat().find(b => b.id === pageId);
-        if (book) addBookToLibrarySection(sourceTag, book);
-        else await fetchStats();
-      } else {
-        await fetchStats();
-      }
-    } catch (err: any) {
-      console.error(err.message);
-      alert(`Błąd: ${err.message}`);
-    } finally {
-      setMarkingId(null);
-    }
-  };
+  const { markingId, markedIds, markAsRead } = useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats });
 
   if (loading && !stats) {
     return (
@@ -160,19 +123,7 @@ export const StatsSection: React.FC = () => {
               color="emerald"
             />
             
-            <div className="pt-4 space-y-3">
-              <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2">Pokrycie Poszczególnych Nagród</p>
-              <div className="grid grid-cols-2 gap-3">
-                {stats.awardCoverage.map((award, idx) => (
-                  <div key={idx} className="bg-slate-950/50 border border-slate-800 p-2 rounded-xl">
-                    <div className="text-xs font-bold text-slate-400 uppercase truncate">{award.name}</div>
-                    <div className="text-lg font-bold font-display text-purple-400">
-                      {Math.round((award.count / award.total) * 100)}%
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <AwardCoverageGrid coverage={stats.awardCoverage} />
           </div>
         </motion.div>
 
@@ -210,32 +161,13 @@ export const StatsSection: React.FC = () => {
               <p className="text-slate-400 text-sm italic text-center py-8">Wszystkie posiadane zasoby zostały przyswojone.</p>
             ) : (
               stats.ownedUnread.map((book, idx) => (
-                <div key={idx} className="flex items-start gap-3 p-3 bg-slate-950/30 rounded-xl border border-slate-800/50 group/book">
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="text-sm font-bold text-slate-200 leading-tight">{book.title}</div>
-                      {book.year && <div className="text-xs font-mono text-slate-400">{book.year}</div>}
-                    </div>
-                    <div className="text-xs text-slate-400 uppercase font-bold tracking-tighter">{book.author}</div>
-                  </div>
-                  
-                  <button
-                    onClick={() => handleMarkAsRead(book.id)}
-                    disabled={markingId !== null}
-                    className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
-                      markingId === book.id 
-                        ? 'bg-emerald-500/20 border-emerald-500/50 text-emerald-400' 
-                        : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-emerald-400 hover:border-emerald-500/30'
-                    }`}
-                    title="Oznacz jako przeczytane"
-                  >
-                    {markingId === book.id ? (
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                    ) : (
-                      <CheckCircle2 className="w-4 h-4" />
-                    )}
-                  </button>
-                </div>
+                <OwnedUnreadItem
+                  key={idx}
+                  book={book}
+                  marking={markingId === book.id}
+                  disabled={markingId !== null}
+                  onMarkAsRead={markAsRead}
+                />
               ))
             )}
           </div>
@@ -257,7 +189,7 @@ export const StatsSection: React.FC = () => {
               <LibraryProgressItem 
                 key={library.id} 
                 library={library} 
-                onMarkAsRead={handleMarkAsRead}
+                onMarkAsRead={markAsRead}
                 markingId={markingId}
               />
             ))}
@@ -307,7 +239,7 @@ export const StatsSection: React.FC = () => {
                 books={identifiedBooks[library.id] || []}
                 onCheck={() => checkLibrary(library.id, library.code)}
                 onStop={stopLibraryCheck}
-                onMarkAsRead={handleMarkAsRead}
+                onMarkAsRead={markAsRead}
                 markingId={markingId}
                 markedIds={markedIds}
                 isChecking={checkingLibrary === library.id}

--- a/src/components/stats/AwardCoverageGrid.tsx
+++ b/src/components/stats/AwardCoverageGrid.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import type { AwardCoverageStat } from "../../hooks/useStats";
+
+interface Props {
+  coverage: AwardCoverageStat[];
+}
+
+/** Siatka pokrycia poszczególnych nagród — procent zdobytych z całości. */
+export const AwardCoverageGrid: React.FC<Props> = ({ coverage }) => (
+  <div className="pt-4 space-y-3">
+    <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2">Pokrycie Poszczególnych Nagród</p>
+    <div className="grid grid-cols-2 gap-3">
+      {coverage.map((award, idx) => (
+        <div key={idx} className="bg-slate-950/50 border border-slate-800 p-2 rounded-xl">
+          <div className="text-xs font-bold text-slate-400 uppercase truncate">{award.name}</div>
+          <div className="text-lg font-bold font-display text-purple-400">
+            {Math.round((award.count / award.total) * 100)}%
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);

--- a/src/components/stats/OwnedUnreadItem.tsx
+++ b/src/components/stats/OwnedUnreadItem.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { CheckCircle2, Loader2 } from "lucide-react";
+
+interface Props {
+  book: { id: string; title: string; author: string; year?: number | null };
+  marking: boolean;      // czy trwa oznaczanie tej konkretnej pozycji
+  disabled: boolean;     // czy jakiekolwiek oznaczanie jest w toku (blokada)
+  onMarkAsRead: (pageId: string) => void;
+}
+
+/** Wiersz pozycji posiadanej, lecz nieprzeczytanej, z akcją „oznacz jako przeczytane". */
+export const OwnedUnreadItem: React.FC<Props> = ({ book, marking, disabled, onMarkAsRead }) => (
+  <div className="flex items-start gap-3 p-3 bg-slate-950/30 rounded-xl border border-slate-800/50 group/book">
+    <div className="flex-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-bold text-slate-200 leading-tight">{book.title}</div>
+        {book.year && <div className="text-xs font-mono text-slate-400">{book.year}</div>}
+      </div>
+      <div className="text-xs text-slate-400 uppercase font-bold tracking-tighter">{book.author}</div>
+    </div>
+
+    <button
+      onClick={() => onMarkAsRead(book.id)}
+      disabled={disabled}
+      className={`p-2 rounded-lg border transition-all opacity-40 group-hover/book:opacity-100 ${
+        marking
+          ? 'bg-emerald-500/20 border-emerald-500/50 text-emerald-400'
+          : 'bg-slate-900 border-slate-800 text-slate-500 hover:text-emerald-400 hover:border-emerald-500/30'
+      }`}
+      title="Oznacz jako przeczytane"
+    >
+      {marking ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle2 className="w-4 h-4" />}
+    </button>
+  </div>
+);

--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from "react";
+import type { IdentifiedBooks } from "./useStats";
+
+type BookRef = { id: string; title: string; author: string; year?: number | null };
+
+const LIBRARY_TAGS = ["Biblioteka", "Biblioteka 9"];
+
+interface Deps {
+  identifiedBooks: IdentifiedBooks;
+  addBookToLibrarySection: (tag: string, book: BookRef) => void;
+  fetchStats: () => Promise<void>;
+}
+
+/**
+ * Oznaczanie pozycji jako przeczytanej (`POST /api/mark-as-read`).
+ * `markingId` blokuje równoległe zapisy; `markedIds` (klucz „{tag}:{pageId}")
+ * trzyma pozycje otagowane w tej sesji — skan biblioteki wyklucza już
+ * otagowane książki, więc rekord ma zostać widoczny, lecz z wyłączonym haczykiem.
+ *
+ * tag domyślnie „Przeczytane" (zasoby posiadane / statystyki biblioteczne);
+ * skaner filii przekazuje znacznik filii („Biblioteka" / „Biblioteka 9").
+ */
+export function useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats }: Deps) {
+  const [markingId, setMarkingId] = useState<string | null>(null);
+  const [markedIds, setMarkedIds] = useState<Set<string>>(new Set());
+
+  const markAsRead = useCallback(async (pageId: string, tag?: string) => {
+    if (markingId) return;
+    setMarkingId(pageId);
+    try {
+      const res = await fetch("/api/mark-as-read", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pageId, tag })
+      });
+      if (!res.ok) throw new Error("Błąd podczas oznaczania pozycji");
+      const sourceTag = tag ?? "Przeczytane";
+      setMarkedIds(prev => new Set(prev).add(`${sourceTag}:${pageId}`));
+
+      // Tag filii dopisuje pozycję wyłącznie do sekcji „Książki dostępne w
+      // bibliotekach" — aktualizujemy ją optymistycznie (natychmiast, odporne na
+      // opóźnienie odczytu Notiona). „Przeczytane" zmienia wiele przekrojów
+      // (autorzy, chronologia, posiadane), więc tam robimy pełny refetch.
+      if (LIBRARY_TAGS.includes(sourceTag)) {
+        const book = Object.values(identifiedBooks).flat().find(b => b.id === pageId);
+        if (book) addBookToLibrarySection(sourceTag, book);
+        else await fetchStats();
+      } else {
+        await fetchStats();
+      }
+    } catch (err: any) {
+      console.error(err.message);
+      alert(`Błąd: ${err.message}`);
+    } finally {
+      setMarkingId(null);
+    }
+  }, [markingId, identifiedBooks, addBookToLibrarySection, fetchStats]);
+
+  return { markingId, markedIds, markAsRead };
+}


### PR DESCRIPTION
## Audyt #2 — krok 4/4, domknięcie (Refs #102)

`StatsSection.tsx` **nie był** god-componentem — to spójny dashboard (7 kart pod jednym `useStats`). Był jednak pod-wyekstrahowany: logika oznaczania pozycji, wiersz posiadane-nieprzeczytane oraz siatka pokrycia nagród (z liczeniem procentów w JSX) siedziały inline. Wyciągnięcie trzech jednostek zgodnie z findingiem audytu.

### Zmiany
- **`src/hooks/useMarkAsRead.ts`** (nowy) — stan `markingId` (blokada równoległych zapisów) + `markedIds` (pozycje otagowane w sesji), `POST /api/mark-as-read` z optymistycznym dopisaniem do sekcji filii (znacznik „Biblioteka"/„Biblioteka 9") albo pełnym refetchem przy „Przeczytane". Logika 1:1 przeniesiona z komponentu.
- **`src/components/stats/OwnedUnreadItem.tsx`** (nowy) — wiersz pozycji posiadanej-nieprzeczytanej z przyciskiem oznaczania (spinner / haczyk).
- **`src/components/stats/AwardCoverageGrid.tsx`** (nowy) — siatka pokrycia nagród, `Math.round((count/total)*100)%`.
- **`src/components/StatsSection.tsx`** — cieńszy: hook zamiast inline handlera, dwa komponenty prezentacyjne zamiast rozwlekłego JSX; niepotrzebne importy (`useState`, `CheckCircle2`, `Loader2`) usunięte.

### Weryfikacja
- Zachowanie 1:1 (UX/API bez zmian).
- `npm run lint` czysty, **270/270** testów, `npm run build` OK.
- Bump `metadata.json` → **1.15.11** (mirror `package.json` + `package-lock.json`).

Domyka issue #102 — cały audyt #2 (kroki 1–4: SyncSummaryResult, App, SchemaEditor, StatsSection) zrealizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_