### PR TITLE
Regał: tabliczka rocznika na górze półki + cienka deseczka między dekadami

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.20.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.20.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.20.2** — **Przekładka dekady = deseczka + tabliczka u góry** (wariant A). Zamiast dużej
+  pionowej tabliczki (34×156): cienka **deseczka** (`DIVIDER_W` 34→10) stojąca między dekadami
+  na dole toru + pozioma **tabliczka rocznika** u góry półki, wyrównana do początku zakresu
+  (tylko przy pierwszym pojawieniu dekady — kontynuacja na nowym rzędzie bez podpisu). `ShelfDivider`
+  przepisany (deseczka + tabliczka top-0, `BOARD_H`=`DIVIDER_H`=168 jako podpora fizyki);
+  `ShelfRow` daje przekładce `z-15` (maluje się ponad granicznymi grzbietami). Fizyka NIETKNIĘTA.
 - **1.20.1** — **Pola wielodatowe wpadają w dekadę** (nie „bez daty"). `parseYear(year)` w
   `bookshelf.ts` wyciąga pierwszy 4-cyfrowy rok z pola (`/\d{4}/`, `null` gdy brak); używany
   przez `decadeOf` (sortowanie tabliczek dekad) i `pubYear` (sort po dacie). Np. „1965/1966",

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -92,8 +92,13 @@ The row builder is shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`
   ignored.** Rendered as coloured dots on the spine / lying book; `hasAward` = `awardWins().length > 0`.
 - **`buildShelfItems(books)` / `decadeOf` / `decadeLabel`** — build the pack items and, since the shelf
   is sorted by year, insert a generic **section divider** (`ShelfDivider`, a `RenderSlot` of kind
-  `"divider"`) at each **decade boundary** (e.g. `1950–1959`). The divider is a generic nameplate — the
-  label is just a string, so a future mode can show an alphabet letter or author surname instead.
+  `"divider"`) at each **decade boundary** (e.g. `1950–1959`). The divider renders as a thin **board**
+  (`DIVIDER_W` = 10 px) standing between the decades plus a horizontal **year nameplate mounted at the
+  top of the shelf**, left-aligned to the board (the start of the range). Variant A: the nameplate is
+  drawn only where the decade first appears — a decade continuing onto the next row has no repeated
+  label. `ShelfRow` gives the divider `z-15` so the board + nameplate paint above the boundary spines;
+  `DIVIDER_H` (168) matches `BOARD_H`, so a spine leaning onto the board rests on its real top edge.
+  The label is just a string, so a future mode can show an alphabet letter or author surname instead.
   `decadeOf` uses `parseYear` (first `\d{4}` in the field), so **multi-date entries**
   (`"1965/1966"`, `"1959 (wyd. pol. 1972)"`, `"wyd. 1948"`) fall into a real decade instead of
   `"bez daty"`; only a field with no 4-digit year is treated as undated.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.20.1",
+  "version": "1.20.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -1,35 +1,51 @@
 import React from "react";
+import { SHELF_ROW_H } from "../../utils/bookshelf";
 
 interface Props {
   label: string;      // np. „1950–1959" (w przyszłości litera alfabetu / nazwisko autora)
-  width?: number;
-  height?: number;
+  width?: number;     // szerokość deseczki (footprint na półce)
+  height?: number;    // wysokość toru rzędu (wyrównanie tabliczki u góry)
 }
 
+/** Wysokość widocznej deseczki — spójna z `DIVIDER_H` w `shelfLayout` (podpora fizyki). */
+export const BOARD_H = 168;
+
 /**
- * Generyczna **tabliczka-przekładka** stojąca na półce między woluminami — czytelny
- * znacznik sekcji. Dziś nadaje ją dekada wydania; ten sam komponent obsłuży dowolną
- * etykietę (litera alfabetu, nazwisko autora itp.). Nieprzeciągalna.
+ * Generyczna **przekładka sekcji**: cienka **deseczka** stojąca między woluminami
+ * (na dole toru) + pozioma **tabliczka** rocznika u góry półki, wyrównana do
+ * początku zakresu (wariant A: tylko przy pierwszym pojawieniu dekady). Etykieta
+ * jest zwykłym stringiem — ten sam komponent obsłuży literę alfabetu / nazwisko
+ * autora itp. Nieprzeciągalna.
  */
-export const ShelfDivider: React.FC<Props> = ({ label, width = 34, height = 156 }) => (
-  <div
-    className="relative shrink-0 flex items-center justify-center select-none rounded-t-[7px] rounded-b-[2px]"
-    style={{
-      width, height,
-      background: "linear-gradient(180deg, #ecdfbe 0%, #d5c193 55%, #b89c68 100%)",
-      boxShadow: "inset 0 0 0 1.5px rgba(120,80,30,.45), inset 1.5px 0 0 rgba(255,255,255,.45), inset -1px 0 4px rgba(90,60,20,.35), 0 8px 12px -6px rgba(0,0,0,.6)",
-    }}
-    title={label}
-    aria-hidden
-  >
-    {/* mosiężny guzik u góry */}
-    <span className="absolute top-1.5 left-1/2 -translate-x-1/2 w-[11px] h-[11px] rounded-full"
-      style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #b8860b 68%, #6b4a08)", boxShadow: "0 1px 2px rgba(0,0,0,.4)" }} />
-    <span
-      className="font-display font-black"
-      style={{ writingMode: "vertical-rl", transform: "rotate(180deg)", color: "#4a3418", fontSize: 12.5, letterSpacing: "0.06em", marginTop: 10, textShadow: "0 1px 0 rgba(255,255,255,.35)" }}
+export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H }) => (
+  <div className="relative select-none" style={{ width, height }} title={label} aria-hidden>
+    {/* cienka deseczka rozgraniczająca (dół toru) */}
+    <div
+      className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
+      style={{
+        width, height: BOARD_H,
+        background: "linear-gradient(90deg, #6b4a26 0, #3e2814 45%, #59391d 55%, #23150a 100%)",
+        boxShadow: "inset 1px 0 0 rgba(255,225,170,.35), inset -1px 0 2px rgba(0,0,0,.5), 0 6px 10px -6px rgba(0,0,0,.6)",
+      }}
     >
+      {/* mosiężny ćwiek */}
+      <span className="absolute top-3 left-1/2 -translate-x-1/2 w-[4px] h-[4px] rounded-full"
+        style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #b8860b 68%, #6b4a08)" }} />
+    </div>
+
+    {/* tabliczka rocznika u góry, lewą krawędzią przy deseczce (rozwija się w prawo) */}
+    <div
+      className="absolute top-0 left-0 flex items-center gap-[6px] whitespace-nowrap font-display font-black rounded-[5px] px-[10px] pt-[3px] pb-[4px]"
+      style={{
+        color: "#4a3418", fontSize: 11.5, letterSpacing: "0.04em",
+        background: "linear-gradient(180deg, #ecdfbe 0%, #d5c193 55%, #b89c68 100%)",
+        boxShadow: "inset 0 0 0 1.5px rgba(120,80,30,.45), inset 0 1px 0 rgba(255,255,255,.5), 0 6px 10px -5px rgba(0,0,0,.7)",
+        textShadow: "0 1px 0 rgba(255,255,255,.35)",
+      }}
+    >
+      <span className="w-[5px] h-[5px] rounded-full shrink-0" style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #9a6f12 70%, #5e4108)" }} />
       {label}
-    </span>
+      <span className="w-[5px] h-[5px] rounded-full shrink-0" style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #9a6f12 70%, #5e4108)" }} />
+    </div>
   </div>
 );

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -28,9 +28,10 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragE
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
         if (slot.kind === "divider") {
+          // z-15: tabliczka u góry + deseczka malują się PONAD granicznymi grzbietami.
           return (
-            <div key={p.key} className="absolute bottom-0" style={{ left: p.x }}>
-              <ShelfDivider label={slot.label} />
+            <div key={p.key} className="absolute bottom-0" style={{ left: p.x, zIndex: 15 }}>
+              <ShelfDivider label={slot.label} width={p.w} />
             </div>
           );
         }

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -5,8 +5,8 @@ import { PackItem } from "./shelfPacking";
 /** Slot do renderu: wolumin/kupka (`ShelfSlot`) albo tabliczka-przekładka sekcji. */
 export type RenderSlot = ShelfSlot | { kind: "divider"; label: string };
 
-const DIVIDER_W = 34;
-const DIVIDER_H = 156;
+const DIVIDER_W = 10;   // cienka deseczka (footprint na półce)
+const DIVIDER_H = 168;  // = BOARD_H w ShelfDivider — realna podpora dla pochyłego sąsiada
 
 /** Dekada roku wydania (np. 1954 → 1950); pola wielodatowe → pierwszy rok; brak → `null`. */
 export function decadeOf(year: string): number | null {
@@ -22,7 +22,8 @@ export function decadeLabel(dec: number | null): string {
 /**
  * Buduje `PackItem[]` (do fizyki `packAndLayout`) i mapę `slotByKey` (do renderu).
  * Woluminy przychodzą już posortowane po dacie wydania; na **granicy każdej dekady**
- * wstawiamy tabliczkę-przekładkę (`divider`). Kupki nie przekraczają granicy dekady
+ * wstawiamy przekładkę (`divider`) — cienką deseczkę na półce z poziomą tabliczką
+ * rocznika u góry (render: `ShelfDivider`). Kupki nie przekraczają granicy dekady
  * (planShelf liczony osobno per dekada). Wspólne dla wszystkich widoków regału.
  */
 export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; slotByKey: Map<string, RenderSlot> } {


### PR DESCRIPTION
## Co i dlaczego

Dużą pionową tabliczkę-przekładkę (34×156 px, zajmującą miejsce książki) zastępujemy dwoma elementami:

- **Deseczka** — cienka (~10 px) drewniana przekładka stojąca między dekadami na dole toru, z mosiężnym ćwiekiem.
- **Tabliczka rocznika** — pozioma, czytelna plakietka u **góry półki**, wyrównana do początku zakresu.

**Wariant A** (uzgodniony): tabliczka tylko przy pierwszym pojawieniu dekady; dekada przechodząca na kolejny rząd jest bez powtórzonego podpisu.

## Zmiana

- `ShelfDivider.tsx` przepisany — deseczka (dół) + tabliczka (`top-0`), `BOARD_H` = 168.
- `ShelfRow.tsx` — przekładka dostaje `z-15`, więc deseczka i tabliczka malują się ponad granicznymi grzbietami.
- `shelfLayout.ts` — `DIVIDER_W` 34→10, `DIVIDER_H` 156→168 (= `BOARD_H`, aby pochyły sąsiad opierał się o realną górną krawędź deseczki).

**Packing engine (fizyka układania książek) nietknięty.** Color-code nagród bez zmian.

## Testy

- `npm run lint` czysty, cała suita zielona (306).
- Wygląd zweryfikowany renderem (headless chromium) przed wdrożeniem.

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_