### PR TITLE
fix(regał): koniec pustych przerw — luz rozkładany równo między stojące książki

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.17.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.17.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.17.3** — **Koniec pustych „dziur" w rzędzie**: luz (po oparciu pochyłych) rozkładany RÓWNO na
+  wszystkie szczeliny między stojącymi grzbietami zamiast skupiania w kilka przerw. Minimalizuje
+  największą szczelinę → pełny rząd ma włoskowe szwy, rzadki rozkłada się równo (żadnej dużej dziury).
+  Usunięte `STRAIGHT_GAP`/`MAX_BREAK` i logika „break". Reguła 13 w docs zaktualizowana. +test (równe
+  szczeliny, fill do prawej). Screenshot OK.
 - **1.17.2** — Stojące książki jeszcze bliżej + **reguły modułu w dokumentacji**. Szew między prostymi
   grzbietami zmniejszony do `STRAIGHT_GAP=1 px`, `packRows` minGap 3→2; nadmiar luzu trafia do
   minimalnej liczby „przerw" (każda ≤ `MAX_BREAK=34 px`, równo rozłożone) zamiast co-4-tej szczeliny.

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -46,9 +46,10 @@ expressed as rules. They are enforced by pure, unit-tested helpers (`utils/books
     never lean outward.
 12. **Every shelf is filled edge-to-edge** — each row's first volume starts at the left edge and the
     last ends at the right edge; there is no ragged gap at the end of a row.
-13. **Upright volumes stand tight together** (a ~1 px seam). Slack is consumed first by leaning books
-    (rule 11); only the overflow becomes a few capped "break" gaps (each ≤ `MAX_BREAK`), so books
-    cluster instead of drifting evenly apart.
+13. **Upright volumes are spaced evenly — no empty holes.** Slack is consumed first by leaning books
+    (rule 11); whatever remains is spread **equally** across every gap between straight spines. That
+    minimises the largest gap, so a full row's seams are hair-thin and a sparse row spreads out
+    uniformly, never leaving a single big empty space.
 
 **Titles & interaction**
 14. **Full titles, never truncated**: an upright spine shrinks its font (6–11 px) to fit the whole
@@ -107,10 +108,10 @@ CSS `flex-wrap`, so two physical rules hold:
 - **Every shelf is filled — no end gap.** `packRows` greedily fills each row; `layoutRow` distributes
   the row's leftover width so the first volume starts at the left edge and the last ends at the right
   edge (`x = 0 … rowWidth`). A tight row has no slack; a sparse row spreads to fill.
-- **Upright books stand tight together.** Two straight-standing spines get only a ~1 px seam
-  (`STRAIGHT_GAP`). Slack is absorbed first by leaning books (resting on their support); only the
-  overflow becomes a **minimal number of "break" gaps** (each ≤ `MAX_BREAK` = 34 px, spread evenly),
-  so upright books cluster together while the row still spans full width.
+- **Upright books are spaced evenly — no empty holes.** Slack is absorbed first by leaning books
+  (resting on their support); whatever remains is spread **equally** across every gap between straight
+  spines. Even distribution minimises the largest gap, so a full row's seams are hair-thin and a
+  sparse row spreads out uniformly — never a single big empty space, while the row still spans full width.
 - **A leaning book rests on its support, never floats.** A book leans **only when there is a gap to
   lean into**, at exactly `θ = atan(gap / supportHeight)` (capped at `MAX_LEAN_DEG`, pivoting at the
   base corner on the support side). That angle makes the book's face meet the top corner of the

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.17.2",
+      "version": "1.17.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.17.2",
+  "version": "1.17.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfPacking.test.ts
+++ b/src/__tests__/shelfPacking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { PackItem, packRows, layoutRow, packAndLayout, STRAIGHT_GAP, MAX_BREAK } from "../utils/shelfPacking";
+import { PackItem, packRows, layoutRow, packAndLayout } from "../utils/shelfPacking";
 import { MAX_LEAN_DEG } from "../utils/bookshelf";
 
 const spine = (key: string, bw = 20, h = 150, leanDir: -1 | 0 | 1 = 0): PackItem => ({ key, kind: "spine", bw, h, leanDir });
@@ -50,16 +50,15 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
     expect(leaner.deg).toBeCloseTo(expectDeg, 4);
   });
 
-  it("keeps upright books touching: most straight gaps ≈ STRAIGHT_GAP, overflow in few capped breaks", () => {
-    // 12 stojących grzbietów, spory luz, brak pochyłów → mają stać tuż koło siebie.
+  it("spaces upright books EVENLY (no big empty gaps): all straight gaps equal", () => {
+    // 12 stojących grzbietów, brak pochyłów → luz rozłożony równo, żadnej „dziury".
     const row = Array.from({ length: 12 }, (_, i) => spine(`s${i}`, 20));
-    const placed = layoutRow(row, 340); // base 240, slack 100 (rząd raczej pełny)
+    const placed = layoutRow(row, 340); // base 240, slack 100
     const gaps: number[] = [];
     for (let i = 1; i < placed.length; i++) gaps.push(placed[i].x - (placed[i - 1].x + placed[i - 1].bw));
-    const tight = gaps.filter((g) => g <= STRAIGHT_GAP + 1e-6).length;
-    const breaks = gaps.filter((g) => g > STRAIGHT_GAP + 1e-6);
-    expect(tight).toBeGreaterThan(breaks.length * 2);         // znaczna większość zwarta
-    for (const g of breaks) expect(g).toBeLessThanOrEqual(MAX_BREAK + 1e-6); // każda przerwa ograniczona
+    const min = Math.min(...gaps), max = Math.max(...gaps);
+    expect(max - min).toBeLessThan(1e-6);                     // wszystkie szczeliny równe
+    expect(max).toBeCloseTo(100 / 11, 6);                     // slack / liczba szczelin
     const last = placed[placed.length - 1];
     expect(last.x + last.bw).toBeCloseTo(340, 6);             // wypełnione do prawej
   });

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -36,10 +36,6 @@ export interface PackOpts {
 }
 
 const DEG = Math.PI / 180;
-/** Szew między stojącymi równo książkami — cienki, żeby stały tuż koło siebie. */
-export const STRAIGHT_GAP = 1;
-/** Maks. rozmiar pojedynczej „przerwy" pochłaniającej nadmiar luzu. */
-export const MAX_BREAK = 34;
 
 /** Zachłanne pakowanie woluminów w rzędy o zadanej szerokości. */
 export function packRows(items: PackItem[], rowWidth: number, minGap = 2): PackItem[][] {
@@ -98,23 +94,12 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap;
     rem -= leanCapSum;
     if (freeIdx.length) {
-      // Stojące równo książki mają stać TUŻ koło siebie: między nimi tylko cienki
-      // szew STRAIGHT_GAP. Nadmiar luzu (gdy pochyłe już oparły się ile mogły) NIE
-      // rozjeżdża wszystkich grzbietów — trafia do minimalnej liczby „przerw",
-      // każda ≤ MAX_BREAK, rozłożonych równomiernie. Reszta książek stoi zwarcie.
-      const room = freeIdx.length * STRAIGHT_GAP;
-      if (rem <= room) {
-        const per = rem / freeIdx.length;
-        for (const i of freeIdx) gaps[i] = per;
-      } else {
-        for (const i of freeIdx) gaps[i] = STRAIGHT_GAP;
-        const extra = rem - room;
-        const nBreaks = Math.min(freeIdx.length, Math.max(1, Math.ceil(extra / MAX_BREAK)));
-        const chosen: number[] = [];
-        for (let b = 0; b < nBreaks; b++) chosen.push(freeIdx[Math.floor(((b + 0.5) * freeIdx.length) / nBreaks)]);
-        const per = extra / chosen.length;
-        for (const i of chosen) gaps[i] += per;
-      }
+      // Nadmiar luzu (po tym, jak pochyłe już oparły się ile mogły) rozkładamy
+      // RÓWNO na wszystkie szczeliny między stojącymi grzbietami. To minimalizuje
+      // największą szczelinę — brak pojedynczych pustych „dziur", wszystkie
+      // książki są równo koło siebie (a na pełnym rzędzie odstęp jest znikomy).
+      const per = rem / freeIdx.length;
+      for (const i of freeIdx) gaps[i] = per;
     } else {
       // brak wolnych szczelin — resztę rozkładamy równo na wszystkie
       const per = rem / (n - 1);


### PR DESCRIPTION
## Cel (Fixes #129)

Skupianie nadmiaru luzu w kilka „przerw" (1.17.2) wyglądało jak puste dziury na półce (grupki książek z pustką między nimi).

### Zmiana
`layoutRow` rozkłada teraz luz — po tym, jak pochyłe książki oparły się o sąsiadów — **RÓWNO na wszystkie szczeliny** między stojącymi grzbietami. To matematycznie **minimalizuje największą szczelinę**:
- pełny rząd → włoskowe, jednakowe szwy (książki tuż koło siebie),
- rzadki rząd → rozkłada się równomiernie, **bez żadnej pojedynczej dużej dziury**.

Rząd nadal spina lewą i prawą krawędź. Usunięte `STRAIGHT_GAP`/`MAX_BREAK` i cała logika „break".

### Weryfikacja
- **Test**: dla rzędu 12 grzbietów wszystkie szczeliny są równe (`max − min < 1e-6`), każda = `slack / liczba szczelin`, ostatni grzbiet dochodzi do prawej krawędzi.
- **Screenshot** (headless chromium): brak dużych pustych przerw, książki równo koło siebie.
- `npm run lint` czysty, **293/293** testów, `npm run build` OK.
- Bump `metadata.json` → **1.17.3**. Reguła 13 w `docs/bookshelf.md` zaktualizowana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_