### PR TITLE
feat(regał): tabliczki dekad + color-code nagród bez nominacji

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.19.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.20.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.20.0** — (1) **Tabliczki dekad**: generyczna przekładka `ShelfDivider` (parchment + mosiężny guzik,
+  pionowy tekst) wstawiana na granicy każdej dekady wydania (`buildShelfItems` grupuje po `decadeOf`,
+  kupki nie przekraczają dekady; `RenderSlot` + `PackItem`/`PlacedItem` kind `divider`). Etykieta
+  generyczna (dziś „1950–1959", w przyszłości litera/nazwisko). (2) **Color-code nagród, bez nominacji**:
+  `awardWins(book)` — tylko wygrane („Nagroda …"/„Wszystkie"), pomija „Nominacja …"; Hugo=złoty,
+  Nebula=fioletowy, Locus=błękitny; kropki na grzbiecie/leżącej książce zamiast jednej bursztynowej.
+  `hasAward` = `awardWins>0`. +8 testów (awardWins, tabliczki dekad). Screenshot OK. Fizyka NIETKNIĘTA.
 - **1.19.2** — Regały mają **5 półek** (`pageSize` 3→5 dla obu). Podpis u góry „Regał N" (było „I/N").
 - **1.19.1** — Powrót do **dwóch regałów** (lewy „Do przeczytania", prawy zawsze „Przeczytane",
   paginacja `Regał N/M`) — drag&drop po staremu; usunięte `LibraryWall`/`Bookcase`/`useMediaQuery`

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -87,6 +87,13 @@ The row builder is shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`
   negative for hashes above 2³¹ and produced out-of-range heights (caught by a bounds test).
 - **`splitShelves(books, overrides)`** — partitions into `{ read, toRead }`, each sorted by
   **publication date** (year, ascending; volumes without a year go last), tie-broken by title.
+- **`awardWins(book)` / `hasAward(book)`** — the **won** awards only, colour-coded (Hugo = gold,
+  Nebula = purple, Locus = blue; `"Wszystkie"` = all three). **Nominations (`"Nominacja …"`) are
+  ignored.** Rendered as coloured dots on the spine / lying book; `hasAward` = `awardWins().length > 0`.
+- **`buildShelfItems(books)` / `decadeOf` / `decadeLabel`** — build the pack items and, since the shelf
+  is sorted by year, insert a generic **section divider** (`ShelfDivider`, a `RenderSlot` of kind
+  `"divider"`) at each **decade boundary** (e.g. `1950–1959`). The divider is a generic nameplate — the
+  label is just a string, so a future mode can show an alphabet letter or author surname instead.
 - **`featuredReads(books, overrides, limit)`** — the cover row: read **and** awarded, newest year
   first (no read-date exists in the data), capped at `limit`.
 - **`shelfPlankBackground()`** — the CSS `repeating-linear-gradient` that paints a wooden plank under

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.19.2",
+      "version": "1.20.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.19.2",
+  "version": "1.20.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, planShelf, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, planShelf, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, awardWins, hasAward, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -200,6 +200,28 @@ describe("bookshelf.shelfPlankBackground", () => {
   });
 });
 
+describe("bookshelf.awardWins (color-code, bez nominacji)", () => {
+  it("counts only wins, color-coded, in Hugo→Nebula→Locus order", () => {
+    const w = awardWins(mk({ awards: ["Nagroda Locus", "Nagroda Hugo"] }));
+    expect(w.map((x) => x.key)).toEqual(["hugo", "locus"]);
+    expect(w[0].color).toMatch(/^#/);
+    expect(w[0].label).toBe("Hugo");
+  });
+  it("ignores nominations entirely", () => {
+    expect(awardWins(mk({ awards: ["Nominacja Hugo", "Nominacja Nebula"] }))).toEqual([]);
+    expect(hasAward(mk({ awards: ["Nominacja Hugo"] }))).toBe(false);
+    // wygrana + nominacja → tylko wygrana
+    expect(awardWins(mk({ awards: ["Nominacja Hugo", "Nagroda Nebula"] })).map((x) => x.key)).toEqual(["nebula"]);
+  });
+  it("treats Wszystkie as all three wins, deduped", () => {
+    expect(awardWins(mk({ awards: ["Wszystkie", "Nagroda Hugo"] })).map((x) => x.key)).toEqual(["hugo", "nebula", "locus"]);
+  });
+  it("no awards → empty", () => {
+    expect(awardWins(mk({ awards: [] }))).toEqual([]);
+    expect(hasAward(mk({ awards: [] }))).toBe(false);
+  });
+});
+
 describe("bookshelf.splitShelves", () => {
   const books = [
     mk({ id: "1", plTitle: "B", author: "Lem", year: "1970", zrodlo: [READ_TAG] }),
@@ -249,7 +271,7 @@ describe("bookshelf.featuredReads", () => {
 
   it("respects the limit", () => {
     const many = Array.from({ length: 20 }, (_, i) =>
-      mk({ id: String(i), plTitle: `T${i}`, zrodlo: [READ_TAG], awards: ["Nagroda X"], year: String(2000 + i) }));
+      mk({ id: String(i), plTitle: `T${i}`, zrodlo: [READ_TAG], awards: ["Nagroda Hugo"], year: String(2000 + i) }));
     expect(featuredReads(many, {}, 5)).toHaveLength(5);
   });
 });

--- a/src/__tests__/shelfLayout.test.ts
+++ b/src/__tests__/shelfLayout.test.ts
@@ -1,5 +1,50 @@
 import { describe, it, expect } from "vitest";
-import { chunk } from "../utils/shelfLayout";
+import { chunk, buildShelfItems, decadeOf, decadeLabel } from "../utils/shelfLayout";
+import { BookIndexEntry } from "../types";
+
+const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
+  id: over.id ?? "x", plTitle: over.plTitle ?? "T", origTitle: "", author: "", year: "",
+  awards: [], zrodlo: [], series: "", partOfCycle: false, ...over,
+});
+
+describe("shelfLayout.decade", () => {
+  it("buckets a year into its decade; blanks → null", () => {
+    expect(decadeOf("1954")).toBe(1950);
+    expect(decadeOf("1960")).toBe(1960);
+    expect(decadeOf("")).toBe(null);
+    expect(decadeOf("brak")).toBe(null);
+    expect(decadeLabel(1950)).toBe("1950–1959");
+    expect(decadeLabel(null)).toBe("bez daty");
+  });
+});
+
+describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {
+  // Posortowane po dacie (jak z splitShelves): 1948, 1952, 1955, 1969, brak.
+  const books = [
+    mk({ id: "a", year: "1948" }),
+    mk({ id: "b", year: "1952" }),
+    mk({ id: "c", year: "1955" }),
+    mk({ id: "d", year: "1969" }),
+    mk({ id: "e", year: "" }),
+  ];
+
+  it("inserts one divider per decade section, before its books", () => {
+    const { items, slotByKey } = buildShelfItems(books);
+    const dividers = items.filter((it) => it.kind === "divider");
+    // dekady: 1940, 1950, 1960, bez daty → 4 tabliczki
+    expect(dividers.length).toBe(4);
+    const labels = dividers.map((d) => (slotByKey.get(d.key) as { label: string }).label);
+    expect(labels).toEqual(["1940–1949", "1950–1959", "1960–1969", "bez daty"]);
+  });
+
+  it("keeps every book exactly once and dividers precede their decade", () => {
+    const { items } = buildShelfItems(books);
+    const seq = items.map((it) => (it.kind === "divider" ? "|" : it.key));
+    // pierwszy item to tabliczka; każda książka pojawia się raz
+    expect(seq[0]).toBe("|");
+    expect(seq.filter((s) => s !== "|")).toEqual(["a", "b", "c", "d", "e"]);
+  });
+});
 
 describe("shelfLayout.chunk", () => {
   it("splits rows into fixed-size segments (regały)", () => {

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
-import { SpineStyle, displayTitle, hasAward, spineFontSize } from "../../utils/bookshelf";
+import { SpineStyle, displayTitle, awardWins, spineFontSize } from "../../utils/bookshelf";
 
 interface Props {
   book: BookIndexEntry;
@@ -31,8 +31,16 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
     >
       {displayTitle(book)}
     </span>
-    {hasAward(book) && (
-      <span className="absolute bottom-[7px] left-1/2 -translate-x-1/2 w-[9px] h-[9px] rounded-full bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,.85)]" title="Nagroda / nominacja" />
-    )}
+    {(() => {
+      const wins = awardWins(book);
+      if (!wins.length) return null;
+      return (
+        <span className="absolute bottom-[6px] left-1/2 -translate-x-1/2 flex flex-col-reverse items-center gap-[3px]" title={wins.map((w) => w.label).join(" · ")}>
+          {wins.map((w) => (
+            <span key={w.key} className="w-[8px] h-[8px] rounded-full" style={{ background: w.color, boxShadow: `0 0 6px ${w.color}` }} />
+          ))}
+        </span>
+      );
+    })()}
   </div>
 );

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
-import { spineStyle, layoutStack, displayTitle, hasAward } from "../../utils/bookshelf";
+import { spineStyle, layoutStack, displayTitle, awardWins } from "../../utils/bookshelf";
 
 interface Props {
   books: BookIndexEntry[];          // każda warstwa to OSOBNA prawdziwa książka
@@ -22,6 +22,7 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
     <div className="relative shrink-0 flex flex-col-reverse items-start" style={{ width: cellW }}>
       {layers.map(({ book, width, fontSize, thickness, lines, x }, i) => {
         const color = spineStyle(book).color;
+        const wins = awardWins(book);
         return (
           <div
             key={book.id}
@@ -43,7 +44,8 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
             <span className="absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px] bg-gradient-to-b from-amber-50/70 via-amber-100/40 to-amber-50/70" aria-hidden />
             {/* PEŁNY tytuł wzdłuż grzbietu — zawijany do max 2 linii zamiast poszerzania */}
             <span
-              className={`absolute inset-y-0 right-3 flex items-center font-bold text-white/90 ${hasAward(book) ? "left-3.5" : "left-2"}`}
+              className="absolute inset-y-0 right-3 flex items-center font-bold text-white/90"
+              style={{ left: wins.length ? 6 + wins.length * 7 : 8 }}
             >
               <span
                 style={{
@@ -60,8 +62,12 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
                 {displayTitle(book)}
               </span>
             </span>
-            {hasAward(book) && (
-              <span className="absolute top-1/2 -translate-y-1/2 left-1 w-[7px] h-[7px] rounded-full bg-amber-400 shadow-[0_0_5px_rgba(251,191,36,.85)]" title="Nagroda / nominacja" />
+            {wins.length > 0 && (
+              <span className="absolute top-1/2 -translate-y-1/2 left-1 flex items-center gap-[2px]" title={wins.map((w) => w.label).join(" · ")}>
+                {wins.map((w) => (
+                  <span key={w.key} className="w-[6px] h-[6px] rounded-full" style={{ background: w.color, boxShadow: `0 0 5px ${w.color}` }} />
+                ))}
+              </span>
             )}
           </div>
         );

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+interface Props {
+  label: string;      // np. „1950–1959" (w przyszłości litera alfabetu / nazwisko autora)
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Generyczna **tabliczka-przekładka** stojąca na półce między woluminami — czytelny
+ * znacznik sekcji. Dziś nadaje ją dekada wydania; ten sam komponent obsłuży dowolną
+ * etykietę (litera alfabetu, nazwisko autora itp.). Nieprzeciągalna.
+ */
+export const ShelfDivider: React.FC<Props> = ({ label, width = 34, height = 156 }) => (
+  <div
+    className="relative shrink-0 flex items-center justify-center select-none rounded-t-[7px] rounded-b-[2px]"
+    style={{
+      width, height,
+      background: "linear-gradient(180deg, #ecdfbe 0%, #d5c193 55%, #b89c68 100%)",
+      boxShadow: "inset 0 0 0 1.5px rgba(120,80,30,.45), inset 1.5px 0 0 rgba(255,255,255,.45), inset -1px 0 4px rgba(90,60,20,.35), 0 8px 12px -6px rgba(0,0,0,.6)",
+    }}
+    title={label}
+    aria-hidden
+  >
+    {/* mosiężny guzik u góry */}
+    <span className="absolute top-1.5 left-1/2 -translate-x-1/2 w-[11px] h-[11px] rounded-full"
+      style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #b8860b 68%, #6b4a08)", boxShadow: "0 1px 2px rgba(0,0,0,.4)" }} />
+    <span
+      className="font-display font-black"
+      style={{ writingMode: "vertical-rl", transform: "rotate(180deg)", color: "#4a3418", fontSize: 12.5, letterSpacing: "0.06em", marginTop: 10, textShadow: "0 1px 0 rgba(255,255,255,.35)" }}
+    >
+      {label}
+    </span>
+  </div>
+);

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
-import { ShelfSlot, spineStyle, SHELF_ROW_H, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { spineStyle, SHELF_ROW_H, SHELF_PLANK_H } from "../../utils/bookshelf";
+import { RenderSlot } from "../../utils/shelfLayout";
 import { PlacedItem } from "../../utils/shelfPacking";
 import { BookSpine } from "./BookSpine";
 import { BookStack } from "./BookStack";
+import { ShelfDivider } from "./ShelfDivider";
 
 export const PLANK_STYLE: React.CSSProperties = {
   height: SHELF_PLANK_H,
@@ -14,7 +16,7 @@ export const PLANK_STYLE: React.CSSProperties = {
 
 interface Props {
   row: PlacedItem[];
-  slotByKey: Map<string, ShelfSlot>;
+  slotByKey: Map<string, RenderSlot>;
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
 }
@@ -25,6 +27,13 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragE
     <div className="relative" style={{ height: SHELF_ROW_H }}>
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
+        if (slot.kind === "divider") {
+          return (
+            <div key={p.key} className="absolute bottom-0" style={{ left: p.x }}>
+              <ShelfDivider label={slot.label} />
+            </div>
+          );
+        }
         if (slot.kind === "stack") {
           return (
             <div key={p.key} className="absolute bottom-0" style={{ left: p.x }}>

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -266,9 +266,36 @@ export function shelfPlankBackground(): { backgroundImage: string } {
   return { backgroundImage };
 }
 
-/** Czy pozycja ma nagrodę/nominację (do pieczęci na grzbiecie i półki „Wyróżnione"). */
+/** Znacznik zdobytej NAGRODY (nie nominacji) z color-code do pieczęci na grzbiecie. */
+export interface AwardMark { key: "hugo" | "nebula" | "locus"; color: string; label: string }
+
+const AWARD_MARKS: Record<AwardMark["key"], AwardMark> = {
+  hugo: { key: "hugo", color: "#fbbf24", label: "Hugo" },      // złoto (rakieta)
+  nebula: { key: "nebula", color: "#c084fc", label: "Nebula" }, // fiolet (mgławica)
+  locus: { key: "locus", color: "#38bdf8", label: "Locus" },   // błękit
+};
+
+/**
+ * Zdobyte nagrody książki z color-code. Bierze TYLKO wygrane („Nagroda …" lub
+ * „Wszystkie" = Hugo+Nebula+Locus) — **nominacje pomijamy**. Zdeduplikowane,
+ * w stałej kolejności Hugo → Nebula → Locus.
+ */
+export function awardWins(book: BookIndexEntry): AwardMark[] {
+  const won = new Set<AwardMark["key"]>();
+  for (const a of book.awards) {
+    const s = a.toLowerCase().trim();
+    if (s === "wszystkie") { won.add("hugo"); won.add("nebula"); won.add("locus"); continue; }
+    if (!s.startsWith("nagroda ")) continue;        // pomijamy „Nominacja …" i inne
+    if (s.includes("hugo")) won.add("hugo");
+    else if (s.includes("nebula")) won.add("nebula");
+    else if (s.includes("locus")) won.add("locus");
+  }
+  return (["hugo", "nebula", "locus"] as const).filter((k) => won.has(k)).map((k) => AWARD_MARKS[k]);
+}
+
+/** Czy pozycja ma zdobytą nagrodę (do pieczęci na grzbiecie i półki „Wyróżnione"). */
 export function hasAward(book: BookIndexEntry): boolean {
-  return book.awards.length > 0;
+  return awardWins(book).length > 0;
 }
 
 /** Rok wydania jako liczba do sortowania; brak/niepoprawny → na koniec. */

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -2,26 +2,61 @@ import { BookIndexEntry } from "../types";
 import { ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle } from "./bookshelf";
 import { PackItem } from "./shelfPacking";
 
+/** Slot do renderu: wolumin/kupka (`ShelfSlot`) albo tabliczka-przekładka sekcji. */
+export type RenderSlot = ShelfSlot | { kind: "divider"; label: string };
+
+const DIVIDER_W = 34;
+const DIVIDER_H = 156;
+
+/** Dekada roku wydania (np. 1954 → 1950); brak/niepoprawny rok → `null` (sekcja „bez daty"). */
+export function decadeOf(year: string): number | null {
+  const y = Number(year);
+  return Number.isFinite(y) && y > 0 ? Math.floor(y / 10) * 10 : null;
+}
+
+/** Etykieta tabliczki dekady, np. „1950–1959" (albo „bez daty"). */
+export function decadeLabel(dec: number | null): string {
+  return dec === null ? "bez daty" : `${dec}–${dec + 9}`;
+}
+
 /**
- * Buduje `PackItem[]` (do fizyki `packAndLayout`) i mapę `slotByKey` (do renderu)
- * dla listy woluminów. Wspólne dla pojedynczego regału i regałów w pokoju.
+ * Buduje `PackItem[]` (do fizyki `packAndLayout`) i mapę `slotByKey` (do renderu).
+ * Woluminy przychodzą już posortowane po dacie wydania; na **granicy każdej dekady**
+ * wstawiamy tabliczkę-przekładkę (`divider`). Kupki nie przekraczają granicy dekady
+ * (planShelf liczony osobno per dekada). Wspólne dla wszystkich widoków regału.
  */
-export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; slotByKey: Map<string, ShelfSlot> } {
-  const slots = planShelf(books);
-  const slotByKey = new Map<string, ShelfSlot>();
-  const items: PackItem[] = slots.map((slot) => {
-    if (slot.kind === "stack") {
-      const key = `stack:${slot.books[0].id}`;
-      slotByKey.set(key, slot);
-      const sl = layoutStack(slot.books);
-      return { key, kind: "stack", bw: sl.cellW, h: sl.height, leanDir: 0 };
+export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; slotByKey: Map<string, RenderSlot> } {
+  const slotByKey = new Map<string, RenderSlot>();
+  const items: PackItem[] = [];
+  let i = 0;
+  let divN = 0;
+
+  while (i < books.length) {
+    const dec = decadeOf(books[i].year);
+    let j = i;
+    while (j < books.length && decadeOf(books[j].year) === dec) j++;
+
+    // Tabliczka na początku sekcji dekady.
+    const dkey = `div:${divN++}`;
+    slotByKey.set(dkey, { kind: "divider", label: decadeLabel(dec) });
+    items.push({ key: dkey, kind: "divider", bw: DIVIDER_W, h: DIVIDER_H, leanDir: 0 });
+
+    // Woluminy tej dekady (kupki/pochyły w obrębie dekady).
+    for (const slot of planShelf(books.slice(i, j))) {
+      if (slot.kind === "stack") {
+        const key = `stack:${slot.books[0].id}`;
+        slotByKey.set(key, slot);
+        const sl = layoutStack(slot.books);
+        items.push({ key, kind: "stack", bw: sl.cellW, h: sl.height, leanDir: 0 });
+      } else {
+        slotByKey.set(slot.book.id, slot);
+        const st = spineStyle(slot.book);
+        const stretch = Math.min(26, Math.max(8, 6 + displayTitle(slot.book).length * 0.5));
+        items.push({ key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1, stretch });
+      }
     }
-    slotByKey.set(slot.book.id, slot);
-    const st = spineStyle(slot.book);
-    // Dłuższy tytuł → grzbiet może zgrubieć bardziej (naturalnie „grubsza książka").
-    const stretch = Math.min(26, Math.max(8, 6 + displayTitle(slot.book).length * 0.5));
-    return { key: slot.book.id, kind: "spine", bw: st.width, h: st.height, leanDir: Math.sign(slot.lean) as -1 | 0 | 1, stretch };
-  });
+    i = j;
+  }
   return { items, slotByKey };
 }
 

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -17,7 +17,7 @@ import { MAX_LEAN_DEG } from "./bookshelf";
 
 export interface PackItem {
   key: string;
-  kind: "spine" | "stack";
+  kind: "spine" | "stack" | "divider";
   bw: number;          // szerokość podstawy (footprint na półce), px
   h: number;           // wysokość widoczna (jako podpora dla sąsiada), px
   leanDir: -1 | 0 | 1; // zamierzony kierunek pochylenia (−1 w lewo, +1 w prawo, 0 brak)
@@ -26,7 +26,7 @@ export interface PackItem {
 
 export interface PlacedItem {
   key: string;
-  kind: "spine" | "stack";
+  kind: "spine" | "stack" | "divider";
   bw: number;
   w: number;           // szerokość do wyrenderowania (≥ bw — po ewentualnym pogrubieniu)
   x: number;           // lewa krawędź, px


### PR DESCRIPTION
## Cel (Fixes #140)

### 1. Tabliczki dekad (przekładki)
Skoro półki są sortowane po dacie wydania, na **granicy każdej dekady** wstawiamy **generyczną tabliczkę** `ShelfDivider` (parchment + mosiężny guzik + pionowy tekst, np. „1950–1959"), stojącą między książkami.
- `buildShelfItems` grupuje książki po `decadeOf()` i wstawia divider przed każdą sekcją; **kupki nie przekraczają dekady** (planShelf liczony per dekada).
- Nowy typ `RenderSlot` (`ShelfSlot | { kind:"divider", label }`), `PackItem`/`PlacedItem` z kind `"divider"`; render w `ShelfRow`.
- **Generyczna** — etykieta to zwykły string, więc przyszły tryb może pokazać literę alfabetu albo nazwisko autora.

### 2. Color-code nagród, bez nominacji
`awardWins(book)` bierze **tylko wygrane** (`"Nagroda …"` lub `"Wszystkie"` = Hugo+Nebula+Locus) i **pomija `"Nominacja …"`**. Color-code: **Hugo = złoty, Nebula = fioletowy, Locus = błękitny**. Kropki na grzbiecie (pionowo) i na leżącej książce (poziomo) zamiast jednej bursztynowej. `hasAward` = `awardWins().length > 0` (więc półka „Wyróżnione" też liczy tylko wygrane).

**Fizyka książek nietknięta.**

### Weryfikacja
- **Testy** (+8): `awardWins` (wygrane vs nominacje, „Wszystkie", dedup, kolejność Hugo→Nebula→Locus); `buildShelfItems` (jedna tabliczka na dekadę, każda książka dokładnie raz, tabliczka przed sekcją); `decadeOf`/`decadeLabel`.
- **Screenshot** (headless chromium): plakietka „1960–1969" między dekadami; kropki nagród (złoty/fiolet/błękit, „Solaris" = wszystkie trzy); książki bez wygranych bez kropek.
- `npm run lint` czysty, **305/305** testów, `npm run build` OK.
- Bump `metadata.json` → **1.20.0**. `docs/bookshelf.md` §3 zaktualizowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_