### PR TITLE
Colour audit #4: text contrast (WCAG)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.23.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.23.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.23.4** — **Audyt kolorów #4: kontrast (WCAG).** Treść czytelna `slate-600`→**`slate-400`**
+  (empty-state'y: „Baza pusta", „Brak szczegółów", „Archiwum milczy…", „Brak unikalnych rekordów" ×2,
+  podpowiedź resetu w OtherToolsCard). Metadane (rok/seria w `BookResultCard`) `slate-600`→**`slate-500`**.
+  Placeholdery `placeholder-slate-700` (SchemaColumnCard) / `-600` (SearchSection) →**`-500`** (były
+  1.9:1, FAIL). Stopka Regału i licznik „/ N" `amber-200/40`→**`/60`**. Tekst błędu/ostrzeżenia bez
+  alfy: `text-red-400/80`→`red-400`, `text-red-500/60`→`red-400` (App.tsx). Separator „," w
+  podpowiedziach Search `slate-600`→`slate-500` (spójnie z „?"). **Zostawione** dekoracyjne ikony
+  (`Circle`/`ChevronRight`/`ChevronDown`/`XCircle`/`BookImage` na `slate-600`). Domyka wdrożenie audytu
+  kolorów (PR #1–#4).
 - **1.23.3** — **Audyt kolorów #3: abstrakcje + martwy kod.** `OtherToolsCard` — 7 ręcznie klepanych
   przycisków (w 2 różnych idiomach) → `RitualButton` sterowany tablicą `rituals` (jeden idiom, centralny
   `ritualButtonTheme`). `YearlyProgressItem` — inline `from-orange-500 to-red-600` → `getRitualGradient("orange")`.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.23.3",
+      "version": "1.23.4",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.23.3",
+  "version": "1.23.4",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ export default function App() {
                 </div>
                 <div className="flex-1">
                   <h3 className="text-lg font-bold text-red-200 uppercase tracking-widest mb-1">Błąd Synchronizacji</h3>
-                  <p className="text-red-400/80 text-sm font-medium">{anyError.state.error}</p>
+                  <p className="text-red-400 text-sm font-medium">{anyError.state.error}</p>
                 </div>
                 <button onClick={() => anyError.reset()} className="p-2 hover:bg-red-500/10 rounded-xl text-red-400 transition-colors">
                   <XCircle className="w-5 h-5" />
@@ -103,7 +103,7 @@ export default function App() {
                     <RefreshCw className="w-4 h-4" />
                     Wymuś Reset Stanu
                   </button>
-                  <p className="text-[10px] text-red-500/60 mt-2 italic">Użyj tej opcji, jeśli jesteś pewien, że żadna inna synchronizacja nie jest aktualnie uruchomiona.</p>
+                  <p className="text-[10px] text-red-400 mt-2 italic">Użyj tej opcji, jeśli jesteś pewien, że żadna inna synchronizacja nie jest aktualnie uruchomiona.</p>
                 </div>
               )}
             </motion.div>

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -160,7 +160,7 @@ export const BookshelfSection: React.FC = () => {
             />
           </div>
 
-          <p className="text-center text-[10px] text-amber-200/40 uppercase tracking-widest font-bold mt-6">
+          <p className="text-center text-[10px] text-amber-200/60 uppercase tracking-widest font-bold mt-6">
             {all.length} woluminów · <span className="text-amber-400/70">●</span> = nagroda · najedź, by wysunąć grzbiet
           </p>
         </RoomDecor>

--- a/src/components/IntegrityCheckCard.tsx
+++ b/src/components/IntegrityCheckCard.tsx
@@ -40,7 +40,7 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
       {items.length > 0 ? (
         items.map((item, i) => <div key={i} className="border-l border-slate-700 pl-2 py-0.5">{item}</div>)
       ) : (
-        <div className="text-slate-600 italic">Brak szczegółów.</div>
+        <div className="text-slate-400 italic">Brak szczegółów.</div>
       )}
     </div>
   );

--- a/src/components/OtherToolsCard.tsx
+++ b/src/components/OtherToolsCard.tsx
@@ -83,7 +83,7 @@ export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
             <AlertTriangle className="w-4 h-4" />
             Resetuj Stan Synchronizacji
           </button>
-          <p className="text-[10px] text-slate-600 mt-2 text-center italic">Użyj tylko jeśli proces utknął w martwym punkcie.</p>
+          <p className="text-[10px] text-slate-400 mt-2 text-center italic">Użyj tylko jeśli proces utknął w martwym punkcie.</p>
         </div>
       )}
     </motion.div>

--- a/src/components/SanctityDebugger.tsx
+++ b/src/components/SanctityDebugger.tsx
@@ -120,7 +120,7 @@ export const SanctityDebugger: React.FC<SanctityDebuggerProps> = ({ result }) =>
                                 ))}
                               </div>
                             ) : (
-                              <div className="text-[9px] text-slate-600 italic p-2">Brak unikalnych rekordów</div>
+                              <div className="text-[9px] text-slate-400 italic p-2">Brak unikalnych rekordów</div>
                             )}
                           </div>
 
@@ -139,7 +139,7 @@ export const SanctityDebugger: React.FC<SanctityDebuggerProps> = ({ result }) =>
                                 ))}
                               </div>
                             ) : (
-                              <div className="text-[9px] text-slate-600 italic p-2">Brak unikalnych rekordów</div>
+                              <div className="text-[9px] text-slate-400 italic p-2">Brak unikalnych rekordów</div>
                             )}
                           </div>
                         </div>

--- a/src/components/SchemaColumnCard.tsx
+++ b/src/components/SchemaColumnCard.tsx
@@ -67,7 +67,7 @@ export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, o
 
           <div className="flex items-center justify-between mb-4">
             <p className="text-[10px] text-slate-500 uppercase tracking-[0.2em] font-bold">Zasoby Opcji</p>
-            {options.length === 0 && <span className="text-[10px] text-slate-600 italic font-display">Baza pusta</span>}
+            {options.length === 0 && <span className="text-[10px] text-slate-400 italic font-display">Baza pusta</span>}
           </div>
 
           <div className="flex flex-wrap gap-2 mb-6">
@@ -97,7 +97,7 @@ export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, o
               <input
                 type="text"
                 placeholder="Wprowadź nową desygnację..."
-                className="w-full pl-4 pr-4 py-3 text-xs bg-slate-950/60 border border-white/5 text-slate-300 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-700 transition-all duration-300 font-display font-medium"
+                className="w-full pl-4 pr-4 py-3 text-xs bg-slate-950/60 border border-white/5 text-slate-300 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-500 transition-all duration-300 font-display font-medium"
                 value={newOptionValue}
                 onChange={(e) => onNewOptionChange(e.target.value)}
                 onKeyDown={(e) => { if (e.key === 'Enter') onAdd(); }}

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -57,7 +57,7 @@ export const SearchSection: React.FC = () => {
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Wpisz fragment tytułu lub nazwisko autora…"
           aria-label="Przeszukaj archiwum"
-          className="w-full pl-14 pr-12 py-4 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-600 transition-all"
+          className="w-full pl-14 pr-12 py-4 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-500 transition-all"
         />
         {query && (
           <button
@@ -102,7 +102,7 @@ export const SearchSection: React.FC = () => {
         </div>
       ) : results.length === 0 ? (
         <div className="text-center py-16 space-y-4">
-          <p className="text-sm text-slate-600 italic">
+          <p className="text-sm text-slate-400 italic">
             {query.trim()
               ? `Archiwum milczy — żaden wolumin nie pasuje do „${query}".`
               : "Archiwum jest puste — brak rekordów do przeszukania."}
@@ -118,7 +118,7 @@ export const SearchSection: React.FC = () => {
                   >
                     {s}
                   </button>
-                  {i < suggestions.length - 1 ? <span className="text-slate-600">, </span> : <span className="text-slate-500">?</span>}
+                  {i < suggestions.length - 1 ? <span className="text-slate-500">, </span> : <span className="text-slate-500">?</span>}
                 </React.Fragment>
               ))}
             </p>

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -71,8 +71,8 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
 
           <div className="text-[11px] text-slate-400 uppercase font-bold tracking-[0.15em] mt-1.5">
             <HighlightedText text={book.author || "—"} query={query} />
-            {book.year ? <span className="text-slate-600"> · {book.year}</span> : null}
-            {book.series ? <span className="text-slate-600 normal-case tracking-normal italic"> · {book.series}</span> : null}
+            {book.year ? <span className="text-slate-500"> · {book.year}</span> : null}
+            {book.series ? <span className="text-slate-500 normal-case tracking-normal italic"> · {book.series}</span> : null}
           </div>
 
           {book.awards.length > 0 && (

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -63,7 +63,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
             className="p-1 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Poprzedni regał">
             <ChevronLeft className="w-4 h-4" />
           </button>
-          <span className="text-[10px] font-display font-bold uppercase tracking-widest text-amber-200/80">Regał {cur + 1}<span className="text-amber-200/40"> / {pageCount}</span></span>
+          <span className="text-[10px] font-display font-bold uppercase tracking-widest text-amber-200/80">Regał {cur + 1}<span className="text-amber-200/60"> / {pageCount}</span></span>
           <button onClick={() => setPage((p) => Math.min(pageCount - 1, Math.min(p, pageCount - 1) + 1))} disabled={cur >= pageCount - 1}
             className="p-1 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Następny regał">
             <ChevronRight className="w-4 h-4" />


### PR DESCRIPTION
Final item of the colour audit — raises low-contrast text to meet WCAG on the `slate-950` ground.

## Changes
- **Readable content** `text-slate-600` → `text-slate-400`: empty states (`SchemaColumnCard` „Baza pusta", `IntegrityCheckCard` „Brak szczegółów", `SearchSection` „Archiwum milczy…", `SanctityDebugger` „Brak unikalnych rekordów" ×2), `OtherToolsCard` reset hint.
- **Metadata** (year/series in `BookResultCard`) `slate-600` → `slate-500`.
- **Placeholders** `placeholder-slate-700` (`SchemaColumnCard`) / `placeholder-slate-600` (`SearchSection`) → `placeholder-slate-500` (were ~1.9:1, FAIL).
- **Low-alpha amber** — Regał footer (`BookshelfSection`) + „/ N" page counter (`Shelf`) `amber-200/40` → `amber-200/60`.
- **Error text drop alpha** (`App.tsx`): `text-red-400/80` → `red-400`, `text-red-500/60` → `red-400`.
- **Search suggestion separator** `slate-600` → `slate-500` (matches the trailing „?").

Decorative icons (`Circle`/`ChevronRight`/`ChevronDown`/`XCircle`/`BookImage`) intentionally left at `slate-600`.

## Verification
- `npm run lint` clean · `npm test` 306/306 green · `npm run build` OK.
- Version bump `1.23.3` → `1.23.4` (metadata.json + package.json + lockfile); backlog changelog updated.

Completes the colour-audit rollout (PR #1–#4). Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_