### PR TITLE
Regał: multi-date entries fall into a decade, not „bez daty"

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.20.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.20.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.20.1** — **Pola wielodatowe wpadają w dekadę** (nie „bez daty"). `parseYear(year)` w
+  `bookshelf.ts` wyciąga pierwszy 4-cyfrowy rok z pola (`/\d{4}/`, `null` gdy brak); używany
+  przez `decadeOf` (sortowanie tabliczek dekad) i `pubYear` (sort po dacie). Np. „1965/1966",
+  „1959 (wyd. pol. 1972)", „wyd. 1948" → dekada zamiast „bez daty". +1 test (multi-date decadeOf).
 - **1.20.0** — (1) **Tabliczki dekad**: generyczna przekładka `ShelfDivider` (parchment + mosiężny guzik,
   pionowy tekst) wstawiana na granicy każdej dekady wydania (`buildShelfItems` grupuje po `decadeOf`,
   kupki nie przekraczają dekady; `RenderSlot` + `PackItem`/`PlacedItem` kind `divider`). Etykieta

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -94,6 +94,9 @@ The row builder is shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`
   is sorted by year, insert a generic **section divider** (`ShelfDivider`, a `RenderSlot` of kind
   `"divider"`) at each **decade boundary** (e.g. `1950–1959`). The divider is a generic nameplate — the
   label is just a string, so a future mode can show an alphabet letter or author surname instead.
+  `decadeOf` uses `parseYear` (first `\d{4}` in the field), so **multi-date entries**
+  (`"1965/1966"`, `"1959 (wyd. pol. 1972)"`, `"wyd. 1948"`) fall into a real decade instead of
+  `"bez daty"`; only a field with no 4-digit year is treated as undated.
 - **`featuredReads(books, overrides, limit)`** — the cover row: read **and** awarded, newest year
   first (no read-date exists in the data), capped at `limit`.
 - **`shelfPlankBackground()`** — the CSS `repeating-linear-gradient` that paints a wooden plank under

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.20.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfLayout.test.ts
+++ b/src/__tests__/shelfLayout.test.ts
@@ -16,6 +16,12 @@ describe("shelfLayout.decade", () => {
     expect(decadeLabel(1950)).toBe("1950–1959");
     expect(decadeLabel(null)).toBe("bez daty");
   });
+  it("takes the FIRST year from multi-date fields (not bez daty)", () => {
+    expect(decadeOf("1965/1966")).toBe(1960);
+    expect(decadeOf("1965, 1966")).toBe(1960);
+    expect(decadeOf("1959 (wyd. pol. 1972)")).toBe(1950);
+    expect(decadeOf("wyd. 1948")).toBe(1940);
+  });
 });
 
 describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -298,10 +298,20 @@ export function hasAward(book: BookIndexEntry): boolean {
   return awardWins(book).length > 0;
 }
 
-/** Rok wydania jako liczba do sortowania; brak/niepoprawny → na koniec. */
+/**
+ * Rok wydania z pola daty. Pole bywa wielokrotne („1965/1966", „1965, 1966",
+ * „1965 (wyd. pol. 1970)") — bierzemy **pierwszy 4-cyfrowy rok z brzegu**, żeby
+ * pozycja i tak trafiła do swojej dekady. Brak roku → `null`.
+ */
+export function parseYear(year: string): number | null {
+  const m = String(year ?? "").match(/\d{4}/);
+  const y = m ? Number(m[0]) : NaN;
+  return Number.isFinite(y) && y > 0 ? y : null;
+}
+
+/** Rok wydania jako liczba do sortowania; brak → na koniec. */
 function pubYear(b: BookIndexEntry): number {
-  const y = Number(b.year);
-  return Number.isFinite(y) && y > 0 ? y : Infinity;
+  return parseYear(b.year) ?? Infinity;
 }
 
 /** Porządek wg daty wydania (rosnąco, chronologicznie), remis → tytuł. */

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -1,5 +1,5 @@
 import { BookIndexEntry } from "../types";
-import { ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle } from "./bookshelf";
+import { ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle, parseYear } from "./bookshelf";
 import { PackItem } from "./shelfPacking";
 
 /** Slot do renderu: wolumin/kupka (`ShelfSlot`) albo tabliczka-przekładka sekcji. */
@@ -8,10 +8,10 @@ export type RenderSlot = ShelfSlot | { kind: "divider"; label: string };
 const DIVIDER_W = 34;
 const DIVIDER_H = 156;
 
-/** Dekada roku wydania (np. 1954 → 1950); brak/niepoprawny rok → `null` (sekcja „bez daty"). */
+/** Dekada roku wydania (np. 1954 → 1950); pola wielodatowe → pierwszy rok; brak → `null`. */
 export function decadeOf(year: string): number | null {
-  const y = Number(year);
-  return Number.isFinite(y) && y > 0 ? Math.floor(y / 10) * 10 : null;
+  const y = parseYear(year);
+  return y === null ? null : Math.floor(y / 10) * 10;
 }
 
 /** Etykieta tabliczki dekady, np. „1950–1959" (albo „bez daty"). */


### PR DESCRIPTION
## Co i dlaczego

Książki, których pole roku zawiera więcej niż jedną datę (np. `1965/1966`, `1959 (wyd. pol. 1972)`, `wyd. 1948`), były klasyfikowane jako „bez daty" i lądowały poza sekcjami dekad.

## Zmiana

- **`parseYear(year)`** (`src/utils/bookshelf.ts`) — wyciąga pierwszy 4-cyfrowy rok z pola (`/\d{4}/`), `null` gdy brak.
- `decadeOf` (`shelfLayout.ts`) i `pubYear` (sort po dacie) korzystają z `parseYear` → pola wielodatowe wpadają w realną dekadę; tylko pola bez żadnego roku pozostają „bez daty".
- Fizyka układania książek **nietknięta**.

## Testy

- +1 test: `decadeOf` dla pól wielodatowych (`shelfLayout.test.ts`).
- `npm run lint` czysty, cała suita zielona.

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_