### PR TITLE
Regał: stylistyka „noosferyczna" Adeptus Mechanicus (cyfrowy relikwiarz)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.20.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.21.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.21.0** — **Regał w stylistyce „noosferycznej" Adeptus Mechanicus (cyfrowy relikwiarz).**
+  Warstwa holo na mosiężnym korpusie: animowany **ticker danych** (marquee) w gzymsie, **godło
+  cog-skull** z wolno obracającą się aureolą + pulsujący glow (`NoosphericCrest`), **narożniki HUD**
+  (teal, pulsujące, zastąpiły mosiężne `CornerBracket`), **siatka noosfery + sweep skanline**
+  (`HoloField`) we wnęce, **pieczęć czystości** z sygnaturą `IX-774`. Tabliczki dekad → runy mono
+  (font `Share Tech Mono`) z cog-skull + świecąca żyła danych na deseczce + smużka projekcji.
+  Grzbiety: teal rim-light + holo **sygnatura katalogowa** (`M####`, deterministyczna z id).
+  Sigilla nagród z teal-obwódką. Animacje CSS (`.noo-*` w `index.css`) z guardem
+  `prefers-reduced-motion`. Fizyka układania i color-code nagród NIETKNIĘTE. Zweryfikowane realnym
+  renderem komponentów (Vite). Nowe/zmienione: `ShelfOrnaments` (+NoosphericCrest/DataTicker/HoloField/HudCorner,
+  −CornerBracket), `ShelfFrame`, `ShelfDivider`, `BookSpine`, `index.css`.
 - **1.20.2** — **Przekładka dekady = deseczka + tabliczka u góry** (wariant A). Zamiast dużej
   pionowej tabliczki (34×156): cienka **deseczka** (`DIVIDER_W` 34→10) stojąca między dekadami
   na dole toru + pozioma **tabliczka rocznika** u góry półki, wyrównana do początku zakresu

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -6,10 +6,16 @@ stand as coloured **spines** (concept A), awarded reads also appear face-out on 
 cover row (concept B). Two shelves — **Do przeczytania** and **Przeczytane** — sit side by side, and
 a book is dragged between them; the drop writes the read state back to Notion. **No AI/LLM.**
 
-Each shelf is drawn as a **wooden cabinet** (`ShelfFrame`): a cornice with a Mechanicus cog sigil +
-title, dark back-panel with vertical planks, brass corner brackets and a hanging purity seal
-(`ShelfOrnaments` — decorative, `aria-hidden`). Rows of spines each rest on a real **plank**, and the
-**Do przeczytania** shelf holds **every** volume (no scroll cap) so the whole backlog is visible at once.
+Each shelf is drawn as a brass **cabinet** (`ShelfFrame`) wearing a **noospheric Adeptus Mechanicus
+skin** (v1.21.0): a cornice with a cog sigil + title and a scrolling **data ticker**, a **cog-skull
+crest** with a slowly rotating halo and pulsing glow (`NoosphericCrest`), pulsing teal **HUD corner
+brackets** (`HudCorner`), a faint noosphere grid + a sweeping **scanline** in the well (`HoloField`),
+and a hanging purity seal with an `IX-774` sigil — all in `ShelfOrnaments` (decorative, `aria-hidden`).
+Spines carry a teal rim-light and a deterministic **holo catalog signature** (`M####`); award sigils
+get a teal ring. All motion is CSS (`.noo-*` in `index.css`) and is disabled under
+`prefers-reduced-motion`. The skin is **purely visual** — packing physics, drag&drop and the award
+colour-code are untouched. Rows of spines each rest on a real **plank**, and the **Do przeczytania**
+shelf holds **every** volume (no scroll cap) so the whole backlog is visible at once.
 
 ## 1a. Operating rules (the "physical shelf" contract)
 These are the invariants the layout obeys — the whole visual design, built up across `1.16.0 → 1.17.2`,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.20.2",
+      "version": "1.21.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.20.2",
+  "version": "1.21.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -9,6 +9,13 @@ interface Props {
   onDragEnd: () => void;
 }
 
+/** Sygnatura katalogowa holo (deterministyczna z id) — cyfrowy detal na grzbiecie. */
+function catalogSig(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return "M" + (1000 + (h % 9000));
+}
+
 /** Grzbiet książki (koncept A) — przeciągalny element regału. */
 export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd }) => (
   <div
@@ -21,10 +28,19 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       width: style.width,
       height: style.height,
       background: `linear-gradient(90deg, rgba(0,0,0,.35), ${style.color} 22%, ${style.color} 78%, rgba(0,0,0,.28))`,
-      boxShadow: "inset 1.5px 0 0 rgba(255,255,255,.14), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6)",
+      boxShadow: "inset 1.5px 0 0 rgba(120,255,240,.20), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6)",
     }}
   >
     <span className="absolute left-0 right-0 h-[10px] top-[9px] bg-black/25" aria-hidden />
+    {style.width >= 26 && (
+      <span
+        className="absolute top-[3px] left-0 right-0 text-center font-mono pointer-events-none"
+        style={{ fontSize: 6, letterSpacing: "0.03em", color: "rgba(63,224,208,.85)", textShadow: "0 0 4px rgba(63,224,208,.8)" }}
+        aria-hidden
+      >
+        {catalogSig(book.id)}
+      </span>
+    )}
     <span
       className="font-bold text-white/85 whitespace-nowrap overflow-hidden max-h-[94%] py-1"
       style={{ fontSize: spineFontSize(style, displayTitle(book)), writingMode: "vertical-rl", transform: "rotate(180deg)", textShadow: "0 1px 2px rgba(0,0,0,.5)" }}
@@ -37,7 +53,7 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       return (
         <span className="absolute bottom-[6px] left-1/2 -translate-x-1/2 flex flex-col-reverse items-center gap-[3px]" title={wins.map((w) => w.label).join(" · ")}>
           {wins.map((w) => (
-            <span key={w.key} className="w-[8px] h-[8px] rounded-full" style={{ background: w.color, boxShadow: `0 0 6px ${w.color}` }} />
+            <span key={w.key} className="w-[8px] h-[8px] rounded-full" style={{ background: w.color, boxShadow: `0 0 6px ${w.color}, 0 0 0 1px rgba(63,224,208,.5)` }} />
           ))}
         </span>
       );

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { SHELF_ROW_H } from "../../utils/bookshelf";
+import { CogSigil } from "./ShelfOrnaments";
 
 interface Props {
   label: string;      // np. „1950–1959" (w przyszłości litera alfabetu / nazwisko autora)
@@ -11,11 +12,12 @@ interface Props {
 export const BOARD_H = 168;
 
 /**
- * Generyczna **przekładka sekcji**: cienka **deseczka** stojąca między woluminami
- * (na dole toru) + pozioma **tabliczka** rocznika u góry półki, wyrównana do
- * początku zakresu (wariant A: tylko przy pierwszym pojawieniu dekady). Etykieta
- * jest zwykłym stringiem — ten sam komponent obsłuży literę alfabetu / nazwisko
- * autora itp. Nieprzeciągalna.
+ * Generyczna **przekładka sekcji** w stylu noosferycznym: cienka **deseczka** z
+ * mosiądzu ze świecącą żyłą danych (na dole toru) + pozioma **tabliczka-runa**
+ * rocznika u góry półki, wyrównana do początku zakresu (wariant A: tylko przy
+ * pierwszym pojawieniu dekady) z projekcyjną smużką światła w dół do deseczki.
+ * Etykieta jest zwykłym stringiem — ten sam komponent obsłuży literę alfabetu /
+ * nazwisko autora itp. Nieprzeciągalna.
  */
 export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H }) => (
   <div className="relative select-none" style={{ width, height }} title={label} aria-hidden>
@@ -24,28 +26,37 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
       className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
       style={{
         width, height: BOARD_H,
-        background: "linear-gradient(90deg, #6b4a26 0, #3e2814 45%, #59391d 55%, #23150a 100%)",
-        boxShadow: "inset 1px 0 0 rgba(255,225,170,.35), inset -1px 0 2px rgba(0,0,0,.5), 0 6px 10px -6px rgba(0,0,0,.6)",
+        background: "linear-gradient(90deg, #8a6b34, #4a3315 45%, #6b4e22 55%, #2a1c0a)",
+        boxShadow: "inset 1px 0 0 rgba(255,230,170,.40), inset -1px 0 2px rgba(0,0,0,.6), 0 6px 10px -6px rgba(0,0,0,.6)",
       }}
     >
-      {/* mosiężny ćwiek */}
-      <span className="absolute top-3 left-1/2 -translate-x-1/2 w-[4px] h-[4px] rounded-full"
-        style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #b8860b 68%, #6b4a08)" }} />
+      {/* cog-finial na szczycie deseczki */}
+      <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(63,224,208,.6)]" />
+      {/* świecąca żyła danych */}
+      <div
+        className="noo-data absolute left-1/2 -translate-x-1/2 rounded-[2px]"
+        style={{ top: 14, bottom: 8, width: 2, background: "linear-gradient(180deg, rgba(63,224,208,.9), rgba(63,224,208,.15))", boxShadow: "0 0 6px rgba(63,224,208,.8)" }}
+      />
     </div>
 
-    {/* tabliczka rocznika u góry, lewą krawędzią przy deseczce (rozwija się w prawo) */}
+    {/* projekcyjna smużka światła z tabliczki w dół do deseczki */}
     <div
-      className="absolute top-0 left-0 flex items-center gap-[6px] whitespace-nowrap font-display font-black rounded-[5px] px-[10px] pt-[3px] pb-[4px]"
+      className="noo-data absolute top-[22px]"
+      style={{ left: 4, width: 2, height: 150, background: "linear-gradient(180deg, rgba(63,224,208,.55), rgba(63,224,208,0))", boxShadow: "0 0 6px rgba(63,224,208,.5)" }}
+    />
+
+    {/* tabliczka-runa rocznika u góry, lewą krawędzią przy deseczce (rozwija się w prawo) */}
+    <div
+      className="absolute top-0 left-0 flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
       style={{
-        color: "#4a3418", fontSize: 11.5, letterSpacing: "0.04em",
-        background: "linear-gradient(180deg, #ecdfbe 0%, #d5c193 55%, #b89c68 100%)",
-        boxShadow: "inset 0 0 0 1.5px rgba(120,80,30,.45), inset 0 1px 0 rgba(255,255,255,.5), 0 6px 10px -5px rgba(0,0,0,.7)",
-        textShadow: "0 1px 0 rgba(255,255,255,.35)",
+        color: "#1c1206", fontSize: 11, letterSpacing: "0.06em",
+        background: "linear-gradient(180deg, #d8b877 0%, #b8860b 58%, #8a6413 100%)",
+        boxShadow: "inset 0 0 0 1.5px #5e4108, inset 0 1px 0 rgba(255,240,200,.6), 0 5px 9px -4px #000, 0 0 12px rgba(63,224,208,.25)",
+        textShadow: "0 1px 0 rgba(255,240,200,.5)",
       }}
     >
-      <span className="w-[5px] h-[5px] rounded-full shrink-0" style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #9a6f12 70%, #5e4108)" }} />
+      <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(63,224,208,.6)]" />
       {label}
-      <span className="w-[5px] h-[5px] rounded-full shrink-0" style={{ background: "radial-gradient(circle at 40% 35%, #f7e0a0, #9a6f12 70%, #5e4108)" }} />
     </div>
   </div>
 );

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CornerBracket, CogSigil, PuritySeal } from "./ShelfOrnaments";
+import { CogSigil, PuritySeal, NoosphericCrest, DataTicker, HoloField, HudCorner } from "./ShelfOrnaments";
 
 export type ShelfAccent = "emerald" | "cyan" | "purple" | "amber";
 
@@ -62,30 +62,35 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
             {title}
           </h3>
           <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
+          {/* Ticker danych (przewijany) — wypełnia wolną przestrzeń gzymsu */}
+          <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ NOOSPHERA·SYNC ++ 01001101·01000001·01010011 ++ AVE·OMNISSIAH ++" />
           <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
           {/* Delikatna listwa świetlna pod gzymsem */}
           <div className="absolute bottom-0 inset-x-6 h-px bg-gradient-to-r from-transparent via-amber-300/25 to-transparent" />
         </div>
 
-        {/* Wnętrze regału — ciemne „plecy" z pionowymi deskami */}
+        {/* Wnętrze regału — ciemne „plecy" z pionowymi deskami + warstwa holo */}
         <div
-          className="relative rounded-lg p-3 pt-4"
+          className="relative rounded-lg p-3 pt-4 overflow-hidden"
           style={{
             background:
               "repeating-linear-gradient(90deg, #140d07 0px, #140d07 26px, #0d0904 27px, #140d07 28px), radial-gradient(120% 80% at 50% 0%, rgba(0,0,0,.15), rgba(0,0,0,.6))",
             boxShadow: "inset 0 3px 12px rgba(0,0,0,.75), inset 0 -2px 6px rgba(0,0,0,.5)",
           }}
         >
-          {children}
+          <HoloField />
+          <div className="relative z-10">{children}</div>
         </div>
       </div>
 
-      {/* Ozdoby (kwiatki) */}
-      <CornerBracket corner="tl" />
-      <CornerBracket corner="tr" />
-      <CornerBracket corner="bl" />
-      <CornerBracket corner="br" />
+      {/* Godło holo (projekcja) + narożniki HUD + pieczęć czystości z sygnaturą */}
+      <NoosphericCrest className="absolute -top-[22px] left-1/2 -translate-x-1/2 z-20" size={46} />
+      <HudCorner corner="tl" />
+      <HudCorner corner="tr" />
+      <HudCorner corner="bl" />
+      <HudCorner corner="br" />
       <PuritySeal className="top-[40px] right-6 z-20" rotate={-9} />
+      <span className="absolute top-[88px] right-[18px] z-20 font-mono text-[8px] tracking-[0.12em] text-red-300/70 pointer-events-none" style={{ textShadow: "0 0 6px rgba(255,60,60,.5)" }} aria-hidden>IX-774</span>
     </div>
   );
 };

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -8,37 +8,6 @@ import React from "react";
 
 type Corner = "tl" | "tr" | "bl" | "br";
 
-const CORNER_POS: Record<Corner, string> = {
-  tl: "top-1 left-1",
-  tr: "top-1 right-1 -scale-x-100",
-  bl: "bottom-1 left-1 -scale-y-100",
-  br: "bottom-1 right-1 -scale-x-100 -scale-y-100",
-};
-
-/** Mosiężny narożnik-okucie (kwiatek introligatorski). */
-export const CornerBracket: React.FC<{ corner: Corner }> = ({ corner }) => (
-  <svg
-    aria-hidden
-    viewBox="0 0 40 40"
-    className={`absolute w-6 h-6 pointer-events-none opacity-70 ${CORNER_POS[corner]}`}
-  >
-    <defs>
-      <linearGradient id={`brass-${corner}`} x1="0" y1="0" x2="1" y2="1">
-        <stop offset="0" stopColor="#f5d992" />
-        <stop offset="0.5" stopColor="#b8860b" />
-        <stop offset="1" stopColor="#6b4a08" />
-      </linearGradient>
-    </defs>
-    <path
-      d="M4 4 H22 Q4 8 8 22 V4 Z M4 4 V20 Q6 6 20 6 H4 Z"
-      fill={`url(#brass-${corner})`}
-      stroke="rgba(0,0,0,.35)"
-      strokeWidth="0.6"
-    />
-    <circle cx="12" cy="12" r="2.4" fill="#2a1c06" stroke="#e9c877" strokeWidth="0.7" />
-  </svg>
-);
-
 /** Sygil koła zębatego Mechanicus (na gzymsie). */
 export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) => (
   <svg aria-hidden viewBox="0 0 48 48" className={className}>
@@ -63,6 +32,78 @@ export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) =
     <rect x="22" y="25" width="4" height="4.5" rx="1" fill="#d9c9a8" />
   </svg>
 );
+
+/* ===================== Warstwa cyfrowa / noosferyczna ===================== */
+
+const TEAL = "#3fe0d0";
+
+/**
+ * Godło Mechanicus jako **projekcja holo**: mosiężny cog-skull + wolno obracająca
+ * się przerywana aureola noosfery + pulsujący teal-glow. Czysto dekoracyjne.
+ */
+export const NoosphericCrest: React.FC<{ size?: number; className?: string }> = ({ size = 46, className = "" }) => (
+  <div className={className} aria-hidden style={{ width: size, height: size }}>
+    <div className="relative w-full h-full">
+      <svg viewBox="0 0 86 86" className="noo-spin absolute inset-[-24%] w-[148%] h-[148%]" style={{ opacity: 0.6 }}>
+        <circle cx="43" cy="43" r="40" fill="none" stroke={TEAL} strokeOpacity="0.5" strokeWidth="1" strokeDasharray="3 4" />
+        <circle cx="43" cy="43" r="32" fill="none" stroke={TEAL} strokeOpacity="0.3" strokeWidth="1" />
+      </svg>
+      <div className="noo-pulse absolute inset-0">
+        <CogSigil className="w-full h-full" />
+      </div>
+    </div>
+  </div>
+);
+
+/** Przewijający się (marquee) ticker danych — inkantacje binarne / machine-cant. */
+export const DataTicker: React.FC<{ text: string; tone?: "teal" | "amber"; slow?: boolean; className?: string }> = ({ text, tone = "teal", slow, className = "" }) => {
+  const color = tone === "amber" ? "#f2c14e" : TEAL;
+  return (
+    <div
+      className={`overflow-hidden rounded-[3px] flex items-center h-[18px] ${className}`}
+      style={{ border: "1px solid rgba(216,184,119,.30)", background: "linear-gradient(180deg,rgba(10,7,4,.9),rgba(5,3,2,.9))", boxShadow: "inset 0 0 8px rgba(63,224,208,.12)" }}
+      aria-hidden
+    >
+      <div className={`flex whitespace-nowrap ${slow ? "noo-marquee-slow" : "noo-marquee"}`}>
+        {[0, 1].map((k) => (
+          <span key={k} className="font-mono px-4" style={{ fontSize: 10.5, letterSpacing: "0.14em", lineHeight: "18px", color, textShadow: `0 0 7px ${color}99` }}>{text}</span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/** Nakładka: subtelna siatka noosfery + przesuwający się skanline (CRT). */
+export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) => (
+  <div className={`pointer-events-none absolute inset-0 overflow-hidden ${className}`} aria-hidden>
+    <div
+      className="absolute inset-0 opacity-50"
+      style={{
+        backgroundImage:
+          "linear-gradient(90deg, rgba(63,224,208,.10) 1px, transparent 1px), linear-gradient(180deg, rgba(63,224,208,.07) 1px, transparent 1px)",
+        backgroundSize: "30px 30px, 30px 30px",
+        WebkitMaskImage: "radial-gradient(120% 90% at 50% 120%, #000, transparent 72%)",
+        maskImage: "radial-gradient(120% 90% at 50% 120%, #000, transparent 72%)",
+      }}
+    />
+    <div
+      className="noo-scan absolute inset-x-0 h-[22px]"
+      style={{ background: "linear-gradient(180deg, rgba(63,224,208,0), rgba(63,224,208,.16), rgba(63,224,208,0))", ["--noo-scan-h" as string]: "920px" }}
+    />
+  </div>
+);
+
+/** Narożnik HUD (celownik) — teal, pulsujący. */
+export const HudCorner: React.FC<{ corner: Corner }> = ({ corner }) => {
+  const base = "absolute w-4 h-4 z-20 pointer-events-none noo-pulse";
+  const box: Record<Corner, React.CSSProperties> = {
+    tl: { top: 6, left: 6, borderTop: `2px solid ${TEAL}`, borderLeft: `2px solid ${TEAL}` },
+    tr: { top: 6, right: 6, borderTop: `2px solid ${TEAL}`, borderRight: `2px solid ${TEAL}`, animationDelay: ".6s" },
+    bl: { bottom: 6, left: 6, borderBottom: `2px solid ${TEAL}`, borderLeft: `2px solid ${TEAL}`, animationDelay: "1.2s" },
+    br: { bottom: 6, right: 6, borderBottom: `2px solid ${TEAL}`, borderRight: `2px solid ${TEAL}`, animationDelay: "1.8s" },
+  };
+  return <span className={base} style={box[corner]} aria-hidden />;
+};
 
 /** Pieczęć czystości zwisająca na wstędze (kwiatek + atrybut z fabuły). */
 export const PuritySeal: React.FC<{ className?: string; rotate?: number }> = ({ className = "", rotate = -8 }) => (

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&family=Share+Tech+Mono&display=swap');
 @import "tailwindcss";
 
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-display: "Space Grotesk", sans-serif;
+  --font-mono: "Share Tech Mono", ui-monospace, monospace;
 }
 
 body {
@@ -35,4 +36,25 @@ body {
 
 .text-gradient {
   @apply bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-purple-600;
+}
+
+/* ===== Regał — warstwa „noosferyczna" (Adeptus Mechanicus / cyfrowa) ===== */
+@keyframes noo-marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+@keyframes noo-pulse {
+  0%, 100% { opacity: .5; filter: drop-shadow(0 0 3px rgba(63, 224, 208, .5)); }
+  50%      { opacity: .95; filter: drop-shadow(0 0 9px rgba(63, 224, 208, .95)); }
+}
+@keyframes noo-spin { to { transform: rotate(360deg); } }
+@keyframes noo-data { 0%, 100% { opacity: .5; } 50% { opacity: 1; } }
+@keyframes noo-scan { 0% { transform: translateY(-24px); } 100% { transform: translateY(var(--noo-scan-h, 200px)); } }
+
+.noo-marquee { animation: noo-marquee 17s linear infinite; }
+.noo-marquee-slow { animation: noo-marquee 22s linear infinite; }
+.noo-pulse { animation: noo-pulse 2.6s ease-in-out infinite; }
+.noo-spin { animation: noo-spin 26s linear infinite; transform-origin: 50% 50%; }
+.noo-data { animation: noo-data 2.2s ease-in-out infinite; }
+.noo-scan { animation: noo-scan 4.4s linear infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .noo-marquee, .noo-marquee-slow, .noo-pulse, .noo-spin, .noo-data, .noo-scan { animation: none !important; }
 }


### PR DESCRIPTION
## Co i dlaczego

Regał dostaje wybrany wariant **Reliquary Datavault — Noospheric**: mosiężny relikwiarz z nałożoną, animowaną warstwą cyfrową (noosfera).

## Zmiana (warstwa wizualna)

- **`ShelfOrnaments`** — nowe: `NoosphericCrest` (cog-skull + obracająca się aureola + puls), `DataTicker` (przewijany marquee), `HoloField` (siatka noosfery + sweep skanline), `HudCorner` (pulsujące teal narożniki HUD). Usunięty nieużywany `CornerBracket`.
- **`ShelfFrame`** — montaż godła, ticker w gzymsie, `HoloField` + skanline we wnęce, narożniki HUD, pieczęć czystości z sygnaturą `IX-774`.
- **`ShelfDivider`** — tabliczki dekad → runy mono (`Share Tech Mono`) z cog-skull, świecąca żyła danych na deseczce, smużka projekcji.
- **`BookSpine`** — teal rim-light + holo sygnatura katalogowa (`M####`, deterministyczna z id); sigilla nagród z teal-obwódką.
- **`index.css`** — keyframes/utility `.noo-*` z guardem `prefers-reduced-motion`; dodany font `Share Tech Mono` (`--font-mono`).

**Fizyka układania książek, drag&drop i color-code nagród — nietknięte.** Wszystkie animacje CSS, wyłączane przy `prefers-reduced-motion`.

## Testy / weryfikacja

- `npm run lint` czysty, cała suita zielona (306), `npm run build` OK.
- Wygląd zweryfikowany **realnym renderem komponentów** (tymczasowa strona Vite, `Shelf` z danymi mock) — godło, ticker, tabliczki, sygnatury, narożniki HUD i skanline potwierdzone; harness usunięty przed commitem.

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_