### PR TITLE
Shelf: keep decade nameplates from overlapping on narrow decades

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.23.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.24.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.24.0** — **Tabliczki dekad: auto-unik kolizji (góra↔dół).** Wąska dekada (mało książek →
+  następna przekładka blisko) powodowała, że pozioma tabliczka rocznika nachodziła na sąsiednią.
+  Nowy pure-helper `assignDividerLevels` (w `shelfLayout`) liczy per-rząd, zachłannie od lewej,
+  które tabliczki muszą zjechać na dół: `plateWidth(label)` estymuje szerokość napisu; jeśli
+  górna kolidowałaby z poprzednią górną → `plate="bottom"`. `ShelfDivider` dostał prop `plate`
+  (dolna tabliczka + smużka światła w górę). Czysto wizualne, fizyka/pakowanie bez zmian. Testy
+  (`plateWidth`, kolizje, łańcuch, sort/ignore) — +5 → 311.
 - **1.23.4** — **Audyt kolorów #4: kontrast (WCAG).** Treść czytelna `slate-600`→**`slate-400`**
   (empty-state'y: „Baza pusta", „Brak szczegółów", „Archiwum milczy…", „Brak unikalnych rekordów" ×2,
   podpowiedź resetu w OtherToolsCard). Metadane (rok/seria w `BookResultCard`) `slate-600`→**`slate-500`**.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.23.4",
+  "version": "1.24.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.23.4",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.23.4",
+      "version": "1.24.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.23.4",
+  "version": "1.24.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfLayout.test.ts
+++ b/src/__tests__/shelfLayout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { chunk, buildShelfItems, decadeOf, decadeLabel } from "../utils/shelfLayout";
+import { chunk, buildShelfItems, decadeOf, decadeLabel, assignDividerLevels, plateWidth } from "../utils/shelfLayout";
+import { PlacedItem } from "../utils/shelfPacking";
 import { BookIndexEntry } from "../types";
 
 const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
@@ -49,6 +50,52 @@ describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {
     // pierwszy item to tabliczka; każda książka pojawia się raz
     expect(seq[0]).toBe("|");
     expect(seq.filter((s) => s !== "|")).toEqual(["a", "b", "c", "d", "e"]);
+  });
+});
+
+describe("shelfLayout.plateWidth / assignDividerLevels", () => {
+  const div = (key: string, x: number): PlacedItem => ({ key, kind: "divider", bw: 10, w: 10, x, deg: 0 });
+  const spine = (key: string, x: number): PlacedItem => ({ key, kind: "spine", bw: 34, w: 34, x, deg: 0 });
+  const labels: Record<string, string> = {
+    a: "1940–1949", b: "1950–1959", c: "1960–1969", d: "1970–1979",
+  };
+  const labelOf = (k: string) => labels[k];
+
+  it("estimates plate width from label length (mono 11px)", () => {
+    expect(plateWidth("1950–1959")).toBe(103); // 37 + 9·7.3
+    expect(plateWidth("bez daty")).toBe(96);   // 37 + 8·7.3
+    expect(plateWidth("")).toBe(37);
+  });
+
+  it("keeps every plate on top when decades are wide enough", () => {
+    const row = [div("a", 0), div("b", 200), div("c", 420)];
+    expect(assignDividerLevels(row, labelOf).size).toBe(0);
+  });
+
+  it("drops a plate to the bottom when the previous decade is too narrow", () => {
+    // b sits only 40px past a → górna tabliczka a (szer. ~103) zderza się z b.
+    const row = [div("a", 0), div("b", 40), div("c", 420)];
+    const lv = assignDividerLevels(row, labelOf);
+    expect(lv.get("b")).toBe("bottom");
+    expect(lv.has("a")).toBe(false);
+    expect(lv.has("c")).toBe(false);
+  });
+
+  it("alternates top/bottom greedily and only the middle plate flips in a tight chain", () => {
+    // a(0) top; b(40) collides top → bottom; c(80) collides both → góra (fallback).
+    const row = [div("a", 0), div("b", 40), div("c", 80)];
+    const lv = assignDividerLevels(row, labelOf);
+    expect(lv.get("b")).toBe("bottom");
+    expect(lv.has("a")).toBe(false);
+    expect(lv.has("c")).toBe(false); // fallback = top
+  });
+
+  it("sorts by x and ignores non-divider items", () => {
+    const row = [spine("s1", 15), div("b", 40), div("a", 0), spine("s2", 200)];
+    const lv = assignDividerLevels(row, labelOf);
+    expect(lv.get("b")).toBe("bottom");
+    expect(lv.has("s1")).toBe(false);
+    expect(lv.has("s2")).toBe(false);
   });
 });
 

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { SHELF_ROW_H } from "../../utils/bookshelf";
+import { DividerLevel } from "../../utils/shelfLayout";
 import { CogSigil } from "./ShelfOrnaments";
 
 interface Props {
   label: string;      // np. „1950–1959" (w przyszłości litera alfabetu / nazwisko autora)
   width?: number;     // szerokość deseczki (footprint na półce)
   height?: number;    // wysokość toru rzędu (wyrównanie tabliczki u góry)
+  /** Poziom tabliczki: „top" (domyślnie) lub „bottom", gdy górna kolidowałaby z sąsiadem. */
+  plate?: DividerLevel;
 }
 
 /** Wysokość widocznej deseczki — spójna z `DIVIDER_H` w `shelfLayout` (podpora fizyki). */
@@ -14,12 +17,16 @@ export const BOARD_H = 168;
 /**
  * Generyczna **przekładka sekcji** w stylu noosferycznym: cienka **deseczka** z
  * mosiądzu ze świecącą żyłą danych (na dole toru) + pozioma **tabliczka-runa**
- * rocznika u góry półki, wyrównana do początku zakresu (wariant A: tylko przy
- * pierwszym pojawieniu dekady) z projekcyjną smużką światła w dół do deseczki.
- * Etykieta jest zwykłym stringiem — ten sam komponent obsłuży literę alfabetu /
- * nazwisko autora itp. Nieprzeciągalna.
+ * rocznika, wyrównana do początku zakresu (wariant A: tylko przy pierwszym
+ * pojawieniu dekady) z projekcyjną smużką światła do deseczki. Tabliczka domyślnie
+ * u góry; gdy dekada jest wąska (mało książek → następna przekładka blisko) i górna
+ * kolidowałaby z sąsiednią, `plate="bottom"` przenosi ją na dół (poziom liczy
+ * `assignDividerLevels`). Etykieta jest zwykłym stringiem — ten sam komponent obsłuży
+ * literę alfabetu / nazwisko autora itp. Nieprzeciągalna.
  */
-export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H }) => (
+export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H, plate = "top" }) => {
+  const atBottom = plate === "bottom";
+  return (
   <div className="relative select-none" style={{ width, height }} title={label} aria-hidden>
     {/* cienka deseczka rozgraniczająca (dół toru) */}
     <div
@@ -39,16 +46,24 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
       />
     </div>
 
-    {/* projekcyjna smużka światła z tabliczki w dół do deseczki */}
+    {/* projekcyjna smużka światła łącząca tabliczkę z deseczką (kierunek zależny od poziomu) */}
     <div
-      className="noo-data absolute top-[22px]"
-      style={{ left: 4, width: 2, height: 150, background: "linear-gradient(180deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))", boxShadow: "0 0 6px rgba(var(--noo-glow),.5)" }}
+      className="noo-data absolute"
+      style={{
+        left: 4, width: 2, height: 150,
+        boxShadow: "0 0 6px rgba(var(--noo-glow),.5)",
+        ...(atBottom
+          ? { bottom: 24, background: "linear-gradient(0deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }
+          : { top: 22, background: "linear-gradient(180deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }),
+      }}
     />
 
-    {/* tabliczka-runa rocznika u góry, lewą krawędzią przy deseczce (rozwija się w prawo) */}
+    {/* tabliczka-runa rocznika, lewą krawędzią przy deseczce (rozwija się w prawo);
+        u góry domyślnie, u dołu gdy górna kolidowałaby z sąsiednią dekadą */}
     <div
-      className="absolute top-0 left-0 flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
+      className="absolute left-0 flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
       style={{
+        ...(atBottom ? { bottom: 4 } : { top: 0 }),
         color: "var(--sk-plate-text)", fontSize: 11, letterSpacing: "0.06em",
         background: "var(--sk-plate-bg)",
         boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), 0 5px 9px -4px #000, 0 0 12px rgba(var(--noo-glow),.25)",
@@ -59,4 +74,5 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
       {label}
     </div>
   </div>
-);
+  );
+};

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
 import { spineStyle, SHELF_ROW_H, SHELF_PLANK_H } from "../../utils/bookshelf";
-import { RenderSlot } from "../../utils/shelfLayout";
+import { RenderSlot, assignDividerLevels } from "../../utils/shelfLayout";
 import { PlacedItem } from "../../utils/shelfPacking";
 import { BookSpine } from "./BookSpine";
 import { BookStack } from "./BookStack";
@@ -22,16 +22,22 @@ interface Props {
 }
 
 /** Jeden rząd półki: woluminy na pozycjach z fizyki + drewniana deska pod spodem. */
-export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragEnd }) => (
+export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragEnd }) => {
+  // Poziom tabliczek dekad (góra/dół) — wąskie dekady zderzałyby napisy u góry.
+  const plateLevels = assignDividerLevels(row, (k) => {
+    const s = slotByKey.get(k);
+    return s && s.kind === "divider" ? s.label : undefined;
+  });
+  return (
   <div>
     <div className="relative" style={{ height: SHELF_ROW_H }}>
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
         if (slot.kind === "divider") {
-          // z-15: tabliczka u góry + deseczka malują się PONAD granicznymi grzbietami.
+          // z-15: tabliczka + deseczka malują się PONAD granicznymi grzbietami.
           return (
             <div key={p.key} className="absolute bottom-0" style={{ left: p.x, zIndex: 15 }}>
-              <ShelfDivider label={slot.label} width={p.w} />
+              <ShelfDivider label={slot.label} width={p.w} plate={plateLevels.get(p.key) ?? "top"} />
             </div>
           );
         }
@@ -57,7 +63,8 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragE
     </div>
     <div style={PLANK_STYLE} />
   </div>
-);
+  );
+};
 
 /** Pusta półka (dla wyrównania stałej wysokości regału) — sama deska. */
 export const EmptyShelfRow: React.FC = () => (

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -1,9 +1,53 @@
 import { BookIndexEntry } from "../types";
 import { ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle, parseYear } from "./bookshelf";
-import { PackItem } from "./shelfPacking";
+import { PackItem, PlacedItem } from "./shelfPacking";
 
 /** Slot do renderu: wolumin/kupka (`ShelfSlot`) albo tabliczka-przekładka sekcji. */
 export type RenderSlot = ShelfSlot | { kind: "divider"; label: string };
+
+/** Poziom, na którym maluje się pozioma tabliczka dekady: u góry (domyślnie) albo u dołu. */
+export type DividerLevel = "top" | "bottom";
+
+/**
+ * Estymowana szerokość poziomej tabliczki rocznika (px) — do wykrywania kolizji.
+ * Sygil koła (13) + gap (6) + padding `px-[9px]` (2×9) + tekst (mono 11px z
+ * `letterSpacing 0.06em` ≈ 7.3 px/znak). To heurystyka, nie pomiar DOM — celuje
+ * w wykrycie „wąskich dekad", nie w subpikselową dokładność.
+ */
+export function plateWidth(label: string): number {
+  return Math.ceil(37 + label.length * 7.3);
+}
+
+/**
+ * Rozdziela tabliczki dekad w JEDNYM rzędzie na dwa poziomy (góra/dół), tak by
+ * sąsiednie nie nachodziły na siebie, gdy dekada jest wąska (mało książek → następna
+ * przekładka blisko). Zachłannie od lewej: tabliczka zostaje na górze, jeśli nie
+ * zderza się z prawą krawędzią ostatniej górnej; inaczej ląduje na dole; a gdy i dół
+ * zajęty (rzadka potrójna kolizja) — wraca na górę (akceptujemy). Zwraca mapę
+ * `key→poziom` TYLKO dla przekładek, które muszą zjechać na dół (reszta = góra).
+ */
+export function assignDividerLevels(
+  row: PlacedItem[],
+  labelOf: (key: string) => string | undefined,
+  gap = 6,
+): Map<string, DividerLevel> {
+  const dividers = row.filter((p) => p.kind === "divider").sort((a, b) => a.x - b.x);
+  const out = new Map<string, DividerLevel>();
+  let topRight = -Infinity;
+  let botRight = -Infinity;
+  for (const d of dividers) {
+    const right = d.x + plateWidth(labelOf(d.key) ?? "");
+    if (d.x >= topRight) {
+      topRight = right + gap;               // góra (domyślna) — nie zapisujemy
+    } else if (d.x >= botRight) {
+      out.set(d.key, "bottom");
+      botRight = right + gap;
+    } else {
+      topRight = right + gap;               // potrójna kolizja → góra
+    }
+  }
+  return out;
+}
 
 const DIVIDER_W = 10;   // cienka deseczka (footprint na półce)
 const DIVIDER_H = 168;  // = BOARD_H w ShelfDivider — realna podpora dla pochyłego sąsiada


### PR DESCRIPTION
A decade with few books left its horizontal year nameplate (which extends right, `whitespace-nowrap`) reaching over the next divider, so it overlapped the neighbouring decade's nameplate. This detects the collision per row and drops the colliding nameplate to the bottom level.

## Changes
- **`assignDividerLevels(row, labelOf)`** (new, in `shelfLayout.ts`) — a pure, per-row greedy pass: walking dividers left→right, a nameplate stays on top unless its span would collide with the previous top plate, in which case it goes to the bottom (a rare triple-collision falls back to top). Returns only the keys that must drop to bottom.
- **`plateWidth(label)`** (new) — estimates the plate's rendered width (cog sigil + gap + padding + mono-11px text) to drive the collision check.
- **`ShelfDivider`** — new prop `plate?: "top" | "bottom"` (default `top`); the bottom plate sits by the plinth and its projection streak is routed upward to the board.
- **`ShelfRow`** — computes levels once per row and passes `plate` to each divider.

Physics/packing untouched — this is purely a render-layer change.

## Verification
- `npm run lint` clean · `npm test` **311/311** green (+5 new) · `npm run build` OK.
- Visually confirmed with a headless-Chromium screenshot: a shelf with a single-book 1960s decade keeps its plate on top while the adjacent 1970s plate drops to the bottom — no overlap.
- Version bump `1.23.4` → `1.24.0` (minor); backlog changelog updated.

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_