### PR TITLE
feat(regał): regały mają 5 półek

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.19.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.19.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,7 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.19.2** — Regały mają **5 półek** (`pageSize` 3→5 dla obu). Podpis u góry „Regał N" (było „I/N").
 - **1.19.1** — Powrót do **dwóch regałów** (lewy „Do przeczytania", prawy zawsze „Przeczytane",
   paginacja `Regał N/M`) — drag&drop po staremu; usunięte `LibraryWall`/`Bookcase`/`useMediaQuery`
   (ściana odrzucona). Numeracja regałów **arabska** (było rzymskie). **Sortowanie półek po DACIE

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.19.1",
+  "version": "1.19.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -75,7 +75,7 @@ export const BookshelfSection: React.FC = () => {
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
       </div>
       <p className="text-center text-[11px] text-slate-500 uppercase tracking-widest font-bold -mt-4">
-        Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał I/N"
+        Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał N"
       </p>
 
       {moveError && (
@@ -126,13 +126,13 @@ export const BookshelfSection: React.FC = () => {
               „Przeczytane" — drag&drop między nimi. Każdy paginowany (Regał N/M). */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <Shelf
-              shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={3}
+              shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={5}
               icon={<BookOpen className="w-4 h-4" />}
               books={toRead} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
             <Shelf
-              shelfId="read" title="Przeczytane" accent="emerald" pageSize={3}
+              shelfId="read" title="Przeczytane" accent="emerald" pageSize={5}
               icon={<CheckCircle2 className="w-4 h-4" />}
               books={read} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}


### PR DESCRIPTION
Follow-up do #137: oba regały (Do przeczytania / Przeczytane) mają teraz **5 półek** (`pageSize` 3→5). Podpis u góry poprawiony na „Regał N" (arabskie).

Fizyka i reszta bez zmian. `npm run lint` czysty, **298/298** testów, `npm run build` OK. Bump → **1.19.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_