### PR TITLE
feat(regał): mniej kupek + zmienne ułożenie (lewo/prawo/rzadko piramida/chaos)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.16.6** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.16.7** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.16.7** — Kupki: **mniej ich** (próg `planShelf` 92→95 → ~5%) + **zmienne ułożenie**. Nowy pure
+  `layoutStack(books)` (+`stackAlign`/`stackChaos`/`layerJitter`): wyrównanie kupki często do lewej,
+  często do prawej, **bardzo rzadko symetryczna piramida** (center ~10%), plus opcjonalny „chaos"
+  (~⅓ kupek: 3–7 px poziomego rozjazdu warstw). Sortowanie największa-na-dole zachowane. `flatBookLayout`
+  bez zbędnego arg `style`. `BookStack` używa `layoutStack` (offset `x` per warstwa). Gwarancja
+  `0≤x≤cellW−width` (brak wystawania). +4 testy (sort, containment, rozkład align, chaos). Screenshot OK.
 - **1.16.6** — Kupki dopracowane (3 reguły): (1) **sortowanie od największej na dole do najmniejszej
   na górze** — `BookStack` sortuje warstwy malejąco po szerokości (piramidka, wyśrodkowana, bez
   jittera); (2) **grzbiety sąsiadujące z kupką przechylają się w jej stronę** — `planShelf` nadpisuje

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -37,10 +37,14 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
   A stack holds **4–7** consecutive volumes. The per-book decision uses the avalanche-mixed (`mix32`)
   title hash so the split stays even across any corpus; every book lands in exactly one slot. Poses
   are `transform`/markup **inside** the fixed-height cell, so plank alignment and drag&drop are untouched.
-  Two stack rules: **no two stacks are ever adjacent** (a stack is always followed by a spine), and a
-  stack's neighbouring spines **lean toward the stack** (`LEAN_TOWARD` — left neighbour tilts right,
-  right neighbour tilts left). Inside a stack, `BookStack` sorts layers **largest at the bottom,
-  smallest at the top** (a centred pyramid).
+  Stacks are **rare** (planner threshold), **never adjacent** (a stack is always followed by a spine),
+  and a stack's neighbouring spines **lean toward the stack** (`LEAN_TOWARD` — left neighbour tilts
+  right, right neighbour tilts left).
+- **`layoutStack(books)`** — full geometry of one stack: layers sorted **largest at the bottom,
+  smallest at the top**, plus a per-stack **alignment** (`stackAlign` — often left, often right,
+  rarely a symmetric centred pyramid) and optional **chaos** (`stackChaos` — ~⅓ of stacks get a
+  3–7 px horizontal scatter via `layerJitter`). Each layer's `x` is clamped to `0 ≤ x ≤ cellW − width`,
+  so a stack never overhangs its cell. `BookStack` just renders what `layoutStack` returns.
 - **`spineFontSize(style, title)` / `flatBookLayout(book, style)`** — size every book to show its
   **full name** (no truncation). A standing spine picks a font (6–11 px) so the whole title fits along
   its height. A lying book is capped at `FLAT_MAX_W` (150 px): a short title stays one line, a longer

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.16.6",
+      "version": "1.16.7",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.16.6",
+  "version": "1.16.7",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -143,11 +143,11 @@ describe("bookshelf.title sizing (pełne nazwy)", () => {
     }
   });
   it("flatBookLayout wraps long titles to 2 lines instead of widening past the cap", () => {
-    const short = flatBookLayout(mk({ plTitle: "Ubik" }), style);
+    const short = flatBookLayout(mk({ plTitle: "Ubik" }));
     expect(short.lines).toBe(1);
     expect(short.width).toBeLessThanOrEqual(FLAT_MAX_W);
 
-    const long = flatBookLayout(mk({ plTitle: "Hyperion i jego długa, rozwlekła kontynuacja opowieści" }), style);
+    const long = flatBookLayout(mk({ plTitle: "Hyperion i jego długa, rozwlekła kontynuacja opowieści" }));
     expect(long.lines).toBe(2);                 // zawija, nie poszerza
     expect(long.width).toBe(FLAT_MAX_W);        // szerokość zaczepiona na limicie
     expect(long.thickness).toBeGreaterThan(short.thickness); // 2 linie → trochę grubsza
@@ -162,6 +162,48 @@ describe("bookshelf.title sizing (pełne nazwy)", () => {
       const availW = FLAT_MAX_W - 20;
       expect(Math.ceil((l === long ? "Hyperion i jego długa, rozwlekła kontynuacja opowieści".length : 4) * 0.6 * l.fontSize / l.lines)).toBeLessThanOrEqual(availW);
     }
+  });
+});
+
+describe("bookshelf.layoutStack (wyrównanie + chaos)", () => {
+  const mkBooks = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => mk({ id: `${prefix}${i}`, plTitle: `${prefix} tom ${i}` }));
+
+  it("sorts largest at the bottom (layers[0]) down to smallest at the top", () => {
+    const { layers } = layoutStack(mkBooks("A", 6));
+    for (let i = 1; i < layers.length; i++) {
+      expect(layers[i - 1].width).toBeGreaterThanOrEqual(layers[i].width);
+    }
+  });
+
+  it("keeps every layer fully inside the cell (0 ≤ x ≤ cellW − width) — no overhang", () => {
+    for (let s = 0; s < 200; s++) {
+      const { cellW, layers } = layoutStack(mkBooks(`S${s}_`, 4 + (s % 4)));
+      for (const l of layers) {
+        expect(l.x).toBeGreaterThanOrEqual(-1e-9);
+        expect(l.x + l.width).toBeLessThanOrEqual(cellW + 1e-9);
+      }
+    }
+  });
+
+  it("aligns left / right often and symmetric (center) only rarely", () => {
+    const counts = { left: 0, right: 0, center: 0 } as Record<string, number>;
+    for (let s = 0; s < 600; s++) counts[stackAlign(mkBooks(`Z${s}_`, 4))]++;
+    expect(counts.center).toBeLessThan(counts.left);   // piramida rzadka
+    expect(counts.center).toBeLessThan(counts.right);
+    expect(counts.left).toBeGreaterThan(0);
+    expect(counts.right).toBeGreaterThan(0);
+  });
+
+  it("chaos is 0 for most stacks, else a small 3–7 px offset", () => {
+    let chaotic = 0;
+    for (let s = 0; s < 600; s++) {
+      const c = stackChaos(mkBooks(`C${s}_`, 4));
+      expect(c === 0 || (c >= 3 && c <= 7)).toBe(true);
+      if (c > 0) chaotic++;
+    }
+    expect(chaotic).toBeGreaterThan(0);
+    expect(chaotic).toBeLessThan(600 / 2); // większość równa
   });
 });
 

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
-import { spineStyle, flatBookLayout, displayTitle, hasAward } from "../../utils/bookshelf";
+import { spineStyle, layoutStack, displayTitle, hasAward } from "../../utils/bookshelf";
 
 interface Props {
   books: BookIndexEntry[];          // każda warstwa to OSOBNA prawdziwa książka
@@ -10,67 +10,62 @@ interface Props {
 
 /**
  * Kupka leżących książek — każda warstwa to osobny wolumin z PEŁNĄ nazwą (max 2
- * linie). Posortowana **od największej na dole do najmniejszej na górze**
- * (piramidka), wyśrodkowana. Każda warstwa ma własny kolor, znacznik nagrody
- * i przeciąganie.
+ * linie). Ułożenie liczy `layoutStack`: sortowanie od największej (dół) do
+ * najmniejszej (góra), wyrównanie do lewej / do prawej / (rzadko) symetryczne,
+ * plus opcjonalny „chaos" (poziomy rozjazd warstw). Każda warstwa ma własny
+ * kolor, znacznik nagrody i przeciąganie.
  */
 export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) => {
-  const layers = books
-    .map((b) => {
-      const style = spineStyle(b);
-      const { width, fontSize, thickness, lines } = flatBookLayout(b, style);
-      return { book: b, width, fontSize, thickness, lines, color: style.color };
-    })
-    // największa (najszersza, przy remisie grubsza) na SPÓD; `flex-col-reverse`
-    // renderuje pierwszy element na dole → sortujemy malejąco.
-    .sort((a, b) => b.width - a.width || b.thickness - a.thickness || a.book.id.localeCompare(b.book.id));
-
-  const cellW = Math.max(...layers.map((l) => l.width));
+  const { cellW, layers } = layoutStack(books);
 
   return (
-    <div className="relative shrink-0 flex flex-col-reverse items-center" style={{ width: cellW }}>
-      {layers.map(({ book, width, fontSize, thickness, lines, color }, i) => (
-        <div
-          key={book.id}
-          draggable
-          onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
-          onDragEnd={onDragEnd}
-          title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
-          className="group/layer relative rounded-[2px] cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-y-0.5"
-          style={{
-            height: thickness,
-            width,
-            marginBottom: i === 0 ? 0 : 1,
-            background: `linear-gradient(0deg, rgba(0,0,0,.42) 0, ${color} 26%, ${color} 74%, rgba(255,255,255,.12) 100%)`,
-            boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",
-          }}
-        >
-          {/* Krawędź kartek (fore-edge) po prawej */}
-          <span className="absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px] bg-gradient-to-b from-amber-50/70 via-amber-100/40 to-amber-50/70" aria-hidden />
-          {/* PEŁNY tytuł wzdłuż grzbietu — zawijany do max 2 linii zamiast poszerzania */}
-          <span
-            className={`absolute inset-y-0 right-3 flex items-center font-bold text-white/90 ${hasAward(book) ? "left-3.5" : "left-2"}`}
+    <div className="relative shrink-0 flex flex-col-reverse items-start" style={{ width: cellW }}>
+      {layers.map(({ book, width, fontSize, thickness, lines, x }, i) => {
+        const color = spineStyle(book).color;
+        return (
+          <div
+            key={book.id}
+            draggable
+            onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
+            onDragEnd={onDragEnd}
+            title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
+            className="group/layer relative rounded-[2px] cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-y-0.5"
+            style={{
+              height: thickness,
+              width,
+              marginLeft: x,
+              marginBottom: i === 0 ? 0 : 1,
+              background: `linear-gradient(0deg, rgba(0,0,0,.42) 0, ${color} 26%, ${color} 74%, rgba(255,255,255,.12) 100%)`,
+              boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",
+            }}
           >
+            {/* Krawędź kartek (fore-edge) po prawej */}
+            <span className="absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px] bg-gradient-to-b from-amber-50/70 via-amber-100/40 to-amber-50/70" aria-hidden />
+            {/* PEŁNY tytuł wzdłuż grzbietu — zawijany do max 2 linii zamiast poszerzania */}
             <span
-              style={{
-                fontSize,
-                lineHeight: 1.08,
-                display: "-webkit-box",
-                WebkitBoxOrient: "vertical",
-                WebkitLineClamp: lines,
-                overflow: "hidden",
-                whiteSpace: lines === 1 ? "nowrap" : "normal",
-                textShadow: "0 1px 2px rgba(0,0,0,.55)",
-              }}
+              className={`absolute inset-y-0 right-3 flex items-center font-bold text-white/90 ${hasAward(book) ? "left-3.5" : "left-2"}`}
             >
-              {displayTitle(book)}
+              <span
+                style={{
+                  fontSize,
+                  lineHeight: 1.08,
+                  display: "-webkit-box",
+                  WebkitBoxOrient: "vertical",
+                  WebkitLineClamp: lines,
+                  overflow: "hidden",
+                  whiteSpace: lines === 1 ? "nowrap" : "normal",
+                  textShadow: "0 1px 2px rgba(0,0,0,.55)",
+                }}
+              >
+                {displayTitle(book)}
+              </span>
             </span>
-          </span>
-          {hasAward(book) && (
-            <span className="absolute top-1/2 -translate-y-1/2 left-1 w-[7px] h-[7px] rounded-full bg-amber-400 shadow-[0_0_5px_rgba(251,191,36,.85)]" title="Nagroda / nominacja" />
-          )}
-        </div>
-      ))}
+            {hasAward(book) && (
+              <span className="absolute top-1/2 -translate-y-1/2 left-1 w-[7px] h-[7px] rounded-full bg-amber-400 shadow-[0_0_5px_rgba(251,191,36,.85)]" title="Nagroda / nominacja" />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -73,8 +73,8 @@ export const MAX_LEAN_DEG = 6;
 /**
  * Planuje sloty dla posortowanej listy woluminów. Decyzja per książka jest
  * deterministyczna (hasz tytułu); kupkę tworzy kilka KOLEJNYCH prawdziwych
- * książek (starter „pożera" następne). ~80 % stoi prosto, ~12 % lekko przechylone,
- * reszta ląduje w kupkach po 4–7 realnych woluminów.
+ * książek (starter „pożera" następne). Zdecydowana większość stoi prosto,
+ * ~12 % lekko przechylone, a kupki (po 4–7 realnych woluminów) są rzadkie.
  *
  * Reguły ułożenia:
  * - **dwie kupki nigdy nie sąsiadują** (po kupce następny slot to zawsze grzbiet),
@@ -89,8 +89,8 @@ export function planShelf(books: BookIndexEntry[]): ShelfSlot[] {
     const b = books[i];
     const x = seed(b);
     const sel = x % 100;
-    // Kupka tylko gdy: los trafił, są ≥2 książki i poprzedni slot NIE był kupką.
-    if (sel >= 92 && books.length - i >= 2 && !prevWasStack) {
+    // Kupka tylko gdy: los trafił (rzadko), są ≥2 książki i poprzedni slot NIE był kupką.
+    if (sel >= 95 && books.length - i >= 2 && !prevWasStack) {
       const size = Math.min(4 + ((x >>> 17) % 4), books.length - i); // 4–7 realnych książek
       slots.push({ kind: "stack", books: books.slice(i, i + size) });
       i += size;
@@ -164,7 +164,7 @@ export const FLAT_MAX_W = 150;
  * szersza). Bardzo długi tytuł dodatkowo zmniejsza czcionkę, aż połowa zmieści
  * się w jednej linii (2 linie zawsze wystarczą). Nic nie jest ucinane.
  */
-export function flatBookLayout(book: BookIndexEntry, _style: SpineStyle): FlatBookLayout {
+export function flatBookLayout(book: BookIndexEntry): FlatBookLayout {
   const len = Math.max(1, displayTitle(book).length);
   const PAD_X = 20;                       // lewy margines tekstu + prawa krawędź kartek
   const availW = FLAT_MAX_W - PAD_X;
@@ -183,6 +183,64 @@ export function flatBookLayout(book: BookIndexEntry, _style: SpineStyle): FlatBo
   const lineH = fontSize + 1;
   const thickness = Math.min(24, Math.max(15, lines * lineH + 4));
   return { width, fontSize, thickness, lines };
+}
+
+// ─── Ułożenie kupki ───────────────────────────────────────────────────────
+export type StackAlign = "left" | "right" | "center";
+
+function stackSeed(books: BookIndexEntry[]): number {
+  return mix32((seed(books[0]) ^ Math.imul(books.length, 0x9e3779b1)) >>> 0);
+}
+
+/**
+ * Wyrównanie kupki: **często do lewej, często do prawej, BARDZO RZADKO symetryczna
+ * piramida** (center). Deterministyczne z pierwszej książki + rozmiaru kupki.
+ */
+export function stackAlign(books: BookIndexEntry[]): StackAlign {
+  const s = stackSeed(books) % 100;
+  if (s < 45) return "left";
+  if (s < 90) return "right";
+  return "center"; // ~10 %
+}
+
+/** Poziom „chaosu" ułożenia w px: 0 = równo, ~⅓ kupek dostaje 3–7 px rozjazdu. */
+export function stackChaos(books: BookIndexEntry[]): number {
+  const s = mix32(stackSeed(books) ^ 0x85ebca6b);
+  return (s % 100) < 34 ? 3 + (s % 5) : 0;
+}
+
+/** Deterministyczny luz pojedynczej książki w kupce, znormalizowany do [-1, 1). */
+export function layerJitter(book: BookIndexEntry): number {
+  const s = mix32(seed(book) ^ 0xc2b2ae35);
+  return ((s % 1000) / 500) - 1;
+}
+
+export interface StackLayoutLayer extends FlatBookLayout { book: BookIndexEntry; x: number }
+export interface StackLayout { cellW: number; align: StackAlign; chaos: number; layers: StackLayoutLayer[] }
+
+/**
+ * Pełne ułożenie kupki: sortuje książki **od największej (dół) do najmniejszej
+ * (góra)**, wybiera wyrównanie (`stackAlign`) i poziom chaosu (`stackChaos`),
+ * i liczy poziomy offset `x` każdej warstwy. Gwarancja: `0 ≤ x ≤ cellW − width`
+ * (nic nie wystaje poza komórkę → brak nachodzenia na sąsiednie sloty).
+ * `layers[0]` to spód kupki (renderować przez `flex-col-reverse`).
+ */
+export function layoutStack(books: BookIndexEntry[]): StackLayout {
+  const align = stackAlign(books);
+  const chaos = stackChaos(books);
+  const sorted = books
+    .map((b) => ({ book: b, ...flatBookLayout(b) }))
+    .sort((a, b) => b.width - a.width || b.thickness - a.thickness || a.book.id.localeCompare(b.book.id));
+  const maxW = Math.max(...sorted.map((l) => l.width));
+  const cellW = maxW + 2 * chaos;
+  const layers = sorted.map((l) => {
+    const slack = cellW - l.width;
+    let x = align === "left" ? chaos : align === "right" ? slack - chaos : slack / 2;
+    x += layerJitter(l.book) * chaos;
+    x = Math.max(0, Math.min(slack, x));
+    return { ...l, x };
+  });
+  return { cellW, align, chaos, layers };
 }
 
 /** Tytuł do pokazania (polski, a gdy brak — oryginalny). */


### PR DESCRIPTION
## Cel (Fixes #121)

1. **Mniej kupek** — próg `planShelf` `92 → 95` (~5% zamiast ~8%).
2. **Zmienne ułożenie** — czasem wszystkie książki przesunięte do lewej, czasem do prawej, bardzo rzadko symetryczna piramida.
3. **Czasem trochę chaotycznie** — poziomy rozjazd warstw.

### Nowy pure helper `layoutStack(books)`
Zbiera całą geometrię kupki (testowalne, poza komponentem):
- **sortowanie największa-na-dole** (bez zmian),
- **`stackAlign`** — `left` (~45%), `right` (~45%), `center`/piramida (~10%, „bardzo rzadko"),
- **`stackChaos`** — ~⅓ kupek dostaje 3–7 px rozjazdu; `layerJitter` daje deterministyczny luz per warstwa,
- offset `x` każdej warstwy z **gwarancją `0 ≤ x ≤ cellW − width`** → kupka nigdy nie wystaje poza komórkę (brak nachodzenia na sąsiednie sloty).

`BookStack` renderuje po prostu to, co zwróci `layoutStack` (`marginLeft: x`). `flatBookLayout` traci zbędny argument `style`.

### Weryfikacja
- **Testy**: sort największa-na-dole; containment `x` dla 200 kupek; rozkład wyrównań (center rzadszy niż left i right); chaos ∈ {0} ∪ [3,7] i większość kupek równa.
- **Screenshot** (headless chromium): w kolejnych rzędach kupki raz dosunięte do lewej, raz do prawej; mniej kupek niż wcześniej; deski wyrównane.
- `npm run lint` czysty, **286/286** testów, `npm run build` OK.
- Bump `metadata.json` → **1.16.7**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_