### PR TITLE
feat(regał): kupki — piramidka, sąsiedzi ku kupce, brak sąsiednich kupek

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.16.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.16.6** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.16.6** — Kupki dopracowane (3 reguły): (1) **sortowanie od największej na dole do najmniejszej
+  na górze** — `BookStack` sortuje warstwy malejąco po szerokości (piramidka, wyśrodkowana, bez
+  jittera); (2) **grzbiety sąsiadujące z kupką przechylają się w jej stronę** — `planShelf` nadpisuje
+  pozę sąsiadów (`LEAN_TOWARD=5`; lewy w prawo, prawy w lewo); (3) **dwie kupki nigdy nie sąsiadują**
+  — po kupce następny slot to zawsze grzbiet (zablokowana kupka → prosto). +2 testy (brak sąsiednich
+  kupek, sąsiedzi pochyleni ku kupce). Screenshot OK. `docs/bookshelf.md` upd.
 - **1.16.5** — Leżące książki: **zawijanie tytułu do 2 linii zamiast poszerzania**. `flatBookLayout`
   ma limit szerokości `FLAT_MAX_W=150`: krótki tytuł → 1 linia (książka na tekst), dłuższy → 2 linie
   (książka trochę grubsza, nie szersza; `lines` w zwrotce). Bardzo długi → dodatkowo mniejsza czcionka,

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -37,6 +37,10 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
   A stack holds **4–7** consecutive volumes. The per-book decision uses the avalanche-mixed (`mix32`)
   title hash so the split stays even across any corpus; every book lands in exactly one slot. Poses
   are `transform`/markup **inside** the fixed-height cell, so plank alignment and drag&drop are untouched.
+  Two stack rules: **no two stacks are ever adjacent** (a stack is always followed by a spine), and a
+  stack's neighbouring spines **lean toward the stack** (`LEAN_TOWARD` — left neighbour tilts right,
+  right neighbour tilts left). Inside a stack, `BookStack` sorts layers **largest at the bottom,
+  smallest at the top** (a centred pyramid).
 - **`spineFontSize(style, title)` / `flatBookLayout(book, style)`** — size every book to show its
   **full name** (no truncation). A standing spine picks a font (6–11 px) so the whole title fits along
   its height. A lying book is capped at `FLAT_MAX_W` (150 px): a short title stays one line, a longer

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.16.5",
+      "version": "1.16.6",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.16.5",
+  "version": "1.16.6",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, spineFontSize, flatBookLayout, FLAT_MAX_W, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -77,6 +77,33 @@ describe("bookshelf.planShelf", () => {
         expect(Math.abs(s.lean)).toBeLessThanOrEqual(MAX_LEAN_DEG);
       }
     }
+  });
+
+  it("never places two stacks next to each other", () => {
+    const slots = planShelf(shelf);
+    for (let k = 1; k < slots.length; k++) {
+      expect(slots[k].kind === "stack" && slots[k - 1].kind === "stack").toBe(false);
+    }
+    expect(slots.some((s) => s.kind === "stack")).toBe(true); // a jakieś kupki są
+  });
+
+  it("leans a stack's neighbours toward the stack (left → +, right → −)", () => {
+    const slots = planShelf(shelf);
+    let checked = 0;
+    for (let k = 0; k < slots.length; k++) {
+      if (slots[k].kind !== "stack") continue;
+      const left = slots[k - 1], right = slots[k + 1];
+      if (left && left.kind === "spine") {
+        expect(Math.abs(left.lean)).toBe(LEAN_TOWARD); checked++;
+        // kierunek pewny tylko gdy grzbiet nie jest wciśnięty między dwie kupki
+        if (slots[k - 2]?.kind !== "stack") expect(left.lean).toBe(LEAN_TOWARD);
+      }
+      if (right && right.kind === "spine") {
+        expect(Math.abs(right.lean)).toBe(LEAN_TOWARD); checked++;
+        if (slots[k + 2]?.kind !== "stack") expect(right.lean).toBe(-LEAN_TOWARD);
+      }
+    }
+    expect(checked).toBeGreaterThan(0);
   });
 });
 

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -8,41 +8,38 @@ interface Props {
   onDragEnd: () => void;
 }
 
-/** Deterministyczny drobny „luz" ułożenia warstwy (0–4 px), z tytułu. */
-function jitter(book: BookIndexEntry): number {
-  let h = 0;
-  const s = displayTitle(book) || book.id;
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
-  return (h >>> 9) % 5;
-}
-
 /**
- * Kupka leżących książek — każda warstwa to osobny wolumin z PEŁNĄ nazwą wzdłuż
- * grzbietu (dobrany rozmiar czcionki / szerokość / grubość, bez ucinania),
- * własnym kolorem, znacznikiem nagrody i przeciąganiem. Renderowane od dołu do góry.
+ * Kupka leżących książek — każda warstwa to osobny wolumin z PEŁNĄ nazwą (max 2
+ * linie). Posortowana **od największej na dole do najmniejszej na górze**
+ * (piramidka), wyśrodkowana. Każda warstwa ma własny kolor, znacznik nagrody
+ * i przeciąganie.
  */
 export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) => {
-  const layers = books.map((b) => {
-    const style = spineStyle(b);
-    const { width, fontSize, thickness, lines } = flatBookLayout(b, style);
-    return { book: b, width, fontSize, thickness, lines, color: style.color, dx: jitter(b) };
-  });
-  const cellW = Math.max(...layers.map((l) => l.width + l.dx));
+  const layers = books
+    .map((b) => {
+      const style = spineStyle(b);
+      const { width, fontSize, thickness, lines } = flatBookLayout(b, style);
+      return { book: b, width, fontSize, thickness, lines, color: style.color };
+    })
+    // największa (najszersza, przy remisie grubsza) na SPÓD; `flex-col-reverse`
+    // renderuje pierwszy element na dole → sortujemy malejąco.
+    .sort((a, b) => b.width - a.width || b.thickness - a.thickness || a.book.id.localeCompare(b.book.id));
+
+  const cellW = Math.max(...layers.map((l) => l.width));
 
   return (
-    <div className="relative shrink-0 flex flex-col-reverse items-start" style={{ width: cellW }}>
-      {layers.map(({ book, width, fontSize, thickness, lines, color, dx }, i) => (
+    <div className="relative shrink-0 flex flex-col-reverse items-center" style={{ width: cellW }}>
+      {layers.map(({ book, width, fontSize, thickness, lines, color }, i) => (
         <div
           key={book.id}
           draggable
           onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
           onDragEnd={onDragEnd}
           title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
-          className="group/layer relative rounded-[2px] cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-x-1"
+          className="group/layer relative rounded-[2px] cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-y-0.5"
           style={{
             height: thickness,
             width,
-            marginLeft: dx,
             marginBottom: i === 0 ? 0 : 1,
             background: `linear-gradient(0deg, rgba(0,0,0,.42) 0, ${color} 26%, ${color} 74%, rgba(255,255,255,.12) 100%)`,
             boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -74,26 +74,48 @@ export const MAX_LEAN_DEG = 6;
  * Planuje sloty dla posortowanej listy woluminów. Decyzja per książka jest
  * deterministyczna (hasz tytułu); kupkę tworzy kilka KOLEJNYCH prawdziwych
  * książek (starter „pożera" następne). ~80 % stoi prosto, ~12 % lekko przechylone,
- * reszta ląduje w kupkach po 2–4 realne woluminy.
+ * reszta ląduje w kupkach po 4–7 realnych woluminów.
+ *
+ * Reguły ułożenia:
+ * - **dwie kupki nigdy nie sąsiadują** (po kupce następny slot to zawsze grzbiet),
+ * - **grzbiety sąsiadujące z kupką przechylają się w jej stronę** (`LEAN_TOWARD`).
  */
+export const LEAN_TOWARD = 5;
+
 export function planShelf(books: BookIndexEntry[]): ShelfSlot[] {
   const slots: ShelfSlot[] = [];
+  let prevWasStack = false;
   for (let i = 0; i < books.length; ) {
     const b = books[i];
     const x = seed(b);
     const sel = x % 100;
-    if (sel < 80 || books.length - i < 2) {
-      slots.push({ kind: "spine", book: b, lean: 0 });
-      i += 1;
-    } else if (sel < 92) {
-      const mag = 3 + ((x >>> 13) % (MAX_LEAN_DEG - 2)); // 3–6°
-      slots.push({ kind: "spine", book: b, lean: (x >>> 3) & 1 ? mag : -mag });
-      i += 1;
-    } else {
+    // Kupka tylko gdy: los trafił, są ≥2 książki i poprzedni slot NIE był kupką.
+    if (sel >= 92 && books.length - i >= 2 && !prevWasStack) {
       const size = Math.min(4 + ((x >>> 17) % 4), books.length - i); // 4–7 realnych książek
       slots.push({ kind: "stack", books: books.slice(i, i + size) });
       i += size;
+      prevWasStack = true;
+    } else if (sel >= 80 && sel < 92) {
+      const mag = 3 + ((x >>> 13) % (MAX_LEAN_DEG - 2)); // 3–6°
+      slots.push({ kind: "spine", book: b, lean: (x >>> 3) & 1 ? mag : -mag });
+      i += 1;
+      prevWasStack = false;
+    } else {
+      // prosto (także zablokowana kupka spada tutaj)
+      slots.push({ kind: "spine", book: b, lean: 0 });
+      i += 1;
+      prevWasStack = false;
     }
+  }
+
+  // Grzbiety tuż obok kupki przechylają się w jej stronę (nadpisuje losową pozę).
+  // Sąsiad kupki jest zawsze grzbitem (dwie kupki nie sąsiadują). Wierzch grzbietu
+  // pochyla się do środka: lewy sąsiad w prawo (+), prawy sąsiad w lewo (−).
+  for (let k = 0; k < slots.length; k++) {
+    if (slots[k].kind !== "stack") continue;
+    const left = slots[k - 1], right = slots[k + 1];
+    if (left && left.kind === "spine") left.lean = LEAN_TOWARD;
+    if (right && right.kind === "spine") right.lean = -LEAN_TOWARD;
   }
   return slots;
 }


### PR DESCRIPTION
## Cel (Fixes #119)

Trzy reguły dla kupek leżących książek.

1. **Sortowanie od największej na dole do najmniejszej na górze** — `BookStack` sortuje warstwy malejąco po szerokości (przy remisie po grubości); z `flex-col-reverse` największa ląduje na spodzie. Kupka jest teraz **wyśrodkowaną piramidką** (usunięty losowy jitter, `items-center`).
2. **Grzbiety sąsiadujące z kupką przechylają się w jej stronę** — po zbudowaniu slotów `planShelf` w post-passie nadpisuje pozę sąsiadów kupki: `LEAN_TOWARD = 5°` (lewy sąsiad wierzchem w prawo `+`, prawy w lewo `−`). Sąsiad kupki jest zawsze grzbitem (patrz reguła 3).
3. **Dwie kupki nigdy nie sąsiadują** — po slocie-kupce następny slot to zawsze grzbiet (`prevWasStack`); zablokowana kupka spada do „prosto".

Deski/stała wysokość toru i reguła braku nachodzenia (`leanLayout`) bez zmian; drag&drop nietknięty.

### Weryfikacja
- **Testy**: brak dwóch sąsiadujących kupek; sąsiedzi kupki mają `|lean| = LEAN_TOWARD`, a kierunek jest pewny (lewy `+`, prawy `−`) poza grzbietem wciśniętym między dwie kupki (stack-spine-stack).
- **Screenshot** (headless chromium): kupki jako piramidki (najszersza na dole), grzbiet tuż obok kupki pochylony ku niej, w żadnym rzędzie dwie kupki obok siebie.
- `npm run lint` czysty, **282/282** testów, `npm run build` OK.
- Bump `metadata.json` → **1.16.6**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_