### PR TITLE
feat(regał): stojące równo książki blisko siebie

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.17.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.17.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.17.1** — Fizyka: **stojące równo książki blisko siebie**. `layoutRow` przycina szczelinę
+  między prostymi grzbietami do `STRAIGHT_MAX=3 px`; luz w pierwszej kolejności pochłaniają pochyłe
+  (oparcie), a dopiero nadmiar trafia do rzadkich „przerw" (co 4-tą wolną szczelinę) → zwarte grupki
+  zamiast równomiernego rozjazdu. Rząd nadal wypełniony do prawej krawędzi. +test. Screenshot OK.
 - **1.17.0** — **Fizyka regału** (nowy `utils/shelfPacking.ts`): (1) **każda półka wypełniona** —
   `Shelf` mierzy szerokość (`ResizeObserver`), pakuje woluminy w rzędy i rozdziela luz tak, że rząd
   spina lewą i prawą krawędź (bez dziury na końcu); (2) **pochylenie z podparciem** — książka pochyla

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -60,6 +60,10 @@ CSS `flex-wrap`, so two physical rules hold:
 - **Every shelf is filled — no end gap.** `packRows` greedily fills each row; `layoutRow` distributes
   the row's leftover width so the first volume starts at the left edge and the last ends at the right
   edge (`x = 0 … rowWidth`). A tight row has no slack; a sparse row spreads to fill.
+- **Upright books stay close together.** The gap between two straight-standing spines is capped at
+  `STRAIGHT_MAX` (3 px). Slack is absorbed first by leaning books (resting on their support), and only
+  the overflow goes into a few "break" gaps (every 4th free gap) — so upright books cluster tightly
+  instead of drifting apart, while the row still spans full width.
 - **A leaning book rests on its support, never floats.** A book leans **only when there is a gap to
   lean into**, at exactly `θ = atan(gap / supportHeight)` (capped at `MAX_LEAN_DEG`, pivoting at the
   base corner on the support side). That angle makes the book's face meet the top corner of the

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.17.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfPacking.test.ts
+++ b/src/__tests__/shelfPacking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { PackItem, packRows, layoutRow, packAndLayout } from "../utils/shelfPacking";
+import { PackItem, packRows, layoutRow, packAndLayout, STRAIGHT_MAX } from "../utils/shelfPacking";
 import { MAX_LEAN_DEG } from "../utils/bookshelf";
 
 const spine = (key: string, bw = 20, h = 150, leanDir: -1 | 0 | 1 = 0): PackItem => ({ key, kind: "spine", bw, h, leanDir });
@@ -48,6 +48,21 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
     const gap = placed[1].x - (leaner.x + leaner.bw);
     const expectDeg = Math.min(MAX_LEAN_DEG, Math.atan(gap / 100) * 180 / Math.PI);
     expect(leaner.deg).toBeCloseTo(expectDeg, 4);
+  });
+
+  it("keeps upright books close: most straight gaps ≤ STRAIGHT_MAX, overflow in few breaks", () => {
+    // 10 stojących grzbietów, spory luz, brak pochyłów → mają stać zwarcie.
+    const row = Array.from({ length: 10 }, (_, i) => spine(`s${i}`, 20));
+    const placed = layoutRow(row, 400); // base 200, slack 200
+    const gaps: number[] = [];
+    for (let i = 1; i < placed.length; i++) gaps.push(placed[i].x - (placed[i - 1].x + placed[i - 1].bw));
+    const tight = gaps.filter((g) => g <= STRAIGHT_MAX + 1e-6).length;
+    const wide = gaps.filter((g) => g > STRAIGHT_MAX + 1e-6).length;
+    expect(tight).toBeGreaterThan(wide);            // większość par blisko siebie
+    expect(wide).toBeLessThanOrEqual(3);            // luz skupiony w kilku przerwach
+    // wciąż wypełnione do prawej krawędzi
+    const last = placed[placed.length - 1];
+    expect(last.x + last.bw).toBeCloseTo(400, 6);
   });
 
   it("stands straight when there is no slack (packed tight → no unsupported lean)", () => {

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -36,6 +36,10 @@ export interface PackOpts {
 }
 
 const DEG = Math.PI / 180;
+/** Maks. szczelina między dwiema stojącymi równo książkami (mają być blisko siebie). */
+export const STRAIGHT_MAX = 3;
+/** Co ile stojących książek powstaje „przerwa" pochłaniająca nadmiar luzu. */
+const GROUP = 4;
 
 /** Zachłanne pakowanie woluminów w rzędy o zadanej szerokości. */
 export function packRows(items: PackItem[], rowWidth: number, minGap = 3): PackItem[][] {
@@ -94,8 +98,22 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap;
     rem -= leanCapSum;
     if (freeIdx.length) {
-      const per = rem / freeIdx.length;
-      for (const i of freeIdx) gaps[i] = per;
+      // Stojące równo książki mają stać BLISKO siebie: szczelina między nimi jest
+      // przycięta do STRAIGHT_MAX. Dopiero nadmiar luzu (gdy pochyłe już wypełniły
+      // ile mogły) trafia do rzadkich „przerw" (co GROUP-tą szczelinę), tworząc
+      // zwarte grupki zamiast równomiernego rozjazdu wszystkich grzbietów.
+      const room = freeIdx.length * STRAIGHT_MAX;
+      if (rem <= room) {
+        const per = rem / freeIdx.length;
+        for (const i of freeIdx) gaps[i] = per;
+      } else {
+        for (const i of freeIdx) gaps[i] = STRAIGHT_MAX;
+        const extra = rem - room;
+        const breaks = freeIdx.filter((_, k) => k % GROUP === 0);
+        const use = breaks.length ? breaks : [freeIdx[0]];
+        const per = extra / use.length;
+        for (const i of use) gaps[i] += per;
+      }
     } else {
       // brak wolnych szczelin — resztę rozkładamy równo na wszystkie
       const per = rem / (n - 1);


### PR DESCRIPTION
## Cel (Fixes #125)

Wcześniej luz rzędu rozkładał się równomiernie między wszystkie stojące grzbiety → odstawały od siebie. Teraz **stojące równo książki stoją zwarcie**.

### Zmiana (`layoutRow`)
- Szczelina między dwoma prostymi grzbietami przycięta do **`STRAIGHT_MAX = 3 px`**.
- Luz rzędu pochłaniają w pierwszej kolejności **pochyłe książki** (opierając się o sąsiada) — one wypełniają przestrzeń.
- Dopiero **nadmiar** luzu trafia do rzadkich „przerw" (co 4-tą wolną szczelinę), tworząc zwarte grupki zamiast równomiernego rozjazdu.
- Rząd **nadal wypełniony do prawej krawędzi** (bez dziury na końcu).

### Weryfikacja
- **Test**: w rzędzie 10 prostych grzbietów ze sporym luzem większość par ma szczelinę ≤ `STRAIGHT_MAX`, luz skupiony w ≤3 przerwach, ostatni grzbiet dochodzi do prawej krawędzi.
- **Screenshot** (headless chromium): stojące grzbiety zwarte, luz w nielicznych przerwach, półki wypełnione.
- `npm run lint` czysty, **293/293** testów, `npm run build` OK.
- Bump `metadata.json` → **1.17.1**. `docs/bookshelf.md` zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_