### PR TITLE
Audyt kolorów #2: ujednolicenie znaczeń (danger, one-concept, sieroty)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.23.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.23.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.23.2** — **Audyt kolorów #2: ujednolicenie znaczeń.** (1) **danger = red** wszędzie: rose→red w
+  IntegrityCheckCard / SchemaColumnCard (krytyczny limit + usuwanie) / ConfirmDialog (destrukcja) /
+  SchemaEditor (banner błędu); rose zostaje **wyłącznie** marką Vinted + rytuałem „Wydawcy". (2) **jedno
+  pojęcie = jeden kolor**: „biblioteka" tag w Search indigo→blue (jak statystyki Biblioteki); kropka „OK"
+  w StatusSection cyan→emerald (sukces=emerald). (3) **kolory-sieroty**: teal→indigo (VintedResolveStatus,
+  kontekst „dane z bazy"), green→emerald (IdentifiedLibraryItem exact-match), violet→purple (nominacja),
+  sky-400→cyan-400 w liniach ParticleBackground.
 - **1.23.1** — **Oprawa Regału = amber (kolor zakładki), spójnie z konwencją „kolor per zakładka".**
   Nowy token `--sk-frame-accent` (Holo+ amber `251,191,36`; Relikwiarz teal — bez zmian) steruje ramką
   (`--sk-frame-border/-glow`), narożnikami HUD (`HudCorner` — lokalnie nadpisuje `--noo-glow`, by puls też

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.23.1",
+      "version": "1.23.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.23.1",
+  "version": "1.23.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -29,8 +29,8 @@ export const ConfirmDialog: React.FC<Props> = ({ open, title, subtitle = "Operac
 
           <div className="p-8">
             <div className="flex items-center gap-4 mb-6">
-              <div className="p-3 bg-rose-500/10 rounded-full border border-rose-500/20">
-                <AlertCircle className="w-8 h-8 text-rose-400" />
+              <div className="p-3 bg-red-500/10 rounded-full border border-red-500/20">
+                <AlertCircle className="w-8 h-8 text-red-400" />
               </div>
               <div>
                 <h3 className="text-xl font-display font-bold text-slate-100 uppercase tracking-wider">{title}</h3>
@@ -44,7 +44,7 @@ export const ConfirmDialog: React.FC<Props> = ({ open, title, subtitle = "Operac
               <button onClick={onCancel} className="flex-1 px-6 py-3 text-sm font-bold text-slate-300 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl transition-all active:scale-95">
                 {cancelLabel}
               </button>
-              <button onClick={onConfirm} className="flex-1 px-6 py-3 text-sm font-bold bg-gradient-to-br from-rose-600 to-rose-900 hover:from-rose-500 hover:to-rose-800 text-white rounded-xl shadow-lg shadow-rose-500/20 transition-all active:scale-95 border border-rose-500/30">
+              <button onClick={onConfirm} className="flex-1 px-6 py-3 text-sm font-bold bg-gradient-to-br from-red-600 to-red-900 hover:from-red-500 hover:to-red-800 text-white rounded-xl shadow-lg shadow-red-500/20 transition-all active:scale-95 border border-red-500/30">
                 {confirmLabel}
               </button>
             </div>

--- a/src/components/IntegrityCheckCard.tsx
+++ b/src/components/IntegrityCheckCard.tsx
@@ -28,7 +28,7 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
         [ ZATWIERDZONO ]
       </div>
     ) : (
-      <div className="flex items-center gap-2 text-rose-400 font-bold text-[9px] uppercase tracking-widest bg-rose-500/10 px-1.5 py-0.5 rounded border border-rose-500/20 animate-pulse">
+      <div className="flex items-center gap-2 text-red-400 font-bold text-[9px] uppercase tracking-widest bg-red-500/10 px-1.5 py-0.5 rounded border border-red-500/20 animate-pulse">
         <AlertTriangle className="w-2.5 h-2.5" />
         [ HEREZJA ]
       </div>
@@ -101,7 +101,7 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
               onClick={() => toggleExpand(check.id)}
               aria-expanded={expanded === check.id}
               className={`w-full flex flex-col p-2 rounded-xl border transition-all cursor-pointer text-left ${
-                result ? (check.status ? 'bg-emerald-500/5 border-emerald-500/10' : 'bg-rose-500/5 border-rose-500/20 animate-pulse') : 'bg-slate-950/30 border-slate-800/50'
+                result ? (check.status ? 'bg-emerald-500/5 border-emerald-500/10' : 'bg-red-500/5 border-red-500/20 animate-pulse') : 'bg-slate-950/30 border-slate-800/50'
               } hover:border-slate-600`}
             >
               <div className="flex items-center justify-between gap-2">
@@ -136,7 +136,7 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
       </div>
 
       {state.error && (
-        <div className="mt-3 p-2 bg-rose-500/10 border border-rose-500/20 rounded-xl text-rose-400 text-[9px] font-medium flex items-center gap-2">
+        <div className="mt-3 p-2 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-[9px] font-medium flex items-center gap-2">
           <AlertTriangle className="w-3 h-3 shrink-0" />
           <span className="truncate">{state.error}</span>
         </div>

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -82,7 +82,7 @@ export const ParticleBackground: React.FC = () => {
 
           if (distance < 120) {
             ctx.beginPath();
-            ctx.strokeStyle = `rgba(56, 189, 248, ${0.2 - distance / 600})`; // Cyan-ish connections
+            ctx.strokeStyle = `rgba(34, 211, 238, ${0.2 - distance / 600})`; // cyan-400 connections
             ctx.lineWidth = 0.5;
             ctx.moveTo(particles[i].x, particles[i].y);
             ctx.lineTo(particles[j].x, particles[j].y);

--- a/src/components/SchemaColumnCard.tsx
+++ b/src/components/SchemaColumnCard.tsx
@@ -37,9 +37,9 @@ export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, o
           {isSelectType && isEditable && (
             <div className="flex items-center gap-2">
               <div className="h-1 w-24 bg-slate-800 rounded-full overflow-hidden">
-                <div className={`h-full transition-all duration-1000 ${isOverLimit ? 'bg-rose-500' : 'bg-cyan-500'}`} style={{ width: `${Math.min(100, (options.length / limit) * 100)}%` }} />
+                <div className={`h-full transition-all duration-1000 ${isOverLimit ? 'bg-red-500' : 'bg-cyan-500'}`} style={{ width: `${Math.min(100, (options.length / limit) * 100)}%` }} />
               </div>
-              <span className={`text-[9px] font-display font-bold uppercase tracking-widest ${isOverLimit ? 'text-rose-400' : 'text-slate-500'}`}>
+              <span className={`text-[9px] font-display font-bold uppercase tracking-widest ${isOverLimit ? 'text-red-400' : 'text-slate-500'}`}>
                 {options.length} / {limit}
               </span>
             </div>
@@ -55,10 +55,10 @@ export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, o
       {isSelectType && (
         <div className="mt-6 pt-6 border-t border-white/5 relative z-10">
           {isOverLimit && isEditable && (
-            <div className="mb-6 p-4 bg-rose-500/5 border border-rose-500/10 rounded-2xl flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-rose-500 mt-0.5 shrink-0" />
-              <div className="text-[11px] text-rose-300/80 font-display font-medium leading-relaxed">
-                <span className="font-bold block mb-1 uppercase tracking-wider text-rose-400">Krytyczny Limit API</span>
+            <div className="mb-6 p-4 bg-red-500/5 border border-red-500/10 rounded-2xl flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
+              <div className="text-[11px] text-red-300/80 font-display font-medium leading-relaxed">
+                <span className="font-bold block mb-1 uppercase tracking-wider text-red-400">Krytyczny Limit API</span>
                 Wykryto {options.length} wpisów. Notion blokuje edycję powyżej {limit}.
                 Zalecana konwersja na <span className="text-cyan-400 font-bold">Plain Text</span> w panelu sterowania Notion.
               </div>
@@ -82,7 +82,7 @@ export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, o
                   <button
                     onClick={() => onDeleteRequest(opt.name)}
                     disabled={updating}
-                    className="text-slate-600 hover:text-rose-500 disabled:opacity-50 transition-colors p-0.5 rounded-md hover:bg-rose-500/10"
+                    className="text-slate-600 hover:text-red-500 disabled:opacity-50 transition-colors p-0.5 rounded-md hover:bg-red-500/10"
                     title="Usuń opcję"
                   >
                     <X className="w-3 h-3" />

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -26,11 +26,11 @@ export function SchemaEditor({ schema, onSchemaUpdated }: SchemaEditorProps) {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="p-3 bg-rose-950/30 text-rose-400 rounded-lg text-xs border border-rose-900/50 flex items-center gap-2"
+            className="p-3 bg-red-950/30 text-red-400 rounded-lg text-xs border border-red-900/50 flex items-center gap-2"
           >
             <AlertCircle className="w-4 h-4" />
             {error}
-            <button onClick={() => setError(null)} className="ml-auto hover:text-rose-200">
+            <button onClick={() => setError(null)} className="ml-auto hover:text-red-200">
               <X className="w-4 h-4" />
             </button>
           </motion.div>

--- a/src/components/StatusSection.tsx
+++ b/src/components/StatusSection.tsx
@@ -55,7 +55,7 @@ export const StatusSection: React.FC<StatusSectionProps> = ({ configStatus }) =>
                 transition={{ delay: 0.2 + idx * 0.1 }}
                 className="flex items-center gap-4 p-4 rounded-2xl bg-slate-950/50 border border-slate-800/50"
               >
-                <div className={`w-3 h-3 rounded-full shadow-[0_0_10px_rgba(0,0,0,0.5)] ${item.status ? 'bg-cyan-500 shadow-cyan-500/50' : 'bg-red-600 shadow-red-600/50'}`} />
+                <div className={`w-3 h-3 rounded-full shadow-[0_0_10px_rgba(0,0,0,0.5)] ${item.status ? 'bg-emerald-500 shadow-emerald-500/50' : 'bg-red-600 shadow-red-600/50'}`} />
                 <div>
                   <div className="text-xs font-bold text-slate-500 uppercase tracking-tighter mb-1">{item.label}</div>
                   <div className={`text-sm font-bold ${item.status ? 'text-slate-200' : 'text-red-400'}`}>

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -9,7 +9,7 @@ function zrodloTheme(tag: string): string {
   const t = tag.toLowerCase();
   if (t.includes("posiadam")) return "bg-emerald-500/10 border-emerald-500/25 text-emerald-300";
   if (t.includes("przeczytane")) return "bg-cyan-500/10 border-cyan-500/25 text-cyan-300";
-  if (t.includes("biblioteka")) return "bg-indigo-500/10 border-indigo-500/25 text-indigo-300";
+  if (t.includes("biblioteka")) return "bg-blue-500/10 border-blue-500/25 text-blue-300";
   if (t.includes("vinted")) return "bg-rose-500/10 border-rose-500/25 text-rose-300";
   return "bg-slate-500/10 border-slate-500/25 text-slate-400";
 }
@@ -18,7 +18,7 @@ function zrodloTheme(tag: string): string {
 function awardTheme(award: string): string {
   return award.toLowerCase().startsWith("nagroda")
     ? "bg-amber-500/10 border-amber-500/25 text-amber-300"
-    : "bg-violet-500/10 border-violet-500/25 text-violet-300";
+    : "bg-purple-500/10 border-purple-500/25 text-purple-300";
 }
 
 interface Props {

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -127,12 +127,12 @@ export const IdentifiedLibraryItem: React.FC<IdentifiedLibraryItemProps> = ({
             return (
             <div key={book.id} className={`flex items-start gap-3 p-3 rounded-xl border transition-colors group/book ${
               isExactMatch 
-                ? "bg-green-500/5 border-green-500/30 hover:border-green-500/50" 
+                ? "bg-emerald-500/5 border-emerald-500/30 hover:border-emerald-500/50" 
                 : "bg-slate-950/30 border-slate-800/50 hover:border-blue-500/30"
             }`}>
               <div className="flex-1">
                 <div className="flex items-center justify-between gap-2">
-                  <div className={`text-sm font-bold leading-tight ${isExactMatch ? "text-green-400" : "text-slate-200"}`}>
+                  <div className={`text-sm font-bold leading-tight ${isExactMatch ? "text-emerald-400" : "text-slate-200"}`}>
                     {book.title}
                   </div>
                   {book.year && <div className="text-xs font-mono text-slate-400">{book.year}</div>}

--- a/src/components/stats/vinted/VintedResolveStatus.tsx
+++ b/src/components/stats/vinted/VintedResolveStatus.tsx
@@ -23,19 +23,19 @@ export const VintedResolveStatus: React.FC<Props> = ({
   <>
     {isResolving && resolveProgress && (
       <div className="px-2 space-y-1">
-        <div className="flex justify-between text-xs text-teal-300 uppercase font-bold">
+        <div className="flex justify-between text-xs text-indigo-300 uppercase font-bold">
           <span className="break-words">{resolveProgress.message}</span>
           {resolveProgress.total > 0 && <span>{resolveProgress.current} / {resolveProgress.total}</span>}
         </div>
         {resolveProgress.total > 0 && (
           <div className="h-1 bg-slate-900 rounded-full overflow-hidden">
-            <motion.div initial={{ width: 0 }} animate={{ width: `${(resolveProgress.current / resolveProgress.total) * 100}%` }} className="h-full bg-teal-500" />
+            <motion.div initial={{ width: 0 }} animate={{ width: `${(resolveProgress.current / resolveProgress.total) * 100}%` }} className="h-full bg-indigo-500" />
           </div>
         )}
       </div>
     )}
     {resolveError && <p className="text-xs text-red-400 italic px-2">{resolveError}</p>}
-    {!isResolving && resolveResult && <p className="text-xs text-teal-300/80 px-2">{resolveResult.message}</p>}
+    {!isResolving && resolveResult && <p className="text-xs text-indigo-300/80 px-2">{resolveResult.message}</p>}
     {storedError && <p className="text-xs text-red-400 italic px-2">{storedError}</p>}
     {stored && stored.results.length === 0 && !isLoadingStored && (
       <p className="text-xs text-slate-500 italic px-2">Baza Vinted jest pusta — najpierw uruchom skan (i „Ustal sprzedawców (baza)").</p>


### PR DESCRIPTION
## Zmiana

1. **danger = red** (spójnie): rose→red w `IntegrityCheckCard`, `SchemaColumnCard`, `ConfirmDialog`, `SchemaEditor`. `rose` = wyłącznie marka Vinted + rytuał „Wydawcy".
2. **jedno pojęcie = jeden kolor**: tag „biblioteka" indigo→blue; kropka „OK" cyan→emerald.
3. **kolory-sieroty**: teal→indigo, green→emerald, violet→purple, sky-400→cyan-400.

Bez zmian logiki. `npm run lint` czysty, testy 306, build OK.

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_