### PR TITLE
Regał: grzbiety Holo+ (szkło w palecie aplikacji + neon + biały tytuł z glow)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.22.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.23.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.23.0** — **Grzbiety zależne od skóry (wariant „E").** Holo+: grzbiet = **szkło w akcencie
+  aplikacji** (paleta `APP_PALETTE` cyan/niebieski/indygo/fiolet/purpura, równoległa do `CLOTH_PALETTE`
+  po tym samym indeksie) + **neonowa lewa krawędź** + **biały tytuł z glow**; kupki i okładki
+  „Wyróżnione" też przemalowane (fore-edge cyan, gwiazdka cyan). Relikwiarz: matowe grzbiety bez zmian.
+  `spineStyle` zwraca dodatkowo `app`/`appRgb`; element podaje akcenty inline (`--spine-muted`/`--spine-app`/
+  `--spine-app-rgb`/`--cm-*`/`--ca-*`), a wygląd nadają **realne reguły** `.skin-* .book-spine/.spine-title/
+  .stack-layer/.fore-edge/.cover-*` w `index.css` (gradient w custom-property z zagnieżdżonym `var()` bywa
+  zjadany przez pipeline CSS — stąd klasy zamiast `var(--sk-...)`). Fizyka/szerokości bez zmian. +2 asercje.
 - **1.22.3** — Sprzątanie ozdób regału: usunięte **pieczęcie czystości** (+ sygnatura IX-774) z ram
   i **proporzec** z tła (`RoomDecor`). Brązowa obwódka korpusu → tokeny `--sk-frame-border` /
   `--sk-frame-glow`: w Holo+ **glow cyan**, w Relikwiarzu brąz. Listwa świetlna gzymsu też w kolorze

--- a/docs/bookshelf.md
+++ b/docs/bookshelf.md
@@ -96,8 +96,14 @@ The row builder is shared (`buildShelfItems` + `chunk` in `utils/shelfLayout.ts`
 
 ## 3. Pure helpers (`src/utils/bookshelf.ts`, unit-tested)
 - **`isRead(book, overrides)`** — read state with optimistic overrides layered over the base tag.
-- **`spineStyle(book)`** — deterministic spine colour (a muted book-cloth palette), width and height
-  from a hash of the title, so a spine looks identical across re-renders. The hash is unsigned
+- **`spineStyle(book)`** — deterministic spine colour, width and height from a hash of the title, so a
+  spine looks identical across re-renders. Returns **two** parallel accents by the same index: `color`
+  (muted `CLOTH_PALETTE`, used by **Relikwiarz**) and `app`/`appRgb` (`APP_PALETTE`, cyan/blue/violet/
+  purple, used by **Holo+**). The element sets both as inline CSS vars (`--spine-muted`/`--spine-app`/
+  `--spine-app-rgb`); the actual look is real per-skin rules in `index.css` (`.skin-* .book-spine` etc.):
+  Holo+ = accent-tinted **glass** + neon left edge + white glowing title; Relikwiarz = matte cloth.
+  (Gradients live in real rules, not `var(--sk-…)` custom properties — a gradient-with-nested-`var()`
+  stored in a custom property gets dropped by the CSS pipeline.) The hash is unsigned
   (`>>> 0`); the height derivation uses an **unsigned** shift (`>>> 3`) — a signed `>> 3` goes
   negative for hashes above 2³¹ and produced out-of-range heights (caught by a bounds test).
 - **`splitShelves(books, overrides)`** — partitions into `{ read, toRead }`, each sorted by

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.22.3",
+      "version": "1.23.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.22.3",
+  "version": "1.23.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BookIndexEntry } from "../types";
-import { isRead, spineStyle, planShelf, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, awardWins, hasAward, CLOTH_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
+import { isRead, spineStyle, planShelf, MAX_LEAN_DEG, LEAN_TOWARD, spineFontSize, flatBookLayout, FLAT_MAX_W, layoutStack, stackAlign, stackChaos, splitShelves, featuredReads, awardWins, hasAward, CLOTH_PALETTE, APP_PALETTE, READ_TAG, shelfPlankBackground, SHELF_ROW_H, SHELF_PLANK_H, SHELF_ROW_GAP } from "../utils/bookshelf";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
   id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
@@ -30,6 +30,10 @@ describe("bookshelf.spineStyle", () => {
     for (const t of ["Diuna", "Hyperion", "Ubik", "Solaris", "Lód"]) {
       const s = spineStyle(mk({ plTitle: t }));
       expect(CLOTH_PALETTE).toContain(s.color);
+      // akcent Holo+ z tego samego indeksu (równoległa paleta)
+      const idx = CLOTH_PALETTE.indexOf(s.color);
+      expect(s.app).toBe(APP_PALETTE[idx][0]);
+      expect(s.appRgb).toBe(APP_PALETTE[idx][1]);
       expect(s.width).toBeGreaterThanOrEqual(16);
       expect(s.width).toBeLessThanOrEqual(27);
       expect(s.height).toBeGreaterThanOrEqual(124);
@@ -108,7 +112,7 @@ describe("bookshelf.planShelf", () => {
 });
 
 describe("bookshelf.title sizing (pełne nazwy)", () => {
-  const style = { color: "#000", width: 20, height: 160 };
+  const style = { color: "#000", app: "#06b6d4", appRgb: "6,182,212", width: 20, height: 160 };
   it("spineFontSize shrinks for longer titles, within 6–11 px", () => {
     const short = spineFontSize(style, "Ubik");
     const long = spineFontSize(style, "Opowieści z meekhańskiego pogranicza. Północ-Południe");

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -23,13 +23,14 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
     onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
     onDragEnd={onDragEnd}
     title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
-    className="group relative shrink-0 flex items-center justify-center cursor-grab active:cursor-grabbing select-none rounded-[3px_3px_1px_1px] transition-transform duration-150 hover:-translate-y-3"
+    className="book-spine group relative shrink-0 flex items-center justify-center cursor-grab active:cursor-grabbing select-none rounded-[3px_3px_1px_1px] transition-transform duration-150 hover:-translate-y-3"
     style={{
       width: style.width,
       height: style.height,
-      background: `linear-gradient(90deg, rgba(0,0,0,.35), ${style.color} 22%, ${style.color} 78%, rgba(0,0,0,.28))`,
-      boxShadow: "inset 1.5px 0 0 rgba(var(--noo-glow),.22), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6)",
-    }}
+      ["--spine-muted" as string]: style.color,
+      ["--spine-app" as string]: style.app,
+      ["--spine-app-rgb" as string]: style.appRgb,
+    } as React.CSSProperties}
   >
     <span className="absolute left-0 right-0 h-[10px] top-[9px] bg-black/25" aria-hidden />
     {style.width >= 26 && (
@@ -42,8 +43,8 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       </span>
     )}
     <span
-      className="font-bold text-white/85 whitespace-nowrap overflow-hidden max-h-[94%] py-1"
-      style={{ fontSize: spineFontSize(style, displayTitle(book)), writingMode: "vertical-rl", transform: "rotate(180deg)", textShadow: "0 1px 2px rgba(0,0,0,.5)" }}
+      className="spine-title font-bold whitespace-nowrap overflow-hidden max-h-[94%] py-1"
+      style={{ fontSize: spineFontSize(style, displayTitle(book)), writingMode: "vertical-rl", transform: "rotate(180deg)" }}
     >
       {displayTitle(book)}
     </span>

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -21,7 +21,7 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
   return (
     <div className="relative shrink-0 flex flex-col-reverse items-start" style={{ width: cellW }}>
       {layers.map(({ book, width, fontSize, thickness, lines, x }, i) => {
-        const color = spineStyle(book).color;
+        const s = spineStyle(book);
         const wins = awardWins(book);
         return (
           <div
@@ -30,21 +30,23 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
             onDragStart={(e) => { e.dataTransfer.setData("text/plain", book.id); e.dataTransfer.effectAllowed = "move"; onDragStart(book); }}
             onDragEnd={onDragEnd}
             title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}${book.year ? " (" + book.year + ")" : ""}`}
-            className="group/layer relative rounded-[2px] cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-y-0.5"
+            className="stack-layer group/layer relative rounded-[2px] cursor-grab active:cursor-grabbing select-none transition-transform duration-150 hover:-translate-y-0.5"
             style={{
               height: thickness,
               width,
               marginLeft: x,
               marginBottom: i === 0 ? 0 : 1,
-              background: `linear-gradient(0deg, rgba(0,0,0,.42) 0, ${color} 26%, ${color} 74%, rgba(255,255,255,.12) 100%)`,
+              ["--spine-muted" as string]: s.color,
+              ["--spine-app" as string]: s.app,
+              ["--spine-app-rgb" as string]: s.appRgb,
               boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",
-            }}
+            } as React.CSSProperties}
           >
             {/* Krawędź kartek (fore-edge) po prawej */}
-            <span className="absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px] bg-gradient-to-b from-amber-50/70 via-amber-100/40 to-amber-50/70" aria-hidden />
+            <span className="fore-edge absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px]" aria-hidden />
             {/* PEŁNY tytuł wzdłuż grzbietu — zawijany do max 2 linii zamiast poszerzania */}
             <span
-              className="absolute inset-y-0 right-3 flex items-center font-bold text-white/90"
+              className="spine-title absolute inset-y-0 right-3 flex items-center font-bold"
               style={{ left: wins.length ? 6 + wins.length * 7 : 8 }}
             >
               <span
@@ -56,7 +58,6 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
                   WebkitLineClamp: lines,
                   overflow: "hidden",
                   whiteSpace: lines === 1 ? "nowrap" : "normal",
-                  textShadow: "0 1px 2px rgba(0,0,0,.55)",
                 }}
               >
                 {displayTitle(book)}

--- a/src/components/shelf/CoverCard.tsx
+++ b/src/components/shelf/CoverCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
-import { CLOTH_PALETTE, displayTitle } from "../../utils/bookshelf";
+import { CLOTH_PALETTE, APP_PALETTE, displayTitle } from "../../utils/bookshelf";
 
 function hash(s: string): number {
   let h = 0;
@@ -8,19 +8,24 @@ function hash(s: string): number {
   return h;
 }
 
-/** Okładka „twarzą" (koncept B) — półka „Wyróżnione". Widok, bez drag&drop. */
+/** Okładka „twarzą" (koncept B) — półka „Wyróżnione". Widok, bez drag&drop.
+ *  Kolory zależne od skóry: matowe (Relikwiarz) lub akcenty aplikacji (Holo+). */
 export const CoverCard: React.FC<{ book: BookIndexEntry }> = ({ book }) => {
   const h = hash(displayTitle(book));
-  const c1 = CLOTH_PALETTE[h % CLOTH_PALETTE.length];
-  const c2 = CLOTH_PALETTE[(h >>> 3) % CLOTH_PALETTE.length];
+  const i1 = h % CLOTH_PALETTE.length;
+  const i2 = (h >>> 3) % CLOTH_PALETTE.length;
   return (
     <div
       title={`${displayTitle(book)}${book.author ? " — " + book.author : ""}`}
-      className="group relative shrink-0 w-[104px] h-[156px] rounded-[6px_3px_3px_6px] overflow-hidden flex flex-col justify-between p-3 pl-4 transition-transform duration-150 hover:-translate-y-2"
-      style={{ background: `linear-gradient(150deg, ${c1}, ${c2})`, boxShadow: "inset -5px 0 8px -6px rgba(0,0,0,.6), 0 10px 16px -8px rgba(0,0,0,.7)" }}
+      className="cover-card group relative shrink-0 w-[104px] h-[156px] rounded-[6px_3px_3px_6px] overflow-hidden flex flex-col justify-between p-3 pl-4 transition-transform duration-150 hover:-translate-y-2"
+      style={{
+        ["--cm-a" as string]: CLOTH_PALETTE[i1], ["--cm-b" as string]: CLOTH_PALETTE[i2],
+        ["--ca-a" as string]: APP_PALETTE[i1][0], ["--ca-b" as string]: APP_PALETTE[i2][0],
+        boxShadow: "inset -5px 0 8px -6px rgba(0,0,0,.6), 0 10px 16px -8px rgba(0,0,0,.7)",
+      } as React.CSSProperties}
     >
       <span className="absolute left-0 top-0 bottom-0 w-1.5 bg-black/25 shadow-[1px_0_2px_rgba(255,255,255,.1)]" aria-hidden />
-      <span className="absolute top-2 right-2 w-4 h-4 rounded-full border-[1.5px] border-amber-300 text-amber-300 text-[9px] flex items-center justify-center">★</span>
+      <span className="cover-badge absolute top-2 right-2 w-4 h-4 rounded-full border-[1.5px] text-[9px] flex items-center justify-center">★</span>
       <div className="text-[12px] font-bold leading-tight text-white text-balance drop-shadow-[0_1px_3px_rgba(0,0,0,.5)]">
         {displayTitle(book)}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,15 @@ body {
   --sk-room-flame: radial-gradient(circle at 50% 72%, #cffafe, #22d3ee 55%, #0e7490);
 }
 
+.skin-noospheric .book-spine {
+  background: linear-gradient(90deg, rgba(0,0,0,.35), var(--spine-muted) 22%, var(--spine-muted) 78%, rgba(0,0,0,.28));
+  box-shadow: inset 1.5px 0 0 rgba(var(--noo-glow),.22), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6);
+}
+.skin-holo .book-spine {
+  background: linear-gradient(90deg, var(--spine-app) 0 2.5px, rgba(var(--spine-app-rgb),.68) 3px, rgba(var(--spine-app-rgb),.42) 55%, rgba(var(--spine-app-rgb),.30) 100%);
+  box-shadow: inset 1.5px 0 0 var(--spine-app), inset -3px 0 6px rgba(0,0,0,.4), 0 0 13px -3px rgba(var(--spine-app-rgb),.8), 0 6px 10px -6px rgba(0,0,0,.7);
+}
+
 @keyframes noo-marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
 @keyframes noo-pulse {
   0%, 100% { opacity: .5; filter: drop-shadow(0 0 3px rgba(var(--noo-glow), .5)); }
@@ -111,3 +120,13 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .noo-marquee, .noo-marquee-slow, .noo-pulse, .noo-spin, .noo-data, .noo-scan { animation: none !important; }
 }
+.skin-noospheric .spine-title { color: rgba(255,255,255,.86); text-shadow: 0 1px 2px rgba(0,0,0,.5); }
+.skin-holo .spine-title { color: #f0f9ff; text-shadow: 0 0 7px rgba(var(--spine-app-rgb),.95), 0 0 2px rgba(255,255,255,.5); }
+.skin-noospheric .stack-layer { background: linear-gradient(0deg, rgba(0,0,0,.42) 0, var(--spine-muted) 26%, var(--spine-muted) 74%, rgba(255,255,255,.12) 100%); }
+.skin-holo .stack-layer { background: linear-gradient(0deg, rgba(var(--spine-app-rgb),.30) 0, rgba(var(--spine-app-rgb),.44) 55%, rgba(var(--spine-app-rgb),.66) 90%, var(--spine-app) 100%); }
+.skin-noospheric .fore-edge { background: linear-gradient(to bottom, rgba(255,251,235,.7), rgba(255,247,220,.4), rgba(255,251,235,.7)); }
+.skin-holo .fore-edge { background: linear-gradient(to bottom, rgba(var(--spine-app-rgb),.75), rgba(255,255,255,.45), rgba(var(--spine-app-rgb),.75)); }
+.skin-noospheric .cover-card { background: linear-gradient(150deg, var(--cm-a), var(--cm-b)); }
+.skin-holo .cover-card { background: linear-gradient(150deg, var(--ca-a), var(--ca-b)); }
+.skin-noospheric .cover-badge { color: #fcd34d; border-color: #fcd34d; }
+.skin-holo .cover-badge { color: #67e8f9; border-color: #67e8f9; }

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -17,15 +17,25 @@ export function isRead(book: BookIndexEntry, overrides: ReadOverrides = {}): boo
 
 /** Deterministyczny wygląd grzbietu — stały dla danego tytułu (bez migotania przy re-renderze). */
 export interface SpineStyle {
-  color: string;
-  width: number;  // px
-  height: number; // px
+  color: string;   // stonowany kolor „płótna" (skóra Relikwiarz)
+  app: string;     // akcent z palety aplikacji (skóra Holo+) — hex
+  appRgb: string;  // ten sam akcent jako „r,g,b" (do rgba(var(...), a))
+  width: number;   // px
+  height: number;  // px
 }
 
-/** Paleta „płótna introligatorskiego" — stonowana, autentyczna. */
+/** Paleta „płótna introligatorskiego" — stonowana, autentyczna (Relikwiarz). */
 export const CLOTH_PALETTE = [
   "#7f1d2e", "#0f5132", "#1e3a5f", "#7c5410", "#3f2d52", "#2b2b2b",
   "#5a2a1e", "#14504f", "#4a3b16", "#5b1f3a", "#243b53", "#6b2737",
+];
+
+/** Paleta akcentów aplikacji (cyan/niebieski/indygo/fiolet/purpura) — Holo+.
+ *  Równoległa do `CLOTH_PALETTE` (ten sam indeks = ta sama książka). */
+export const APP_PALETTE: readonly (readonly [string, string])[] = [
+  ["#06b6d4", "6,182,212"], ["#3b82f6", "59,130,246"], ["#6366f1", "99,102,241"], ["#8b5cf6", "139,92,246"],
+  ["#a855f7", "168,85,247"], ["#14b8a6", "20,184,166"], ["#0ea5e9", "14,165,233"], ["#4f46e5", "79,70,229"],
+  ["#7c3aed", "124,58,237"], ["#0891b2", "8,145,178"], ["#2563eb", "37,99,235"], ["#9333ea", "147,51,234"],
 ];
 
 function hash(s: string): number {
@@ -36,8 +46,11 @@ function hash(s: string): number {
 
 export function spineStyle(book: BookIndexEntry): SpineStyle {
   const h = hash(book.plTitle || book.origTitle || book.id);
+  const idx = h % CLOTH_PALETTE.length;
+  const [app, appRgb] = APP_PALETTE[idx];
   return {
-    color: CLOTH_PALETTE[h % CLOTH_PALETTE.length],
+    color: CLOTH_PALETTE[idx],
+    app, appRgb,
     width: 16 + (h % 12),          // 16–27 px
     height: 124 + ((h >>> 3) % 48), // 124–171 px (unsigned shift — h bywa >2^31)
   };


### PR DESCRIPTION
## Co i dlaczego

Wariant **E** dla Holo+: grzbiety jako **szkło w akcencie aplikacji** (cyan/niebieski/indygo/fiolet/purpura), z **neonową lewą krawędzią** i **białym tytułem z poświatą**. Kupki i okładki „Wyróżnione" też w akcentach aplikacji. **Relikwiarz** zostaje przy matowych, ciepłych grzbietach.

## Zmiana

- `spineStyle` → dodatkowo `app`/`appRgb` z `APP_PALETTE` (równoległa do `CLOTH_PALETTE`, ten sam indeks = ta sama książka).
- `BookSpine` / `BookStack` / `CoverCard` podają akcenty inline (`--spine-*` / `--cm-*` / `--ca-*`) i dostają klasy (`book-spine`, `spine-title`, `stack-layer`, `fore-edge`, `cover-card`, `cover-badge`).
- Wygląd = **realne reguły** `.skin-* .…` w `index.css` (nie `var(--sk-…)` — gradient z zagnieżdżonym `var()` w custom-property bywa gubiony przez pipeline CSS).
- Fizyka (szerokości/wysokości) i award color-code **nietknięte**.

## Testy / weryfikacja

- `npm run lint` czysty, suita zielona (306, +2 asercje), `npm run build` OK (CSS kompiluje się bez błędu).
- Obie skóry zweryfikowane realnym renderem komponentów (Vite) na tle `bg-slate-950`.

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_