### PR TITLE
feat(regał): drewniany korpus regału + ozdoby Mechanicus + wszystkie woluminy

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.15.11** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.16.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.16.0** — Regał jako mebel: prawdziwy korpus `ShelfFrame` (drewniany gzyms + boki + cokół,
+  ciemne „plecy" z pionowymi deskami) + ozdoby Mechanicus `ShelfOrnaments` (mosiężne narożniki,
+  sygil koła zębatego z czaszką, zwisająca pieczęć czystości — dekoracyjne, `aria-hidden`).
+  Każdy rząd grzbietów stoi na osobnej **desce** — trick: komórki o stałej wysokości `SHELF_ROW_H`
+  (>171 px grzbiet) → każdy zawinięty wiersz skacze o `ROW_H+GAP`, więc jeden powtarzalny gradient
+  (`shelfPlankBackground`, testowany) trafia deską pod każdy rząd niezależnie od szerokości.
+  Półka „Do przeczytania" mieści **wszystkie** woluminy (zdjęty scroll-cap `max-h-520`).
+  Ramę reużywa też „Wyróżnione". +2 testy (helper deski). Weryfikacja wizualna: screenshot
+  headless-chromium potwierdził wyrównanie desek. `docs/bookshelf.md` zaktualizowany.
 - **1.15.11** — Audyt #2 krok 4/4 (#102): `StatsSection` (NIE god — spójny dashboard, ale
   pod-wyekstrahowany). Logika oznaczania → hook `useMarkAsRead` (stan `markingId`/`markedIds`
   + optymistyczny update filii / pełny refetch „Przeczytane"); wiersz posiadane-nieprzeczytane

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -6,6 +6,11 @@ stand as coloured **spines** (concept A), awarded reads also appear face-out on 
 cover row (concept B). Two shelves — **Do przeczytania** and **Przeczytane** — sit side by side, and
 a book is dragged between them; the drop writes the read state back to Notion. **No AI/LLM.**
 
+Each shelf is drawn as a **wooden cabinet** (`ShelfFrame`): a cornice with a Mechanicus cog sigil +
+title, dark back-panel with vertical planks, brass corner brackets and a hanging purity seal
+(`ShelfOrnaments` — decorative, `aria-hidden`). Rows of spines each rest on a real **plank**, and the
+**Do przeczytania** shelf holds **every** volume (no scroll cap) so the whole backlog is visible at once.
+
 ## 2. Data
 - Reuses **`GET /api/books`** (`BookIndexEntry[]`, see [skryptorium-search.md](./skryptorium-search.md)) —
   the same slim index the search uses. Read state is derived from the `zrodlo` (Źródło) tag
@@ -21,6 +26,10 @@ a book is dragged between them; the drop writes the read state back to Notion. *
   then title.
 - **`featuredReads(books, overrides, limit)`** — the cover row: read **and** awarded, newest year
   first (no read-date exists in the data), capped at `limit`.
+- **`shelfPlankBackground()`** — the CSS `repeating-linear-gradient` that paints a wooden plank under
+  every row. Rows use fixed-height cells (`SHELF_ROW_H` > tallest spine), so every wrapped line
+  advances by exactly `SHELF_ROW_H + SHELF_ROW_GAP`; the gradient period matches, so a plank lands
+  directly beneath each row regardless of viewport width or how many spines fit per line.
 
 ## 4. Drag & drop + persistence
 - Native HTML5 DnD: each `BookSpine` is `draggable` and puts its id on the dataTransfer; each `Shelf`
@@ -37,6 +46,8 @@ a book is dragged between them; the drop writes the read state back to Notion. *
   so only known Źródło tags can be written.
 
 ## 5. Scope notes
-Concept A (spines) + B (featured covers) shipped; the alternate 40k "Krypta Danych" neon skin (C)
-was a rejected mock. Out of scope for now: virtualization for extreme counts, per-shelf sort/filter,
-and a write-in-progress animation on the dragged spine.
+Concept A (spines) + B (featured covers) shipped, now inside the `ShelfFrame` cabinet; the alternate
+40k "Krypta Danych" neon skin (C) was a rejected mock. The **Do przeczytania** shelf renders all
+volumes (no virtualization) — fine for the current ~700-book index; virtualization is the fallback if
+counts grow large. Out of scope for now: per-shelf sort/filter and a write-in-progress animation on
+the dragged spine.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.15.11",
+      "version": "1.16.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.15.11",
+  "version": "1.16.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG } from "../utils/bookshelf";
+import { isRead, spineStyle, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -35,6 +35,23 @@ describe("bookshelf.spineStyle", () => {
       expect(s.height).toBeGreaterThanOrEqual(124);
       expect(s.height).toBeLessThanOrEqual(171);
     }
+  });
+});
+
+describe("bookshelf.shelfPlankBackground", () => {
+  it("draws a plank starting at the row baseline and repeats per row advance", () => {
+    const { backgroundImage } = shelfPlankBackground();
+    expect(backgroundImage.startsWith("repeating-linear-gradient(180deg,")).toBe(true);
+    // Deska zaczyna się dokładnie pod spodem rzędu (SHELF_ROW_H) …
+    expect(backgroundImage).toContain(`${SHELF_ROW_H}px`);
+    // … kończy po SHELF_PLANK_H …
+    expect(backgroundImage).toContain(`${SHELF_ROW_H + SHELF_PLANK_H}px`);
+    // … a okres powtórzenia = skok jednego rzędu (ROW_H + GAP).
+    expect(backgroundImage).toContain(`${SHELF_ROW_H + SHELF_ROW_GAP}px`);
+  });
+
+  it("keeps the plank thinner than the row gap (mieści się w prześwicie)", () => {
+    expect(SHELF_PLANK_H).toBeLessThan(SHELF_ROW_GAP);
   });
 });
 

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -6,6 +6,7 @@ import { useMarkRead } from "../hooks/useMarkRead";
 import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
 import { Shelf } from "./shelf/Shelf";
 import { CoverCard } from "./shelf/CoverCard";
+import { ShelfFrame } from "./shelf/ShelfFrame";
 
 export const BookshelfSection: React.FC = () => {
   const { books, loading, error, fetchBooks } = useBooks();
@@ -103,17 +104,19 @@ export const BookshelfSection: React.FC = () => {
         <>
           {/* Półka „Wyróżnione" (okładki twarzą) */}
           {featured.length > 0 && (
-            <div className="rounded-3xl border border-purple-500/20 bg-gradient-to-b from-purple-950/20 to-black/40 p-4 sm:p-5">
-              <div className="flex items-center gap-2 mb-4">
-                <Sparkles className="w-4 h-4 text-purple-300" />
-                <h3 className="text-sm font-bold uppercase tracking-widest text-purple-200">Wyróżnione — nagrodzone, przeczytane</h3>
-                <span className="px-2 py-0.5 rounded-lg text-[10px] font-bold border bg-purple-500/10 border-purple-500/25 text-purple-300">{featured.length}</span>
-              </div>
-              <div className="flex gap-3.5 overflow-x-auto pb-1 custom-scrollbar">
+            <ShelfFrame
+              title="Wyróżnione — nagrodzone, przeczytane"
+              icon={<Sparkles className="w-4 h-4" />}
+              accent="purple" count={featured.length}
+            >
+              <div className="flex items-end gap-3.5 overflow-x-auto pb-1 pt-1 custom-scrollbar">
                 {featured.map((b) => <CoverCard key={b.id} book={b} />)}
               </div>
-              <div className="h-4 rounded-[3px] mt-1 bg-gradient-to-b from-amber-800/70 via-amber-950/80 to-black shadow-[0_10px_16px_-6px_rgba(0,0,0,.7),inset_0_1px_0_rgba(255,220,170,.12)]" />
-            </div>
+              <div
+                className="h-[15px] mt-[2px] rounded-[2px]"
+                style={{ background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)", boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)" }}
+              />
+            </ShelfFrame>
           )}
 
           {/* Dwa regały */}

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 import { BookIndexEntry } from "../../types";
-import { ShelfId, spineStyle } from "../../utils/bookshelf";
+import { ShelfId, spineStyle, shelfPlankBackground, SHELF_ROW_H, SHELF_ROW_GAP } from "../../utils/bookshelf";
 import { BookSpine } from "./BookSpine";
+import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
 
 interface Props {
   shelfId: ShelfId;
   title: string;
   icon: React.ReactNode;
-  accent: "emerald" | "cyan";
+  accent: Extract<ShelfAccent, "emerald" | "cyan">;
   books: BookIndexEntry[];
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
@@ -16,45 +17,43 @@ interface Props {
   dragging: boolean;
 }
 
-const ACCENT = {
-  emerald: { text: "text-emerald-300", ring: "border-emerald-500/40", glow: "shadow-[0_0_24px_rgba(52,211,153,.18)]", chip: "bg-emerald-500/10 border-emerald-500/25 text-emerald-300" },
-  cyan: { text: "text-cyan-300", ring: "border-cyan-500/40", glow: "shadow-[0_0_24px_rgba(34,211,238,.18)]", chip: "bg-cyan-500/10 border-cyan-500/25 text-cyan-300" },
-};
+const PLANK_BG = shelfPlankBackground();
 
-/** Jeden regał = drop-target z półkami grzbietów (zawijanymi w rzędy). */
+/** Jeden regał = drewniany korpus + drop-target z grzbietami na deskach (wszystkie, bez przewijania). */
 export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, dragging }) => {
   const [over, setOver] = useState(false);
-  const a = ACCENT[accent];
+
+  const rootProps: React.HTMLAttributes<HTMLDivElement> = {
+    onDragOver: (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true); },
+    onDragLeave: (e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setOver(false); },
+    onDrop: (e) => { e.preventDefault(); setOver(false); onDropBook(shelfId); },
+  };
 
   return (
-    <div
-      onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true); }}
-      onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setOver(false); }}
-      onDrop={(e) => { e.preventDefault(); setOver(false); onDropBook(shelfId); }}
-      className={`rounded-3xl border p-4 sm:p-5 bg-gradient-to-b from-amber-950/30 to-black/40 transition-colors ${
-        over ? `${a.ring} ${a.glow}` : dragging ? "border-white/15 border-dashed" : "border-amber-900/40"
-      }`}
+    <ShelfFrame
+      title={title} icon={icon} accent={accent} count={books.length}
+      highlight={over ? "target" : dragging ? "dragging" : "idle"}
+      headerExtra={dragging ? <span className="text-[10px] uppercase tracking-widest text-amber-200/70 font-bold">upuść tutaj</span> : null}
+      rootProps={rootProps}
     >
-      <div className="flex items-center gap-2 mb-4">
-        <span className={a.text}>{icon}</span>
-        <h3 className="text-sm font-bold uppercase tracking-widest text-slate-200">{title}</h3>
-        <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{books.length}</span>
-        {dragging && <span className="ml-auto text-[10px] uppercase tracking-widest text-slate-500 font-bold">upuść tutaj</span>}
-      </div>
-
       {books.length === 0 ? (
-        <div className="min-h-[120px] flex items-center justify-center text-xs text-slate-600 italic">
+        <div className="min-h-[140px] flex items-center justify-center text-xs text-slate-500 italic">
           {dragging ? "Upuść wolumin, aby przenieść" : "Pusto na tej półce"}
         </div>
       ) : (
-        <div className="flex flex-wrap items-end gap-[5px] content-end max-h-[520px] overflow-y-auto pr-1 custom-scrollbar">
+        <div
+          className="flex flex-wrap items-end justify-start"
+          style={{ ...PLANK_BG, rowGap: `${SHELF_ROW_GAP}px`, columnGap: "5px" }}
+        >
           {books.map((b) => (
-            <BookSpine key={b.id} book={b} style={spineStyle(b)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+            // Komórka o stałej wysokości toru → wszystkie zawinięte rzędy równe,
+            // więc deska (tło) trafia dokładnie pod spód każdego z nich.
+            <div key={b.id} className="flex items-end shrink-0" style={{ height: SHELF_ROW_H }}>
+              <BookSpine book={b} style={spineStyle(b)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+            </div>
           ))}
         </div>
       )}
-      {/* Deska półki */}
-      <div className="h-4 rounded-[3px] mt-1 bg-gradient-to-b from-amber-800/70 via-amber-950/80 to-black shadow-[0_10px_16px_-6px_rgba(0,0,0,.7),inset_0_1px_0_rgba(255,220,170,.15)]" />
-    </div>
+    </ShelfFrame>
   );
 };

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { CornerBracket, CogSigil, PuritySeal } from "./ShelfOrnaments";
+
+export type ShelfAccent = "emerald" | "cyan" | "purple" | "amber";
+
+const ACCENT: Record<ShelfAccent, { text: string; chip: string; glow: string; ring: string }> = {
+  emerald: { text: "text-emerald-200", chip: "bg-emerald-500/10 border-emerald-500/30 text-emerald-200", glow: "shadow-[0_0_28px_rgba(52,211,153,.22)]", ring: "border-emerald-400/50" },
+  cyan: { text: "text-cyan-200", chip: "bg-cyan-500/10 border-cyan-500/30 text-cyan-200", glow: "shadow-[0_0_28px_rgba(34,211,238,.22)]", ring: "border-cyan-400/50" },
+  purple: { text: "text-purple-200", chip: "bg-purple-500/10 border-purple-500/30 text-purple-200", glow: "shadow-[0_0_28px_rgba(168,85,247,.22)]", ring: "border-purple-400/50" },
+  amber: { text: "text-amber-200", chip: "bg-amber-500/10 border-amber-500/30 text-amber-200", glow: "shadow-[0_0_28px_rgba(251,191,36,.22)]", ring: "border-amber-400/50" },
+};
+
+interface Props {
+  title: string;
+  icon: React.ReactNode;
+  accent: ShelfAccent;
+  count: number;
+  /** Stan podświetlenia ramy: cel upuszczenia / aktywne przeciąganie / spoczynek. */
+  highlight?: "idle" | "target" | "dragging";
+  /** Dodatkowa treść po prawej w gzymsie (np. przycisk skanu, „upuść tutaj"). */
+  headerExtra?: React.ReactNode;
+  /** Handlery drag&drop montowane na korpusie mebla. */
+  rootProps?: React.HTMLAttributes<HTMLDivElement>;
+  children: React.ReactNode;
+}
+
+/**
+ * Drewniany korpus regału (gzyms + boki + cokół) z ozdobami Mechanicus.
+ * Wnętrze („plecy" regału) trzyma przekazane grzbiety/okładki. Reużywalne przez
+ * obie półki i sekcję „Wyróżnione".
+ */
+export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highlight = "idle", headerExtra, rootProps, children }) => {
+  const a = ACCENT[accent];
+  const stateRing =
+    highlight === "target" ? `${a.ring} ${a.glow}` :
+    highlight === "dragging" ? "border-amber-400/30 border-dashed" :
+    "border-amber-950/70";
+
+  return (
+    <div
+      {...rootProps}
+      className={`relative rounded-[18px] border-2 transition-all duration-200 ${stateRing}`}
+      style={{
+        background: "linear-gradient(150deg, #3b2817 0%, #2a1c0f 45%, #1a1109 100%)",
+        boxShadow: "0 24px 40px -22px rgba(0,0,0,.85), inset 0 1px 0 rgba(255,210,150,.10)",
+      }}
+    >
+      {/* Boczne słupki + cokół tworzy padding; gzyms nakładamy górnym paddingiem */}
+      <div className="px-3 pb-4 pt-[52px] sm:px-4">
+        {/* Gzyms (cornice) */}
+        <div
+          className="absolute top-0 inset-x-0 h-[46px] rounded-t-[16px] flex items-center gap-3 px-4 overflow-hidden"
+          style={{
+            background: "linear-gradient(180deg, #4a3220 0%, #2f2012 60%, #1e140b 100%)",
+            boxShadow: "inset 0 -2px 5px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,214,160,.18)",
+          }}
+        >
+          {/* Sygil koła zębatego */}
+          <CogSigil className="w-7 h-7 shrink-0 drop-shadow-[0_1px_2px_rgba(0,0,0,.6)]" />
+          <span className={a.text}>{icon}</span>
+          <h3 className="text-sm font-display font-bold uppercase tracking-[0.22em] text-amber-100/90 whitespace-nowrap drop-shadow-[0_1px_2px_rgba(0,0,0,.7)]">
+            {title}
+          </h3>
+          <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
+          <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
+          {/* Delikatna listwa świetlna pod gzymsem */}
+          <div className="absolute bottom-0 inset-x-6 h-px bg-gradient-to-r from-transparent via-amber-300/25 to-transparent" />
+        </div>
+
+        {/* Wnętrze regału — ciemne „plecy" z pionowymi deskami */}
+        <div
+          className="relative rounded-lg p-3 pt-4"
+          style={{
+            background:
+              "repeating-linear-gradient(90deg, #140d07 0px, #140d07 26px, #0d0904 27px, #140d07 28px), radial-gradient(120% 80% at 50% 0%, rgba(0,0,0,.15), rgba(0,0,0,.6))",
+            boxShadow: "inset 0 3px 12px rgba(0,0,0,.75), inset 0 -2px 6px rgba(0,0,0,.5)",
+          }}
+        >
+          {children}
+        </div>
+      </div>
+
+      {/* Ozdoby (kwiatki) */}
+      <CornerBracket corner="tl" />
+      <CornerBracket corner="tr" />
+      <CornerBracket corner="bl" />
+      <CornerBracket corner="br" />
+      <PuritySeal className="top-[40px] right-6 z-20" rotate={-9} />
+    </div>
+  );
+};

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+/**
+ * Ozdoby regału w klimacie Adeptus Mechanicus („atrybuty z fabuły" + kwiatki):
+ * mosiężne narożniki, pieczęć czystości na wstędze, sygil koła zębatego.
+ * Czysto dekoracyjne (aria-hidden) — nie wpływają na drag&drop.
+ */
+
+type Corner = "tl" | "tr" | "bl" | "br";
+
+const CORNER_POS: Record<Corner, string> = {
+  tl: "top-1 left-1",
+  tr: "top-1 right-1 -scale-x-100",
+  bl: "bottom-1 left-1 -scale-y-100",
+  br: "bottom-1 right-1 -scale-x-100 -scale-y-100",
+};
+
+/** Mosiężny narożnik-okucie (kwiatek introligatorski). */
+export const CornerBracket: React.FC<{ corner: Corner }> = ({ corner }) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 40 40"
+    className={`absolute w-6 h-6 pointer-events-none opacity-70 ${CORNER_POS[corner]}`}
+  >
+    <defs>
+      <linearGradient id={`brass-${corner}`} x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stopColor="#f5d992" />
+        <stop offset="0.5" stopColor="#b8860b" />
+        <stop offset="1" stopColor="#6b4a08" />
+      </linearGradient>
+    </defs>
+    <path
+      d="M4 4 H22 Q4 8 8 22 V4 Z M4 4 V20 Q6 6 20 6 H4 Z"
+      fill={`url(#brass-${corner})`}
+      stroke="rgba(0,0,0,.35)"
+      strokeWidth="0.6"
+    />
+    <circle cx="12" cy="12" r="2.4" fill="#2a1c06" stroke="#e9c877" strokeWidth="0.7" />
+  </svg>
+);
+
+/** Sygil koła zębatego Mechanicus (na gzymsie). */
+export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) => (
+  <svg aria-hidden viewBox="0 0 48 48" className={className}>
+    <defs>
+      <radialGradient id="cog-brass" cx="0.4" cy="0.35" r="0.75">
+        <stop offset="0" stopColor="#ffe9b0" />
+        <stop offset="0.55" stopColor="#c8961f" />
+        <stop offset="1" stopColor="#6b4a08" />
+      </radialGradient>
+    </defs>
+    <g fill="url(#cog-brass)" stroke="rgba(0,0,0,.4)" strokeWidth="0.6">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <rect key={i} x="22.4" y="1.5" width="3.2" height="8" rx="1" transform={`rotate(${i * 36} 24 24)`} />
+      ))}
+      <circle cx="24" cy="24" r="15.5" />
+    </g>
+    <circle cx="24" cy="24" r="11" fill="#241706" stroke="#e9c877" strokeWidth="1" />
+    {/* Stylizowana czaszka Mechanicus — pół twarz, pół czacha */}
+    <circle cx="24" cy="21" r="6" fill="#d9c9a8" />
+    <circle cx="21.6" cy="21" r="1.4" fill="#241706" />
+    <circle cx="26.4" cy="21" r="1.4" fill="#241706" />
+    <rect x="22" y="25" width="4" height="4.5" rx="1" fill="#d9c9a8" />
+  </svg>
+);
+
+/** Pieczęć czystości zwisająca na wstędze (kwiatek + atrybut z fabuły). */
+export const PuritySeal: React.FC<{ className?: string; rotate?: number }> = ({ className = "", rotate = -8 }) => (
+  <div
+    aria-hidden
+    className={`absolute pointer-events-none select-none ${className}`}
+    style={{ transform: `rotate(${rotate}deg)`, transformOrigin: "top center" }}
+    title="Pieczęć czystości"
+  >
+    {/* Wstęga pergaminu */}
+    <div className="relative flex flex-col items-center">
+      <div className="w-[13px] h-9 bg-gradient-to-b from-[#e8dcc0] via-[#d8c8a2] to-[#b9a271] shadow-[0_2px_4px_rgba(0,0,0,.5)]"
+        style={{ clipPath: "polygon(0 0, 100% 0, 100% 86%, 50% 100%, 0 86%)" }} />
+      {/* Woskowa pieczęć */}
+      <div className="-mt-3 w-[22px] h-[22px] rounded-full flex items-center justify-center shadow-[0_2px_5px_rgba(0,0,0,.6),inset_0_2px_3px_rgba(255,255,255,.25)]"
+        style={{ background: "radial-gradient(circle at 35% 30%, #a83246, #6d1526 65%, #3f0a15)" }}>
+        <span className="text-[11px] leading-none text-amber-200/70 font-black" style={{ textShadow: "0 1px 1px rgba(0,0,0,.6)" }}>☼</span>
+      </div>
+    </div>
+  </div>
+);

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -48,6 +48,38 @@ export function displayTitle(book: BookIndexEntry): string {
   return book.plTitle || book.origTitle;
 }
 
+// ─── Geometria regału (deski) ─────────────────────────────────────────────
+// Rzędy grzbietów mają STAŁĄ wysokość, dzięki czemu każdy zawinięty wiersz
+// zaczyna się na tej samej wysokości i można pod nim narysować drewnianą deskę
+// jednym powtarzalnym gradientem — niezależnie od szerokości ekranu i liczby
+// książek w wierszu. `ROW_H` > najwyższy grzbiet (171 px), `GAP` mieści deskę.
+export const SHELF_ROW_H = 178;   // px — wysokość toru jednego rzędu
+export const SHELF_PLANK_H = 15;  // px — grubość widocznej deski
+export const SHELF_ROW_GAP = 30;  // px — prześwit pod rzędem (deska + cień + luz)
+
+/**
+ * Tło powtarzalne rysujące drewnianą deskę tuż pod spodem każdego rzędu grzbietów.
+ * Grzbiety są wyrównane do dołu toru `SHELF_ROW_H`, więc deska ląduje dokładnie
+ * pod nimi (w prześwicie `SHELF_ROW_GAP`). Zwraca gotowy `background` (CSS).
+ */
+export function shelfPlankBackground(): { backgroundImage: string } {
+  const top = SHELF_ROW_H;                        // górna krawędź deski (linia książek)
+  const bot = SHELF_ROW_H + SHELF_PLANK_H;        // dolna krawędź deski
+  const period = SHELF_ROW_H + SHELF_ROW_GAP;     // skok pionowy na jeden rząd
+  const backgroundImage =
+    `repeating-linear-gradient(180deg,` +
+    ` rgba(0,0,0,0) 0px,` +
+    ` rgba(0,0,0,0) ${top}px,` +
+    ` rgba(255,214,160,0.45) ${top}px,` +          // rozświetlona krawędź (blat)
+    ` #5a3a1e ${top + 1}px,` +                      // drewno — góra
+    ` #3a2413 ${top + Math.round(SHELF_PLANK_H * 0.55)}px,` +
+    ` #1c1108 ${bot - 1}px,` +                      // drewno — dół
+    ` rgba(0,0,0,0.85) ${bot}px,` +                 // cień rzucany pod deską
+    ` rgba(0,0,0,0) ${bot + 6}px,` +
+    ` rgba(0,0,0,0) ${period}px)`;
+  return { backgroundImage };
+}
+
 /** Czy pozycja ma nagrodę/nominację (do pieczęci na grzbiecie i półki „Wyróżnione"). */
 export function hasAward(book: BookIndexEntry): boolean {
   return book.awards.length > 0;


### PR DESCRIPTION
## Cel (Fixes #107)

Regał przemodelowany z płaskiego kontenera na **prawdziwy mebel**: drewniany korpus, rzędy grzbietów stojące na deskach, ozdoby w klimacie Adeptus Mechanicus, i półka „Do przeczytania" mieszcząca **wszystkie** woluminy.

### Nowe pliki
- **`src/components/shelf/ShelfFrame.tsx`** — drewniany korpus: gzyms (sygil koła zębatego + ikona + tytuł + licznik), ciemne „plecy" z pionowymi deskami, cokół, stany podświetlenia dla drop-targetu. Reużywany przez obie półki **i** sekcję „Wyróżnione".
- **`src/components/shelf/ShelfOrnaments.tsx`** — ozdoby („atrybuty z fabuły" + kwiatki): mosiężne narożniki (`CornerBracket`), sygil Mechanicus z czaszką (`CogSigil`), zwisająca pieczęć czystości na wstędze (`PuritySeal`). Czysto dekoracyjne, `aria-hidden`.

### Deski pod każdym rzędem (sedno „prawdziwego" wyglądu)
- Grzbiety siedzą w komórkach o **stałej wysokości** `SHELF_ROW_H` (178 px > najwyższy grzbiet 171). Dzięki temu każdy zawinięty wiersz flexa skacze dokładnie o `SHELF_ROW_H + SHELF_ROW_GAP`, więc jeden **powtarzalny gradient** (`shelfPlankBackground`) rysuje drewnianą deskę pod każdym rzędem — niezależnie od szerokości ekranu i liczby grzbietów w wierszu.
- Nowy testowany helper `shelfPlankBackground()` + stałe `SHELF_ROW_H/PLANK_H/ROW_GAP` w `utils/bookshelf.ts`.

### Wszystkie książki
- Zdjęty scroll-cap `max-h-[520px] overflow-y-auto` — półka **Do przeczytania** pokazuje teraz **cały** backlog naraz (bez wirtualizacji; OK dla ~700 pozycji).

### Weryfikacja
- Wyrównanie desek potwierdzone **screenshotem** (headless chromium na statycznym repro) — rzędy zawijają się swobodnie, deska zawsze ląduje pod spodem każdego rzędu.
- `npm run lint` czysty, **272/272** testy (2 nowe), `npm run build` OK.
- Zachowanie drag&drop + zapis do Notion bez zmian.
- Bump `metadata.json` → **1.16.0**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_