### PR TITLE
Regał: dwie skóry + przełącznik (Holo+ w kolorystyce aplikacji, domyślnie)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.21.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.22.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.22.0** — **Dwie skóry regału + przełącznik (Holo+ domyślnie).** Skóry sterowane WYŁĄCZNIE
+  zmiennymi CSS (`.skin-holo` / `.skin-noospheric` w `index.css`: `--sk-*` gradienty/kolory +
+  `--noo-glow`/`--noo-accent2` triplety RGB używane przez keyframes i inline `rgba(var(--noo-glow),a)`),
+  więc przełączenie to tylko podmiana klasy na wrapperze — zero prop-drillingu. **Holo+** = kolorystyka
+  aplikacji (cyan `#22d3ee` + purpura `#a855f7` na adamancie/slate), **Relikwiarz** = dotychczasowy
+  mosiądz+teal. Przełącznik w nagłówku „Regał" (segmentowy, cyan active); wybór trwa w localStorage
+  (`shelfSkin`, domyślnie `holo`) — `src/utils/shelfSkin.ts`. Komponenty (`ShelfFrame`, `ShelfOrnaments`
+  z `CogSigil` var-driven, `ShelfDivider`, `BookSpine`, `ShelfRow` plank, `Shelf` cokół/nóżki,
+  `BookshelfSection` featured plank) czytają `var(--sk-*)`. Fizyka/color-code NIETKNIĘTE. Obie skóry
+  zweryfikowane realnym renderem (Vite).
 - **1.21.0** — **Regał w stylistyce „noosferycznej" Adeptus Mechanicus (cyfrowy relikwiarz).**
   Warstwa holo na mosiężnym korpusie: animowany **ticker danych** (marquee) w gzymsie, **godło
   cog-skull** z wolno obracającą się aureolą + pulsujący glow (`NoosphericCrest`), **narożniki HUD**

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -11,11 +11,20 @@ skin** (v1.21.0): a cornice with a cog sigil + title and a scrolling **data tick
 crest** with a slowly rotating halo and pulsing glow (`NoosphericCrest`), pulsing teal **HUD corner
 brackets** (`HudCorner`), a faint noosphere grid + a sweeping **scanline** in the well (`HoloField`),
 and a hanging purity seal with an `IX-774` sigil — all in `ShelfOrnaments` (decorative, `aria-hidden`).
-Spines carry a teal rim-light and a deterministic **holo catalog signature** (`M####`); award sigils
-get a teal ring. All motion is CSS (`.noo-*` in `index.css`) and is disabled under
+Spines carry a rim-light and a deterministic **holo catalog signature** (`M####`); award sigils
+get a glow ring. All motion is CSS (`.noo-*` in `index.css`) and is disabled under
 `prefers-reduced-motion`. The skin is **purely visual** — packing physics, drag&drop and the award
 colour-code are untouched. Rows of spines each rest on a real **plank**, and the **Do przeczytania**
 shelf holds **every** volume (no scroll cap) so the whole backlog is visible at once.
+
+**Two skins, switchable (v1.22.0).** The whole look is driven **only by CSS variables** — a `.skin-holo`
+or `.skin-noospheric` class on the wrapper sets every `--sk-*` gradient/colour plus `--noo-glow` /
+`--noo-accent2` (RGB triplets used by the keyframes and by `rgba(var(--noo-glow), a)` inline), so
+switching is a class swap with no prop-drilling. **Holo+** (default) uses the app palette — cyan
+`#22d3ee` + purple `#a855f7` on an adamant/slate cabinet; **Relikwiarz** is the warm brass + teal
+look. The segmented toggle lives in the Regał header; the choice persists in `localStorage`
+(`shelfSkin`, default `holo`) via `src/utils/shelfSkin.ts` (`loadSkin`/`saveSkin`/`skinClass`).
+Every shelf component reads `var(--sk-*)`; `CogSigil` fills come from `--sk-cog-*`.
 
 ## 1a. Operating rules (the "physical shelf" contract)
 These are the invariants the layout obeys — the whole visual design, built up across `1.16.0 → 1.17.2`,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useMemo, useCallback, useRef } from "react";
+import React, { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { Library, BookOpen, CheckCircle2, Sparkles, Loader2, AlertCircle, X } from "lucide-react";
 import { BookIndexEntry } from "../types";
 import { useBooks } from "../hooks/useBooks";
 import { useMarkRead } from "../hooks/useMarkRead";
 import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
+import { ShelfSkin, SHELF_SKINS, skinClass, loadSkin, saveSkin } from "../utils/shelfSkin";
 import { Shelf } from "./shelf/Shelf";
 import { CoverCard } from "./shelf/CoverCard";
 import { ShelfFrame } from "./shelf/ShelfFrame";
@@ -16,6 +17,8 @@ export const BookshelfSection: React.FC = () => {
   const [overrides, setOverrides] = useState<ReadOverrides>({});
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
+  const [skin, setSkin] = useState<ShelfSkin>(loadSkin);
+  useEffect(() => { saveSkin(skin); }, [skin]);
 
   // Zapis stanu „przeczytane" jest SERIALIZOWANY per książka (latest-wins). Backend
   // `mutateMultiSelect` to nieatomowy retrieve→modify→update, więc dwa nakładające się
@@ -78,6 +81,23 @@ export const BookshelfSection: React.FC = () => {
         Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał N"
       </p>
 
+      {/* Przełącznik skóry regału (Holo+ / Relikwiarz) — wybór trwa w localStorage */}
+      <div className="flex items-center justify-center gap-2 -mt-3">
+        <span className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">Skóra</span>
+        <div className="inline-flex rounded-lg border border-white/10 overflow-hidden">
+          {SHELF_SKINS.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => setSkin(s.id)}
+              aria-pressed={skin === s.id}
+              className={`px-3 py-1 text-[11px] font-bold uppercase tracking-wider font-display transition-colors ${skin === s.id ? "bg-cyan-500/20 text-cyan-200" : "text-slate-400 hover:text-slate-200 hover:bg-white/5"}`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {moveError && (
         <div className="glass-card p-4 rounded-2xl border-red-500/30 bg-red-500/5 max-w-2xl mx-auto flex items-center gap-3">
           <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
@@ -102,6 +122,7 @@ export const BookshelfSection: React.FC = () => {
           </div>
         </div>
       ) : (
+        <div className={skinClass(skin)}>
         <RoomDecor>
           {/* Półka „Wyróżnione" (okładki twarzą) */}
           {featured.length > 0 && (
@@ -116,7 +137,7 @@ export const BookshelfSection: React.FC = () => {
                 </div>
                 <div
                   className="h-[15px] mt-[2px] rounded-[2px]"
-                  style={{ background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)", boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)" }}
+                  style={{ background: "var(--sk-plank-bg)", boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)" }}
                 />
               </ShelfFrame>
             </div>
@@ -143,6 +164,7 @@ export const BookshelfSection: React.FC = () => {
             {all.length} woluminów · <span className="text-amber-400/70">●</span> = nagroda · najedź, by wysunąć grzbiet
           </p>
         </RoomDecor>
+        </div>
       )}
     </div>
   );

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -28,14 +28,14 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       width: style.width,
       height: style.height,
       background: `linear-gradient(90deg, rgba(0,0,0,.35), ${style.color} 22%, ${style.color} 78%, rgba(0,0,0,.28))`,
-      boxShadow: "inset 1.5px 0 0 rgba(120,255,240,.20), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6)",
+      boxShadow: "inset 1.5px 0 0 rgba(var(--noo-glow),.22), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6)",
     }}
   >
     <span className="absolute left-0 right-0 h-[10px] top-[9px] bg-black/25" aria-hidden />
     {style.width >= 26 && (
       <span
         className="absolute top-[3px] left-0 right-0 text-center font-mono pointer-events-none"
-        style={{ fontSize: 6, letterSpacing: "0.03em", color: "rgba(63,224,208,.85)", textShadow: "0 0 4px rgba(63,224,208,.8)" }}
+        style={{ fontSize: 6, letterSpacing: "0.03em", color: "rgba(var(--noo-glow),.85)", textShadow: "0 0 4px rgba(var(--noo-glow),.8)" }}
         aria-hidden
       >
         {catalogSig(book.id)}
@@ -53,7 +53,7 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       return (
         <span className="absolute bottom-[6px] left-1/2 -translate-x-1/2 flex flex-col-reverse items-center gap-[3px]" title={wins.map((w) => w.label).join(" · ")}>
           {wins.map((w) => (
-            <span key={w.key} className="w-[8px] h-[8px] rounded-full" style={{ background: w.color, boxShadow: `0 0 6px ${w.color}, 0 0 0 1px rgba(63,224,208,.5)` }} />
+            <span key={w.key} className="w-[8px] h-[8px] rounded-full" style={{ background: w.color, boxShadow: `0 0 6px ${w.color}, 0 0 0 1px rgba(var(--noo-glow),.5)` }} />
           ))}
         </span>
       );

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -103,9 +103,9 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
       </ShelfFrame>
 
       {/* Cokół / nóżki — regał „stoi na podłodze" */}
-      <div className="mx-2 h-[10px] rounded-b-[6px]" style={{ background: "linear-gradient(180deg,#3a2915,#1c1108)", boxShadow: "0 10px 16px -6px rgba(0,0,0,.7)" }} aria-hidden />
+      <div className="mx-2 h-[10px] rounded-b-[6px]" style={{ background: "var(--sk-plinth)", boxShadow: "0 10px 16px -6px rgba(0,0,0,.7)" }} aria-hidden />
       <div className="flex justify-between px-6" aria-hidden>
-        {[0, 1].map((i) => <div key={i} className="w-8 h-[9px] rounded-b-[4px]" style={{ background: "linear-gradient(180deg,#2a1c0f,#120b06)" }} />)}
+        {[0, 1].map((i) => <div key={i} className="w-8 h-[9px] rounded-b-[4px]" style={{ background: "var(--sk-foot)" }} />)}
       </div>
     </div>
   );

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -26,33 +26,33 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
       className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
       style={{
         width, height: BOARD_H,
-        background: "linear-gradient(90deg, #8a6b34, #4a3315 45%, #6b4e22 55%, #2a1c0a)",
-        boxShadow: "inset 1px 0 0 rgba(255,230,170,.40), inset -1px 0 2px rgba(0,0,0,.6), 0 6px 10px -6px rgba(0,0,0,.6)",
+        background: "var(--sk-board-bg)",
+        boxShadow: "inset 1px 0 0 rgba(var(--noo-glow),.35), inset -1px 0 2px rgba(0,0,0,.6), 0 6px 10px -6px rgba(0,0,0,.6)",
       }}
     >
       {/* cog-finial na szczycie deseczki */}
-      <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(63,224,208,.6)]" />
+      <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
       {/* świecąca żyła danych */}
       <div
         className="noo-data absolute left-1/2 -translate-x-1/2 rounded-[2px]"
-        style={{ top: 14, bottom: 8, width: 2, background: "linear-gradient(180deg, rgba(63,224,208,.9), rgba(63,224,208,.15))", boxShadow: "0 0 6px rgba(63,224,208,.8)" }}
+        style={{ top: 14, bottom: 8, width: 2, background: "linear-gradient(180deg, rgba(var(--noo-glow),.9), rgba(var(--noo-glow),.15))", boxShadow: "0 0 6px rgba(var(--noo-glow),.8)" }}
       />
     </div>
 
     {/* projekcyjna smużka światła z tabliczki w dół do deseczki */}
     <div
       className="noo-data absolute top-[22px]"
-      style={{ left: 4, width: 2, height: 150, background: "linear-gradient(180deg, rgba(63,224,208,.55), rgba(63,224,208,0))", boxShadow: "0 0 6px rgba(63,224,208,.5)" }}
+      style={{ left: 4, width: 2, height: 150, background: "linear-gradient(180deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))", boxShadow: "0 0 6px rgba(var(--noo-glow),.5)" }}
     />
 
     {/* tabliczka-runa rocznika u góry, lewą krawędzią przy deseczce (rozwija się w prawo) */}
     <div
       className="absolute top-0 left-0 flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
       style={{
-        color: "#1c1206", fontSize: 11, letterSpacing: "0.06em",
-        background: "linear-gradient(180deg, #d8b877 0%, #b8860b 58%, #8a6413 100%)",
-        boxShadow: "inset 0 0 0 1.5px #5e4108, inset 0 1px 0 rgba(255,240,200,.6), 0 5px 9px -4px #000, 0 0 12px rgba(63,224,208,.25)",
-        textShadow: "0 1px 0 rgba(255,240,200,.5)",
+        color: "var(--sk-plate-text)", fontSize: 11, letterSpacing: "0.06em",
+        background: "var(--sk-plate-bg)",
+        boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), 0 5px 9px -4px #000, 0 0 12px rgba(var(--noo-glow),.25)",
+        textShadow: "0 0 6px rgba(var(--noo-glow),.45)",
       }}
     >
       <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(63,224,208,.6)]" />

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -41,8 +41,8 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
       {...rootProps}
       className={`relative rounded-[18px] border-2 transition-all duration-200 ${stateRing}`}
       style={{
-        background: "linear-gradient(150deg, #3b2817 0%, #2a1c0f 45%, #1a1109 100%)",
-        boxShadow: "0 24px 40px -22px rgba(0,0,0,.85), inset 0 1px 0 rgba(255,210,150,.10)",
+        background: "var(--sk-cab-bg)",
+        boxShadow: "0 24px 40px -22px rgba(0,0,0,.85), inset 0 1px 0 rgba(var(--noo-glow),.10)",
       }}
     >
       {/* Boczne słupki + cokół tworzy padding; gzyms nakładamy górnym paddingiem */}
@@ -51,8 +51,8 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
         <div
           className="absolute top-0 inset-x-0 h-[46px] rounded-t-[16px] flex items-center gap-3 px-4 overflow-hidden"
           style={{
-            background: "linear-gradient(180deg, #4a3220 0%, #2f2012 60%, #1e140b 100%)",
-            boxShadow: "inset 0 -2px 5px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,214,160,.18)",
+            background: "var(--sk-cornice-bg)",
+            boxShadow: "inset 0 -2px 5px rgba(0,0,0,.6), inset 0 1px 0 rgba(var(--noo-glow),.14)",
           }}
         >
           {/* Sygil koła zębatego */}
@@ -73,8 +73,7 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
         <div
           className="relative rounded-lg p-3 pt-4 overflow-hidden"
           style={{
-            background:
-              "repeating-linear-gradient(90deg, #140d07 0px, #140d07 26px, #0d0904 27px, #140d07 28px), radial-gradient(120% 80% at 50% 0%, rgba(0,0,0,.15), rgba(0,0,0,.6))",
+            background: "var(--sk-well-bg)",
             boxShadow: "inset 0 3px 12px rgba(0,0,0,.75), inset 0 -2px 6px rgba(0,0,0,.5)",
           }}
         >
@@ -90,7 +89,7 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
       <HudCorner corner="bl" />
       <HudCorner corner="br" />
       <PuritySeal className="top-[40px] right-6 z-20" rotate={-9} />
-      <span className="absolute top-[88px] right-[18px] z-20 font-mono text-[8px] tracking-[0.12em] text-red-300/70 pointer-events-none" style={{ textShadow: "0 0 6px rgba(255,60,60,.5)" }} aria-hidden>IX-774</span>
+      <span className="absolute top-[88px] right-[18px] z-20 font-mono text-[8px] tracking-[0.12em] pointer-events-none" style={{ color: "rgba(var(--noo-glow),.75)", textShadow: "0 0 6px rgba(var(--noo-glow),.5)" }} aria-hidden>IX-774</span>
     </div>
   );
 };

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -8,45 +8,43 @@ import React from "react";
 
 type Corner = "tl" | "tr" | "bl" | "br";
 
-/** Sygil koła zębatego Mechanicus (na gzymsie). */
+/**
+ * Sygil koła zębatego Mechanicus (cog-skull). Kolory pochodzą ze zmiennych skóry
+ * (`--sk-cog-*`), więc przełączenie skóry przemalowuje go bez zmiany komponentu.
+ */
 export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) => (
   <svg aria-hidden viewBox="0 0 48 48" className={className}>
-    <defs>
-      <radialGradient id="cog-brass" cx="0.4" cy="0.35" r="0.75">
-        <stop offset="0" stopColor="#ffe9b0" />
-        <stop offset="0.55" stopColor="#c8961f" />
-        <stop offset="1" stopColor="#6b4a08" />
-      </radialGradient>
-    </defs>
-    <g fill="url(#cog-brass)" stroke="rgba(0,0,0,.4)" strokeWidth="0.6">
+    <g style={{ fill: "var(--sk-cog-ring)" }} stroke="rgba(0,0,0,.4)" strokeWidth="0.6">
       {Array.from({ length: 10 }).map((_, i) => (
         <rect key={i} x="22.4" y="1.5" width="3.2" height="8" rx="1" transform={`rotate(${i * 36} 24 24)`} />
       ))}
       <circle cx="24" cy="24" r="15.5" />
     </g>
-    <circle cx="24" cy="24" r="11" fill="#241706" stroke="#e9c877" strokeWidth="1" />
+    <circle cx="24" cy="24" r="11" style={{ fill: "var(--sk-cog-disc)" }} />
     {/* Stylizowana czaszka Mechanicus — pół twarz, pół czacha */}
-    <circle cx="24" cy="21" r="6" fill="#d9c9a8" />
-    <circle cx="21.6" cy="21" r="1.4" fill="#241706" />
-    <circle cx="26.4" cy="21" r="1.4" fill="#241706" />
-    <rect x="22" y="25" width="4" height="4.5" rx="1" fill="#d9c9a8" />
+    <circle cx="24" cy="21" r="6" style={{ fill: "var(--sk-cog-skull)" }} />
+    <circle cx="21.6" cy="21" r="1.4" style={{ fill: "var(--sk-cog-disc)" }} />
+    <circle cx="26.4" cy="21" r="1.4" style={{ fill: "var(--sk-cog-disc)" }} />
+    <rect x="22" y="25" width="4" height="4.5" rx="1" style={{ fill: "var(--sk-cog-skull)" }} />
   </svg>
 );
 
 /* ===================== Warstwa cyfrowa / noosferyczna ===================== */
-
-const TEAL = "#3fe0d0";
+/* Kolor poświaty pochodzi ze zmiennej skóry `--noo-glow` (triplet RGB). */
+const GLOW = (a: number) => `rgba(var(--noo-glow), ${a})`;
+const ACCENT2 = (a: number) => `rgba(var(--noo-accent2), ${a})`;
 
 /**
- * Godło Mechanicus jako **projekcja holo**: mosiężny cog-skull + wolno obracająca
- * się przerywana aureola noosfery + pulsujący teal-glow. Czysto dekoracyjne.
+ * Godło Mechanicus jako **projekcja holo**: cog-skull + wolno obracająca się
+ * przerywana aureola noosfery (drugi pierścień w akcencie skóry) + pulsujący glow.
+ * Czysto dekoracyjne.
  */
 export const NoosphericCrest: React.FC<{ size?: number; className?: string }> = ({ size = 46, className = "" }) => (
   <div className={className} aria-hidden style={{ width: size, height: size }}>
     <div className="relative w-full h-full">
       <svg viewBox="0 0 86 86" className="noo-spin absolute inset-[-24%] w-[148%] h-[148%]" style={{ opacity: 0.6 }}>
-        <circle cx="43" cy="43" r="40" fill="none" stroke={TEAL} strokeOpacity="0.5" strokeWidth="1" strokeDasharray="3 4" />
-        <circle cx="43" cy="43" r="32" fill="none" stroke={TEAL} strokeOpacity="0.3" strokeWidth="1" />
+        <circle cx="43" cy="43" r="40" fill="none" stroke={GLOW(0.5)} strokeWidth="1" strokeDasharray="3 4" />
+        <circle cx="43" cy="43" r="32" fill="none" stroke={ACCENT2(0.35)} strokeWidth="1" />
       </svg>
       <div className="noo-pulse absolute inset-0">
         <CogSigil className="w-full h-full" />
@@ -56,17 +54,17 @@ export const NoosphericCrest: React.FC<{ size?: number; className?: string }> = 
 );
 
 /** Przewijający się (marquee) ticker danych — inkantacje binarne / machine-cant. */
-export const DataTicker: React.FC<{ text: string; tone?: "teal" | "amber"; slow?: boolean; className?: string }> = ({ text, tone = "teal", slow, className = "" }) => {
-  const color = tone === "amber" ? "#f2c14e" : TEAL;
+export const DataTicker: React.FC<{ text: string; tone?: "glow" | "accent"; slow?: boolean; className?: string }> = ({ text, tone = "glow", slow, className = "" }) => {
+  const color = tone === "accent" ? ACCENT2(1) : GLOW(1);
   return (
     <div
       className={`overflow-hidden rounded-[3px] flex items-center h-[18px] ${className}`}
-      style={{ border: "1px solid rgba(216,184,119,.30)", background: "linear-gradient(180deg,rgba(10,7,4,.9),rgba(5,3,2,.9))", boxShadow: "inset 0 0 8px rgba(63,224,208,.12)" }}
+      style={{ border: `1px solid ${GLOW(0.3)}`, background: "linear-gradient(180deg,rgba(4,8,14,.9),rgba(2,4,8,.9))", boxShadow: `inset 0 0 8px ${GLOW(0.12)}` }}
       aria-hidden
     >
       <div className={`flex whitespace-nowrap ${slow ? "noo-marquee-slow" : "noo-marquee"}`}>
         {[0, 1].map((k) => (
-          <span key={k} className="font-mono px-4" style={{ fontSize: 10.5, letterSpacing: "0.14em", lineHeight: "18px", color, textShadow: `0 0 7px ${color}99` }}>{text}</span>
+          <span key={k} className="font-mono px-4" style={{ fontSize: 10.5, letterSpacing: "0.14em", lineHeight: "18px", color, textShadow: `0 0 7px ${tone === "accent" ? ACCENT2(0.6) : GLOW(0.6)}` }}>{text}</span>
         ))}
       </div>
     </div>
@@ -79,8 +77,7 @@ export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) 
     <div
       className="absolute inset-0 opacity-50"
       style={{
-        backgroundImage:
-          "linear-gradient(90deg, rgba(63,224,208,.10) 1px, transparent 1px), linear-gradient(180deg, rgba(63,224,208,.07) 1px, transparent 1px)",
+        backgroundImage: `linear-gradient(90deg, ${GLOW(0.1)} 1px, transparent 1px), linear-gradient(180deg, ${GLOW(0.07)} 1px, transparent 1px)`,
         backgroundSize: "30px 30px, 30px 30px",
         WebkitMaskImage: "radial-gradient(120% 90% at 50% 120%, #000, transparent 72%)",
         maskImage: "radial-gradient(120% 90% at 50% 120%, #000, transparent 72%)",
@@ -88,19 +85,20 @@ export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) 
     />
     <div
       className="noo-scan absolute inset-x-0 h-[22px]"
-      style={{ background: "linear-gradient(180deg, rgba(63,224,208,0), rgba(63,224,208,.16), rgba(63,224,208,0))", ["--noo-scan-h" as string]: "920px" }}
+      style={{ background: `linear-gradient(180deg, ${GLOW(0)}, ${GLOW(0.16)}, ${GLOW(0)})`, ["--noo-scan-h" as string]: "920px" }}
     />
   </div>
 );
 
-/** Narożnik HUD (celownik) — teal, pulsujący. */
+/** Narożnik HUD (celownik) — w kolorze poświaty skóry, pulsujący. */
 export const HudCorner: React.FC<{ corner: Corner }> = ({ corner }) => {
   const base = "absolute w-4 h-4 z-20 pointer-events-none noo-pulse";
+  const c = GLOW(1);
   const box: Record<Corner, React.CSSProperties> = {
-    tl: { top: 6, left: 6, borderTop: `2px solid ${TEAL}`, borderLeft: `2px solid ${TEAL}` },
-    tr: { top: 6, right: 6, borderTop: `2px solid ${TEAL}`, borderRight: `2px solid ${TEAL}`, animationDelay: ".6s" },
-    bl: { bottom: 6, left: 6, borderBottom: `2px solid ${TEAL}`, borderLeft: `2px solid ${TEAL}`, animationDelay: "1.2s" },
-    br: { bottom: 6, right: 6, borderBottom: `2px solid ${TEAL}`, borderRight: `2px solid ${TEAL}`, animationDelay: "1.8s" },
+    tl: { top: 6, left: 6, borderTop: `2px solid ${c}`, borderLeft: `2px solid ${c}` },
+    tr: { top: 6, right: 6, borderTop: `2px solid ${c}`, borderRight: `2px solid ${c}`, animationDelay: ".6s" },
+    bl: { bottom: 6, left: 6, borderBottom: `2px solid ${c}`, borderLeft: `2px solid ${c}`, animationDelay: "1.2s" },
+    br: { bottom: 6, right: 6, borderBottom: `2px solid ${c}`, borderRight: `2px solid ${c}`, animationDelay: "1.8s" },
   };
   return <span className={base} style={box[corner]} aria-hidden />;
 };
@@ -119,7 +117,7 @@ export const PuritySeal: React.FC<{ className?: string; rotate?: number }> = ({ 
         style={{ clipPath: "polygon(0 0, 100% 0, 100% 86%, 50% 100%, 0 86%)" }} />
       {/* Woskowa pieczęć */}
       <div className="-mt-3 w-[22px] h-[22px] rounded-full flex items-center justify-center shadow-[0_2px_5px_rgba(0,0,0,.6),inset_0_2px_3px_rgba(255,255,255,.25)]"
-        style={{ background: "radial-gradient(circle at 35% 30%, #a83246, #6d1526 65%, #3f0a15)" }}>
+        style={{ background: "var(--sk-seal-wax)" }}>
         <span className="text-[11px] leading-none text-amber-200/70 font-black" style={{ textShadow: "0 1px 1px rgba(0,0,0,.6)" }}>☼</span>
       </div>
     </div>

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -9,7 +9,7 @@ import { ShelfDivider } from "./ShelfDivider";
 
 export const PLANK_STYLE: React.CSSProperties = {
   height: SHELF_PLANK_H,
-  background: "linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%)",
+  background: "var(--sk-plank-bg)",
   boxShadow: "0 8px 14px -6px rgba(0,0,0,.75)",
   borderRadius: 2,
 };

--- a/src/index.css
+++ b/src/index.css
@@ -39,10 +39,46 @@ body {
 }
 
 /* ===== Regał — warstwa „noosferyczna" (Adeptus Mechanicus / cyfrowa) ===== */
+/* Dwie skóry sterowane wyłącznie zmiennymi CSS — przełącznik zmienia tylko klasę.
+   `--noo-glow`/`--noo-accent2` = triplet RGB (do rgba(var(--noo-glow), .x)). */
+:root { --noo-glow: 63, 224, 208; --noo-accent2: 63, 224, 208; }
+
+/* Relikwiarz — mosiądz + teal (dotychczasowy). */
+.skin-noospheric {
+  --noo-glow: 63, 224, 208; --noo-accent2: 63, 224, 208;
+  --sk-cab-bg: linear-gradient(150deg, #3b2817 0%, #2a1c0f 45%, #1a1109 100%);
+  --sk-cornice-bg: linear-gradient(180deg, #4a3220 0%, #2f2012 60%, #1e140b 100%);
+  --sk-well-bg: repeating-linear-gradient(90deg, #140d07 0px, #140d07 26px, #0d0904 27px, #140d07 28px), radial-gradient(120% 80% at 50% 0%, rgba(0,0,0,.15), rgba(0,0,0,.6));
+  --sk-plank-bg: linear-gradient(180deg, rgba(255,214,160,.45) 0, #5a3a1e 1px, #3a2413 55%, #1c1108 100%);
+  --sk-plate-bg: linear-gradient(180deg, #d8b877 0%, #b8860b 58%, #8a6413 100%);
+  --sk-plate-text: #1c1206; --sk-plate-edge: #5e4108;
+  --sk-board-bg: linear-gradient(90deg, #8a6b34, #4a3315 45%, #6b4e22 55%, #2a1c0a);
+  --sk-cog-ring: #c8961f; --sk-cog-skull: #d9c9a8; --sk-cog-disc: #241706;
+  --sk-seal-wax: radial-gradient(circle at 35% 30%, #a83246, #6d1526 65%, #3f0a15);
+  --sk-plinth: linear-gradient(180deg, #3a2915, #1c1108);
+  --sk-foot: linear-gradient(180deg, #2a1c0f, #120b06);
+}
+
+/* Holo+ — kolorystyka aplikacji (cyan/purpura na adamancie), mocne holo. */
+.skin-holo {
+  --noo-glow: 34, 211, 238; --noo-accent2: 168, 85, 247;
+  --sk-cab-bg: linear-gradient(150deg, #0f1b2e 0%, #0a1220 45%, #05090f 100%);
+  --sk-cornice-bg: linear-gradient(180deg, #123047 0%, #0b1a2b 60%, #060d17 100%);
+  --sk-well-bg: repeating-linear-gradient(90deg, #0a1422 0px, #0a1422 26px, #07101c 27px, #0a1422 28px), radial-gradient(120% 80% at 50% 0%, rgba(0,0,0,.1), rgba(0,0,0,.55));
+  --sk-plank-bg: linear-gradient(180deg, rgba(120,240,255,.40) 0, #1c5a72 1px, #0e3a4c 55%, #04101a 100%);
+  --sk-plate-bg: linear-gradient(180deg, rgba(12,40,54,.94), rgba(6,20,30,.94));
+  --sk-plate-text: #bdf2ff; --sk-plate-edge: #1e8fa8;
+  --sk-board-bg: linear-gradient(180deg, #7fe8ff, #22b8d8 40%, #0a5a68);
+  --sk-cog-ring: #5fdcff; --sk-cog-skull: #04141c; --sk-cog-disc: #061620;
+  --sk-seal-wax: radial-gradient(circle at 35% 30%, #7fe8ff, #1fa8c8 65%, #0a4a58);
+  --sk-plinth: linear-gradient(180deg, #123047, #060d17);
+  --sk-foot: linear-gradient(180deg, #0c1e30, #05090f);
+}
+
 @keyframes noo-marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
 @keyframes noo-pulse {
-  0%, 100% { opacity: .5; filter: drop-shadow(0 0 3px rgba(63, 224, 208, .5)); }
-  50%      { opacity: .95; filter: drop-shadow(0 0 9px rgba(63, 224, 208, .95)); }
+  0%, 100% { opacity: .5; filter: drop-shadow(0 0 3px rgba(var(--noo-glow), .5)); }
+  50%      { opacity: .95; filter: drop-shadow(0 0 9px rgba(var(--noo-glow), .95)); }
 }
 @keyframes noo-spin { to { transform: rotate(360deg); } }
 @keyframes noo-data { 0%, 100% { opacity: .5; } 50% { opacity: 1; } }

--- a/src/utils/shelfSkin.ts
+++ b/src/utils/shelfSkin.ts
@@ -1,0 +1,32 @@
+/**
+ * Skóry regału — sterowane wyłącznie zmiennymi CSS (`.skin-*` w `index.css`),
+ * więc przełączenie to tylko podmiana klasy na wrapperze. Wybór trwa w localStorage.
+ */
+export type ShelfSkin = "holo" | "noospheric";
+
+export const SHELF_SKINS: { id: ShelfSkin; label: string }[] = [
+  { id: "holo", label: "Holo+" },
+  { id: "noospheric", label: "Relikwiarz" },
+];
+
+const KEY = "shelfSkin";
+
+export const skinClass = (s: ShelfSkin): string => (s === "holo" ? "skin-holo" : "skin-noospheric");
+
+/** Domyślnie **Holo+**; odczyt odporny na brak/uszkodzony localStorage. */
+export function loadSkin(): ShelfSkin {
+  try {
+    const s = localStorage.getItem(KEY);
+    return s === "noospheric" || s === "holo" ? s : "holo";
+  } catch {
+    return "holo";
+  }
+}
+
+export function saveSkin(s: ShelfSkin): void {
+  try {
+    localStorage.setItem(KEY, s);
+  } catch {
+    /* prywatny tryb / brak dostępu — wybór po prostu nie przetrwa reloadu */
+  }
+}


### PR DESCRIPTION
## Co i dlaczego

Regał dostaje **dwie skóry** i **przełącznik**:
- **Holo+** (domyślnie) — kolorystyka aplikacji: cyan `#22d3ee` + purpura `#a855f7` na adamancie/slate, mocne holo.
- **Relikwiarz** — dotychczasowy mosiądz + teal (v1.21.0).

## Jak

Skóry sterowane **wyłącznie zmiennymi CSS** (`.skin-holo` / `.skin-noospheric` w `index.css`: `--sk-*` gradienty/kolory + `--noo-glow`/`--noo-accent2` triplety RGB używane przez keyframes i inline `rgba(var(--noo-glow), a)`) — przełączenie to podmiana klasy na wrapperze, **bez prop-drillingu**.

- `utils/shelfSkin.ts` (nowy): typ `ShelfSkin`, `skinClass`, `loadSkin`/`saveSkin` (localStorage `shelfSkin`, domyślnie `holo`).
- `BookshelfSection`: stan skóry + segmentowy przełącznik w nagłówku + klasa skóry na wrapperze.
- Komponenty regału (`ShelfFrame`, `ShelfOrnaments` z var-driven `CogSigil`, `ShelfDivider`, `BookSpine`, `ShelfRow` plank, `Shelf` cokół/nóżki, featured plank) czytają `var(--sk-*)`.

**Fizyka układania książek i color-code nagród — nietknięte.**

## Testy / weryfikacja

- `npm run lint` czysty, cała suita zielona (306), `npm run build` OK.
- **Obie skóry** zweryfikowane realnym renderem komponentów (Vite) — Holo+ (cyan/purpura, adamant) i Relikwiarz (mosiądz/teal); harness usunięty przed commitem.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_