### PR TITLE
feat(regał): dynamiczne pozy grzbietów — przechył i leżące stosiki

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.16.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.16.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.16.1** — Dynamika póz na półce: `spinePose(book)` (deterministyczna, avalanche-mix hasza →
+  równomierny rozkład niezależny od korpusu): ~66% stoi prosto, ~27% przechylone (`lean`, 4–11°,
+  pivot u podstawy — oparte o sąsiada), ~7% leży na płask jako mały stosik (`flat`, 1–3 książki,
+  `FlatBook` z widoczną krawędzią kartek). Poza to tylko `transform`/inny render w komórce — NIE
+  rusza stałej wysokości toru, więc deski dalej się zgadzają. Drag&drop zachowany. +3 testy
+  (determinizm, zakresy, rozkład). Weryfikacja wizualna screenshotem. `docs/bookshelf.md` zaktualizowany.
 - **1.16.0** — Regał jako mebel: prawdziwy korpus `ShelfFrame` (drewniany gzyms + boki + cokół,
   ciemne „plecy" z pionowymi deskami) + ozdoby Mechanicus `ShelfOrnaments` (mosiężne narożniki,
   sygil koła zębatego z czaszką, zwisająca pieczęć czystości — dekoracyjne, `aria-hidden`).

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -30,6 +30,12 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
   every row. Rows use fixed-height cells (`SHELF_ROW_H` > tallest spine), so every wrapped line
   advances by exactly `SHELF_ROW_H + SHELF_ROW_GAP`; the gradient period matches, so a plank lands
   directly beneath each row regardless of viewport width or how many spines fit per line.
+- **`spinePose(book)`** — deterministic pose for a bit of shelf dynamism: **straight** (~66%),
+  **lean** (~27%, tilt 4–11° pivoting at the base, as if resting on a neighbour) or **flat** (~7%,
+  a small 1–3-book pile lying down, rendered by `FlatBook`). The title hash is avalanche-mixed
+  (`mix32`) before slicing so the split stays even across any title corpus (a raw rolling hash of
+  near-identical titles is skewed). The pose is a `transform`/markup change **inside** the
+  fixed-height cell, so it never disturbs the plank alignment; drag&drop is unchanged.
 
 ## 4. Drag & drop + persistence
 - Native HTML5 DnD: each `BookSpine` is `draggable` and puts its id on the dataTransfer; each `Shelf`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.16.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, spinePose, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -35,6 +35,37 @@ describe("bookshelf.spineStyle", () => {
       expect(s.height).toBeGreaterThanOrEqual(124);
       expect(s.height).toBeLessThanOrEqual(171);
     }
+  });
+});
+
+describe("bookshelf.spinePose", () => {
+  it("is deterministic for the same title", () => {
+    const a = spinePose(mk({ plTitle: "Diuna" }));
+    const b = spinePose(mk({ plTitle: "Diuna", id: "other" }));
+    expect(a).toEqual(b);
+  });
+  it("produces only valid poses within bounds", () => {
+    for (let i = 0; i < 400; i++) {
+      const p = spinePose(mk({ plTitle: `Tytuł ${i}` }));
+      if (p.kind === "lean") {
+        expect(Math.abs(p.deg)).toBeGreaterThanOrEqual(4);
+        expect(Math.abs(p.deg)).toBeLessThanOrEqual(11);
+      } else if (p.kind === "flat") {
+        expect(p.w).toBeGreaterThanOrEqual(74);
+        expect(p.w).toBeLessThanOrEqual(119);
+        expect(p.layers).toBeGreaterThanOrEqual(1);
+        expect(p.layers).toBeLessThanOrEqual(3);
+      } else {
+        expect(p.kind).toBe("straight");
+      }
+    }
+  });
+  it("keeps most books upright, with a minority leaning/flat", () => {
+    const counts = { straight: 0, lean: 0, flat: 0 } as Record<string, number>;
+    for (let i = 0; i < 600; i++) counts[spinePose(mk({ plTitle: `Vol ${i}` })).kind]++;
+    expect(counts.straight).toBeGreaterThan(counts.lean + counts.flat); // większość stoi prosto
+    expect(counts.lean).toBeGreaterThan(0);
+    expect(counts.flat).toBeGreaterThan(0);
   });
 });
 

--- a/src/components/shelf/FlatBook.tsx
+++ b/src/components/shelf/FlatBook.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { BookIndexEntry } from "../../types";
+import { SpineStyle, SpinePose, CLOTH_PALETTE, displayTitle, hasAward } from "../../utils/bookshelf";
+
+interface Props {
+  book: BookIndexEntry;
+  style: SpineStyle;             // kolor bazowy + grubość grzbietu (wysokość leżącej książki)
+  pose: Extract<SpinePose, { kind: "flat" }>;
+  onDragStart: (book: BookIndexEntry) => void;
+  onDragEnd: () => void;
+}
+
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+/**
+ * Książka (lub mały stosik książek) leżąca na płask na desce — pozioma bryła
+ * z widoczną krawędzią kartek u góry. Przeciągalna tak samo jak grzbiet.
+ */
+export const FlatBook: React.FC<Props> = ({ book, style, pose, onDragStart, onDragEnd }) => {
+  const base = hash(displayTitle(book));
+  const layerH = Math.max(14, Math.min(22, style.width));   // grubość jednej książki
+  return (
+    <div
+      draggable
+      onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
+      onDragEnd={onDragEnd}
+      title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
+      className="group relative shrink-0 cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-y-1.5 flex flex-col-reverse items-start"
+      style={{ width: pose.w }}
+    >
+      {Array.from({ length: pose.layers }).map((_, i) => {
+        const c = CLOTH_PALETTE[(base + i * 7) % CLOTH_PALETTE.length];
+        return (
+          <div
+            key={i}
+            className="relative rounded-[2px]"
+            style={{
+              height: layerH,
+              width: pose.w - i * 6,
+              marginLeft: i * 3,
+              marginBottom: i === 0 ? 0 : 1,
+              background: `linear-gradient(0deg, rgba(0,0,0,.4) 0, ${c} 26%, ${c} 74%, rgba(255,255,255,.10) 100%)`,
+              boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",
+            }}
+          >
+            {/* Krawędź kartek (fore-edge) po prawej */}
+            <span className="absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px] bg-gradient-to-b from-amber-50/70 via-amber-100/40 to-amber-50/70" aria-hidden />
+            {/* Tytuł tylko na wierzchniej książce stosu */}
+            {i === pose.layers - 1 && (
+              <span className="absolute inset-y-0 left-2 right-3 flex items-center text-[9px] font-bold text-white/85 truncate" style={{ textShadow: "0 1px 2px rgba(0,0,0,.5)" }}>
+                {displayTitle(book)}
+              </span>
+            )}
+          </div>
+        );
+      })}
+      {hasAward(book) && (
+        <span className="absolute -top-1 right-1 w-[8px] h-[8px] rounded-full bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,.85)] z-10" title="Nagroda / nominacja" />
+      )}
+    </div>
+  );
+};

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { BookIndexEntry } from "../../types";
-import { ShelfId, spineStyle, shelfPlankBackground, SHELF_ROW_H, SHELF_ROW_GAP } from "../../utils/bookshelf";
+import { ShelfId, spineStyle, spinePose, shelfPlankBackground, SHELF_ROW_H, SHELF_ROW_GAP } from "../../utils/bookshelf";
 import { BookSpine } from "./BookSpine";
+import { FlatBook } from "./FlatBook";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
 
 interface Props {
@@ -45,13 +46,26 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
           className="flex flex-wrap items-end justify-start"
           style={{ ...PLANK_BG, rowGap: `${SHELF_ROW_GAP}px`, columnGap: "5px" }}
         >
-          {books.map((b) => (
+          {books.map((b) => {
+            const pose = spinePose(b);
             // Komórka o stałej wysokości toru → wszystkie zawinięte rzędy równe,
-            // więc deska (tło) trafia dokładnie pod spód każdego z nich.
-            <div key={b.id} className="flex items-end shrink-0" style={{ height: SHELF_ROW_H }}>
-              <BookSpine book={b} style={spineStyle(b)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
-            </div>
-          ))}
+            // więc deska (tło) trafia dokładnie pod spód każdego z nich. Poza
+            // (przechył / leżenie) to tylko transform / inny render — nie rusza
+            // layoutu komórki, więc deski dalej się zgadzają.
+            return (
+              <div key={b.id} className="flex items-end shrink-0" style={{ height: SHELF_ROW_H }}>
+                {pose.kind === "flat" ? (
+                  <FlatBook book={b} style={spineStyle(b)} pose={pose} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                ) : (
+                  <div
+                    style={pose.kind === "lean" ? { transform: `rotate(${pose.deg}deg)`, transformOrigin: "bottom center" } : undefined}
+                  >
+                    <BookSpine book={b} style={spineStyle(b)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </ShelfFrame>

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -43,6 +43,43 @@ export function spineStyle(book: BookIndexEntry): SpineStyle {
   };
 }
 
+/**
+ * Poza grzbietu na półce — deterministyczna (z hasza tytułu), by regał miał
+ * trochę dynamiki, ale nie migotał przy re-renderze / zawijaniu wierszy.
+ * - `straight` — stoi prosto (większość),
+ * - `lean` — przechylony o `deg` stopni, jakby oparty o sąsiada (pivot u podstawy),
+ * - `flat` — leży na płask jako mały stosik (`layers` książek, szerokość `w`).
+ */
+export type SpinePose =
+  | { kind: "straight" }
+  | { kind: "lean"; deg: number }
+  | { kind: "flat"; w: number; layers: number };
+
+/** Avalanche-mix (xxHash-style) — rozprasza bity, by rozkład póz był równomierny
+ *  niezależnie od korpusu tytułów (goły rolling-hash sąsiednich napisów jest skośny). */
+function mix32(n: number): number {
+  let x = n >>> 0;
+  x ^= x >>> 16; x = Math.imul(x, 0x7feb352d);
+  x ^= x >>> 15; x = Math.imul(x, 0x846ca68b);
+  x ^= x >>> 16;
+  return x >>> 0;
+}
+
+export function spinePose(book: BookIndexEntry): SpinePose {
+  const x = mix32(hash(book.plTitle || book.origTitle || book.id));
+  const sel = x % 100;                          // ~66% prosto, ~27% przechył, ~7% leżą
+  if (sel < 66) return { kind: "straight" };
+  if (sel < 93) {
+    const mag = 4 + ((x >>> 13) % 8);          // 4–11°
+    return { kind: "lean", deg: (x >>> 3) & 1 ? mag : -mag };
+  }
+  return {
+    kind: "flat",
+    w: 74 + ((x >>> 17) % 46),                 // 74–119 px (szerokość leżącej książki)
+    layers: 1 + ((x >>> 23) % 3),              // 1–3 książki w stosiku
+  };
+}
+
 /** Tytuł do pokazania (polski, a gdy brak — oryginalny). */
 export function displayTitle(book: BookIndexEntry): string {
   return book.plTitle || book.origTitle;


### PR DESCRIPTION
## Cel (Fixes #109)

Grzbiety stały idealnie prosto (sztywno). Teraz każda książka dostaje **deterministyczną** (stabilną per tytuł, bez migotania) pozę, żeby regał ożył.

### Pozy (`spinePose` w `utils/bookshelf.ts`)
- **`straight`** (~66%) — stoi prosto.
- **`lean`** (~27%) — przechył 4–11°, pivot u podstawy (jakby oparta o sąsiada; przy krawędziach nachodzi na sąsiedni grzbiet — pożądany efekt).
- **`flat`** (~7%) — leży na płask jako mały stosik 1–3 książek (nowy `FlatBook` z widoczną krawędzią kartek).

Hasz tytułu jest **avalanche-miksowany** (`mix32`) przed cięciem na bity — bez tego goły rolling-hash sąsiednich tytułów jest skośny i wychodziło ~50/50 zamiast „większość prosto".

### Dlaczego nie psuje desek ani drag&drop
Poza to wyłącznie `transform` (lean) albo inny markup (flat) **wewnątrz** komórki o stałej wysokości `SHELF_ROW_H`. Transform nie zmienia layoutu, więc każdy zawinięty wiersz dalej skacze o `ROW_H+GAP` i deska (tło) trafia pod rząd. `FlatBook` i `BookSpine` są tak samo `draggable`.

### Weryfikacja
- **Screenshot** (headless chromium, statyczne repro): część prosto, część przechylona, gdzieniegdzie leżące stosiki; deski dalej wyrównane.
- `npm run lint` czysty, **275/275** testów (3 nowe: determinizm, zakresy, rozkład), `npm run build` OK.
- Bump `metadata.json` → **1.16.1**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_