### PR TITLE
feat(regał): brak przerw między stojącymi — luz pogrubia grzbiety

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.17.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.17.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.17.4** — **Brak powietrza między stojącymi książkami — luz pogrubia grzbiety**. Zamiast wkładać
+  luz w szczeliny, `layoutRow` po oparciu pochyłych POGRUBIA stojące grzbiety (`PackItem.stretch`,
+  water-filling `widenEvenly`, waga ~ długość tytułu → dłuższy tytuł = grubsza książka). Książki się
+  stykają jak na prawdziwej półce; kupki/pochyłe nie grubieją; dopiero po nasyceniu limitów zostaje
+  włoskowa równa szczelina. `PlacedItem.w` (szerokość renderowania), `Shelf` renderuje grzbiet `p.w`.
+  +2 testy (pogrubienie zeruje szczeliny; fallback równych szczelin przy `stretch=0`). Reguła 13 upd.
 - **1.17.3** — **Koniec pustych „dziur" w rzędzie**: luz (po oparciu pochyłych) rozkładany RÓWNO na
   wszystkie szczeliny między stojącymi grzbietami zamiast skupiania w kilka przerw. Minimalizuje
   największą szczelinę → pełny rząd ma włoskowe szwy, rzadki rozkłada się równo (żadnej dużej dziury).

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -46,10 +46,10 @@ expressed as rules. They are enforced by pure, unit-tested helpers (`utils/books
     never lean outward.
 12. **Every shelf is filled edge-to-edge** — each row's first volume starts at the left edge and the
     last ends at the right edge; there is no ragged gap at the end of a row.
-13. **Upright volumes are spaced evenly — no empty holes.** Slack is consumed first by leaning books
-    (rule 11); whatever remains is spread **equally** across every gap between straight spines. That
-    minimises the largest gap, so a full row's seams are hair-thin and a sparse row spreads out
-    uniformly, never leaving a single big empty space.
+13. **No air between upright books — the leftover thickens the spines.** After leaning books take
+    their rest gaps (rule 11), the remaining slack is absorbed by **making the straight spines thicker**
+    (weighted so longer-titled volumes thicken more), because real shelves have no gaps between
+    standing books. Only if every spine hits its thickness cap does a hair-thin even gap remain.
 
 **Titles & interaction**
 14. **Full titles, never truncated**: an upright spine shrinks its font (6–11 px) to fit the whole
@@ -108,10 +108,11 @@ CSS `flex-wrap`, so two physical rules hold:
 - **Every shelf is filled — no end gap.** `packRows` greedily fills each row; `layoutRow` distributes
   the row's leftover width so the first volume starts at the left edge and the last ends at the right
   edge (`x = 0 … rowWidth`). A tight row has no slack; a sparse row spreads to fill.
-- **Upright books are spaced evenly — no empty holes.** Slack is absorbed first by leaning books
-  (resting on their support); whatever remains is spread **equally** across every gap between straight
-  spines. Even distribution minimises the largest gap, so a full row's seams are hair-thin and a
-  sparse row spreads out uniformly — never a single big empty space, while the row still spans full width.
+- **No air between upright books — leftover thickens the spines.** Slack is absorbed first by leaning
+  books (resting on their support); whatever remains is used to **make the straight spines thicker**
+  (`PackItem.stretch`, water-filled and weighted so longer-titled volumes grow more) so books touch
+  like on a real shelf. Piles and leaning books are never thickened; only if every spine hits its
+  `stretch` cap does a hair-thin even gap remain. The row still spans full width.
 - **A leaning book rests on its support, never floats.** A book leans **only when there is a gap to
   lean into**, at exactly `θ = atan(gap / supportHeight)` (capped at `MAX_LEAN_DEG`, pivoting at the
   base corner on the support side). That angle makes the book's face meet the top corner of the

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.17.3",
+      "version": "1.17.4",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.17.3",
+  "version": "1.17.4",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfPacking.test.ts
+++ b/src/__tests__/shelfPacking.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { PackItem, packRows, layoutRow, packAndLayout } from "../utils/shelfPacking";
 import { MAX_LEAN_DEG } from "../utils/bookshelf";
 
-const spine = (key: string, bw = 20, h = 150, leanDir: -1 | 0 | 1 = 0): PackItem => ({ key, kind: "spine", bw, h, leanDir });
+const spine = (key: string, bw = 20, h = 150, leanDir: -1 | 0 | 1 = 0, stretch = 0): PackItem => ({ key, kind: "spine", bw, h, leanDir, stretch });
 
 describe("shelfPacking.packRows", () => {
   it("packs items into rows that fit the width", () => {
@@ -50,17 +50,29 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
     expect(leaner.deg).toBeCloseTo(expectDeg, 4);
   });
 
-  it("spaces upright books EVENLY (no big empty gaps): all straight gaps equal", () => {
-    // 12 stojących grzbietów, brak pochyłów → luz rozłożony równo, żadnej „dziury".
-    const row = Array.from({ length: 12 }, (_, i) => spine(`s${i}`, 20));
-    const placed = layoutRow(row, 340); // base 240, slack 100
-    const gaps: number[] = [];
-    for (let i = 1; i < placed.length; i++) gaps.push(placed[i].x - (placed[i - 1].x + placed[i - 1].bw));
-    const min = Math.min(...gaps), max = Math.max(...gaps);
-    expect(max - min).toBeLessThan(1e-6);                     // wszystkie szczeliny równe
-    expect(max).toBeCloseTo(100 / 11, 6);                     // slack / liczba szczelin
+  it("fills slack by THICKENING straight spines (no gaps) — real shelves have no air between books", () => {
+    // 12 stojących grzbietów z zapasem na pogrubienie → luz idzie w grubość, nie w szczeliny.
+    const row = Array.from({ length: 12 }, (_, i) => spine(`s${i}`, 20, 150, 0, 20));
+    const placed = layoutRow(row, 340); // base 240, slack 100, łączny zapas 240
+    for (let i = 1; i < placed.length; i++) {
+      const gap = placed[i].x - (placed[i - 1].x + placed[i - 1].w);
+      expect(gap).toBeLessThan(1e-6);                         // książki się stykają — zero przerw
+    }
+    for (const p of placed) expect(p.w).toBeGreaterThanOrEqual(p.bw); // grzbiety zgrubiały
+    const widened = placed.reduce((s, p) => s + (p.w - p.bw), 0);
+    expect(widened).toBeCloseTo(100, 4);                      // cały luz wchłonięty przez grubość
     const last = placed[placed.length - 1];
-    expect(last.x + last.bw).toBeCloseTo(340, 6);             // wypełnione do prawej
+    expect(last.x + last.w).toBeCloseTo(340, 6);              // wypełnione do prawej
+  });
+
+  it("falls back to EVEN gaps only when spines can't thicken further (stretch = 0)", () => {
+    const row = Array.from({ length: 12 }, (_, i) => spine(`s${i}`, 20)); // stretch 0
+    const placed = layoutRow(row, 340);
+    const gaps: number[] = [];
+    for (let i = 1; i < placed.length; i++) gaps.push(placed[i].x - (placed[i - 1].x + placed[i - 1].w));
+    const min = Math.min(...gaps), max = Math.max(...gaps);
+    expect(max - min).toBeLessThan(1e-6);                     // równe (żadnej pojedynczej dziury)
+    expect(placed[placed.length - 1].x + placed[placed.length - 1].w).toBeCloseTo(340, 6);
   });
 
   it("stands straight when there is no slack (packed tight → no unsupported lean)", () => {

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { BookIndexEntry } from "../../types";
-import { ShelfId, ShelfSlot, spineStyle, planShelf, layoutStack, SHELF_ROW_H, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { ShelfId, ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle, SHELF_ROW_H, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
 import { PackItem, packAndLayout } from "../../utils/shelfPacking";
 import { BookSpine } from "./BookSpine";
 import { BookStack } from "./BookStack";
@@ -58,7 +58,9 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
     }
     slotByKey.set(slot.book.id, slot);
     const st = spineStyle(slot.book);
-    return { key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1 };
+    // Dłuższy tytuł → grzbiet może zgrubieć bardziej (naturalnie „grubsza książka").
+    const stretch = Math.min(26, Math.max(8, 6 + displayTitle(slot.book).length * 0.5));
+    return { key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1, stretch };
   });
 
   const rows = width > 0 ? packAndLayout(items, { rowWidth: width }) : [];
@@ -96,7 +98,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
                         ? { left: p.x, transform: `rotate(${p.deg}deg)`, transformOrigin: p.deg > 0 ? "bottom right" : "bottom left" }
                         : { left: p.x }}
                     >
-                      <BookSpine book={slot.book} style={spineStyle(slot.book)} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+                      <BookSpine book={slot.book} style={{ ...spineStyle(slot.book), width: p.w }} onDragStart={onDragStart} onDragEnd={onDragEnd} />
                     </div>
                   );
                 })}

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -4,9 +4,11 @@ import { MAX_LEAN_DEG } from "./bookshelf";
  * Fizyczne rozłożenie woluminów na półkach regału.
  *
  * Zasady „fizyki":
- * - **Każda półka jest wypełniona** — wolny luz w rzędzie jest rozdzielany na
- *   szczeliny, tak że pierwszy wolumin zaczyna się na lewej krawędzi, a ostatni
- *   kończy na prawej (bez dziury na końcu).
+ * - **Każda półka jest wypełniona bez pustych dziur** — luz rzędu pochłaniają w
+ *   pierwszej kolejności pochyłe (oparcie), a resztę wchłania POGRUBIENIE stojących
+ *   grzbietów (grubsze książki), bo nikt nie stawia książek z przerwami między
+ *   nimi. Dopiero gdyby pogrubienie osiągnęło limity, znikomy resztek luzu idzie
+ *   równo w szczeliny.
  * - **Książka pochyla się tylko wtedy, gdy ma się o co oprzeć.** Kąt wynika z
  *   geometrii: `θ = atan(szczelina / wysokość_podpory)`, więc wierzch dokładnie
  *   dosięga górnej krawędzi sąsiada/kupki (opiera się o niego), a nie wisi
@@ -19,13 +21,15 @@ export interface PackItem {
   bw: number;          // szerokość podstawy (footprint na półce), px
   h: number;           // wysokość widoczna (jako podpora dla sąsiada), px
   leanDir: -1 | 0 | 1; // zamierzony kierunek pochylenia (−1 w lewo, +1 w prawo, 0 brak)
+  stretch?: number;    // ile px grzbiet MOŻE zgrubieć, by wypełnić luz (0 = nie pogrubiamy)
 }
 
 export interface PlacedItem {
   key: string;
   kind: "spine" | "stack";
   bw: number;
-  x: number;           // lewa krawędź podstawy, px
+  w: number;           // szerokość do wyrenderowania (≥ bw — po ewentualnym pogrubieniu)
+  x: number;           // lewa krawędź, px
   deg: number;         // rzeczywisty kąt pochylenia (0 = prosto)
 }
 
@@ -66,10 +70,11 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
   const slack = Math.max(0, rowWidth - base);
 
   if (n === 1) {
-    return [{ ...strip(row[0]), x: slack / 2, deg: 0 }];
+    return [{ ...strip(row[0]), w: row[0].bw, x: slack / 2, deg: 0 }];
   }
 
   const gaps = new Array(n - 1).fill(0);
+  const extra = new Array(n).fill(0); // pogrubienie każdego grzbietu (px)
   const tanMax = Math.tan(maxLeanDeg * DEG);
 
   // Która szczelina jest „szczeliną oparcia" (książka pochyla się w nią na sąsiada).
@@ -86,37 +91,44 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
   const leanIdx = leanAt.map((l, i) => (l ? i : -1)).filter((i) => i >= 0);
   const freeIdx = gaps.map((_, i) => i).filter((i) => !leanAt[i]);
 
-  // Rozdział luzu: najpierw szczeliny oparcia do swojego limitu (książka opiera
-  // się o sąsiada pod kątem ≤ MAX_LEAN), reszta luzu równo w wolne szczeliny.
+  // Rozdział luzu.
   let rem = slack;
   const leanCapSum = leanIdx.reduce((s, i) => s + leanAt[i]!.cap, 0);
   if (leanCapSum <= rem) {
+    // 1) Pochyłe książki opierają się o sąsiada (szczelina oparcia do limitu).
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap;
     rem -= leanCapSum;
-    if (freeIdx.length) {
-      // Nadmiar luzu (po tym, jak pochyłe już oparły się ile mogły) rozkładamy
-      // RÓWNO na wszystkie szczeliny między stojącymi grzbietami. To minimalizuje
-      // największą szczelinę — brak pojedynczych pustych „dziur", wszystkie
-      // książki są równo koło siebie (a na pełnym rzędzie odstęp jest znikomy).
-      const per = rem / freeIdx.length;
-      for (const i of freeIdx) gaps[i] = per;
-    } else {
-      // brak wolnych szczelin — resztę rozkładamy równo na wszystkie
-      const per = rem / (n - 1);
-      for (let i = 0; i < n - 1; i++) gaps[i] += per;
+    // 2) Resztę WCHŁANIA pogrubienie stojących grzbietów — grubsze książki
+    //    wypełniają rząd zamiast zostawiać nienaturalne przerwy. Nie pogrubiamy
+    //    kupek ani książek, które się pochylają.
+    const leaners = new Set(leanIdx.map((i) => leanAt[i]!.leaner));
+    const widenable = row
+      .map((it, i) => (it.kind === "spine" && !leaners.has(i) ? i : -1))
+      .filter((i) => i >= 0 && (row[i].stretch ?? 0) > 0);
+    rem = widenEvenly(rem, widenable, (i) => row[i].stretch ?? 0, extra);
+    // 3) Znikomy resztek (gdy pogrubienie osiągnęło limity) — równo w szczeliny.
+    if (rem > 1e-6) {
+      if (freeIdx.length) {
+        const per = rem / freeIdx.length;
+        for (const i of freeIdx) gaps[i] += per;
+      } else {
+        const per = rem / (n - 1);
+        for (let i = 0; i < n - 1; i++) gaps[i] += per;
+      }
     }
   } else {
-    // luz mniejszy niż suma limitów — skalujemy szczeliny oparcia proporcjonalnie
+    // luz mniejszy niż suma limitów oparcia — skalujemy szczeliny proporcjonalnie
     const scale = leanCapSum > 0 ? rem / leanCapSum : 0;
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap * scale;
   }
 
-  // Pozycje.
+  // Pozycje (szerokość = podstawa + pogrubienie).
   const placed: PlacedItem[] = [];
   let x = 0;
   for (let i = 0; i < n; i++) {
-    placed.push({ ...strip(row[i]), x, deg: 0 });
-    if (i < n - 1) x += row[i].bw + gaps[i];
+    const w = row[i].bw + extra[i];
+    placed.push({ ...strip(row[i]), w, x, deg: 0 });
+    if (i < n - 1) x += w + gaps[i];
   }
 
   // Kąty oparcia: θ = atan(szczelina / wysokość_podpory), znak wg strony podpory.
@@ -131,13 +143,39 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
   return placed;
 }
 
-function strip(it: PackItem): Omit<PlacedItem, "x" | "deg"> {
+function strip(it: PackItem): Omit<PlacedItem, "x" | "deg" | "w"> {
   return { key: it.key, kind: it.kind, bw: it.bw };
+}
+
+/**
+ * Rozdziela `rem` px na pogrubienie grzbietów `idx`, każdy do limitu `capOf(i)`.
+ * Water-filling: równe dokładanie do jeszcze-nienasyconych, aż zabraknie luzu lub
+ * miejsca. Zapisuje przyrost do `extra` i zwraca niewykorzystany luz.
+ */
+function widenEvenly(rem: number, idx: number[], capOf: (i: number) => number, extra: number[]): number {
+  let active = idx.filter((i) => capOf(i) - extra[i] > 1e-6);
+  let guard = 0;
+  while (rem > 1e-6 && active.length && guard++ < 12) {
+    const share = rem / active.length;
+    const next: number[] = [];
+    let progressed = false;
+    for (const i of active) {
+      const room = capOf(i) - extra[i];
+      const add = Math.min(share, room);
+      extra[i] += add;
+      rem -= add;
+      if (add > 1e-9) progressed = true;
+      if (capOf(i) - extra[i] > 1e-6) next.push(i);
+    }
+    active = next;
+    if (!progressed) break;
+  }
+  return rem;
 }
 
 /** Pakuje i rozkłada wszystkie woluminy na wypełnione rzędy. */
 export function packAndLayout(items: PackItem[], opts: PackOpts): PlacedItem[][] {
   if (opts.rowWidth <= 0) return [];
-  const rows = packRows(items, opts.rowWidth, opts.minGap ?? 3);
+  const rows = packRows(items, opts.rowWidth, opts.minGap ?? 2);
   return rows.map((r) => layoutRow(r, opts.rowWidth, opts.maxLeanDeg ?? MAX_LEAN_DEG));
 }


### PR DESCRIPTION
## Cel (Fixes #131)

Stojące książki były równo rozłożone, ale wciąż z małymi przerwami — nienaturalnie (nikt nie stawia książek z powietrzem między nimi). Rozwiązanie: **luz rzędu wypełnia GRUBOŚĆ grzbietów**, a nie szczeliny.

### Zmiana
Po tym, jak pochyłe książki oparły się o sąsiadów (rule 11), pozostały luz `layoutRow` wchłania przez **pogrubienie stojących grzbietów**, aż się stykają:
- **`PackItem.stretch`** — ile px dany grzbiet może zgrubieć. `Shelf` liczy to z **długości tytułu** (dłuższy tytuł → grubsza książka; honoruje „szczególnie te z dwuliniowymi tytułami").
- **`widenEvenly`** — water-filling: równe dokładanie do nienasyconych grzbietów aż do ich limitów.
- **`PlacedItem.w`** — szerokość do wyrenderowania; `Shelf` rysuje grzbiet szerokości `p.w`.
- **Kupki i pochyłe książki nie grubieją.** Dopiero gdy każdy grzbiet osiągnie limit, zostaje włoskowa, równa szczelina. Rząd nadal spina obie krawędzie.

### Weryfikacja
- **Testy**: przy zapasie na grubość szczeliny = 0 (książki się stykają), cały luz wchłonięty przez grubość (`Σ(w−bw)=slack`), longer-title → grubszy; przy `stretch=0` fallback do równych szczelin.
- **Screenshot** (headless chromium): stojące grzbiety grubsze i stykające się, bez powietrza; pochyłe dalej oparte o kupki.
- `npm run lint` czysty, **294/294** testów, `npm run build` OK.
- Bump `metadata.json` → **1.17.4**. Reguła 13 w `docs/bookshelf.md` zaktualizowana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_