### PR TITLE
feat(regał): Sala Archiwum — pokój z regałami stałej wysokości i segmentami

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.17.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.18.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.18.0** — **Sala Archiwum**: regały stoją w POKOJU zamiast jednej długiej listy 700 pozycji.
+  `RoomDecor` — ciepły skryptorium (drewniana ściana z panelami, podłoga, kinkiety z migoczącym
+  światłem `motion`, kurz, proporzec, sygil koła zębatego, winieta; `aria-hidden`). Regały mają
+  **stałą wysokość** (`Shelf` prop `pageSize=3` rzędy) i dzielą się na **segmenty „Regał I/N"** ze
+  strzałkami; brakujące rzędy dopełniane pustą deską (stała wysokość); świeca na szczycie + cokół/
+  nóżki („stoi na podłodze"). Wspólny builder `buildShelfItems` + `chunk` (`utils/shelfLayout.ts`),
+  render rzędu wyjęty do `ShelfRow`/`EmptyShelfRow`. Fizyka książek NIETKNIĘTA. +3 testy (`chunk`).
+  Weryfikacja mockiem-screenshotem. Wybór usera: ciepły / bogato / segmenty po kolei. **Iteracja 1** —
+  możliwe rozszerzenie do gęstej poziomej ściany wielu regałów.
 - **1.17.4** — **Brak powietrza między stojącymi książkami — luz pogrubia grzbiety**. Zamiast wkładać
   luz w szczeliny, `layoutRow` po oparciu pochyłych POGRUBIA stojące grzbiety (`PackItem.stretch`,
   water-filling `widenEvenly`, waga ~ długość tytułu → dłuższy tytuł = grubsza książka). Książki się

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -59,6 +59,18 @@ expressed as rules. They are enforced by pure, unit-tested helpers (`utils/books
     drop writes read-state back to Notion (§4). Read/`toRead` split and per-book optimistic move are
     unchanged by any of the above.
 
+## 1b. Sala Archiwum (room view)
+The shelves live inside a **warm scriptorium room** (`RoomDecor`, `aria-hidden`): a wooden panelled
+wall, floor, wall sconces with a flickering flame and warm glow (`motion`), drifting dust motes, a
+pennant, a faint Mechanicus cog watermark, and a vignette. Purely decorative — it never touches the
+book physics.
+
+Each shelf is a **fixed-height bookcase**: `Shelf` takes a `pageSize` (rows per bookcase) and slices
+its packed rows into segments **"Regał I / N"** navigated with ◄ ► arrows; short pages are padded with
+empty planks so the bookcase height is constant, and a candle + plinth/feet make it "stand on the
+floor". This replaces the single ~700-tall list — you page through Regały instead. The row builder is
+shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`; one row → `ShelfRow`).
+
 ## 2. Data
 - Reuses **`GET /api/books`** (`BookIndexEntry[]`, see [skryptorium-search.md](./skryptorium-search.md)) —
   the same slim index the search uses. Read state is derived from the `zrodlo` (Źródło) tag

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.17.4",
+  "version": "1.18.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.17.4",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.17.4",
+      "version": "1.18.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.17.4",
+  "version": "1.18.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfLayout.test.ts
+++ b/src/__tests__/shelfLayout.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { chunk } from "../utils/shelfLayout";
+
+describe("shelfLayout.chunk", () => {
+  it("splits rows into fixed-size segments (regały)", () => {
+    expect(chunk([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([[1, 2, 3], [4, 5, 6], [7]]);
+  });
+  it("returns a single segment for size ≤ 0 or when everything fits", () => {
+    expect(chunk([1, 2], 0)).toEqual([[1, 2]]);
+    expect(chunk([1, 2], 5)).toEqual([[1, 2]]);
+  });
+  it("keeps every element exactly once, in order", () => {
+    const arr = Array.from({ length: 25 }, (_, i) => i);
+    const segs = chunk(arr, 4);
+    expect(segs.flat()).toEqual(arr);
+    expect(segs.every((s) => s.length <= 4)).toBe(true);
+  });
+});

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -7,6 +7,7 @@ import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../
 import { Shelf } from "./shelf/Shelf";
 import { CoverCard } from "./shelf/CoverCard";
 import { ShelfFrame } from "./shelf/ShelfFrame";
+import { RoomDecor } from "./shelf/RoomDecor";
 
 export const BookshelfSection: React.FC = () => {
   const { books, loading, error, fetchBooks } = useBooks();
@@ -74,7 +75,7 @@ export const BookshelfSection: React.FC = () => {
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
       </div>
       <p className="text-center text-[11px] text-slate-500 uppercase tracking-widest font-bold -mt-4">
-        Przeciągnij wolumin między regałami — zapis trafia do kolumny „Źródło" w Notion
+        Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał I/N"
       </p>
 
       {moveError && (
@@ -101,44 +102,46 @@ export const BookshelfSection: React.FC = () => {
           </div>
         </div>
       ) : (
-        <>
+        <RoomDecor>
           {/* Półka „Wyróżnione" (okładki twarzą) */}
           {featured.length > 0 && (
-            <ShelfFrame
-              title="Wyróżnione — nagrodzone, przeczytane"
-              icon={<Sparkles className="w-4 h-4" />}
-              accent="purple" count={featured.length}
-            >
-              <div className="flex items-end gap-3.5 overflow-x-auto pb-1 pt-1 custom-scrollbar">
-                {featured.map((b) => <CoverCard key={b.id} book={b} />)}
-              </div>
-              <div
-                className="h-[15px] mt-[2px] rounded-[2px]"
-                style={{ background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)", boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)" }}
-              />
-            </ShelfFrame>
+            <div className="mb-8">
+              <ShelfFrame
+                title="Wyróżnione — nagrodzone, przeczytane"
+                icon={<Sparkles className="w-4 h-4" />}
+                accent="purple" count={featured.length}
+              >
+                <div className="flex items-end gap-3.5 overflow-x-auto pb-1 pt-1 custom-scrollbar">
+                  {featured.map((b) => <CoverCard key={b.id} book={b} />)}
+                </div>
+                <div
+                  className="h-[15px] mt-[2px] rounded-[2px]"
+                  style={{ background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)", boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)" }}
+                />
+              </ShelfFrame>
+            </div>
           )}
 
-          {/* Dwa regały */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+          {/* Dwa regały stałej wysokości (segmenty „Regał I/N") stojące w pokoju */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <Shelf
-              shelfId="toRead" title="Do przeczytania" accent="cyan"
+              shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={3}
               icon={<BookOpen className="w-4 h-4" />}
               books={toRead} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
             <Shelf
-              shelfId="read" title="Przeczytane" accent="emerald"
+              shelfId="read" title="Przeczytane" accent="emerald" pageSize={3}
               icon={<CheckCircle2 className="w-4 h-4" />}
               books={read} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
           </div>
 
-          <p className="text-center text-[10px] text-slate-600 uppercase tracking-widest font-bold">
+          <p className="text-center text-[10px] text-amber-200/40 uppercase tracking-widest font-bold mt-6">
             {all.length} woluminów · <span className="text-amber-400/70">●</span> = nagroda · najedź, by wysunąć grzbiet
           </p>
-        </>
+        </RoomDecor>
       )}
     </div>
   );

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { motion } from "motion/react";
+
+/** Sygil koła zębatego (Mechanicus) — ozdoba pokoju. */
+const CogMark: React.FC<{ size: number; color: string; className?: string; style?: React.CSSProperties }> = ({ size, color, className, style }) => (
+  <svg viewBox="0 0 48 48" width={size} height={size} className={className} style={style} aria-hidden>
+    <g fill={color}>
+      {Array.from({ length: 12 }).map((_, i) => (
+        <rect key={i} x="22.2" y="0.5" width="3.6" height="9" rx="1" transform={`rotate(${i * 30} 24 24)`} />
+      ))}
+      <circle cx="24" cy="24" r="15" />
+    </g>
+    <circle cx="24" cy="24" r="10.5" fill="none" stroke={color} strokeWidth="2" />
+    <circle cx="24" cy="24" r="3" fill={color} />
+  </svg>
+);
+
+/** Świeca z migoczącym płomieniem i ciepłą poświatą. */
+const Sconce: React.FC<{ className?: string }> = ({ className }) => (
+  <div className={`absolute pointer-events-none ${className ?? ""}`} aria-hidden>
+    <svg viewBox="0 0 60 70" width="52" height="60">
+      <path d="M30 26 V54 M18 54 h24 M22 54 q8 7 16 0" stroke="#b8860b" strokeWidth="3" fill="none" strokeLinecap="round" />
+      <ellipse cx="30" cy="24" rx="5" ry="3" fill="#3a2a12" />
+    </svg>
+    <motion.div
+      className="absolute left-[22px] top-[6px] w-[9px] h-[15px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
+      style={{ background: "radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00)" }}
+      animate={{ scaleY: [1, 1.14, 0.95, 1.08, 1], opacity: [0.85, 1, 0.8, 1, 0.9] }}
+      transition={{ duration: 1.6, repeat: Infinity, ease: "easeInOut" }}
+    />
+    <motion.div
+      className="absolute -left-[70px] -top-[64px] w-[200px] h-[200px] rounded-full"
+      style={{ background: "radial-gradient(closest-side, rgba(255,165,70,.24), transparent)", filter: "blur(6px)" }}
+      animate={{ opacity: [0.65, 0.85, 0.6, 0.8, 0.7] }}
+      transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
+    />
+  </div>
+);
+
+/** Dryfująca drobinka kurzu w świetle. */
+const Mote: React.FC<{ i: number }> = ({ i }) => {
+  const left = (i * 61) % 100;
+  const top = 12 + ((i * 37) % 60);
+  const dur = 7 + (i % 5) * 1.7;
+  return (
+    <motion.div
+      className="absolute w-[3px] h-[3px] rounded-full bg-amber-200/40"
+      style={{ left: `${left}%`, top: `${top}%`, filter: "blur(1px)" }}
+      animate={{ y: [0, -14, 0], opacity: [0.15, 0.5, 0.15] }}
+      transition={{ duration: dur, repeat: Infinity, ease: "easeInOut", delay: (i % 7) * 0.6 }}
+    />
+  );
+};
+
+/**
+ * „Sala Archiwum" — ciepły skryptorium wokół regałów: drewniana ściana z panelami,
+ * podłoga, kinkiety z migoczącym światłem, proporzec, sygil koła zębatego, kurz
+ * i winieta. Czysto dekoracyjne (aria-hidden). Fizyki książek nie dotyka.
+ */
+export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div
+    className="relative rounded-[20px] overflow-hidden px-4 pt-10 pb-[120px] sm:px-8"
+    style={{
+      background:
+        "linear-gradient(180deg, #2a2018 0%, #241b12 55%, #1b140d 100%), repeating-linear-gradient(90deg, rgba(255,220,170,.03) 0 2px, transparent 2px 130px)",
+      boxShadow: "inset 0 2px 0 rgba(255,220,170,.08), inset 0 40px 80px -40px rgba(0,0,0,.7)",
+    }}
+  >
+    {/* Znak wodny koła zębatego */}
+    <CogMark size={320} color="#c8961f" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
+
+    {/* Proporzec z sygilem */}
+    <div className="absolute left-1/2 -translate-x-1/2 top-0 w-[92px] h-[128px] hidden sm:flex items-center justify-center pointer-events-none"
+      style={{ background: "linear-gradient(180deg,#5b1f2a,#3a121a)", clipPath: "polygon(0 0,100% 0,100% 82%,50% 100%,0 82%)", boxShadow: "0 6px 14px rgba(0,0,0,.6)" }} aria-hidden>
+      <CogMark size={46} color="#d9b45a" />
+    </div>
+
+    {/* Kinkiety */}
+    <Sconce className="left-3 top-16 hidden md:block" />
+    <Sconce className="right-3 top-16 hidden md:block" />
+
+    {/* Kurz w powietrzu */}
+    {Array.from({ length: 16 }).map((_, i) => <Mote key={i} i={i} />)}
+
+    {/* Treść (regały) */}
+    <div className="relative z-10">{children}</div>
+
+    {/* Podłoga */}
+    <div className="absolute left-0 right-0 bottom-0 h-[120px] pointer-events-none"
+      style={{ background: "linear-gradient(180deg,#3a2a19 0,#241a10 40%,#150e07 100%)", boxShadow: "inset 0 16px 26px -12px rgba(0,0,0,.85)" }} aria-hidden />
+
+    {/* Winieta */}
+    <div className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(120% 90% at 50% 40%, rgba(0,0,0,0) 45%, rgba(0,0,0,.5) 100%)" }} aria-hidden />
+  </div>
+);

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,9 +1,10 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { BookIndexEntry } from "../../types";
-import { ShelfId, ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle, SHELF_ROW_H, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
-import { PackItem, packAndLayout } from "../../utils/shelfPacking";
-import { BookSpine } from "./BookSpine";
-import { BookStack } from "./BookStack";
+import { ShelfId, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { packAndLayout } from "../../utils/shelfPacking";
+import { buildShelfItems, chunk } from "../../utils/shelfLayout";
+import { ShelfRow, EmptyShelfRow } from "./ShelfRow";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
 
 interface Props {
@@ -16,18 +17,17 @@ interface Props {
   onDragEnd: () => void;
   onDropBook: (target: ShelfId) => void;
   dragging: boolean;
+  /** Gdy podane: regał ma STAŁĄ wysokość tylu rzędów i dzieli się na segmenty „Regał I/N". */
+  pageSize?: number;
 }
 
-const PLANK_STYLE: React.CSSProperties = {
-  height: SHELF_PLANK_H,
-  background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)",
-  boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)",
-  borderRadius: 2,
-};
+const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII"];
+const roman = (n: number) => ROMAN[n - 1] ?? String(n);
 
 /** Jeden regał: drewniany korpus + FIZYCZNE rozłożenie woluminów (wypełnione półki, oparte pochyły). */
-export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, dragging }) => {
+export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, dragging, pageSize }) => {
   const [over, setOver] = useState(false);
+  const [page, setPage] = useState(0);
   const wellRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
@@ -47,67 +47,69 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
     onDrop: (e) => { e.preventDefault(); setOver(false); onDropBook(shelfId); },
   };
 
-  const slots = planShelf(books);
-  const slotByKey = new Map<string, ShelfSlot>();
-  const items: PackItem[] = slots.map((slot) => {
-    if (slot.kind === "stack") {
-      const key = `stack:${slot.books[0].id}`;
-      slotByKey.set(key, slot);
-      const sl = layoutStack(slot.books);
-      return { key, kind: "stack", bw: sl.cellW, h: sl.height, leanDir: 0 };
-    }
-    slotByKey.set(slot.book.id, slot);
-    const st = spineStyle(slot.book);
-    // Dłuższy tytuł → grzbiet może zgrubieć bardziej (naturalnie „grubsza książka").
-    const stretch = Math.min(26, Math.max(8, 6 + displayTitle(slot.book).length * 0.5));
-    return { key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1, stretch };
-  });
-
+  const { items, slotByKey } = buildShelfItems(books);
   const rows = width > 0 ? packAndLayout(items, { rowWidth: width }) : [];
 
-  return (
-    <ShelfFrame
-      title={title} icon={icon} accent={accent} count={books.length}
-      highlight={over ? "target" : dragging ? "dragging" : "idle"}
-      headerExtra={dragging ? <span className="text-[10px] uppercase tracking-widest text-amber-200/70 font-bold">upuść tutaj</span> : null}
-      rootProps={rootProps}
-    >
-      {books.length === 0 ? (
-        <div className="min-h-[140px] flex items-center justify-center text-xs text-slate-500 italic">
-          {dragging ? "Upuść wolumin, aby przenieść" : "Pusto na tej półce"}
-        </div>
-      ) : (
-        <div ref={wellRef} className="flex flex-col" style={{ rowGap: SHELF_ROW_GAP - SHELF_PLANK_H }}>
-          {rows.map((row, ri) => (
-            <div key={ri}>
-              <div className="relative" style={{ height: SHELF_ROW_H }}>
-                {row.map((p) => {
-                  const slot = slotByKey.get(p.key)!;
-                  if (slot.kind === "stack") {
-                    return (
-                      <div key={p.key} className="absolute bottom-0" style={{ left: p.x }}>
-                        <BookStack books={slot.books} onDragStart={onDragStart} onDragEnd={onDragEnd} />
-                      </div>
-                    );
-                  }
-                  return (
-                    <div
-                      key={p.key}
-                      className="absolute bottom-0"
-                      style={p.deg
-                        ? { left: p.x, transform: `rotate(${p.deg}deg)`, transformOrigin: p.deg > 0 ? "bottom right" : "bottom left" }
-                        : { left: p.x }}
-                    >
-                      <BookSpine book={slot.book} style={{ ...spineStyle(slot.book), width: p.w }} onDragStart={onDragStart} onDragEnd={onDragEnd} />
-                    </div>
-                  );
-                })}
-              </div>
-              <div style={PLANK_STYLE} />
-            </div>
-          ))}
+  // Segmenty „Regał I/N" przy stałej wysokości.
+  const segments = pageSize ? chunk(rows, pageSize) : [rows];
+  const pageCount = Math.max(1, segments.length);
+  const cur = Math.min(page, pageCount - 1);
+  const shown = segments[cur] ?? [];
+  const pad = pageSize ? Math.max(0, pageSize - shown.length) : 0;
+
+  const headerExtra = (
+    <div className="flex items-center gap-2">
+      {dragging && <span className="text-[10px] uppercase tracking-widest text-amber-200/70 font-bold">upuść tutaj</span>}
+      {pageSize && pageCount > 1 && (
+        <div className="flex items-center gap-1.5">
+          <button onClick={() => setPage((p) => Math.max(0, Math.min(p, pageCount - 1) - 1))} disabled={cur === 0}
+            className="p-1 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Poprzedni regał">
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <span className="text-[10px] font-display font-bold uppercase tracking-widest text-amber-200/80">Regał {roman(cur + 1)}<span className="text-amber-200/40"> / {pageCount}</span></span>
+          <button onClick={() => setPage((p) => Math.min(pageCount - 1, Math.min(p, pageCount - 1) + 1))} disabled={cur >= pageCount - 1}
+            className="p-1 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Następny regał">
+            <ChevronRight className="w-4 h-4" />
+          </button>
         </div>
       )}
-    </ShelfFrame>
+    </div>
+  );
+
+  return (
+    <div className="relative">
+      {/* Świeca na szczycie regału */}
+      <div className="absolute -top-[26px] left-8 z-20 pointer-events-none" aria-hidden>
+        <div className="w-[9px] h-[24px] mx-auto rounded-[2px] bg-gradient-to-b from-[#e8dcc0] via-[#d8c8a2] to-[#b9a271]" />
+        <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 w-[8px] h-[13px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
+          style={{ background: "radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00)", boxShadow: "0 0 14px 5px rgba(255,150,40,.5)" }} />
+      </div>
+
+      <ShelfFrame
+        title={title} icon={icon} accent={accent} count={books.length}
+        highlight={over ? "target" : dragging ? "dragging" : "idle"}
+        headerExtra={headerExtra}
+        rootProps={rootProps}
+      >
+        {books.length === 0 ? (
+          <div className="min-h-[140px] flex items-center justify-center text-xs text-slate-500 italic">
+            {dragging ? "Upuść wolumin, aby przenieść" : "Pusto na tej półce"}
+          </div>
+        ) : (
+          <div ref={wellRef} className="flex flex-col" style={{ rowGap: SHELF_ROW_GAP - SHELF_PLANK_H }}>
+            {shown.map((row, ri) => (
+              <ShelfRow key={cur * 1000 + ri} row={row} slotByKey={slotByKey} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+            ))}
+            {Array.from({ length: pad }).map((_, i) => <EmptyShelfRow key={`pad${i}`} />)}
+          </div>
+        )}
+      </ShelfFrame>
+
+      {/* Cokół / nóżki — regał „stoi na podłodze" */}
+      <div className="mx-2 h-[10px] rounded-b-[6px]" style={{ background: "linear-gradient(180deg,#3a2915,#1c1108)", boxShadow: "0 10px 16px -6px rgba(0,0,0,.7)" }} aria-hidden />
+      <div className="flex justify-between px-6" aria-hidden>
+        {[0, 1].map((i) => <div key={i} className="w-8 h-[9px] rounded-b-[4px]" style={{ background: "linear-gradient(180deg,#2a1c0f,#120b06)" }} />)}
+      </div>
+    </div>
   );
 };

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { BookIndexEntry } from "../../types";
+import { ShelfSlot, spineStyle, SHELF_ROW_H, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { PlacedItem } from "../../utils/shelfPacking";
+import { BookSpine } from "./BookSpine";
+import { BookStack } from "./BookStack";
+
+export const PLANK_STYLE: React.CSSProperties = {
+  height: SHELF_PLANK_H,
+  background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)",
+  boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)",
+  borderRadius: 2,
+};
+
+interface Props {
+  row: PlacedItem[];
+  slotByKey: Map<string, ShelfSlot>;
+  onDragStart: (book: BookIndexEntry) => void;
+  onDragEnd: () => void;
+}
+
+/** Jeden rząd półki: woluminy na pozycjach z fizyki + drewniana deska pod spodem. */
+export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragEnd }) => (
+  <div>
+    <div className="relative" style={{ height: SHELF_ROW_H }}>
+      {row.map((p) => {
+        const slot = slotByKey.get(p.key)!;
+        if (slot.kind === "stack") {
+          return (
+            <div key={p.key} className="absolute bottom-0" style={{ left: p.x }}>
+              <BookStack books={slot.books} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+            </div>
+          );
+        }
+        return (
+          <div
+            key={p.key}
+            className="absolute bottom-0"
+            style={p.deg
+              ? { left: p.x, transform: `rotate(${p.deg}deg)`, transformOrigin: p.deg > 0 ? "bottom right" : "bottom left" }
+              : { left: p.x }}
+          >
+            <BookSpine book={slot.book} style={{ ...spineStyle(slot.book), width: p.w }} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+          </div>
+        );
+      })}
+    </div>
+    <div style={PLANK_STYLE} />
+  </div>
+);
+
+/** Pusta półka (dla wyrównania stałej wysokości regału) — sama deska. */
+export const EmptyShelfRow: React.FC = () => (
+  <div>
+    <div style={{ height: SHELF_ROW_H }} />
+    <div style={PLANK_STYLE} />
+  </div>
+);

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -1,0 +1,34 @@
+import { BookIndexEntry } from "../types";
+import { ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle } from "./bookshelf";
+import { PackItem } from "./shelfPacking";
+
+/**
+ * Buduje `PackItem[]` (do fizyki `packAndLayout`) i mapę `slotByKey` (do renderu)
+ * dla listy woluminów. Wspólne dla pojedynczego regału i regałów w pokoju.
+ */
+export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; slotByKey: Map<string, ShelfSlot> } {
+  const slots = planShelf(books);
+  const slotByKey = new Map<string, ShelfSlot>();
+  const items: PackItem[] = slots.map((slot) => {
+    if (slot.kind === "stack") {
+      const key = `stack:${slot.books[0].id}`;
+      slotByKey.set(key, slot);
+      const sl = layoutStack(slot.books);
+      return { key, kind: "stack", bw: sl.cellW, h: sl.height, leanDir: 0 };
+    }
+    slotByKey.set(slot.book.id, slot);
+    const st = spineStyle(slot.book);
+    // Dłuższy tytuł → grzbiet może zgrubieć bardziej (naturalnie „grubsza książka").
+    const stretch = Math.min(26, Math.max(8, 6 + displayTitle(slot.book).length * 0.5));
+    return { key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1, stretch };
+  });
+  return { items, slotByKey };
+}
+
+/** Dzieli tablicę na porcje po `size` (np. rzędy → segmenty-regały). */
+export function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) return [arr];
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}


### PR DESCRIPTION
## Cel (Fixes #133)

Zakładka **Regał Archiwum** to teraz **pokój z regałami**, a nie jedna długa lista ~700 pozycji. Wrażenie „pracy na regałach i półkach".

### Co doszło
- **`RoomDecor`** — ciepły skryptorium wokół regałów: drewniana ściana z panelami, podłoga, **kinkiety z migoczącym płomieniem i ciepłą poświatą** (`motion`), dryfujący kurz, proporzec z sygilem, znak wodny koła zębatego, winieta. Czysto dekoracyjne (`aria-hidden`).
- **Regały stałej wysokości** — `Shelf` przyjmuje `pageSize` (rzędy na regał) i dzieli spakowane rzędy na **segmenty „Regał I / N"** ze strzałkami ◄ ►. Krótsza strona dopełniana pustą deską (stała wysokość); świeca na szczycie + cokół/nóżki („stoi na podłodze"). Koniec z pojedynczą listą 700-wysoką — przechodzisz między Regałami.
- **Refaktor pod reużycie**: `buildShelfItems` + `chunk` (`utils/shelfLayout.ts`), render pojedynczego rzędu wyjęty do `ShelfRow`/`EmptyShelfRow`.
- **Fizyka książek (`shelfPacking`) NIETKNIĘTA** — regały używają dokładnie tego samego silnika.

Wybory z rozmowy: **ciepły skryptorium** / **bogato** / **segmenty po kolei**. To **iteracja 1** (2 regały paginowane obok siebie); łatwo rozszerzyć do gęstej poziomej ściany wielu regałów, jeśli zechcesz.

### Weryfikacja
- Wierny **mock-screenshot** złożenia (pokój + featured + 2 regały z pagerem/świecą/cokołem) potwierdza kompozycję.
- `npm run lint` czysty, **297/297** testów (+3 `chunk`), `npm run build` OK.
- Fallback: układ dwóch regałów działa też w 1 kolumnie na wąskim ekranie.
- Bump `metadata.json` → **1.18.0**. `docs/bookshelf.md` §1b zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_