### PR TITLE
Audyt kolorów #1: amberowa oprawa Regału w Holo+

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.23.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.23.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.23.1** — **Oprawa Regału = amber (kolor zakładki), spójnie z konwencją „kolor per zakładka".**
+  Nowy token `--sk-frame-accent` (Holo+ amber `251,191,36`; Relikwiarz teal — bez zmian) steruje ramką
+  (`--sk-frame-border/-glow`), narożnikami HUD (`HudCorner` — lokalnie nadpisuje `--noo-glow`, by puls też
+  był amber) i listwą gzymsu. Wnętrze (godło/deseczki/ticker/sygnatury/szkło książek) zostaje na `--noo-glow`
+  (cyan). „Mosiężna oprawa relikwiarza trzymająca cyanowe data-tomy". Zaczyna wdrożenie audytu kolorów.
 - **1.23.0** — **Grzbiety zależne od skóry (wariant „E").** Holo+: grzbiet = **szkło w akcencie
   aplikacji** (paleta `APP_PALETTE` cyan/niebieski/indygo/fiolet/purpura, równoległa do `CLOTH_PALETTE`
   po tym samym indeksie) + **neonowa lewa krawędź** + **biały tytuł z glow**; kupki i okładki

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.23.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -68,8 +68,8 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
           {/* Ticker danych (przewijany) — wypełnia wolną przestrzeń gzymsu */}
           <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ NOOSPHERA·SYNC ++ 01001101·01000001·01010011 ++ AVE·OMNISSIAH ++" />
           <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
-          {/* Delikatna listwa świetlna pod gzymsem (w kolorze poświaty skóry) */}
-          <div className="absolute bottom-0 inset-x-6 h-px" style={{ background: "linear-gradient(90deg, transparent, rgba(var(--noo-glow),.28), transparent)" }} />
+          {/* Delikatna listwa świetlna pod gzymsem (w kolorze oprawy Regału) */}
+          <div className="absolute bottom-0 inset-x-6 h-px" style={{ background: "linear-gradient(90deg, transparent, rgba(var(--sk-frame-accent),.28), transparent)" }} />
         </div>
 
         {/* Wnętrze regału — ciemne „plecy" z pionowymi deskami + warstwa holo */}

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -90,15 +90,17 @@ export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) 
   </div>
 );
 
-/** Narożnik HUD (celownik) — w kolorze poświaty skóry, pulsujący. */
+/** Narożnik HUD (celownik) — w kolorze OPRAWY Regału (`--sk-frame-accent`, amber),
+ *  pulsujący. Lokalnie nadpisuje `--noo-glow`, by pulsujący glow też był w akcencie ramki. */
 export const HudCorner: React.FC<{ corner: Corner }> = ({ corner }) => {
   const base = "absolute w-4 h-4 z-20 pointer-events-none noo-pulse";
-  const c = GLOW(1);
+  const c = "rgb(var(--sk-frame-accent))";
+  const common = { ["--noo-glow" as string]: "var(--sk-frame-accent)" };
   const box: Record<Corner, React.CSSProperties> = {
-    tl: { top: 6, left: 6, borderTop: `2px solid ${c}`, borderLeft: `2px solid ${c}` },
-    tr: { top: 6, right: 6, borderTop: `2px solid ${c}`, borderRight: `2px solid ${c}`, animationDelay: ".6s" },
-    bl: { bottom: 6, left: 6, borderBottom: `2px solid ${c}`, borderLeft: `2px solid ${c}`, animationDelay: "1.2s" },
-    br: { bottom: 6, right: 6, borderBottom: `2px solid ${c}`, borderRight: `2px solid ${c}`, animationDelay: "1.8s" },
+    tl: { ...common, top: 6, left: 6, borderTop: `2px solid ${c}`, borderLeft: `2px solid ${c}` },
+    tr: { ...common, top: 6, right: 6, borderTop: `2px solid ${c}`, borderRight: `2px solid ${c}`, animationDelay: ".6s" },
+    bl: { ...common, bottom: 6, left: 6, borderBottom: `2px solid ${c}`, borderLeft: `2px solid ${c}`, animationDelay: "1.2s" },
+    br: { ...common, bottom: 6, right: 6, borderBottom: `2px solid ${c}`, borderRight: `2px solid ${c}`, animationDelay: "1.8s" },
   };
-  return <span className={base} style={box[corner]} aria-hidden />;
+  return <span className={base} style={box[corner] as React.CSSProperties} aria-hidden />;
 };

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,7 @@ body {
   --sk-board-bg: linear-gradient(90deg, #8a6b34, #4a3315 45%, #6b4e22 55%, #2a1c0a);
   --sk-cog-ring: #c8961f; --sk-cog-skull: #d9c9a8; --sk-cog-disc: #241706;
   --sk-frame-border: #3a2413; --sk-frame-glow: 0 0 0 rgba(0,0,0,0);
+  --sk-frame-accent: 63, 224, 208; /* oprawa/HUD Relikwiarza — teal (bez zmian) */
   --sk-plinth: linear-gradient(180deg, #3a2915, #1c1108);
   --sk-foot: linear-gradient(180deg, #2a1c0f, #120b06);
   /* Sala Archiwum (RoomDecor) — ciepła */
@@ -79,7 +80,10 @@ body {
   --sk-plate-text: #a5f0fc; --sk-plate-edge: #1e7a99;
   --sk-board-bg: linear-gradient(180deg, #67e8f9, #22d3ee 40%, #0e7490);
   --sk-cog-ring: #22d3ee; --sk-cog-skull: #04101c; --sk-cog-disc: #060a14;
-  --sk-frame-border: rgba(34,211,238,.45); --sk-frame-glow: 0 0 20px rgba(34,211,238,.16);
+  /* Oprawa Regału = amber (kolor zakładki „Regał"), spójnie w obu skórach;
+     wnętrze (godło/deseczki/ticker/sygnatury/książki) zostaje na --noo-glow (cyan). */
+  --sk-frame-accent: 251, 191, 36;
+  --sk-frame-border: rgba(var(--sk-frame-accent),.45); --sk-frame-glow: 0 0 20px rgba(var(--sk-frame-accent),.16);
   --sk-plinth: linear-gradient(180deg, #0f172a, #060a14);
   --sk-foot: linear-gradient(180deg, #0b1120, #03060f);
   /* Sala Archiwum (RoomDecor) — zlewa się z tłem aplikacji (slate-950) */


### PR DESCRIPTION
## Co i dlaczego

Konwencja aplikacji: jeden kolor na zakładkę. Regał = amber, więc oprawa regału też amber — także w Holo+ (ramka była cyan).

## Zmiana

- Nowy token `--sk-frame-accent` (Holo+ `251,191,36` amber; Relikwiarz `63,224,208` teal — bez zmian).
- Steruje: ramką (`--sk-frame-border`/`--sk-frame-glow`), narożnikami HUD (`HudCorner` lokalnie nadpisuje `--noo-glow`, żeby puls też był amber) i listwą gzymsu.
- Wnętrze (godło, deseczki, ticker, sygnatury, szkło książek) zostaje na `--noo-glow` (cyan).

Pierwszy z serii PR-ów wdrażających audyt kolorów. Zweryfikowane realnym renderem (Vite). Lint/testy (306)/build OK.

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_