### PR TITLE
Regał: bez pieczęci i proporca; brązowa obwódka → cyan glow (Holo+)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.22.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.22.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.22.3** — Sprzątanie ozdób regału: usunięte **pieczęcie czystości** (+ sygnatura IX-774) z ram
+  i **proporzec** z tła (`RoomDecor`). Brązowa obwódka korpusu → tokeny `--sk-frame-border` /
+  `--sk-frame-glow`: w Holo+ **glow cyan**, w Relikwiarzu brąz. Listwa świetlna gzymsu też w kolorze
+  poświaty skóry. Usunięty martwy `PuritySeal` + nieużywane `--sk-seal-wax` / `--sk-room-pennant` /
+  `--sk-room-cog2`.
 - **1.22.2** — **Holo+ dostrojony do palety aplikacji.** Korpus/wnęka/cokół = slate-900→slate-950
   (jak karty i tło `bg-slate-950`), sala `RoomDecor` zlewa się z tłem strony; akcenty cyan-400
   (`#22d3ee`) + purpura-500 (`#a855f7`, pieczęć/aureola/proporzec) — spójne z gradientem nagłówka

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.22.2",
+      "version": "1.22.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.22.2",
+  "version": "1.22.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -69,12 +69,6 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
     {/* Znak wodny koła zębatego */}
     <CogMark size={320} color="var(--sk-room-cog)" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
 
-    {/* Proporzec z sygilem */}
-    <div className="absolute left-1/2 -translate-x-1/2 top-0 w-[92px] h-[128px] hidden sm:flex items-center justify-center pointer-events-none"
-      style={{ background: "var(--sk-room-pennant)", clipPath: "polygon(0 0,100% 0,100% 82%,50% 100%,0 82%)", boxShadow: "0 6px 14px rgba(0,0,0,.6)" }} aria-hidden>
-      <CogMark size={46} color="var(--sk-room-cog2)" />
-    </div>
-
     {/* Kinkiety */}
     <Sconce className="left-3 top-16 hidden md:block" />
     <Sconce className="right-3 top-16 hidden md:block" />

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CogSigil, PuritySeal, NoosphericCrest, DataTicker, HoloField, HudCorner } from "./ShelfOrnaments";
+import { CogSigil, NoosphericCrest, DataTicker, HoloField, HudCorner } from "./ShelfOrnaments";
 
 export type ShelfAccent = "emerald" | "cyan" | "purple" | "amber";
 
@@ -31,10 +31,12 @@ interface Props {
  */
 export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highlight = "idle", headerExtra, rootProps, children }) => {
   const a = ACCENT[accent];
+  // Idle: kolor obwódki i poświata pochodzą ze skóry (`--sk-frame-*`) — brąz w
+  // Relikwiarzu, cyan-glow w Holo+. Stany target/dragging nadpisują klasą.
   const stateRing =
     highlight === "target" ? `${a.ring} ${a.glow}` :
     highlight === "dragging" ? "border-amber-400/30 border-dashed" :
-    "border-amber-950/70";
+    "";
 
   return (
     <div
@@ -42,7 +44,8 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
       className={`relative rounded-[18px] border-2 transition-all duration-200 ${stateRing}`}
       style={{
         background: "var(--sk-cab-bg)",
-        boxShadow: "0 24px 40px -22px rgba(0,0,0,.85), inset 0 1px 0 rgba(var(--noo-glow),.10)",
+        boxShadow: "0 24px 40px -22px rgba(0,0,0,.85), inset 0 1px 0 rgba(var(--noo-glow),.10), var(--sk-frame-glow)",
+        ...(highlight === "idle" ? { borderColor: "var(--sk-frame-border)" } : {}),
       }}
     >
       {/* Boczne słupki + cokół tworzy padding; gzyms nakładamy górnym paddingiem */}
@@ -65,8 +68,8 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
           {/* Ticker danych (przewijany) — wypełnia wolną przestrzeń gzymsu */}
           <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ NOOSPHERA·SYNC ++ 01001101·01000001·01010011 ++ AVE·OMNISSIAH ++" />
           <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
-          {/* Delikatna listwa świetlna pod gzymsem */}
-          <div className="absolute bottom-0 inset-x-6 h-px bg-gradient-to-r from-transparent via-amber-300/25 to-transparent" />
+          {/* Delikatna listwa świetlna pod gzymsem (w kolorze poświaty skóry) */}
+          <div className="absolute bottom-0 inset-x-6 h-px" style={{ background: "linear-gradient(90deg, transparent, rgba(var(--noo-glow),.28), transparent)" }} />
         </div>
 
         {/* Wnętrze regału — ciemne „plecy" z pionowymi deskami + warstwa holo */}
@@ -82,14 +85,12 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
         </div>
       </div>
 
-      {/* Godło holo (projekcja) + narożniki HUD + pieczęć czystości z sygnaturą */}
+      {/* Godło holo (projekcja) + narożniki HUD */}
       <NoosphericCrest className="absolute -top-[22px] left-1/2 -translate-x-1/2 z-20" size={46} />
       <HudCorner corner="tl" />
       <HudCorner corner="tr" />
       <HudCorner corner="bl" />
       <HudCorner corner="br" />
-      <PuritySeal className="top-[40px] right-6 z-20" rotate={-9} />
-      <span className="absolute top-[88px] right-[18px] z-20 font-mono text-[8px] tracking-[0.12em] pointer-events-none" style={{ color: "rgba(var(--noo-glow),.75)", textShadow: "0 0 6px rgba(var(--noo-glow),.5)" }} aria-hidden>IX-774</span>
     </div>
   );
 };

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -102,24 +102,3 @@ export const HudCorner: React.FC<{ corner: Corner }> = ({ corner }) => {
   };
   return <span className={base} style={box[corner]} aria-hidden />;
 };
-
-/** Pieczęć czystości zwisająca na wstędze (kwiatek + atrybut z fabuły). */
-export const PuritySeal: React.FC<{ className?: string; rotate?: number }> = ({ className = "", rotate = -8 }) => (
-  <div
-    aria-hidden
-    className={`absolute pointer-events-none select-none ${className}`}
-    style={{ transform: `rotate(${rotate}deg)`, transformOrigin: "top center" }}
-    title="Pieczęć czystości"
-  >
-    {/* Wstęga pergaminu */}
-    <div className="relative flex flex-col items-center">
-      <div className="w-[13px] h-9 bg-gradient-to-b from-[#e8dcc0] via-[#d8c8a2] to-[#b9a271] shadow-[0_2px_4px_rgba(0,0,0,.5)]"
-        style={{ clipPath: "polygon(0 0, 100% 0, 100% 86%, 50% 100%, 0 86%)" }} />
-      {/* Woskowa pieczęć */}
-      <div className="-mt-3 w-[22px] h-[22px] rounded-full flex items-center justify-center shadow-[0_2px_5px_rgba(0,0,0,.6),inset_0_2px_3px_rgba(255,255,255,.25)]"
-        style={{ background: "var(--sk-seal-wax)" }}>
-        <span className="text-[11px] leading-none text-amber-200/70 font-black" style={{ textShadow: "0 1px 1px rgba(0,0,0,.6)" }}>☼</span>
-      </div>
-    </div>
-  </div>
-);

--- a/src/index.css
+++ b/src/index.css
@@ -54,15 +54,14 @@ body {
   --sk-plate-text: #1c1206; --sk-plate-edge: #5e4108;
   --sk-board-bg: linear-gradient(90deg, #8a6b34, #4a3315 45%, #6b4e22 55%, #2a1c0a);
   --sk-cog-ring: #c8961f; --sk-cog-skull: #d9c9a8; --sk-cog-disc: #241706;
-  --sk-seal-wax: radial-gradient(circle at 35% 30%, #a83246, #6d1526 65%, #3f0a15);
+  --sk-frame-border: #3a2413; --sk-frame-glow: 0 0 0 rgba(0,0,0,0);
   --sk-plinth: linear-gradient(180deg, #3a2915, #1c1108);
   --sk-foot: linear-gradient(180deg, #2a1c0f, #120b06);
   /* Sala Archiwum (RoomDecor) — ciepła */
   --sk-room-bg: linear-gradient(180deg, #2a2018 0%, #241b12 55%, #1b140d 100%), repeating-linear-gradient(90deg, rgba(255,220,170,.03) 0 2px, transparent 2px 130px);
   --sk-room-inset: rgba(255,220,170,.08);
   --sk-room-floor: linear-gradient(180deg, #3a2a19 0, #241a10 40%, #150e07 100%);
-  --sk-room-cog: #c8961f; --sk-room-cog2: #d9b45a;
-  --sk-room-pennant: linear-gradient(180deg, #5b1f2a, #3a121a);
+  --sk-room-cog: #c8961f;
   --sk-room-mote: rgba(251,224,175,.4);
   --sk-room-glow: rgba(255,165,70,.24);
   --sk-room-flame: radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00);
@@ -80,16 +79,14 @@ body {
   --sk-plate-text: #a5f0fc; --sk-plate-edge: #1e7a99;
   --sk-board-bg: linear-gradient(180deg, #67e8f9, #22d3ee 40%, #0e7490);
   --sk-cog-ring: #22d3ee; --sk-cog-skull: #04101c; --sk-cog-disc: #060a14;
-  /* pieczęć w akcencie purpurowym aplikacji */
-  --sk-seal-wax: radial-gradient(circle at 35% 30%, #c084fc, #a855f7 65%, #6b21a8);
+  --sk-frame-border: rgba(34,211,238,.45); --sk-frame-glow: 0 0 20px rgba(34,211,238,.16);
   --sk-plinth: linear-gradient(180deg, #0f172a, #060a14);
   --sk-foot: linear-gradient(180deg, #0b1120, #03060f);
   /* Sala Archiwum (RoomDecor) — zlewa się z tłem aplikacji (slate-950) */
   --sk-room-bg: linear-gradient(180deg, #0a0f1c 0%, #060a14 55%, #020510 100%), repeating-linear-gradient(90deg, rgba(34,211,238,.03) 0 2px, transparent 2px 130px);
   --sk-room-inset: rgba(34,211,238,.08);
   --sk-room-floor: linear-gradient(180deg, #0e1626 0, #070c16 40%, #02050d 100%);
-  --sk-room-cog: #1e6a8c; --sk-room-cog2: #22d3ee;
-  --sk-room-pennant: linear-gradient(180deg, #3b1d6b, #241243);
+  --sk-room-cog: #1e6a8c;
   --sk-room-mote: rgba(34,211,238,.4);
   --sk-room-glow: rgba(34,211,238,.22);
   --sk-room-flame: radial-gradient(circle at 50% 72%, #cffafe, #22d3ee 55%, #0e7490);


### PR DESCRIPTION
## Zmiana

- Usunięte **pieczęcie czystości** (+ sygnatura `IX-774`) z ram regałów (`ShelfFrame`).
- Usunięty **proporzec/flaga** z tła Sali Archiwum (`RoomDecor`).
- Obwódka korpusu sterowana skórą (`--sk-frame-border` / `--sk-frame-glow`): w **Holo+ glow cyan**, w Relikwiarzu brąz. Listwa świetlna gzymsu też idzie za poświatą skóry.
- Sprzątnięty martwy `PuritySeal` + nieużywane `--sk-seal-wax` / `--sk-room-pennant` / `--sk-room-cog2`.

## Weryfikacja

- `npm run lint` czysty, suita zielona (306), build OK.
- Render Holo+ na `bg-slate-950` — czysty prawy-górny róg (bez pieczęci), brak proporca, obwódka jako cyan glow.

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_