### PR TITLE
feat(regał): większe stosiki leżących + reguła braku nachodzenia grzbietów

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.16.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.16.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.16.2** — Pozy: więcej książek w stosiku (`flat` layers **3–5**, było 1–3) + **reguła: żadna
+  książka nie nachodzi na drugą**. Nowy helper `spineLayout(style, pose)` — komórka rezerwuje
+  szerokość obróconego grzbietu (`cellW = W·cosθ + H·sinθ`) i przesuwa go (`shiftX`), by bbox był
+  wyśrodkowany; przechylony wolumin zostaje w swoim torze (między komórkami `column-gap`). +2 testy
+  (containment 4 narożników, footprint prosto/flat). Weryfikacja screenshotem. `docs/bookshelf.md` upd.
 - **1.16.1** — Dynamika póz na półce: `spinePose(book)` (deterministyczna, avalanche-mix hasza →
   równomierny rozkład niezależny od korpusu): ~66% stoi prosto, ~27% przechylone (`lean`, 4–11°,
   pivot u podstawy — oparte o sąsiada), ~7% leży na płask jako mały stosik (`flat`, 1–3 książki,

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -31,11 +31,16 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
   advances by exactly `SHELF_ROW_H + SHELF_ROW_GAP`; the gradient period matches, so a plank lands
   directly beneath each row regardless of viewport width or how many spines fit per line.
 - **`spinePose(book)`** — deterministic pose for a bit of shelf dynamism: **straight** (~66%),
-  **lean** (~27%, tilt 4–11° pivoting at the base, as if resting on a neighbour) or **flat** (~7%,
-  a small 1–3-book pile lying down, rendered by `FlatBook`). The title hash is avalanche-mixed
-  (`mix32`) before slicing so the split stays even across any title corpus (a raw rolling hash of
-  near-identical titles is skewed). The pose is a `transform`/markup change **inside** the
-  fixed-height cell, so it never disturbs the plank alignment; drag&drop is unchanged.
+  **lean** (~27%, tilt 4–11° pivoting at the base) or **flat** (~7%, a small **3–5**-book pile lying
+  down, rendered by `FlatBook`). The title hash is avalanche-mixed (`mix32`) before slicing so the
+  split stays even across any title corpus (a raw rolling hash of near-identical titles is skewed).
+  The pose is a `transform`/markup change **inside** the fixed-height cell, so it never disturbs the
+  plank alignment; drag&drop is unchanged.
+- **`spineLayout(style, pose)`** — enforces the **no-overlap rule**: each cell reserves the width of
+  the *rotated* spine (`cellW = W·cosθ + H·sinθ`) and offsets it (`shiftX`) so the rotated bounding
+  box is centred in the cell. A leaning volume therefore stays inside its own track and never crosses
+  into a neighbour (the `column-gap` between cells is preserved). Straight/flat cells reserve exactly
+  their footprint. Unit-tested by checking all four rotated corners fall within `±cellW/2`.
 
 ## 4. Drag & drop + persistence
 - Native HTML5 DnD: each `BookSpine` is `draggable` and puts its id on the dataTransfer; each `Shelf`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.16.1",
+  "version": "1.16.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, spinePose, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, spinePose, spineLayout, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -53,8 +53,8 @@ describe("bookshelf.spinePose", () => {
       } else if (p.kind === "flat") {
         expect(p.w).toBeGreaterThanOrEqual(74);
         expect(p.w).toBeLessThanOrEqual(119);
-        expect(p.layers).toBeGreaterThanOrEqual(1);
-        expect(p.layers).toBeLessThanOrEqual(3);
+        expect(p.layers).toBeGreaterThanOrEqual(3);
+        expect(p.layers).toBeLessThanOrEqual(5);
       } else {
         expect(p.kind).toBe("straight");
       }
@@ -66,6 +66,40 @@ describe("bookshelf.spinePose", () => {
     expect(counts.straight).toBeGreaterThan(counts.lean + counts.flat); // większość stoi prosto
     expect(counts.lean).toBeGreaterThan(0);
     expect(counts.flat).toBeGreaterThan(0);
+  });
+});
+
+describe("bookshelf.spineLayout (reguła: brak nachodzenia)", () => {
+  // Obrócony prostokąt W×H o kąt θ ma bbox szerokości W·cosθ + H·sinθ; komórka
+  // musi go w całości mieścić, wyśrodkowanego (shiftX), by nie wchodził na sąsiada.
+  it("reserves at least the rotated bounding box and centers it", () => {
+    for (let i = 0; i < 400; i++) {
+      const b = mk({ plTitle: `Tom ${i}` });
+      const style = spineStyle(b);
+      const pose = spinePose(b);
+      const { cellW, shiftX, rotate } = spineLayout(style, pose);
+      if (pose.kind === "lean") {
+        const a = (rotate * Math.PI) / 180;
+        const bbox = style.width * Math.abs(Math.cos(a)) + style.height * Math.abs(Math.sin(a));
+        expect(cellW).toBeGreaterThanOrEqual(bbox);      // komórka mieści cały obrót
+        // Cztery narożniki grzbietu obrócone jak w CSS (pivot u dołu, wierzch w y=−H),
+        // przesunięte o shiftX — wszystkie muszą zostać w [−cellW/2, cellW/2].
+        const W = style.width, H = style.height;
+        const corners = [[-W / 2, 0], [W / 2, 0], [-W / 2, -H], [W / 2, -H]]
+          .map(([x, y]) => x * Math.cos(a) - y * Math.sin(a) + shiftX);
+        expect(Math.max(...corners)).toBeLessThanOrEqual(cellW / 2 + 1e-6);
+        expect(Math.min(...corners)).toBeGreaterThanOrEqual(-cellW / 2 - 1e-6);
+        expect(Math.sign(shiftX)).toBe(-Math.sign(rotate)); // przesuw w stronę przeciwną do przechyłu
+      } else {
+        expect(shiftX).toBe(0);
+        expect(rotate).toBe(0);
+      }
+    }
+  });
+  it("straight/flat cells reserve exactly their footprint", () => {
+    const straight = mk({ plTitle: "Prosto stojąca" });
+    const sp = spinePose(straight);
+    if (sp.kind === "straight") expect(spineLayout(spineStyle(straight), sp).cellW).toBe(spineStyle(straight).width);
   });
 });
 

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { BookIndexEntry } from "../../types";
-import { ShelfId, spineStyle, spinePose, shelfPlankBackground, SHELF_ROW_H, SHELF_ROW_GAP } from "../../utils/bookshelf";
+import { ShelfId, spineStyle, spinePose, spineLayout, shelfPlankBackground, SHELF_ROW_H, SHELF_ROW_GAP } from "../../utils/bookshelf";
 import { BookSpine } from "./BookSpine";
 import { FlatBook } from "./FlatBook";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
@@ -47,20 +47,23 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
           style={{ ...PLANK_BG, rowGap: `${SHELF_ROW_GAP}px`, columnGap: "5px" }}
         >
           {books.map((b) => {
+            const style = spineStyle(b);
             const pose = spinePose(b);
-            // Komórka o stałej wysokości toru → wszystkie zawinięte rzędy równe,
-            // więc deska (tło) trafia dokładnie pod spód każdego z nich. Poza
-            // (przechył / leżenie) to tylko transform / inny render — nie rusza
-            // layoutu komórki, więc deski dalej się zgadzają.
+            const layout = spineLayout(style, pose);
+            // Komórka ma stałą wysokość toru (deski się zgadzają) i szerokość
+            // `cellW` = szerokość obróconego grzbietu, więc przechylona książka
+            // mieści się w swoim torze i NIE nachodzi na sąsiada.
             return (
-              <div key={b.id} className="flex items-end shrink-0" style={{ height: SHELF_ROW_H }}>
+              <div key={b.id} className="flex items-end justify-center shrink-0" style={{ height: SHELF_ROW_H, width: layout.cellW }}>
                 {pose.kind === "flat" ? (
-                  <FlatBook book={b} style={spineStyle(b)} pose={pose} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                  <FlatBook book={b} style={style} pose={pose} onDragStart={onDragStart} onDragEnd={onDragEnd} />
                 ) : (
                   <div
-                    style={pose.kind === "lean" ? { transform: `rotate(${pose.deg}deg)`, transformOrigin: "bottom center" } : undefined}
+                    style={pose.kind === "lean"
+                      ? { transform: `translateX(${layout.shiftX}px) rotate(${layout.rotate}deg)`, transformOrigin: "bottom center" }
+                      : undefined}
                   >
-                    <BookSpine book={b} style={spineStyle(b)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                    <BookSpine book={b} style={style} onDragStart={onDragStart} onDragEnd={onDragEnd} />
                   </div>
                 )}
               </div>

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -76,8 +76,32 @@ export function spinePose(book: BookIndexEntry): SpinePose {
   return {
     kind: "flat",
     w: 74 + ((x >>> 17) % 46),                 // 74–119 px (szerokość leżącej książki)
-    layers: 1 + ((x >>> 23) % 3),              // 1–3 książki w stosiku
+    layers: 3 + ((x >>> 23) % 3),              // 3–5 książek w stosiku
   };
+}
+
+/**
+ * Layout komórki grzbietu na półce. Reguła: **żadna książka nie nachodzi na drugą** —
+ * komórka rezerwuje dokładnie tyle szerokości, ile zajmuje obrócony grzbiet
+ * (`cellW`), a `shiftX` przesuwa go tak, by obrócony prostokąt był wyśrodkowany
+ * w komórce. Dzięki temu przechylony wolumin mieści się w swoim torze i nie
+ * dotyka sąsiadów (między komórkami zostaje `column-gap`).
+ */
+export interface SpineLayout {
+  cellW: number;   // szerokość komórki (flex-item), px
+  shiftX: number;  // przesunięcie poziome grzbietu, px (centrowanie obróconego bboxa)
+  rotate: number;  // kąt obrotu, ° (0 = prosto)
+}
+
+export function spineLayout(style: SpineStyle, pose: SpinePose): SpineLayout {
+  if (pose.kind === "flat") return { cellW: pose.w, shiftX: 0, rotate: 0 };
+  if (pose.kind === "lean") {
+    const rad = (Math.abs(pose.deg) * Math.PI) / 180;
+    const cellW = Math.ceil(style.width * Math.cos(rad) + style.height * Math.sin(rad)) + 1;
+    const shiftX = -Math.sign(pose.deg) * (style.height * Math.sin(rad)) / 2;
+    return { cellW, shiftX, rotate: pose.deg };
+  }
+  return { cellW: style.width, shiftX: 0, rotate: 0 };
 }
 
 /** Tytuł do pokazania (polski, a gdy brak — oryginalny). */


### PR DESCRIPTION
## Cel (Fixes #111)

1. **Leżących więcej na każdej kupce** — `flat.layers` z **1–3 → 3–5**.
2. **Reguła: żadna książka nie nachodzi na drugą** — przechylone grzbiety zostają w swoim torze.

### Jak działa no-overlap
Nowy pure helper **`spineLayout(style, pose)`** (`utils/bookshelf.ts`):
- `cellW = ⌈W·cosθ + H·sinθ⌉` — komórka flexa rezerwuje szerokość **obróconego** grzbitu (a nie tylko jego pionowej szerokości);
- `shiftX = −sign(θ)·(H·sinθ)/2` — przesuwa grzbiet tak, by obrócony bounding-box był **wyśrodkowany** w komórce (inaczej wierzchołek wychodziłby jedną stroną poza tor).

Skoro każdy grzbiet mieści się w swojej komórce, a między komórkami zostaje `column-gap` (5 px), **sąsiednie książki nigdy się nie stykają**. Wysokość toru (`SHELF_ROW_H`) bez zmian → deski dalej trafiają pod każdy rząd. `FlatBook`/`BookSpine` nadal `draggable`.

### Weryfikacja
- **Test**: dla 400 tytułów wszystkie 4 obrócone narożniki grzbietu mieszczą się w `±cellW/2` (containment), + footprint prosto/flat.
- **Screenshot** (headless chromium): wyższe stosiki (5–6 książek), przechylone woluminy mają własną przestrzeń i nie wchodzą na sąsiadów; deski wyrównane.
- `npm run lint` czysty, **277/277** testów (2 nowe), `npm run build` OK.
- Bump `metadata.json` → **1.16.2**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_