### PR TITLE
feat(regał): fizyka półek — wypełnione rzędy + pochylone książki z podparciem

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.16.7** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.17.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.17.0** — **Fizyka regału** (nowy `utils/shelfPacking.ts`): (1) **każda półka wypełniona** —
+  `Shelf` mierzy szerokość (`ResizeObserver`), pakuje woluminy w rzędy i rozdziela luz tak, że rząd
+  spina lewą i prawą krawędź (bez dziury na końcu); (2) **pochylenie z podparciem** — książka pochyla
+  się TYLKO gdy ma szczelinę do oparcia; kąt `θ=atan(szczelina/wys_podpory)` (≤MAX_LEAN, pivot w rogu
+  podstawy od strony podpory) → wierzch dosięga górnej krawędzi sąsiada/kupki, nie wisi bezwładnie.
+  Rząd ciasny → książki stoją prosto (emergentna fizyka). Render przeszedł z flex-wrap na własne
+  rzędy z deską per-rząd; usunięty martwy `leanLayout`. `layoutStack` zwraca `height` (podpora).
+  +8 testów fizyki (fill, kąt oparcia, brak pochyłu przy 0-luzie i na krawędzi). Screenshot OK.
 - **1.16.7** — Kupki: **mniej ich** (próg `planShelf` 92→95 → ~5%) + **zmienne ułożenie**. Nowy pure
   `layoutStack(books)` (+`stackAlign`/`stackChaos`/`layerJitter`): wyrównanie kupki często do lewej,
   często do prawej, **bardzo rzadko symetryczna piramida** (center ~10%), plus opcjonalny „chaos"

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -51,11 +51,24 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
   one **wraps to two lines** (the book gets a touch thicker, not wider — `lines` in the return);
   a very long title also shrinks the font until half fits on a line (two lines always suffice).
   `BookStack` renders the title with `-webkit-line-clamp`.
-- **`leanLayout(style, deg)`** — enforces the **no-overlap rule** for a tilted spine: the cell
-  reserves the *rotated* width (`cellW = W·cosθ + H·sinθ`) and offsets it (`shiftX`) so the rotated
-  box is centred, keeping the volume inside its own track (the `column-gap` between cells is
-  preserved). `deg === 0` → plain spine width. Unit-tested by checking all four rotated corners fall
-  within `±cellW/2`.
+- **`layoutStack(books)`** also returns the stack **`height`** (sum of layer thicknesses), used as a
+  support height when a neighbouring spine leans onto the pile.
+
+## 3a. Shelf physics (`src/utils/shelfPacking.ts`, unit-tested)
+`Shelf` measures its inner width (`ResizeObserver`) and lays out volumes with real packing instead of
+CSS `flex-wrap`, so two physical rules hold:
+- **Every shelf is filled — no end gap.** `packRows` greedily fills each row; `layoutRow` distributes
+  the row's leftover width so the first volume starts at the left edge and the last ends at the right
+  edge (`x = 0 … rowWidth`). A tight row has no slack; a sparse row spreads to fill.
+- **A leaning book rests on its support, never floats.** A book leans **only when there is a gap to
+  lean into**, at exactly `θ = atan(gap / supportHeight)` (capped at `MAX_LEAN_DEG`, pivoting at the
+  base corner on the support side). That angle makes the book's face meet the top corner of the
+  neighbour/pile it leans toward — it rests on it. No gap → the book stands straight (packed tight →
+  upright, emergent physics). Edge volumes never lean outward (no support beyond the row edge).
+
+`planShelf` supplies each spine's intended lean **direction** (sign); the **angle** is derived at
+layout time from the actual gap. Each row is rendered as an absolutely-positioned band of height
+`SHELF_ROW_H` with its own wooden plank beneath it.
 - **`BookStack`** (`shelf/BookStack.tsx`) — renders a `stack` slot: each real volume as its own
   lying book (colour from its title, title along the spine, award marker, individually draggable).
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.16.7",
+  "version": "1.17.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.16.7",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.16.7",
+      "version": "1.17.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.16.7",
+  "version": "1.17.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, planShelf, leanLayout, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, planShelf, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -104,30 +104,6 @@ describe("bookshelf.planShelf", () => {
       }
     }
     expect(checked).toBeGreaterThan(0);
-  });
-});
-
-describe("bookshelf.leanLayout (reguła: brak nachodzenia)", () => {
-  it("straight cell reserves exactly the spine width", () => {
-    const style = spineStyle(mk({ plTitle: "Prosto" }));
-    expect(leanLayout(style, 0)).toEqual({ cellW: style.width, shiftX: 0 });
-  });
-  it("reserves the rotated bounding box and centers it (corners within ±cellW/2)", () => {
-    for (let i = 0; i < 400; i++) {
-      const style = spineStyle(mk({ plTitle: `Tom ${i}` }));
-      for (const deg of [-6, -3, 3, 6]) {
-        const { cellW, shiftX } = leanLayout(style, deg);
-        const a = (deg * Math.PI) / 180;
-        const bbox = style.width * Math.abs(Math.cos(a)) + style.height * Math.abs(Math.sin(a));
-        expect(cellW).toBeGreaterThanOrEqual(bbox);
-        const W = style.width, H = style.height;
-        const corners = [[-W / 2, 0], [W / 2, 0], [-W / 2, -H], [W / 2, -H]]
-          .map(([x, y]) => x * Math.cos(a) - y * Math.sin(a) + shiftX);
-        expect(Math.max(...corners)).toBeLessThanOrEqual(cellW / 2 + 1e-6);
-        expect(Math.min(...corners)).toBeGreaterThanOrEqual(-cellW / 2 - 1e-6);
-        expect(Math.sign(shiftX)).toBe(-Math.sign(deg));
-      }
-    }
   });
 });
 

--- a/src/__tests__/shelfPacking.test.ts
+++ b/src/__tests__/shelfPacking.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { PackItem, packRows, layoutRow, packAndLayout } from "../utils/shelfPacking";
+import { MAX_LEAN_DEG } from "../utils/bookshelf";
+
+const spine = (key: string, bw = 20, h = 150, leanDir: -1 | 0 | 1 = 0): PackItem => ({ key, kind: "spine", bw, h, leanDir });
+
+describe("shelfPacking.packRows", () => {
+  it("packs items into rows that fit the width", () => {
+    const items = Array.from({ length: 30 }, (_, i) => spine(`b${i}`, 20));
+    const rows = packRows(items, 200, 3);
+    for (const r of rows) {
+      const base = r.reduce((s, it) => s + it.bw, 0) + 3 * (r.length - 1);
+      expect(base).toBeLessThanOrEqual(200 + 1e-9);
+    }
+    expect(rows.flat().map((x) => x.key)).toEqual(items.map((x) => x.key)); // nic nie zgubione
+  });
+  it("always keeps at least one item per row even if too wide", () => {
+    const rows = packRows([spine("wide", 400)], 200, 3);
+    expect(rows).toEqual([[expect.objectContaining({ key: "wide" })]]);
+  });
+});
+
+describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
+  it("fills the row edge-to-edge: first at x=0, last ends at rowWidth", () => {
+    const row = [spine("a", 20), spine("b", 30), spine("c", 25)];
+    const placed = layoutRow(row, 200);
+    expect(placed[0].x).toBeCloseTo(0, 6);
+    const last = placed[placed.length - 1];
+    expect(last.x + last.bw).toBeCloseTo(200, 6);
+  });
+
+  it("keeps items in order and non-overlapping at the base", () => {
+    const row = [spine("a", 20), spine("b", 30, 150, 1), spine("c", 25)];
+    const placed = layoutRow(row, 220);
+    for (let i = 1; i < placed.length; i++) {
+      expect(placed[i].x).toBeGreaterThanOrEqual(placed[i - 1].x + placed[i - 1].bw - 1e-9);
+    }
+  });
+
+  it("a leaning book rests at θ = atan(gap / supportHeight), capped at MAX_LEAN", () => {
+    // a leans right onto b (support height 100). Duży luz → kąt ograniczony do MAX_LEAN.
+    const row = [spine("a", 20, 150, 1), spine("b", 30, 100)];
+    const placed = layoutRow(row, 400);
+    const leaner = placed[0];
+    expect(leaner.deg).toBeGreaterThan(0);              // pochyla się w prawo (w stronę podpory)
+    expect(leaner.deg).toBeLessThanOrEqual(MAX_LEAN_DEG + 1e-9);
+    // gap między a i b odpowiada kątowi: gap = supportH * tan(deg)
+    const gap = placed[1].x - (leaner.x + leaner.bw);
+    const expectDeg = Math.min(MAX_LEAN_DEG, Math.atan(gap / 100) * 180 / Math.PI);
+    expect(leaner.deg).toBeCloseTo(expectDeg, 4);
+  });
+
+  it("stands straight when there is no slack (packed tight → no unsupported lean)", () => {
+    const row = [spine("a", 100, 150, 1), spine("b", 100, 150)];
+    const placed = layoutRow(row, 200); // base 200 == rowWidth → slack 0
+    expect(placed[0].deg).toBe(0);
+    expect(placed[1].deg).toBe(0);
+  });
+
+  it("never leans an edge book outward (no support beyond the row edge)", () => {
+    const row = [spine("a", 20, 150, -1), spine("b", 20, 150), spine("c", 20, 150, 1)];
+    const placed = layoutRow(row, 300);
+    expect(placed[0].deg).toBe(0);                       // pierwszy nie pochyli się w lewo (brak podpory)
+    expect(placed[placed.length - 1].deg).toBe(0);       // ostatni nie pochyli się w prawo
+  });
+});
+
+describe("shelfPacking.packAndLayout", () => {
+  it("returns no rows for non-positive width and fills every row otherwise", () => {
+    const items = Array.from({ length: 40 }, (_, i) => spine(`b${i}`, 18 + (i % 5)));
+    expect(packAndLayout(items, { rowWidth: 0 })).toEqual([]);
+    const rows = packAndLayout(items, { rowWidth: 240 });
+    for (const row of rows) {
+      if (row.length === 1) continue;                    // pojedyncze centrowane
+      const last = row[row.length - 1];
+      expect(last.x + last.bw).toBeCloseTo(240, 4);      // każdy rząd wypełniony do prawej
+    }
+  });
+});

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 import { BookIndexEntry } from "../../types";
-import { ShelfId, spineStyle, planShelf, leanLayout, shelfPlankBackground, SHELF_ROW_H, SHELF_ROW_GAP } from "../../utils/bookshelf";
+import { ShelfId, ShelfSlot, spineStyle, planShelf, layoutStack, SHELF_ROW_H, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { PackItem, packAndLayout } from "../../utils/shelfPacking";
 import { BookSpine } from "./BookSpine";
 import { BookStack } from "./BookStack";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
@@ -14,15 +15,31 @@ interface Props {
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
   onDropBook: (target: ShelfId) => void;
-  /** Czy trwa przeciąganie (do podświetlenia stref upuszczenia). */
   dragging: boolean;
 }
 
-const PLANK_BG = shelfPlankBackground();
+const PLANK_STYLE: React.CSSProperties = {
+  height: SHELF_PLANK_H,
+  background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)",
+  boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)",
+  borderRadius: 2,
+};
 
-/** Jeden regał = drewniany korpus + drop-target z grzbietami/kupkami na deskach (wszystkie, bez przewijania). */
+/** Jeden regał: drewniany korpus + FIZYCZNE rozłożenie woluminów (wypełnione półki, oparte pochyły). */
 export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, dragging }) => {
   const [over, setOver] = useState(false);
+  const wellRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = wellRef.current;
+    if (!el) return;
+    const update = () => setWidth(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const rootProps: React.HTMLAttributes<HTMLDivElement> = {
     onDragOver: (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true); },
@@ -31,6 +48,20 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
   };
 
   const slots = planShelf(books);
+  const slotByKey = new Map<string, ShelfSlot>();
+  const items: PackItem[] = slots.map((slot) => {
+    if (slot.kind === "stack") {
+      const key = `stack:${slot.books[0].id}`;
+      slotByKey.set(key, slot);
+      const sl = layoutStack(slot.books);
+      return { key, kind: "stack", bw: sl.cellW, h: sl.height, leanDir: 0 };
+    }
+    slotByKey.set(slot.book.id, slot);
+    const st = spineStyle(slot.book);
+    return { key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1 };
+  });
+
+  const rows = width > 0 ? packAndLayout(items, { rowWidth: width }) : [];
 
   return (
     <ShelfFrame
@@ -44,32 +75,35 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
           {dragging ? "Upuść wolumin, aby przenieść" : "Pusto na tej półce"}
         </div>
       ) : (
-        <div
-          className="flex flex-wrap items-end justify-start"
-          style={{ ...PLANK_BG, rowGap: `${SHELF_ROW_GAP}px`, columnGap: "5px" }}
-        >
-          {slots.map((slot) => {
-            // Komórka o stałej wysokości toru → wszystkie zawinięte rzędy równe,
-            // więc deska (tło) trafia dokładnie pod spód każdego z nich.
-            if (slot.kind === "stack") {
-              return (
-                <div key={`stack:${slot.books[0].id}`} className="flex items-end justify-center shrink-0" style={{ height: SHELF_ROW_H }}>
-                  <BookStack books={slot.books} onDragStart={onDragStart} onDragEnd={onDragEnd} />
-                </div>
-              );
-            }
-            const style = spineStyle(slot.book);
-            const { cellW, shiftX } = leanLayout(style, slot.lean);
-            return (
-              <div key={slot.book.id} className="flex items-end justify-center shrink-0" style={{ height: SHELF_ROW_H, width: cellW }}>
-                <div
-                  style={slot.lean ? { transform: `translateX(${shiftX}px) rotate(${slot.lean}deg)`, transformOrigin: "bottom center" } : undefined}
-                >
-                  <BookSpine book={slot.book} style={style} onDragStart={onDragStart} onDragEnd={onDragEnd} />
-                </div>
+        <div ref={wellRef} className="flex flex-col" style={{ rowGap: SHELF_ROW_GAP - SHELF_PLANK_H }}>
+          {rows.map((row, ri) => (
+            <div key={ri}>
+              <div className="relative" style={{ height: SHELF_ROW_H }}>
+                {row.map((p) => {
+                  const slot = slotByKey.get(p.key)!;
+                  if (slot.kind === "stack") {
+                    return (
+                      <div key={p.key} className="absolute bottom-0" style={{ left: p.x }}>
+                        <BookStack books={slot.books} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                      </div>
+                    );
+                  }
+                  return (
+                    <div
+                      key={p.key}
+                      className="absolute bottom-0"
+                      style={p.deg
+                        ? { left: p.x, transform: `rotate(${p.deg}deg)`, transformOrigin: p.deg > 0 ? "bottom right" : "bottom left" }
+                        : { left: p.x }}
+                    >
+                      <BookSpine book={slot.book} style={spineStyle(slot.book)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                    </div>
+                  );
+                })}
               </div>
-            );
-          })}
+              <div style={PLANK_STYLE} />
+            </div>
+          ))}
         </div>
       )}
     </ShelfFrame>

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -120,22 +120,6 @@ export function planShelf(books: BookIndexEntry[]): ShelfSlot[] {
   return slots;
 }
 
-/**
- * Layout przechylonego grzbietu. Reguła: **żadna książka nie nachodzi na drugą** —
- * komórka rezerwuje szerokość OBRÓCONEGO grzbietu (`cellW`), a `shiftX` przesuwa go,
- * by obrócony prostokąt był wyśrodkowany w komórce (inaczej wierzchołek wychodzi
- * jedną stroną poza tor). Dla `deg === 0` → zwykła szerokość, bez przesunięcia.
- */
-export interface LeanLayout { cellW: number; shiftX: number; }
-
-export function leanLayout(style: SpineStyle, deg: number): LeanLayout {
-  if (!deg) return { cellW: style.width, shiftX: 0 };
-  const rad = (Math.abs(deg) * Math.PI) / 180;
-  const cellW = Math.ceil(style.width * Math.cos(rad) + style.height * Math.sin(rad)) + 1;
-  const shiftX = -Math.sign(deg) * (style.height * Math.sin(rad)) / 2;
-  return { cellW, shiftX };
-}
-
 // Przybliżona szerokość znaku względem rozmiaru czcionki (font bold) — celowo
 // zawyżona, by CAŁY tytuł na pewno się zmieścił (bez ucinania / wielokropka).
 const CHAR_W = 0.6;
@@ -216,7 +200,7 @@ export function layerJitter(book: BookIndexEntry): number {
 }
 
 export interface StackLayoutLayer extends FlatBookLayout { book: BookIndexEntry; x: number }
-export interface StackLayout { cellW: number; align: StackAlign; chaos: number; layers: StackLayoutLayer[] }
+export interface StackLayout { cellW: number; height: number; align: StackAlign; chaos: number; layers: StackLayoutLayer[] }
 
 /**
  * Pełne ułożenie kupki: sortuje książki **od największej (dół) do najmniejszej
@@ -240,7 +224,9 @@ export function layoutStack(books: BookIndexEntry[]): StackLayout {
     x = Math.max(0, Math.min(slack, x));
     return { ...l, x };
   });
-  return { cellW, align, chaos, layers };
+  // Wysokość kupki: suma grubości warstw + 1 px marginesu między nimi.
+  const height = layers.reduce((s, l) => s + l.thickness, 0) + Math.max(0, layers.length - 1);
+  return { cellW, height, align, chaos, layers };
 }
 
 /** Tytuł do pokazania (polski, a gdy brak — oryginalny). */

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -1,0 +1,139 @@
+import { MAX_LEAN_DEG } from "./bookshelf";
+
+/**
+ * Fizyczne rozłożenie woluminów na półkach regału.
+ *
+ * Zasady „fizyki":
+ * - **Każda półka jest wypełniona** — wolny luz w rzędzie jest rozdzielany na
+ *   szczeliny, tak że pierwszy wolumin zaczyna się na lewej krawędzi, a ostatni
+ *   kończy na prawej (bez dziury na końcu).
+ * - **Książka pochyla się tylko wtedy, gdy ma się o co oprzeć.** Kąt wynika z
+ *   geometrii: `θ = atan(szczelina / wysokość_podpory)`, więc wierzch dokładnie
+ *   dosięga górnej krawędzi sąsiada/kupki (opiera się o niego), a nie wisi
+ *   bezwładnie pod kątem. Brak szczeliny → książka stoi prosto. Kąt ≤ MAX_LEAN.
+ */
+
+export interface PackItem {
+  key: string;
+  kind: "spine" | "stack";
+  bw: number;          // szerokość podstawy (footprint na półce), px
+  h: number;           // wysokość widoczna (jako podpora dla sąsiada), px
+  leanDir: -1 | 0 | 1; // zamierzony kierunek pochylenia (−1 w lewo, +1 w prawo, 0 brak)
+}
+
+export interface PlacedItem {
+  key: string;
+  kind: "spine" | "stack";
+  bw: number;
+  x: number;           // lewa krawędź podstawy, px
+  deg: number;         // rzeczywisty kąt pochylenia (0 = prosto)
+}
+
+export interface PackOpts {
+  rowWidth: number;
+  minGap?: number;     // minimalny odstęp rezerwowany przy pakowaniu
+  maxLeanDeg?: number;
+}
+
+const DEG = Math.PI / 180;
+
+/** Zachłanne pakowanie woluminów w rzędy o zadanej szerokości. */
+export function packRows(items: PackItem[], rowWidth: number, minGap = 3): PackItem[][] {
+  const rows: PackItem[][] = [];
+  let row: PackItem[] = [];
+  let used = 0;
+  for (const it of items) {
+    const add = it.bw + (row.length ? minGap : 0);
+    if (row.length && used + add > rowWidth) {
+      rows.push(row);
+      row = [];
+      used = 0;
+    }
+    row.push(it);
+    used += row.length === 1 ? it.bw : add;
+  }
+  if (row.length) rows.push(row);
+  return rows;
+}
+
+/**
+ * Rozkłada jeden rząd na całą szerokość i liczy kąty pochylenia „z podparciem".
+ * Zwraca pozycje `x` (lewa krawędź) i kąt `deg` każdego woluminu.
+ */
+export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LEAN_DEG): PlacedItem[] {
+  const n = row.length;
+  const base = row.reduce((s, it) => s + it.bw, 0);
+  const slack = Math.max(0, rowWidth - base);
+
+  if (n === 1) {
+    return [{ ...strip(row[0]), x: slack / 2, deg: 0 }];
+  }
+
+  const gaps = new Array(n - 1).fill(0);
+  const tanMax = Math.tan(maxLeanDeg * DEG);
+
+  // Która szczelina jest „szczeliną oparcia" (książka pochyla się w nią na sąsiada).
+  type Lean = { leaner: number; support: number; cap: number };
+  const leanAt: (Lean | undefined)[] = new Array(n - 1).fill(undefined);
+  for (let i = 0; i < n; i++) {
+    const it = row[i];
+    if (it.leanDir === 1 && i < n - 1 && !leanAt[i]) {
+      leanAt[i] = { leaner: i, support: i + 1, cap: row[i + 1].h * tanMax };
+    } else if (it.leanDir === -1 && i > 0 && !leanAt[i - 1]) {
+      leanAt[i - 1] = { leaner: i, support: i - 1, cap: row[i - 1].h * tanMax };
+    }
+  }
+  const leanIdx = leanAt.map((l, i) => (l ? i : -1)).filter((i) => i >= 0);
+  const freeIdx = gaps.map((_, i) => i).filter((i) => !leanAt[i]);
+
+  // Rozdział luzu: najpierw szczeliny oparcia do swojego limitu (książka opiera
+  // się o sąsiada pod kątem ≤ MAX_LEAN), reszta luzu równo w wolne szczeliny.
+  let rem = slack;
+  const leanCapSum = leanIdx.reduce((s, i) => s + leanAt[i]!.cap, 0);
+  if (leanCapSum <= rem) {
+    for (const i of leanIdx) gaps[i] = leanAt[i]!.cap;
+    rem -= leanCapSum;
+    if (freeIdx.length) {
+      const per = rem / freeIdx.length;
+      for (const i of freeIdx) gaps[i] = per;
+    } else {
+      // brak wolnych szczelin — resztę rozkładamy równo na wszystkie
+      const per = rem / (n - 1);
+      for (let i = 0; i < n - 1; i++) gaps[i] += per;
+    }
+  } else {
+    // luz mniejszy niż suma limitów — skalujemy szczeliny oparcia proporcjonalnie
+    const scale = leanCapSum > 0 ? rem / leanCapSum : 0;
+    for (const i of leanIdx) gaps[i] = leanAt[i]!.cap * scale;
+  }
+
+  // Pozycje.
+  const placed: PlacedItem[] = [];
+  let x = 0;
+  for (let i = 0; i < n; i++) {
+    placed.push({ ...strip(row[i]), x, deg: 0 });
+    if (i < n - 1) x += row[i].bw + gaps[i];
+  }
+
+  // Kąty oparcia: θ = atan(szczelina / wysokość_podpory), znak wg strony podpory.
+  for (const i of leanIdx) {
+    const { leaner, support } = leanAt[i]!;
+    const gap = gaps[i];
+    const hs = row[support].h || 1;
+    let deg = Math.atan(gap / hs) / DEG;
+    deg = Math.min(deg, maxLeanDeg);
+    placed[leaner].deg = leaner < support ? deg : -deg;
+  }
+  return placed;
+}
+
+function strip(it: PackItem): Omit<PlacedItem, "x" | "deg"> {
+  return { key: it.key, kind: it.kind, bw: it.bw };
+}
+
+/** Pakuje i rozkłada wszystkie woluminy na wypełnione rzędy. */
+export function packAndLayout(items: PackItem[], opts: PackOpts): PlacedItem[][] {
+  if (opts.rowWidth <= 0) return [];
+  const rows = packRows(items, opts.rowWidth, opts.minGap ?? 3);
+  return rows.map((r) => layoutRow(r, opts.rowWidth, opts.maxLeanDeg ?? MAX_LEAN_DEG));
+}


### PR DESCRIPTION
## Cel (Fixes #123)

Rozbudowa układu regału o **zasady fizyki**. Nowy pure moduł `utils/shelfPacking.ts`; `Shelf` mierzy szerokość (`ResizeObserver`) i układa woluminy sam, zamiast polegać na CSS `flex-wrap`.

### 1. Każda półka wypełniona — bez dziur
`packRows` zachłannie pakuje woluminy w rzędy; `layoutRow` rozdziela wolny luz na szczeliny tak, że **pierwszy wolumin startuje na lewej krawędzi, a ostatni kończy na prawej** (`x = 0 … rowWidth`). Rząd ciasny → brak luzu; rząd rzadki → rozłożony, ale wypełniony.

### 2. Pochylona książka opiera się o podporę (nie wisi bezwładnie)
Książka pochyla się **tylko gdy ma szczelinę do oparcia**, pod kątem dokładnie `θ = atan(szczelina / wysokość_podpory)` (≤ `MAX_LEAN_DEG`, pivot w rogu podstawy od strony podpory). Ten kąt sprawia, że lico książki dosięga górnej krawędzi sąsiada/kupki — **opiera się o nią**. Brak szczeliny → książka stoi prosto (ciasny rząd = pionowo, fizyka emergentna). Wolumin na krawędzi rzędu nigdy nie pochyla się na zewnątrz (brak podpory poza krawędzią).

`planShelf` podaje tylko **kierunek** pochyłu (znak); **kąt** liczony jest przy układaniu z realnej szczeliny. Każdy rząd renderowany jest jako pasmo o wysokości `SHELF_ROW_H` z własną drewnianą deską pod spodem.

Usunięty martwy `leanLayout` (zastąpiony fizyką). `layoutStack` zwraca teraz `height` (wysokość kupki jako podpora).

### Weryfikacja
- **Testy** (`shelfPacking.test.ts`, +8): rząd wypełniony do prawej; kąt = `atan(gap/H)` z limitem; **brak pochyłu przy zerowym luzie** (ciasno = prosto) i **na krawędzi rzędu**; pakowanie nie gubi woluminów.
- **Screenshot** (headless chromium): półki wypełnione od lewej do prawej krawędzi; grzbiet obok kupki pochylony i **oparty** o nią; deski pod każdym rzędem.
- `npm run lint` czysty, **292/292** testów, `npm run build` OK.
- Bump `metadata.json` → **1.17.0**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_