### PR TITLE
Regał: tło Sali Archiwum (RoomDecor) idzie za skórą

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.22.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.22.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,10 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.22.1** — **Skóra obejmuje też Salę Archiwum (`RoomDecor`).** Tło pokoju (ściana, podłoga,
+  znak wodny koła, proporzec, kurz, płomień + poświata kinkietów) czyta `--sk-room-*` — Holo+ dostaje
+  chłodną salę cyan/adamant, Relikwiarz zostaje ciepły mosiądz. `CogMark` maluje kolor przez `style`
+  (atrybut `fill` nie rozwiązuje `var()`). Nowe tokeny `--sk-room-{bg,inset,floor,cog,cog2,pennant,mote,glow,flame}`.
 - **1.22.0** — **Dwie skóry regału + przełącznik (Holo+ domyślnie).** Skóry sterowane WYŁĄCZNIE
   zmiennymi CSS (`.skin-holo` / `.skin-noospheric` w `index.css`: `--sk-*` gradienty/kolory +
   `--noo-glow`/`--noo-accent2` triplety RGB używane przez keyframes i inline `rgba(var(--noo-glow),a)`),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.22.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 import { motion } from "motion/react";
 
-/** Sygil koła zębatego (Mechanicus) — ozdoba pokoju. */
+/** Sygil koła zębatego (Mechanicus) — ozdoba pokoju. Kolor przez `style`, by
+ *  rozwiązywały się zmienne skóry (`var(--sk-room-cog*)`). */
 const CogMark: React.FC<{ size: number; color: string; className?: string; style?: React.CSSProperties }> = ({ size, color, className, style }) => (
   <svg viewBox="0 0 48 48" width={size} height={size} className={className} style={style} aria-hidden>
-    <g fill={color}>
+    <g style={{ fill: color }}>
       {Array.from({ length: 12 }).map((_, i) => (
         <rect key={i} x="22.2" y="0.5" width="3.6" height="9" rx="1" transform={`rotate(${i * 30} 24 24)`} />
       ))}
       <circle cx="24" cy="24" r="15" />
     </g>
-    <circle cx="24" cy="24" r="10.5" fill="none" stroke={color} strokeWidth="2" />
-    <circle cx="24" cy="24" r="3" fill={color} />
+    <circle cx="24" cy="24" r="10.5" fill="none" style={{ stroke: color }} strokeWidth="2" />
+    <circle cx="24" cy="24" r="3" style={{ fill: color }} />
   </svg>
 );
 
@@ -24,13 +25,13 @@ const Sconce: React.FC<{ className?: string }> = ({ className }) => (
     </svg>
     <motion.div
       className="absolute left-[22px] top-[6px] w-[9px] h-[15px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
-      style={{ background: "radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00)" }}
+      style={{ background: "var(--sk-room-flame)" }}
       animate={{ scaleY: [1, 1.14, 0.95, 1.08, 1], opacity: [0.85, 1, 0.8, 1, 0.9] }}
       transition={{ duration: 1.6, repeat: Infinity, ease: "easeInOut" }}
     />
     <motion.div
       className="absolute -left-[70px] -top-[64px] w-[200px] h-[200px] rounded-full"
-      style={{ background: "radial-gradient(closest-side, rgba(255,165,70,.24), transparent)", filter: "blur(6px)" }}
+      style={{ background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(6px)" }}
       animate={{ opacity: [0.65, 0.85, 0.6, 0.8, 0.7] }}
       transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
     />
@@ -44,8 +45,8 @@ const Mote: React.FC<{ i: number }> = ({ i }) => {
   const dur = 7 + (i % 5) * 1.7;
   return (
     <motion.div
-      className="absolute w-[3px] h-[3px] rounded-full bg-amber-200/40"
-      style={{ left: `${left}%`, top: `${top}%`, filter: "blur(1px)" }}
+      className="absolute w-[3px] h-[3px] rounded-full"
+      style={{ left: `${left}%`, top: `${top}%`, filter: "blur(1px)", background: "var(--sk-room-mote)" }}
       animate={{ y: [0, -14, 0], opacity: [0.15, 0.5, 0.15] }}
       transition={{ duration: dur, repeat: Infinity, ease: "easeInOut", delay: (i % 7) * 0.6 }}
     />
@@ -61,18 +62,17 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
   <div
     className="relative rounded-[20px] overflow-hidden px-4 pt-10 pb-[120px] sm:px-8"
     style={{
-      background:
-        "linear-gradient(180deg, #2a2018 0%, #241b12 55%, #1b140d 100%), repeating-linear-gradient(90deg, rgba(255,220,170,.03) 0 2px, transparent 2px 130px)",
-      boxShadow: "inset 0 2px 0 rgba(255,220,170,.08), inset 0 40px 80px -40px rgba(0,0,0,.7)",
+      background: "var(--sk-room-bg)",
+      boxShadow: "inset 0 2px 0 var(--sk-room-inset), inset 0 40px 80px -40px rgba(0,0,0,.7)",
     }}
   >
     {/* Znak wodny koła zębatego */}
-    <CogMark size={320} color="#c8961f" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
+    <CogMark size={320} color="var(--sk-room-cog)" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
 
     {/* Proporzec z sygilem */}
     <div className="absolute left-1/2 -translate-x-1/2 top-0 w-[92px] h-[128px] hidden sm:flex items-center justify-center pointer-events-none"
-      style={{ background: "linear-gradient(180deg,#5b1f2a,#3a121a)", clipPath: "polygon(0 0,100% 0,100% 82%,50% 100%,0 82%)", boxShadow: "0 6px 14px rgba(0,0,0,.6)" }} aria-hidden>
-      <CogMark size={46} color="#d9b45a" />
+      style={{ background: "var(--sk-room-pennant)", clipPath: "polygon(0 0,100% 0,100% 82%,50% 100%,0 82%)", boxShadow: "0 6px 14px rgba(0,0,0,.6)" }} aria-hidden>
+      <CogMark size={46} color="var(--sk-room-cog2)" />
     </div>
 
     {/* Kinkiety */}
@@ -87,7 +87,7 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
 
     {/* Podłoga */}
     <div className="absolute left-0 right-0 bottom-0 h-[120px] pointer-events-none"
-      style={{ background: "linear-gradient(180deg,#3a2a19 0,#241a10 40%,#150e07 100%)", boxShadow: "inset 0 16px 26px -12px rgba(0,0,0,.85)" }} aria-hidden />
+      style={{ background: "var(--sk-room-floor)", boxShadow: "inset 0 16px 26px -12px rgba(0,0,0,.85)" }} aria-hidden />
 
     {/* Winieta */}
     <div className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(120% 90% at 50% 40%, rgba(0,0,0,0) 45%, rgba(0,0,0,.5) 100%)" }} aria-hidden />

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,15 @@ body {
   --sk-seal-wax: radial-gradient(circle at 35% 30%, #a83246, #6d1526 65%, #3f0a15);
   --sk-plinth: linear-gradient(180deg, #3a2915, #1c1108);
   --sk-foot: linear-gradient(180deg, #2a1c0f, #120b06);
+  /* Sala Archiwum (RoomDecor) — ciepła */
+  --sk-room-bg: linear-gradient(180deg, #2a2018 0%, #241b12 55%, #1b140d 100%), repeating-linear-gradient(90deg, rgba(255,220,170,.03) 0 2px, transparent 2px 130px);
+  --sk-room-inset: rgba(255,220,170,.08);
+  --sk-room-floor: linear-gradient(180deg, #3a2a19 0, #241a10 40%, #150e07 100%);
+  --sk-room-cog: #c8961f; --sk-room-cog2: #d9b45a;
+  --sk-room-pennant: linear-gradient(180deg, #5b1f2a, #3a121a);
+  --sk-room-mote: rgba(251,224,175,.4);
+  --sk-room-glow: rgba(255,165,70,.24);
+  --sk-room-flame: radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00);
 }
 
 /* Holo+ — kolorystyka aplikacji (cyan/purpura na adamancie), mocne holo. */
@@ -73,6 +82,15 @@ body {
   --sk-seal-wax: radial-gradient(circle at 35% 30%, #7fe8ff, #1fa8c8 65%, #0a4a58);
   --sk-plinth: linear-gradient(180deg, #123047, #060d17);
   --sk-foot: linear-gradient(180deg, #0c1e30, #05090f);
+  /* Sala Archiwum (RoomDecor) — chłodna, cyan/adamant */
+  --sk-room-bg: linear-gradient(180deg, #0e1a2b 0%, #0a1424 55%, #060c16 100%), repeating-linear-gradient(90deg, rgba(120,220,255,.03) 0 2px, transparent 2px 130px);
+  --sk-room-inset: rgba(120,220,255,.08);
+  --sk-room-floor: linear-gradient(180deg, #12263a 0, #0b1826 40%, #05090f 100%);
+  --sk-room-cog: #2f7fa0; --sk-room-cog2: #5fd0e8;
+  --sk-room-pennant: linear-gradient(180deg, #123a4a, #0a2230);
+  --sk-room-mote: rgba(120,220,255,.4);
+  --sk-room-glow: rgba(60,200,240,.24);
+  --sk-room-flame: radial-gradient(circle at 50% 72%, #dffcff, #3fd0f0 55%, #1080c0);
 }
 
 @keyframes noo-marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }


### PR DESCRIPTION
## Co i dlaczego

Po v1.22.0 korpus regału zmieniał kolory ze skórą, ale **tło pokoju** (`RoomDecor`) zostawało ciepłe/brązowe także przy Holo+.

## Zmiana

- `RoomDecor` czyta zestaw tokenów `--sk-room-{bg,inset,floor,cog,cog2,pennant,mote,glow,flame}` → Holo+ dostaje chłodną salę cyan/adamant (ściana, podłoga, znak wodny koła, proporzec, kurz, płomień + poświata kinkietów), Relikwiarz zostaje ciepły mosiądz.
- `CogMark` maluje kolor przez `style` (atrybut SVG `fill` nie rozwiązuje `var()`).

## Weryfikacja

- `npm run lint` czysty, suita zielona (306), build OK.
- Obie sale zweryfikowane realnym renderem (Vite).

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_