### PR TITLE
Audyt kolorów #3: abstrakcje + martwy kod

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.23.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.23.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.23.3** — **Audyt kolorów #3: abstrakcje + martwy kod.** `OtherToolsCard` — 7 ręcznie klepanych
+  przycisków (w 2 różnych idiomach) → `RitualButton` sterowany tablicą `rituals` (jeden idiom, centralny
+  `ritualButtonTheme`). `YearlyProgressItem` — inline `from-orange-500 to-red-600` → `getRitualGradient("orange")`.
+  `ritualGradient` dopełniony do **8 kluczy** (dodane rose/indigo/blue/amber) — koniec cichego fallbacku na
+  zielono dla tych rytuałów; `Record<RitualColor,…>`. Usunięty martwy wpis `amber` w `ShelfFrame.ACCENT`
+  (+ zwężony typ `ShelfAccent`).
 - **1.23.2** — **Audyt kolorów #2: ujednolicenie znaczeń.** (1) **danger = red** wszędzie: rose→red w
   IntegrityCheckCard / SchemaColumnCard (krytyczny limit + usuwanie) / ConfirmDialog (destrukcja) /
   SchemaEditor (banner błędu); rose zostaje **wyłącznie** marką Vinted + rytuałem „Wydawcy". (2) **jedno

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.23.2",
+      "version": "1.23.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.23.2",
+  "version": "1.23.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/OtherToolsCard.tsx
+++ b/src/components/OtherToolsCard.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Settings, Search, RefreshCw, AlertTriangle, Sparkles, Database, BookOpen, Layers } from "lucide-react";
 import { motion } from "motion/react";
 import { useSync } from "../hooks/useSync";
+import { RitualButton } from "./stats/RitualButton";
+import { RitualColor } from "../theme/ritualColors";
 
 interface OtherToolsCardProps {
   schemaSync: ReturnType<typeof useSync>;
@@ -40,13 +42,16 @@ export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
   handleResetSync,
   isAnySyncLoading
 }) => {
-  const schemaSyncState = schemaSync.state;
-  const purifySyncState = purifySync.state;
-  const publisherSyncState = publisherSync.state;
-  const seriesSyncState = seriesSync.state;
-  const cyclesSyncState = cyclesSync.state;
-  const duplicatesSyncState = duplicatesSync.state;
-  const lpSyncState = lpSync.state;
+  // Wszystkie rytuały jednym idiomem (`RitualButton` + centralny `ritualButtonTheme`).
+  const rituals: { color: RitualColor; icon: typeof Database; title: string; subtitle: string; onClick: () => void; animate?: "spin" | "pulse" }[] = [
+    { color: "emerald", icon: Database, title: "Rytuał Inicjacji Schematu", subtitle: "Weryfikacja i kreacja brakujących kolumn w bazie Notion", onClick: handleSyncSchema, animate: schemaSync.state.loading ? "pulse" : undefined },
+    { color: "amber", icon: Sparkles, title: "Rytuał Puryfikacji", subtitle: "Oczyszczanie tytułów z nadmiarowych znaków i formatowania", onClick: handleSyncPurify, animate: purifySync.state.loading ? "pulse" : undefined },
+    { color: "purple", icon: RefreshCw, title: "Rytuał Rekonstrukcji Liczb", subtitle: "Rekalkulacja i naprawa numeracji porządkowej rekordów", onClick: handleSyncLp, animate: lpSync.state.loading ? "spin" : undefined },
+    { color: "blue", icon: RefreshCw, title: "Rytuał Oznaczania Cykli", subtitle: "Automatyczne przypisywanie książek do cykli wydawniczych", onClick: handleCyclesSync, animate: cyclesSync.state.loading ? "spin" : undefined },
+    { color: "rose", icon: BookOpen, title: "Rytuał Wydania", subtitle: "Eksploracja i aktualizacja danych o wydawcach z Encyklopedii", onClick: handleSyncPublisher, animate: publisherSync.state.loading ? "pulse" : undefined },
+    { color: "indigo", icon: Layers, title: "Rytuał Seryjny", subtitle: "Eksploracja i aktualizacja danych o seriach wydawniczych", onClick: handleSyncSeries, animate: seriesSync.state.loading ? "pulse" : undefined },
+    { color: "orange", icon: Search, title: "Rytuał Wykrycia Duplikacji", subtitle: "Identyfikacja i oznaczanie potencjalnych duplikatów w bazie", onClick: handleSyncDuplicates, animate: duplicatesSync.state.loading ? "pulse" : undefined },
+  ];
   return (
     <motion.div 
       initial={{ opacity: 0, x: 20 }}
@@ -60,110 +65,13 @@ export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
       </h2>
       
       <div className="grid grid-cols-1 gap-4 flex-1">
-        {/* 1. Rytuał Inicjacji Schematu */}
-        <button 
-          onClick={handleSyncSchema} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-emerald-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-emerald-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 bg-slate-900 rounded-xl group-hover:bg-emerald-500/20 transition-colors">
-            <Database className={`w-5 h-5 text-emerald-400 ${schemaSyncState.loading ? 'animate-pulse' : ''}`} />
-          </div>
-          <div className="text-left">
-            <h3 className="font-bold text-slate-200 group-hover:text-emerald-400 transition-colors">Rytuał Inicjacji Schematu</h3>
-            <p className="text-xs text-slate-500 mt-1 uppercase font-bold tracking-tighter">Weryfikacja i kreacja brakujących kolumn w bazie Notion</p>
-          </div>
-        </button>
-
-        {/* 2. Rytuał Puryfikacji */}
-        <button 
-          onClick={handleSyncPurify} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-amber-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-amber-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 bg-slate-900 rounded-xl group-hover:bg-amber-500/20 transition-colors">
-            <Sparkles className={`w-5 h-5 text-amber-400 ${purifySyncState.loading ? 'animate-pulse' : ''}`} />
-          </div>
-          <div className="text-left">
-            <h3 className="font-bold text-slate-200 group-hover:text-amber-400 transition-colors">Rytuał Puryfikacji</h3>
-            <p className="text-xs text-slate-500 mt-1 uppercase font-bold tracking-tighter">Oczyszczanie tytułów z nadmiarowych znaków i formatowania</p>
-          </div>
-        </button>
-
-        {/* 3. Rytuał Rekonstrukcji Liczb */}
-        <button 
-          onClick={handleSyncLp} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-purple-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-purple-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 rounded-xl bg-purple-500/10 text-purple-400 group-hover:scale-110 transition-transform">
-            <RefreshCw className={`w-5 h-5 ${lpSyncState.loading ? 'animate-spin' : ''}`} />
-          </div>
-          <div className="text-left">
-            <div className="font-bold text-slate-200 group-hover:text-purple-400 transition-colors">Rytuał Rekonstrukcji Liczb</div>
-            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Rekalkulacja i naprawa numeracji porządkowej rekordów</div>
-          </div>
-        </button>
-
-        {/* 4. Rytuał Oznaczania Cykli */}
-        <button 
-          onClick={handleCyclesSync} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-blue-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-blue-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 rounded-xl bg-blue-500/10 text-blue-400 group-hover:scale-110 transition-transform">
-            <RefreshCw className={`w-5 h-5 ${cyclesSyncState.loading ? 'animate-spin' : ''}`} />
-          </div>
-          <div className="text-left">
-            <div className="font-bold text-slate-200 group-hover:text-blue-400 transition-colors">Rytuał Oznaczania Cykli</div>
-            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Automatyczne przypisywanie książek do cykli wydawniczych</div>
-          </div>
-        </button>
-
-        {/* 5. Rytuał Wydania */}
-        <button 
-          onClick={handleSyncPublisher} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-rose-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-rose-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 rounded-xl bg-rose-500/10 text-rose-400 group-hover:scale-110 transition-transform">
-            <BookOpen className={`w-5 h-5 ${publisherSyncState.loading ? 'animate-pulse' : ''}`} />
-          </div>
-          <div className="text-left">
-            <div className="font-bold text-slate-200 group-hover:text-rose-400 transition-colors">Rytuał Wydania</div>
-            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Eksploracja i aktualizacja danych o wydawcach z Encyklopedii</div>
-          </div>
-        </button>
-
-        {/* 6. Rytuał Seryjny */}
-        <button 
-          onClick={handleSyncSeries} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-indigo-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-indigo-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 rounded-xl bg-indigo-500/10 text-indigo-400 group-hover:scale-110 transition-transform">
-            <Layers className={`w-5 h-5 ${seriesSyncState.loading ? 'animate-pulse' : ''}`} />
-          </div>
-          <div className="text-left">
-            <div className="font-bold text-slate-200 group-hover:text-indigo-400 transition-colors">Rytuał Seryjny</div>
-            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Eksploracja i aktualizacja danych o seriach wydawniczych</div>
-          </div>
-        </button>
-
-        {/* 7. Rytuał Wykrycia Duplikacji */}
-        <button 
-          onClick={handleSyncDuplicates} 
-          disabled={isAnySyncLoading}
-          className="flex items-center gap-4 p-4 bg-slate-950/50 border border-slate-800 rounded-2xl hover:border-orange-500/50 hover:bg-slate-900/50 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg hover:shadow-orange-500/10 group disabled:opacity-50 disabled:hover:scale-100"
-        >
-          <div className="p-3 rounded-xl bg-orange-500/10 text-orange-400 group-hover:scale-110 transition-transform">
-            <Search className={`w-5 h-5 ${duplicatesSyncState.loading ? 'animate-pulse' : ''}`} />
-          </div>
-          <div className="text-left">
-            <div className="font-bold text-slate-200 group-hover:text-orange-400 transition-colors">Rytuał Wykrycia Duplikacji</div>
-            <div className="text-xs text-slate-500 uppercase font-bold tracking-tighter">Identyfikacja i oznaczanie potencjalnych duplikatów w bazie</div>
-          </div>
-        </button>
+        {rituals.map((r) => (
+          <RitualButton
+            key={r.title}
+            color={r.color} icon={r.icon} title={r.title} subtitle={r.subtitle}
+            onClick={r.onClick} animate={r.animate} disabled={isAnySyncLoading}
+          />
+        ))}
       </div>
 
       {handleResetSync && (

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { CogSigil, NoosphericCrest, DataTicker, HoloField, HudCorner } from "./ShelfOrnaments";
 
-export type ShelfAccent = "emerald" | "cyan" | "purple" | "amber";
+export type ShelfAccent = "emerald" | "cyan" | "purple";
 
 const ACCENT: Record<ShelfAccent, { text: string; chip: string; glow: string; ring: string }> = {
   emerald: { text: "text-emerald-200", chip: "bg-emerald-500/10 border-emerald-500/30 text-emerald-200", glow: "shadow-[0_0_28px_rgba(52,211,153,.22)]", ring: "border-emerald-400/50" },
   cyan: { text: "text-cyan-200", chip: "bg-cyan-500/10 border-cyan-500/30 text-cyan-200", glow: "shadow-[0_0_28px_rgba(34,211,238,.22)]", ring: "border-cyan-400/50" },
   purple: { text: "text-purple-200", chip: "bg-purple-500/10 border-purple-500/30 text-purple-200", glow: "shadow-[0_0_28px_rgba(168,85,247,.22)]", ring: "border-purple-400/50" },
-  amber: { text: "text-amber-200", chip: "bg-amber-500/10 border-amber-500/30 text-amber-200", glow: "shadow-[0_0_28px_rgba(251,191,36,.22)]", ring: "border-amber-400/50" },
 };
 
 interface Props {

--- a/src/components/stats/YearlyProgressItem.tsx
+++ b/src/components/stats/YearlyProgressItem.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import { motion } from "motion/react";
 import { Calendar, ChevronDown, ChevronUp, CheckCircle2, Circle } from "lucide-react";
 import { YearlyStat } from "../../hooks/useStats";
+import { getRitualGradient } from "../../theme/ritualColors";
 
 export const YearlyProgressItem: React.FC<{ year: YearlyStat }> = ({ year }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const percent = year.total > 0 ? Math.round((year.read / year.total) * 100) : 0;
+  const { gradient, shadow } = getRitualGradient("orange");
 
   return (
     <div className="space-y-2">
@@ -26,7 +28,7 @@ export const YearlyProgressItem: React.FC<{ year: YearlyStat }> = ({ year }) => 
         <motion.div 
           initial={{ width: 0 }}
           animate={{ width: `${percent}%` }}
-          className="h-full rounded-full bg-gradient-to-r from-orange-500 to-red-600 shadow-lg shadow-orange-500/20"
+          className={`h-full rounded-full bg-gradient-to-r ${gradient} shadow-lg ${shadow}`}
         />
       </div>
       {isExpanded && (

--- a/src/theme/ritualColors.ts
+++ b/src/theme/ritualColors.ts
@@ -90,12 +90,16 @@ export interface RitualGradient {
   shadow: string;
 }
 
-export const ritualGradient: Record<string, RitualGradient> = {
-  cyan:    { gradient: "from-cyan-500 to-blue-600",     shadow: "shadow-cyan-500/20" },
-  purple:  { gradient: "from-purple-500 to-indigo-600", shadow: "shadow-purple-500/20" },
-  orange:  { gradient: "from-orange-500 to-red-600",    shadow: "shadow-orange-500/20" },
-  emerald: { gradient: "from-emerald-500 to-teal-600",  shadow: "shadow-emerald-500/20" },
+export const ritualGradient: Record<RitualColor, RitualGradient> = {
+  cyan:    { gradient: "from-cyan-500 to-blue-600",      shadow: "shadow-cyan-500/20" },
+  purple:  { gradient: "from-purple-500 to-indigo-600",  shadow: "shadow-purple-500/20" },
+  orange:  { gradient: "from-orange-500 to-red-600",     shadow: "shadow-orange-500/20" },
+  emerald: { gradient: "from-emerald-500 to-teal-600",   shadow: "shadow-emerald-500/20" },
+  rose:    { gradient: "from-rose-500 to-pink-600",      shadow: "shadow-rose-500/20" },
+  indigo:  { gradient: "from-indigo-500 to-purple-600",  shadow: "shadow-indigo-500/20" },
+  blue:    { gradient: "from-blue-500 to-indigo-600",    shadow: "shadow-blue-500/20" },
+  amber:   { gradient: "from-amber-500 to-orange-600",   shadow: "shadow-amber-500/20" },
 };
 
 export const getRitualGradient = (color?: string | null): RitualGradient =>
-  ritualGradient[color as string] ?? ritualGradient.emerald;
+  ritualGradient[color as RitualColor] ?? ritualGradient.emerald;


### PR DESCRIPTION
## Zmiana

- `OtherToolsCard`: 7 ręcznych przycisków (2 idiomy) → `RitualButton` z tablicy `rituals`.
- `YearlyProgressItem`: inline gradient → `getRitualGradient("orange")`.
- `ritualGradient` → 8 kluczy (koniec cichego fallbacku na zielono); `Record<RitualColor,…>`.
- Usunięty martwy `ShelfFrame.ACCENT.amber` (+ zwężony `ShelfAccent`).

Bez zmian logiki. `npm run lint` czysty, testy 306, build OK.

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_