### PR TITLE
feat(regał): gęsta pozioma ściana regałów (5 półek/regał) na desktop

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.18.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.19.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.19.0** — **Gęsta pozioma ściana regałów** (desktop): `LibraryWall` pokazuje aktywną kolekcję
+  (przełącznik Do przeczytania / Przeczytane) jako wiele **regałów po 5 półek** obok siebie,
+  skalowanych transformem do wysokości viewportu (mierzy naturalny rozmiar regału + `innerHeight`),
+  z oknem „Regały I–VI / N" (strzałki). Przenoszenie między kolekcjami: **dok upuszczania** na dole
+  podczas przeciągania (`onDropBook(other)`). Nowe: `Bookcase` (regał stałej wielkości bez pomiaru),
+  `LibraryWall`, hook `useMediaQuery`. Wąski ekran (<1024) → fallback do dwóch regałów paginowanych.
+  Fizyka NIETKNIĘTA (regały używają `packAndLayout` przy `rowWidth=300`). Weryfikacja mockiem
+  (6 regałów × 5 półek). Lint/testy/build OK. `docs` §1b upd.
 - **1.18.0** — **Sala Archiwum**: regały stoją w POKOJU zamiast jednej długiej listy 700 pozycji.
   `RoomDecor` — ciepły skryptorium (drewniana ściana z panelami, podłoga, kinkiety z migoczącym
   światłem `motion`, kurz, proporzec, sygil koła zębatego, winieta; `aria-hidden`). Regały mają

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -65,11 +65,20 @@ wall, floor, wall sconces with a flickering flame and warm glow (`motion`), drif
 pennant, a faint Mechanicus cog watermark, and a vignette. Purely decorative — it never touches the
 book physics.
 
-Each shelf is a **fixed-height bookcase**: `Shelf` takes a `pageSize` (rows per bookcase) and slices
-its packed rows into segments **"Regał I / N"** navigated with ◄ ► arrows; short pages are padded with
-empty planks so the bookcase height is constant, and a candle + plinth/feet make it "stand on the
-floor". This replaces the single ~700-tall list — you page through Regały instead. The row builder is
-shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`; one row → `ShelfRow`).
+**Desktop (≥1024 px): a dense horizontal wall.** `LibraryWall` shows the active collection (a toggle
+switches **Do przeczytania / Przeczytane**) as many **5-shelf bookcases** side by side. It measures one
+bookcase's natural size and the viewport height, `transform: scale`s the whole row to fit the height,
+and shows as many bookcases as fit the width — the rest are reached with the **"Regały I–VI / N"** pager.
+Read-state is flipped by dragging a volume onto the **drop dock** that appears at the bottom during a
+drag. Each bookcase is a `Bookcase` (fixed size, candle + plinth). Books flow across bookcases in order.
+
+**Narrow screens: two fixed-height bookcases.** `Shelf` takes a `pageSize` (rows per bookcase) and
+slices its packed rows into segments **"Regał I / N"** (◄ ► arrows); short pages are padded with empty
+planks so the height is constant, with a candle + plinth. You page through Regały instead of one
+~700-tall list.
+
+The row builder is shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`; one row → `ShelfRow`),
+and the physics (`shelfPacking`) is identical in both layouts.
 
 ## 2. Data
 - Reuses **`GET /api/books`** (`BookIndexEntry[]`, see [skryptorium-search.md](./skryptorium-search.md)) —

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -8,10 +8,13 @@ import { Shelf } from "./shelf/Shelf";
 import { CoverCard } from "./shelf/CoverCard";
 import { ShelfFrame } from "./shelf/ShelfFrame";
 import { RoomDecor } from "./shelf/RoomDecor";
+import { LibraryWall } from "./shelf/LibraryWall";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 
 export const BookshelfSection: React.FC = () => {
   const { books, loading, error, fetchBooks } = useBooks();
   const { setRead } = useMarkRead();
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
 
   const [overrides, setOverrides] = useState<ReadOverrides>({});
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
@@ -122,21 +125,28 @@ export const BookshelfSection: React.FC = () => {
             </div>
           )}
 
-          {/* Dwa regały stałej wysokości (segmenty „Regał I/N") stojące w pokoju */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Shelf
-              shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={3}
-              icon={<BookOpen className="w-4 h-4" />}
-              books={toRead} dragging={!!dragging}
+          {/* Desktop: gęsta ściana regałów. Wąski ekran: dwa regały stałej wysokości. */}
+          {isDesktop ? (
+            <LibraryWall
+              toRead={toRead} read={read} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
-            <Shelf
-              shelfId="read" title="Przeczytane" accent="emerald" pageSize={3}
-              icon={<CheckCircle2 className="w-4 h-4" />}
-              books={read} dragging={!!dragging}
-              onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
-            />
-          </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-6">
+              <Shelf
+                shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={3}
+                icon={<BookOpen className="w-4 h-4" />}
+                books={toRead} dragging={!!dragging}
+                onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
+              />
+              <Shelf
+                shelfId="read" title="Przeczytane" accent="emerald" pageSize={3}
+                icon={<CheckCircle2 className="w-4 h-4" />}
+                books={read} dragging={!!dragging}
+                onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
+              />
+            </div>
+          )}
 
           <p className="text-center text-[10px] text-amber-200/40 uppercase tracking-widest font-bold mt-6">
             {all.length} woluminów · <span className="text-amber-400/70">●</span> = nagroda · najedź, by wysunąć grzbiet

--- a/src/components/shelf/Bookcase.tsx
+++ b/src/components/shelf/Bookcase.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Library } from "lucide-react";
+import { BookIndexEntry } from "../../types";
+import { ShelfSlot, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { PlacedItem } from "../../utils/shelfPacking";
+import { ShelfRow, EmptyShelfRow } from "./ShelfRow";
+import { ShelfFrame } from "./ShelfFrame";
+
+interface Props {
+  name: string;                 // „Regał III"
+  count: number;                // ile woluminów w tym regale
+  rows: PlacedItem[][];         // rzędy tego regału (≤ shelves)
+  slotByKey: Map<string, ShelfSlot>;
+  shelves: number;              // stała liczba półek (dopełniane pustą deską)
+  innerWidth: number;           // szerokość rzędu (== rowWidth z packAndLayout)
+  onDragStart: (book: BookIndexEntry) => void;
+  onDragEnd: () => void;
+}
+
+/** Jeden regał ściany: stała liczba półek, świeca na szczycie, cokół. Bez pomiaru/pagera. */
+export const Bookcase: React.FC<Props> = ({ name, count, rows, slotByKey, shelves, innerWidth, onDragStart, onDragEnd }) => {
+  const pad = Math.max(0, shelves - rows.length);
+  return (
+    <div className="relative shrink-0">
+      {/* Świeca na szczycie */}
+      <div className="absolute -top-[24px] left-7 z-20 pointer-events-none" aria-hidden>
+        <div className="w-[8px] h-[22px] mx-auto rounded-[2px] bg-gradient-to-b from-[#e8dcc0] via-[#d8c8a2] to-[#b9a271]" />
+        <div className="absolute -top-[12px] left-1/2 -translate-x-1/2 w-[7px] h-[12px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
+          style={{ background: "radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00)", boxShadow: "0 0 12px 4px rgba(255,150,40,.5)" }} />
+      </div>
+
+      <ShelfFrame title={name} icon={<Library className="w-4 h-4" />} accent="amber" count={count} highlight="idle">
+        <div className="flex flex-col mx-auto" style={{ rowGap: SHELF_ROW_GAP - SHELF_PLANK_H, width: innerWidth }}>
+          {rows.map((row, ri) => (
+            <ShelfRow key={ri} row={row} slotByKey={slotByKey} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+          ))}
+          {Array.from({ length: pad }).map((_, i) => <EmptyShelfRow key={`pad${i}`} />)}
+        </div>
+      </ShelfFrame>
+
+      {/* Cokół / nóżki */}
+      <div className="mx-2 h-[10px] rounded-b-[6px]" style={{ background: "linear-gradient(180deg,#3a2915,#1c1108)", boxShadow: "0 10px 16px -6px rgba(0,0,0,.7)" }} aria-hidden />
+      <div className="flex justify-between px-6" aria-hidden>
+        {[0, 1].map((i) => <div key={i} className="w-8 h-[9px] rounded-b-[4px]" style={{ background: "linear-gradient(180deg,#2a1c0f,#120b06)" }} />)}
+      </div>
+    </div>
+  );
+};

--- a/src/components/shelf/LibraryWall.tsx
+++ b/src/components/shelf/LibraryWall.tsx
@@ -1,0 +1,146 @@
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, BookOpen, CheckCircle2 } from "lucide-react";
+import { BookIndexEntry } from "../../types";
+import { ShelfId } from "../../utils/bookshelf";
+import { packAndLayout } from "../../utils/shelfPacking";
+import { buildShelfItems, chunk } from "../../utils/shelfLayout";
+import { Bookcase } from "./Bookcase";
+
+interface Props {
+  toRead: BookIndexEntry[];
+  read: BookIndexEntry[];
+  dragging: boolean;
+  onDragStart: (book: BookIndexEntry) => void;
+  onDragEnd: () => void;
+  onDropBook: (target: ShelfId) => void;
+}
+
+const CASE_W = 300;        // szerokość rzędu w regale (== rowWidth)
+const SHELVES = 5;         // półek na regał
+const GAP = 26;            // odstęp między regałami (naturalny, przed skalą)
+const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
+
+/**
+ * Gęsta pozioma ŚCIANA regałów. Aktywną kolekcję (do przeczytania / przeczytane)
+ * dzieli na regały po `SHELVES` półek, skaluje do wysokości viewportu i pokazuje
+ * tyle regałów, ile zmieści się na szerokość; resztę przełączasz strzałkami.
+ * Przenoszenie między kolekcjami: dok upuszczania na dole (podczas przeciągania).
+ */
+export const LibraryWall: React.FC<Props> = ({ toRead, read, dragging, onDragStart, onDragEnd, onDropBook }) => {
+  const [collection, setCollection] = useState<ShelfId>("toRead");
+  const [win, setWin] = useState(0);
+  const [availW, setAvailW] = useState(0);
+  const [availH, setAvailH] = useState(560);
+  const [dockOver, setDockOver] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const measRef = useRef<HTMLDivElement>(null);
+  const [nat, setNat] = useState({ w: CASE_W + 40, h: 900 });
+
+  useLayoutEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    const upd = () => {
+      setAvailW(el.clientWidth);
+      setAvailH(Math.max(420, Math.min(920, window.innerHeight - 260)));
+    };
+    upd();
+    const ro = new ResizeObserver(upd);
+    ro.observe(el);
+    window.addEventListener("resize", upd);
+    return () => { ro.disconnect(); window.removeEventListener("resize", upd); };
+  }, []);
+
+  const books = collection === "toRead" ? toRead : read;
+  const { items, slotByKey } = useMemo(() => buildShelfItems(books), [books]);
+  const rows = availW > 0 ? packAndLayout(items, { rowWidth: CASE_W }) : [];
+  const cases = chunk(rows, SHELVES);
+
+  // Zmierz naturalny rozmiar jednego regału (stały — dopełniany do SHELVES).
+  useLayoutEffect(() => {
+    const el = measRef.current;
+    if (el && el.offsetHeight > 0) setNat({ w: el.offsetWidth, h: el.offsetHeight });
+  }, [cases.length === 0]);
+
+  const scale = Math.min(1, availH / nat.h);
+  const perScreen = Math.max(1, Math.floor((availW / scale + GAP) / (nat.w + GAP)));
+  const winCount = Math.max(1, Math.ceil(cases.length / perScreen));
+  const winIdx = Math.min(win, winCount - 1);
+  const from = winIdx * perScreen;
+  const shown = cases.slice(from, from + perScreen);
+
+  const other: ShelfId = collection === "toRead" ? "read" : "toRead";
+  const toggle = (id: ShelfId, label: string, n: number, Icon: React.FC<{ className?: string }>) => (
+    <button
+      onClick={() => { setCollection(id); setWin(0); }}
+      className={`flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-display font-bold uppercase tracking-widest border transition-all ${
+        collection === id ? "bg-amber-500/15 border-amber-500/40 text-amber-100" : "border-white/10 text-amber-200/50 hover:text-amber-100"}`}
+    >
+      <Icon className="w-4 h-4" />{label}<span className="text-amber-200/40">· {n}</span>
+    </button>
+  );
+
+  return (
+    <div className="relative z-10">
+      {/* Przełącznik kolekcji + pager */}
+      <div className="flex flex-wrap items-center justify-center gap-3 mb-6">
+        {toggle("toRead", "Do przeczytania", toRead.length, BookOpen)}
+        {toggle("read", "Przeczytane", read.length, CheckCircle2)}
+        {winCount > 1 && (
+          <div className="flex items-center gap-1.5 ml-2">
+            <button onClick={() => setWin((p) => Math.max(0, Math.min(p, winCount - 1) - 1))} disabled={winIdx === 0}
+              className="p-1.5 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Poprzednie regały">
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <span className="text-[11px] font-display font-bold uppercase tracking-widest text-amber-200/80">
+              Regały {ROMAN[from] ?? from + 1}–{ROMAN[Math.min(from + shown.length, cases.length) - 1] ?? Math.min(from + shown.length, cases.length)}<span className="text-amber-200/40"> / {cases.length}</span>
+            </span>
+            <button onClick={() => setWin((p) => Math.min(winCount - 1, Math.min(p, winCount - 1) + 1))} disabled={winIdx >= winCount - 1}
+              className="p-1.5 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Następne regały">
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Ściana regałów (skalowana do wysokości) */}
+      <div ref={rowRef} className="relative flex justify-center" style={{ height: nat.h * scale + 40 }}>
+        {books.length === 0 ? (
+          <div className="text-sm text-amber-200/40 italic pt-16">Ta kolekcja jest pusta.</div>
+        ) : (
+          <div className="absolute top-0 left-1/2" style={{ transform: `translateX(-50%) scale(${scale})`, transformOrigin: "top center", display: "flex", gap: GAP }}>
+            {shown.map((caseRows, i) => (
+              <Bookcase
+                key={from + i}
+                name={`Regał ${ROMAN[from + i] ?? from + i + 1}`}
+                count={caseRows.reduce((s, r) => s + r.length, 0)}
+                rows={caseRows} slotByKey={slotByKey} shelves={SHELVES} innerWidth={CASE_W}
+                onDragStart={onDragStart} onDragEnd={onDragEnd}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Ukryty regał do pomiaru naturalnego rozmiaru */}
+      <div ref={measRef} className="absolute -left-[9999px] top-0 pointer-events-none opacity-0" aria-hidden>
+        <Bookcase name="Regał" count={0} rows={cases[0] ?? []} slotByKey={slotByKey} shelves={SHELVES} innerWidth={CASE_W} onDragStart={() => {}} onDragEnd={() => {}} />
+      </div>
+
+      {/* Dok upuszczania (podczas przeciągania) — przenosi do drugiej kolekcji */}
+      {dragging && (
+        <div
+          onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!dockOver) setDockOver(true); }}
+          onDragLeave={() => setDockOver(false)}
+          onDrop={(e) => { e.preventDefault(); setDockOver(false); onDropBook(other); }}
+          className={`mt-6 mx-auto max-w-2xl flex items-center justify-center gap-3 py-4 rounded-2xl border-2 border-dashed transition-all ${
+            dockOver ? "border-amber-400/70 bg-amber-500/10 text-amber-100" : "border-amber-500/30 text-amber-200/70"}`}
+        >
+          {other === "read" ? <CheckCircle2 className="w-5 h-5" /> : <BookOpen className="w-5 h-5" />}
+          <span className="text-sm font-display font-bold uppercase tracking-widest">
+            Upuść tutaj → {other === "read" ? "Przeczytane" : "Do przeczytania"}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/** Reaktywny match media-query (np. „(min-width: 1024px)"). SSR-safe. */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== "undefined" && "matchMedia" in window ? window.matchMedia(query).matches : false
+  );
+  useEffect(() => {
+    if (typeof window === "undefined" || !("matchMedia" in window)) return;
+    const m = window.matchMedia(query);
+    const on = () => setMatches(m.matches);
+    on();
+    m.addEventListener("change", on);
+    return () => m.removeEventListener("change", on);
+  }, [query]);
+  return matches;
+}


### PR DESCRIPTION
## Cel (Fixes #135)

Iteracja 2 Sali Archiwum: na desktopie **gęsta pozioma ściana regałów**, po **5 półek** na regał.

### `LibraryWall` (desktop ≥1024 px)
- **Przełącznik kolekcji**: Do przeczytania / Przeczytane (pokazujemy jedną naraz jako ścianę).
- **Wiele regałów po 5 półek** obok siebie. Cała kolekcja jest pakowana fizyką (`packAndLayout`, `rowWidth=300`), rzędy cięte na regały po 5 (`chunk`).
- **Skalowanie do wysokości viewportu**: mierzy naturalny rozmiar jednego regału (ukryty pomiarowy) + `innerHeight`, `transform: scale` na całym rzędzie, i pokazuje tyle regałów, ile zmieści się na szerokość. Resztę przełączasz oknem **„Regały I–VI / N"** (◄ ►).
- **Przenoszenie między kolekcjami**: podczas przeciągania pojawia się **dok upuszczania** na dole („Upuść tutaj → Przeczytane/Do przeczytania"); drop wywołuje `onDropBook` drugiej kolekcji (istniejąca, serializowana logika zapisu).
- Nowe: `Bookcase` (regał stałej wielkości, bez pomiaru/pagera), `LibraryWall`, hook `useMediaQuery`.

**Wąski ekran (<1024)** → fallback do dwóch regałów paginowanych (z 1.18.0), drag między nimi.

**Fizyka książek NIETKNIĘTA** — regały używają dokładnie tego samego silnika.

### Weryfikacja
- Wierny **mock-screenshot**: 6 regałów × 5 półek, przełącznik, pager, świece, kinkiety, sygil — gęsta ściana.
- `npm run lint` czysty, **297/297** testów, `npm run build` OK.
- Bump `metadata.json` → **1.19.0**. `docs/bookshelf.md` §1b zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_