### PR TITLE
feat(regał): zawijaj tytuł leżącej książki do 2 linii zamiast poszerzania

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.16.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.16.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.16.5** — Leżące książki: **zawijanie tytułu do 2 linii zamiast poszerzania**. `flatBookLayout`
+  ma limit szerokości `FLAT_MAX_W=150`: krótki tytuł → 1 linia (książka na tekst), dłuższy → 2 linie
+  (książka trochę grubsza, nie szersza; `lines` w zwrotce). Bardzo długi → dodatkowo mniejsza czcionka,
+  aż połowa mieści się w linii (2 linie zawsze wystarczą, brak ucinania). `BookStack` renderuje tytuł
+  przez `-webkit-line-clamp`. +test (short=1 linia, long=2 linie i width=cap, grubszy). Screenshot OK.
 - **1.16.4** — Większe kupki (`planShelf` stack **4–7** realnych książek, było 2–4) + **pełne nazwy
   na każdej książce** (bez ucinania). `spineFontSize(style,title)` dobiera czcionkę stojącego
   grzbietu (6–11 px) tak, by cały tytuł zmieścił się na wysokości; `flatBookLayout(book,style)` dobiera

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -39,8 +39,10 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
   are `transform`/markup **inside** the fixed-height cell, so plank alignment and drag&drop are untouched.
 - **`spineFontSize(style, title)` / `flatBookLayout(book, style)`** — size every book to show its
   **full name** (no truncation). A standing spine picks a font (6–11 px) so the whole title fits along
-  its height; a lying book picks font + width + thickness so the full title fits horizontally (wider
-  book for a longer title, smaller font only when very long; thickness 15–18 px).
+  its height. A lying book is capped at `FLAT_MAX_W` (150 px): a short title stays one line, a longer
+  one **wraps to two lines** (the book gets a touch thicker, not wider — `lines` in the return);
+  a very long title also shrinks the font until half fits on a line (two lines always suffice).
+  `BookStack` renders the title with `-webkit-line-clamp`.
 - **`leanLayout(style, deg)`** — enforces the **no-overlap rule** for a tilted spine: the cell
   reserves the *rotated* width (`cellW = W·cosθ + H·sinθ`) and offsets it (`shiftX`) so the rotated
   box is centred, keeping the volume inside its own track (the `column-gap` between cells is

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.16.4",
+      "version": "1.16.5",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.16.4",
+  "version": "1.16.5",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, spineFontSize, flatBookLayout, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, spineFontSize, flatBookLayout, FLAT_MAX_W, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -115,15 +115,25 @@ describe("bookshelf.title sizing (pełne nazwy)", () => {
       expect(f).toBeLessThanOrEqual(11);
     }
   });
-  it("flatBookLayout reserves enough width for the full title (no clipping)", () => {
-    for (const title of ["Ubik", "Diuna", "Hyperion i jego długa, rozwlekła kontynuacja opowieści"]) {
-      const { width, fontSize, thickness } = flatBookLayout({ ...mk({ plTitle: title }) }, style);
-      // szerokość mieści oszacowany tekst (0.6·len·font) + margines:
-      expect(width).toBeGreaterThanOrEqual(Math.ceil(title.length * 0.6 * fontSize));
-      expect(fontSize).toBeGreaterThanOrEqual(7);
-      expect(fontSize).toBeLessThanOrEqual(11);
-      expect(thickness).toBeGreaterThanOrEqual(15);
-      expect(thickness).toBeLessThanOrEqual(24);
+  it("flatBookLayout wraps long titles to 2 lines instead of widening past the cap", () => {
+    const short = flatBookLayout(mk({ plTitle: "Ubik" }), style);
+    expect(short.lines).toBe(1);
+    expect(short.width).toBeLessThanOrEqual(FLAT_MAX_W);
+
+    const long = flatBookLayout(mk({ plTitle: "Hyperion i jego długa, rozwlekła kontynuacja opowieści" }), style);
+    expect(long.lines).toBe(2);                 // zawija, nie poszerza
+    expect(long.width).toBe(FLAT_MAX_W);        // szerokość zaczepiona na limicie
+    expect(long.thickness).toBeGreaterThan(short.thickness); // 2 linie → trochę grubsza
+
+    for (const l of [short, long]) {
+      expect(l.width).toBeLessThanOrEqual(FLAT_MAX_W);
+      expect(l.fontSize).toBeGreaterThanOrEqual(7);
+      expect(l.fontSize).toBeLessThanOrEqual(10);
+      expect(l.thickness).toBeGreaterThanOrEqual(15);
+      expect(l.thickness).toBeLessThanOrEqual(24);
+      // 2 linie muszą wystarczyć na pełny tytuł: połowa tekstu mieści się w linii
+      const availW = FLAT_MAX_W - 20;
+      expect(Math.ceil((l === long ? "Hyperion i jego długa, rozwlekła kontynuacja opowieści".length : 4) * 0.6 * l.fontSize / l.lines)).toBeLessThanOrEqual(availW);
     }
   });
 });

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -24,14 +24,14 @@ function jitter(book: BookIndexEntry): number {
 export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) => {
   const layers = books.map((b) => {
     const style = spineStyle(b);
-    const { width, fontSize, thickness } = flatBookLayout(b, style);
-    return { book: b, width, fontSize, thickness, color: style.color, dx: jitter(b) };
+    const { width, fontSize, thickness, lines } = flatBookLayout(b, style);
+    return { book: b, width, fontSize, thickness, lines, color: style.color, dx: jitter(b) };
   });
   const cellW = Math.max(...layers.map((l) => l.width + l.dx));
 
   return (
     <div className="relative shrink-0 flex flex-col-reverse items-start" style={{ width: cellW }}>
-      {layers.map(({ book, width, fontSize, thickness, color, dx }, i) => (
+      {layers.map(({ book, width, fontSize, thickness, lines, color, dx }, i) => (
         <div
           key={book.id}
           draggable
@@ -50,12 +50,24 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
         >
           {/* Krawędź kartek (fore-edge) po prawej */}
           <span className="absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px] bg-gradient-to-b from-amber-50/70 via-amber-100/40 to-amber-50/70" aria-hidden />
-          {/* PEŁNY tytuł wzdłuż grzbietu (bez ucinania) */}
+          {/* PEŁNY tytuł wzdłuż grzbietu — zawijany do max 2 linii zamiast poszerzania */}
           <span
-            className={`absolute inset-y-0 right-3 flex items-center font-bold text-white/90 whitespace-nowrap ${hasAward(book) ? "left-3.5" : "left-2"}`}
-            style={{ fontSize, textShadow: "0 1px 2px rgba(0,0,0,.55)" }}
+            className={`absolute inset-y-0 right-3 flex items-center font-bold text-white/90 ${hasAward(book) ? "left-3.5" : "left-2"}`}
           >
-            {displayTitle(book)}
+            <span
+              style={{
+                fontSize,
+                lineHeight: 1.08,
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: lines,
+                overflow: "hidden",
+                whiteSpace: lines === 1 ? "nowrap" : "normal",
+                textShadow: "0 1px 2px rgba(0,0,0,.55)",
+              }}
+            >
+              {displayTitle(book)}
+            </span>
           </span>
           {hasAward(book) && (
             <span className="absolute top-1/2 -translate-y-1/2 left-1 w-[7px] h-[7px] rounded-full bg-amber-400 shadow-[0_0_5px_rgba(251,191,36,.85)]" title="Nagroda / nominacja" />

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -130,24 +130,37 @@ export function spineFontSize(style: SpineStyle, title: string): number {
 }
 
 /** Wymiary LEŻĄCEJ książki tak, by cała nazwa się zmieściła (pozioma, wzdłuż grzbietu). */
-export interface FlatBookLayout { width: number; fontSize: number; thickness: number; }
+export interface FlatBookLayout { width: number; fontSize: number; thickness: number; lines: 1 | 2 }
+
+/** Górny limit szerokości leżącej książki — powyżej niego tytuł ZAWIJAMY do 2 linii. */
+export const FLAT_MAX_W = 150;
 
 /**
- * Dobiera szerokość, czcionkę i grubość leżącej książki tak, by zmieścić PEŁNY
- * tytuł: najpierw próbuje dużej czcionki, przy długich tytułach schodzi do 7 px
- * (i wtedy poszerza), a grubość rośnie lekko z czcionką (grubsza książka mieści
- * większy napis). Nic nie jest ucinane.
+ * Dobiera szerokość, czcionkę, grubość i liczbę linii leżącej książki tak, by
+ * zmieścić PEŁNY tytuł BEZ poszerzania ponad `FLAT_MAX_W`: krótki tytuł → 1 linia
+ * (książka dokładnie na tekst), dłuższy → 2 linie (książka trochę grubsza, nie
+ * szersza). Bardzo długi tytuł dodatkowo zmniejsza czcionkę, aż połowa zmieści
+ * się w jednej linii (2 linie zawsze wystarczą). Nic nie jest ucinane.
  */
-export function flatBookLayout(book: BookIndexEntry, style: SpineStyle): FlatBookLayout {
+export function flatBookLayout(book: BookIndexEntry, _style: SpineStyle): FlatBookLayout {
   const len = Math.max(1, displayTitle(book).length);
-  const PAD = 22;        // lewy margines tekstu + prawa krawędź kartek/nagroda
-  const MAX_W = 240;     // powyżej tej szerokości wolimy zmniejszyć czcionkę
-  const textW = (f: number) => Math.ceil(len * CHAR_W * f);
-  let fontSize = 11;
-  while (fontSize > 7 && textW(fontSize) + PAD > MAX_W) fontSize--;
-  const width = Math.max(72, textW(fontSize) + PAD);
-  const thickness = Math.min(24, Math.max(15, fontSize + 7));
-  return { width, fontSize, thickness };
+  const PAD_X = 20;                       // lewy margines tekstu + prawa krawędź kartek
+  const availW = FLAT_MAX_W - PAD_X;
+  const oneLine = (f: number) => len * CHAR_W * f;
+
+  let fontSize = 10;
+  let lines: 1 | 2 = 1;
+  let width: number;
+  if (oneLine(fontSize) <= availW) {
+    width = Math.max(72, Math.ceil(oneLine(fontSize)) + PAD_X);
+  } else {
+    lines = 2;
+    width = FLAT_MAX_W;
+    while (fontSize > 7 && Math.ceil(oneLine(fontSize) / 2) > availW) fontSize--;
+  }
+  const lineH = fontSize + 1;
+  const thickness = Math.min(24, Math.max(15, lines * lineH + 4));
+  return { width, fontSize, thickness, lines };
 }
 
 /** Tytuł do pokazania (polski, a gdy brak — oryginalny). */


### PR DESCRIPTION
## Cel (Fixes #117)

Po #115 długie tytuły robiły bardzo szerokie leżące książki. Teraz tytuł **zawija się do 2 linii** — książka jest trochę grubsza, ale nie szersza.

### Zmiany
- **`flatBookLayout`** ma limit `FLAT_MAX_W = 150 px`:
  - krótki tytuł → **1 linia** (książka dokładnie na tekst, ≤ limit),
  - dłuższy → **2 linie** (szerokość = limit, grubość rośnie o jedną linię, `lines` w zwrotce),
  - bardzo długi → dodatkowo mniejsza czcionka, aż połowa tytułu mieści się w jednej linii (2 linie zawsze wystarczą → brak ucinania).
- **`BookStack`** renderuje tytuł przez `-webkit-line-clamp` (1 lub 2 linie).

Grubość dalej ≤ 24 px, więc kupka 4–7 książek mieści się w wysokości toru (`SHELF_ROW_H`) → deski wyrównane; drag&drop i reguła braku nachodzenia bez zmian.

### Weryfikacja
- **Test**: krótki tytuł → `lines===1`; długi → `lines===2`, `width===FLAT_MAX_W`, grubszy niż krótki; połowa tekstu mieści się w linii.
- **Screenshot** (headless chromium): „Nawiedziny w domu na wzgórzu", „Opowieści z meekhańskiego pogranicza. Północ-Południe", „Blade Runner: Czy androidy śnią…" zawijają się do 2 linii w węższych książkach; krótkie tytuły 1 linia; deski wyrównane.
- `npm run lint` czysty, **280/280** testów, `npm run build` OK.
- Bump `metadata.json` → **1.16.5**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_