### PR TITLE
feat(regał): stojące książki jeszcze bliżej + reguły modułu w dokumentacji

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.17.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.17.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.17.2** — Stojące książki jeszcze bliżej + **reguły modułu w dokumentacji**. Szew między prostymi
+  grzbietami zmniejszony do `STRAIGHT_GAP=1 px`, `packRows` minGap 3→2; nadmiar luzu trafia do
+  minimalnej liczby „przerw" (każda ≤ `MAX_BREAK=34 px`, równo rozłożone) zamiast co-4-tej szczeliny.
+  `docs/bookshelf.md` §1a — cały arc `1.16.0→1.17.2` ujęty jako **reguły działania** (15 punktów:
+  mebel/deski, pozy, kupki, fizyka fill+oparcie+zwarcie, pełne nazwy, drag). +test (zwarte + przerwy ≤cap).
 - **1.17.1** — Fizyka: **stojące równo książki blisko siebie**. `layoutRow` przycina szczelinę
   między prostymi grzbietami do `STRAIGHT_MAX=3 px`; luz w pierwszej kolejności pochłaniają pochyłe
   (oparcie), a dopiero nadmiar trafia do rzadkich „przerw" (co 4-tą wolną szczelinę) → zwarte grupki

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -11,6 +11,53 @@ title, dark back-panel with vertical planks, brass corner brackets and a hanging
 (`ShelfOrnaments` — decorative, `aria-hidden`). Rows of spines each rest on a real **plank**, and the
 **Do przeczytania** shelf holds **every** volume (no scroll cap) so the whole backlog is visible at once.
 
+## 1a. Operating rules (the "physical shelf" contract)
+These are the invariants the layout obeys — the whole visual design, built up across `1.16.0 → 1.17.2`,
+expressed as rules. They are enforced by pure, unit-tested helpers (`utils/bookshelf.ts`,
+`utils/shelfPacking.ts`); the components only render what those return. All decisions are
+**deterministic from the title hash**, so the shelf never flickers between renders or re-wraps.
+
+**Furniture & planks**
+1. Every shelf is a wooden cabinet (cornice + posts + plinth + ornaments); ornaments are decorative
+   and `aria-hidden`.
+2. Every **row of volumes rests on its own plank**; rows are fixed-height bands so planks always land
+   directly under the books.
+3. The **Do przeczytania** shelf shows **all** volumes at once (no scroll cap).
+
+**Poses (per volume, deterministic)**
+4. Most volumes **stand upright**; a minority lean; stacks are **rare**.
+5. A volume leans **at most `MAX_LEAN_DEG` (6°)**, and only where it makes physical sense (see §11).
+6. A book's spine colour / width / height and its pose are stable for a given title (hash-derived,
+   avalanche-mixed so the split is even across any corpus).
+
+**Stacks (lying piles)**
+7. A stack is **several real, consecutive volumes** lying down — each its own title/colour/award/drag —
+   never one spine faking a pile. A stack holds **4–7** volumes.
+8. **Two stacks are never adjacent** (a stack is always followed by an upright volume).
+9. The upright volumes **next to a stack lean toward it** (they rest on it — see §11).
+10. Inside a stack, volumes are sorted **largest at the bottom → smallest at the top**; the pile is
+    aligned **often to the left, often to the right, and only rarely a symmetric centred pyramid**,
+    with an occasional small horizontal "chaos" scatter. No layer overhangs the pile.
+
+**Physics: filling & resting**
+11. **A book leans only when there is a gap to lean into**, at exactly `θ = atan(gap / supportHeight)`
+    (≤ 6°, pivoting at the base corner on the support side) — its face meets the top corner of the
+    neighbour/pile and **rests on it**, never floating. No gap → it stands straight. Edge volumes
+    never lean outward.
+12. **Every shelf is filled edge-to-edge** — each row's first volume starts at the left edge and the
+    last ends at the right edge; there is no ragged gap at the end of a row.
+13. **Upright volumes stand tight together** (a ~1 px seam). Slack is consumed first by leaning books
+    (rule 11); only the overflow becomes a few capped "break" gaps (each ≤ `MAX_BREAK`), so books
+    cluster instead of drifting evenly apart.
+
+**Titles & interaction**
+14. **Full titles, never truncated**: an upright spine shrinks its font (6–11 px) to fit the whole
+    title along its height; a lying book fits the full title too, wrapping to **two lines** rather
+    than widening past `FLAT_MAX_W` (150 px).
+15. Every volume — upright or in a pile — is individually **draggable** between the two shelves; the
+    drop writes read-state back to Notion (§4). Read/`toRead` split and per-book optimistic move are
+    unchanged by any of the above.
+
 ## 2. Data
 - Reuses **`GET /api/books`** (`BookIndexEntry[]`, see [skryptorium-search.md](./skryptorium-search.md)) —
   the same slim index the search uses. Read state is derived from the `zrodlo` (Źródło) tag
@@ -60,10 +107,10 @@ CSS `flex-wrap`, so two physical rules hold:
 - **Every shelf is filled — no end gap.** `packRows` greedily fills each row; `layoutRow` distributes
   the row's leftover width so the first volume starts at the left edge and the last ends at the right
   edge (`x = 0 … rowWidth`). A tight row has no slack; a sparse row spreads to fill.
-- **Upright books stay close together.** The gap between two straight-standing spines is capped at
-  `STRAIGHT_MAX` (3 px). Slack is absorbed first by leaning books (resting on their support), and only
-  the overflow goes into a few "break" gaps (every 4th free gap) — so upright books cluster tightly
-  instead of drifting apart, while the row still spans full width.
+- **Upright books stand tight together.** Two straight-standing spines get only a ~1 px seam
+  (`STRAIGHT_GAP`). Slack is absorbed first by leaning books (resting on their support); only the
+  overflow becomes a **minimal number of "break" gaps** (each ≤ `MAX_BREAK` = 34 px, spread evenly),
+  so upright books cluster together while the row still spans full width.
 - **A leaning book rests on its support, never floats.** A book leans **only when there is a gap to
   lean into**, at exactly `θ = atan(gap / supportHeight)` (capped at `MAX_LEAN_DEG`, pivoting at the
   base corner on the support side). That angle makes the book's face meet the top corner of the

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.17.1",
+      "version": "1.17.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.17.1",
+  "version": "1.17.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfPacking.test.ts
+++ b/src/__tests__/shelfPacking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { PackItem, packRows, layoutRow, packAndLayout, STRAIGHT_MAX } from "../utils/shelfPacking";
+import { PackItem, packRows, layoutRow, packAndLayout, STRAIGHT_GAP, MAX_BREAK } from "../utils/shelfPacking";
 import { MAX_LEAN_DEG } from "../utils/bookshelf";
 
 const spine = (key: string, bw = 20, h = 150, leanDir: -1 | 0 | 1 = 0): PackItem => ({ key, kind: "spine", bw, h, leanDir });
@@ -50,19 +50,18 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
     expect(leaner.deg).toBeCloseTo(expectDeg, 4);
   });
 
-  it("keeps upright books close: most straight gaps ≤ STRAIGHT_MAX, overflow in few breaks", () => {
-    // 10 stojących grzbietów, spory luz, brak pochyłów → mają stać zwarcie.
-    const row = Array.from({ length: 10 }, (_, i) => spine(`s${i}`, 20));
-    const placed = layoutRow(row, 400); // base 200, slack 200
+  it("keeps upright books touching: most straight gaps ≈ STRAIGHT_GAP, overflow in few capped breaks", () => {
+    // 12 stojących grzbietów, spory luz, brak pochyłów → mają stać tuż koło siebie.
+    const row = Array.from({ length: 12 }, (_, i) => spine(`s${i}`, 20));
+    const placed = layoutRow(row, 340); // base 240, slack 100 (rząd raczej pełny)
     const gaps: number[] = [];
     for (let i = 1; i < placed.length; i++) gaps.push(placed[i].x - (placed[i - 1].x + placed[i - 1].bw));
-    const tight = gaps.filter((g) => g <= STRAIGHT_MAX + 1e-6).length;
-    const wide = gaps.filter((g) => g > STRAIGHT_MAX + 1e-6).length;
-    expect(tight).toBeGreaterThan(wide);            // większość par blisko siebie
-    expect(wide).toBeLessThanOrEqual(3);            // luz skupiony w kilku przerwach
-    // wciąż wypełnione do prawej krawędzi
+    const tight = gaps.filter((g) => g <= STRAIGHT_GAP + 1e-6).length;
+    const breaks = gaps.filter((g) => g > STRAIGHT_GAP + 1e-6);
+    expect(tight).toBeGreaterThan(breaks.length * 2);         // znaczna większość zwarta
+    for (const g of breaks) expect(g).toBeLessThanOrEqual(MAX_BREAK + 1e-6); // każda przerwa ograniczona
     const last = placed[placed.length - 1];
-    expect(last.x + last.bw).toBeCloseTo(400, 6);
+    expect(last.x + last.bw).toBeCloseTo(340, 6);             // wypełnione do prawej
   });
 
   it("stands straight when there is no slack (packed tight → no unsupported lean)", () => {

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -36,13 +36,13 @@ export interface PackOpts {
 }
 
 const DEG = Math.PI / 180;
-/** Maks. szczelina między dwiema stojącymi równo książkami (mają być blisko siebie). */
-export const STRAIGHT_MAX = 3;
-/** Co ile stojących książek powstaje „przerwa" pochłaniająca nadmiar luzu. */
-const GROUP = 4;
+/** Szew między stojącymi równo książkami — cienki, żeby stały tuż koło siebie. */
+export const STRAIGHT_GAP = 1;
+/** Maks. rozmiar pojedynczej „przerwy" pochłaniającej nadmiar luzu. */
+export const MAX_BREAK = 34;
 
 /** Zachłanne pakowanie woluminów w rzędy o zadanej szerokości. */
-export function packRows(items: PackItem[], rowWidth: number, minGap = 3): PackItem[][] {
+export function packRows(items: PackItem[], rowWidth: number, minGap = 2): PackItem[][] {
   const rows: PackItem[][] = [];
   let row: PackItem[] = [];
   let used = 0;
@@ -98,21 +98,22 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap;
     rem -= leanCapSum;
     if (freeIdx.length) {
-      // Stojące równo książki mają stać BLISKO siebie: szczelina między nimi jest
-      // przycięta do STRAIGHT_MAX. Dopiero nadmiar luzu (gdy pochyłe już wypełniły
-      // ile mogły) trafia do rzadkich „przerw" (co GROUP-tą szczelinę), tworząc
-      // zwarte grupki zamiast równomiernego rozjazdu wszystkich grzbietów.
-      const room = freeIdx.length * STRAIGHT_MAX;
+      // Stojące równo książki mają stać TUŻ koło siebie: między nimi tylko cienki
+      // szew STRAIGHT_GAP. Nadmiar luzu (gdy pochyłe już oparły się ile mogły) NIE
+      // rozjeżdża wszystkich grzbietów — trafia do minimalnej liczby „przerw",
+      // każda ≤ MAX_BREAK, rozłożonych równomiernie. Reszta książek stoi zwarcie.
+      const room = freeIdx.length * STRAIGHT_GAP;
       if (rem <= room) {
         const per = rem / freeIdx.length;
         for (const i of freeIdx) gaps[i] = per;
       } else {
-        for (const i of freeIdx) gaps[i] = STRAIGHT_MAX;
+        for (const i of freeIdx) gaps[i] = STRAIGHT_GAP;
         const extra = rem - room;
-        const breaks = freeIdx.filter((_, k) => k % GROUP === 0);
-        const use = breaks.length ? breaks : [freeIdx[0]];
-        const per = extra / use.length;
-        for (const i of use) gaps[i] += per;
+        const nBreaks = Math.min(freeIdx.length, Math.max(1, Math.ceil(extra / MAX_BREAK)));
+        const chosen: number[] = [];
+        for (let b = 0; b < nBreaks; b++) chosen.push(freeIdx[Math.floor(((b + 0.5) * freeIdx.length) / nBreaks)]);
+        const per = extra / chosen.length;
+        for (const i of chosen) gaps[i] += per;
       }
     } else {
       // brak wolnych szczelin — resztę rozkładamy równo na wszystkie


### PR DESCRIPTION
## Cel (Fixes #127)

### 1. Więcej książek koło siebie
- Szew między prostymi grzbietami zmniejszony: `STRAIGHT_MAX (3 px) → STRAIGHT_GAP (1 px)`; `packRows` minGap `3 → 2`.
- Nadmiar luzu (po tym jak pochyłe książki oparły się o sąsiadów) trafia do **minimalnej liczby „przerw"**, każda **≤ `MAX_BREAK` = 34 px**, rozłożonych równomiernie — zamiast dawnego „co 4-tą szczelinę".
- Efekt: stojące grzbiety stoją **tuż koło siebie** w zwartych grupach; rząd **nadal wypełniony do prawej krawędzi**.

### 2. Reguły działania modułu w dokumentacji
`docs/bookshelf.md` → nowa sekcja **§1a „Operating rules"** ujmuje cały arc `1.16.0 → 1.17.2` jako **15 reguł** (kontrakt „fizycznej półki"): mebel + deski, pozy, kupki (osobne książki / rzadkie / nie sąsiadują / sortowanie / wyrównanie), fizyka (pochylenie z oparciem, wypełnienie do krawędzi, zwarte stojące), pełne nazwy / 2 linie, drag&drop. Wszystkie deterministyczne z hasza tytułu, wymuszane przez czyste, testowane helpery.

### Weryfikacja
- **Test**: w raczej pełnym rzędzie większość par grzbietów zwarta (≈`STRAIGHT_GAP`), każda przerwa ≤ `MAX_BREAK`, ostatni grzbiet dochodzi do prawej krawędzi.
- **Screenshot** (headless chromium): stojące grzbiety w zwartych grupach, luz w nielicznych ograniczonych przerwach.
- `npm run lint` czysty, **293/293** testów, `npm run build` OK.
- Bump `metadata.json` → **1.17.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_