### PR TITLE
Shelf dividers: shelf-edge aware, amber in Holo+, plates on the plank, bottom sigil

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.24.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.25.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.25.0** — **Przekładki dekad: krawędź półki, amber w Holo+, plakietki na deskę, sygil u dołu.**
+  (1) **Granica półki**: `assignDividerLevels` → `assignDividerPlacement(row, labelOf, rowWidth)` — zwraca
+  `{level, dir}`; gdy tabliczka wyszłaby poza prawą krawędź (`x + plateWidth > rowWidth`), rozwija się
+  **w lewo** (`dir="left"`, prawy brzeg przy deseczce). `ShelfRow` dostaje `rowWidth` z `Shelf` (well).
+  (2) **Amber w Holo+**: reguła `.skin-holo .shelf-divider` nadpisuje lokalnie `--noo-glow`→`--sk-frame-accent`
+  + deseczkę/tabliczkę/sygil na amber (spójnie z oprawą Regału); Relikwiarz bez zmian (teal/mosiądz).
+  (3) **Dolne plakietki na linii półki**: `bottom:-12` — nachodzą na deskę, przestały zasłaniać tytuły;
+  z-index przekładki 15→**30** (plakietki zawsze nad grzbietami i deską). (4) **Sygil u dołu** każdej
+  przekładki (drugi `CogSigil` na linii półki). Czysto render; fizyka/pakowanie bez zmian. Testy: +2 → 313.
 - **1.24.0** — **Tabliczki dekad: auto-unik kolizji (góra↔dół).** Wąska dekada (mało książek →
   następna przekładka blisko) powodowała, że pozioma tabliczka rocznika nachodziła na sąsiednią.
   Nowy pure-helper `assignDividerLevels` (w `shelfLayout`) liczy per-rząd, zachłannie od lewej,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.25.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfLayout.test.ts
+++ b/src/__tests__/shelfLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { chunk, buildShelfItems, decadeOf, decadeLabel, assignDividerLevels, plateWidth } from "../utils/shelfLayout";
+import { chunk, buildShelfItems, decadeOf, decadeLabel, assignDividerPlacement, plateWidth } from "../utils/shelfLayout";
 import { PlacedItem } from "../utils/shelfPacking";
 import { BookIndexEntry } from "../types";
 
@@ -53,13 +53,14 @@ describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {
   });
 });
 
-describe("shelfLayout.plateWidth / assignDividerLevels", () => {
+describe("shelfLayout.plateWidth / assignDividerPlacement", () => {
   const div = (key: string, x: number): PlacedItem => ({ key, kind: "divider", bw: 10, w: 10, x, deg: 0 });
   const spine = (key: string, x: number): PlacedItem => ({ key, kind: "spine", bw: 34, w: 34, x, deg: 0 });
   const labels: Record<string, string> = {
     a: "1940–1949", b: "1950–1959", c: "1960–1969", d: "1970–1979",
   };
   const labelOf = (k: string) => labels[k];
+  const W = 2000; // szeroka półka — bez zawijania przy prawej krawędzi
 
   it("estimates plate width from label length (mono 11px)", () => {
     expect(plateWidth("1950–1959")).toBe(103); // 37 + 9·7.3
@@ -67,35 +68,51 @@ describe("shelfLayout.plateWidth / assignDividerLevels", () => {
     expect(plateWidth("")).toBe(37);
   });
 
-  it("keeps every plate on top when decades are wide enough", () => {
+  it("keeps every plate top/right when decades are wide enough", () => {
     const row = [div("a", 0), div("b", 200), div("c", 420)];
-    expect(assignDividerLevels(row, labelOf).size).toBe(0);
+    const pl = assignDividerPlacement(row, labelOf, W);
+    expect([...pl.values()].every((p) => p.level === "top" && p.dir === "right")).toBe(true);
   });
 
   it("drops a plate to the bottom when the previous decade is too narrow", () => {
     // b sits only 40px past a → górna tabliczka a (szer. ~103) zderza się z b.
     const row = [div("a", 0), div("b", 40), div("c", 420)];
-    const lv = assignDividerLevels(row, labelOf);
-    expect(lv.get("b")).toBe("bottom");
-    expect(lv.has("a")).toBe(false);
-    expect(lv.has("c")).toBe(false);
+    const pl = assignDividerPlacement(row, labelOf, W);
+    expect(pl.get("b")?.level).toBe("bottom");
+    expect(pl.get("a")?.level).toBe("top");
+    expect(pl.get("c")?.level).toBe("top");
   });
 
   it("alternates top/bottom greedily and only the middle plate flips in a tight chain", () => {
     // a(0) top; b(40) collides top → bottom; c(80) collides both → góra (fallback).
     const row = [div("a", 0), div("b", 40), div("c", 80)];
-    const lv = assignDividerLevels(row, labelOf);
-    expect(lv.get("b")).toBe("bottom");
-    expect(lv.has("a")).toBe(false);
-    expect(lv.has("c")).toBe(false); // fallback = top
+    const pl = assignDividerPlacement(row, labelOf, W);
+    expect(pl.get("a")?.level).toBe("top");
+    expect(pl.get("b")?.level).toBe("bottom");
+    expect(pl.get("c")?.level).toBe("top"); // fallback = top
+  });
+
+  it("extends a plate leftward when it would overflow the right shelf edge", () => {
+    // rowWidth 300; b przy 240 → 240+103=343 > 300 → rozwija się w lewo (bez kolizji z a).
+    const row = [div("a", 0), div("b", 240)];
+    const pl = assignDividerPlacement(row, labelOf, 300);
+    expect(pl.get("a")?.dir).toBe("right");
+    expect(pl.get("b")?.dir).toBe("left");
+    expect(pl.get("b")?.level).toBe("top");
+  });
+
+  it("disables edge detection when rowWidth ≤ 0 (all rightward)", () => {
+    const row = [div("a", 0), div("b", 240)];
+    const pl = assignDividerPlacement(row, labelOf, 0);
+    expect([...pl.values()].every((p) => p.dir === "right")).toBe(true);
   });
 
   it("sorts by x and ignores non-divider items", () => {
     const row = [spine("s1", 15), div("b", 40), div("a", 0), spine("s2", 200)];
-    const lv = assignDividerLevels(row, labelOf);
-    expect(lv.get("b")).toBe("bottom");
-    expect(lv.has("s1")).toBe(false);
-    expect(lv.has("s2")).toBe(false);
+    const pl = assignDividerPlacement(row, labelOf, W);
+    expect(pl.get("b")?.level).toBe("bottom");
+    expect(pl.has("s1")).toBe(false);
+    expect(pl.has("s2")).toBe(false);
   });
 });
 

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -95,7 +95,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
         ) : (
           <div ref={wellRef} className="flex flex-col" style={{ rowGap: SHELF_ROW_GAP - SHELF_PLANK_H }}>
             {shown.map((row, ri) => (
-              <ShelfRow key={cur * 1000 + ri} row={row} slotByKey={slotByKey} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+              <ShelfRow key={cur * 1000 + ri} row={row} slotByKey={slotByKey} rowWidth={width} onDragStart={onDragStart} onDragEnd={onDragEnd} />
             ))}
             {Array.from({ length: pad }).map((_, i) => <EmptyShelfRow key={`pad${i}`} />)}
           </div>

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { SHELF_ROW_H } from "../../utils/bookshelf";
-import { DividerLevel } from "../../utils/shelfLayout";
+import { DividerLevel, DividerDir } from "../../utils/shelfLayout";
 import { CogSigil } from "./ShelfOrnaments";
 
 interface Props {
@@ -9,6 +9,8 @@ interface Props {
   height?: number;    // wysokość toru rzędu (wyrównanie tabliczki u góry)
   /** Poziom tabliczki: „top" (domyślnie) lub „bottom", gdy górna kolidowałaby z sąsiadem. */
   plate?: DividerLevel;
+  /** Kierunek rozwijania tabliczki: „right" (domyślnie) lub „left" przy prawej krawędzi półki. */
+  dir?: DividerDir;
 }
 
 /** Wysokość widocznej deseczki — spójna z `DIVIDER_H` w `shelfLayout` (podpora fizyki). */
@@ -16,18 +18,21 @@ export const BOARD_H = 168;
 
 /**
  * Generyczna **przekładka sekcji** w stylu noosferycznym: cienka **deseczka** z
- * mosiądzu ze świecącą żyłą danych (na dole toru) + pozioma **tabliczka-runa**
- * rocznika, wyrównana do początku zakresu (wariant A: tylko przy pierwszym
- * pojawieniu dekady) z projekcyjną smużką światła do deseczki. Tabliczka domyślnie
- * u góry; gdy dekada jest wąska (mało książek → następna przekładka blisko) i górna
- * kolidowałaby z sąsiednią, `plate="bottom"` przenosi ją na dół (poziom liczy
- * `assignDividerLevels`). Etykieta jest zwykłym stringiem — ten sam komponent obsłuży
- * literę alfabetu / nazwisko autora itp. Nieprzeciągalna.
+ * mosiądzu ze świecącą żyłą danych + sygilami koła u góry i u dołu + pozioma
+ * **tabliczka-runa** rocznika przy początku zakresu (wariant A: tylko przy pierwszym
+ * pojawieniu dekady) z projekcyjną smużką światła do deseczki. Rozmieszczenie liczy
+ * `assignDividerPlacement`: tabliczka domyślnie u góry i w prawo, ale gdy dekada jest
+ * wąska i górna kolidowałaby z sąsiednią → `plate="bottom"` (siada na krawędzi półki,
+ * by nie zasłaniać tytułów), a przy prawej krawędzi półki → `dir="left"` (rozwija się
+ * w lewo). Klasa `shelf-divider` pozwala skórze przemalować całą przekładkę (Holo+ =
+ * amber, w kolorze oprawy Regału). Etykieta to zwykły string — ten sam komponent
+ * obsłuży literę alfabetu / nazwisko autora itp. Nieprzeciągalna.
  */
-export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H, plate = "top" }) => {
+export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H, plate = "top", dir = "right" }) => {
   const atBottom = plate === "bottom";
+  const toLeft = dir === "left";
   return (
-  <div className="relative select-none" style={{ width, height }} title={label} aria-hidden>
+  <div className="shelf-divider relative select-none" style={{ width, height }} title={label} aria-hidden>
     {/* cienka deseczka rozgraniczająca (dół toru) */}
     <div
       className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
@@ -39,6 +44,8 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
     >
       {/* cog-finial na szczycie deseczki */}
       <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
+      {/* cog-finial u dołu deseczki (na linii półki) */}
+      <CogSigil className="absolute -bottom-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
       {/* świecąca żyła danych */}
       <div
         className="noo-data absolute left-1/2 -translate-x-1/2 rounded-[2px]"
@@ -53,24 +60,26 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
         left: 4, width: 2, height: 150,
         boxShadow: "0 0 6px rgba(var(--noo-glow),.5)",
         ...(atBottom
-          ? { bottom: 24, background: "linear-gradient(0deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }
+          ? { bottom: 30, background: "linear-gradient(0deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }
           : { top: 22, background: "linear-gradient(180deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }),
       }}
     />
 
-    {/* tabliczka-runa rocznika, lewą krawędzią przy deseczce (rozwija się w prawo);
-        u góry domyślnie, u dołu gdy górna kolidowałaby z sąsiednią dekadą */}
+    {/* tabliczka-runa rocznika, krawędzią przy deseczce; u góry domyślnie, u dołu (na
+        linii półki, nachodzi na deskę) gdy górna kolidowałaby z sąsiadem; rozwija się
+        w prawo, a przy prawej krawędzi półki w lewo. z-2 → zawsze nad grzbietami. */}
     <div
-      className="absolute left-0 flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
+      className="absolute z-[2] flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
       style={{
-        ...(atBottom ? { bottom: 4 } : { top: 0 }),
+        ...(atBottom ? { bottom: -12 } : { top: 0 }),
+        ...(toLeft ? { right: 0 } : { left: 0 }),
         color: "var(--sk-plate-text)", fontSize: 11, letterSpacing: "0.06em",
         background: "var(--sk-plate-bg)",
         boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), 0 5px 9px -4px #000, 0 0 12px rgba(var(--noo-glow),.25)",
         textShadow: "0 0 6px rgba(var(--noo-glow),.45)",
       }}
     >
-      <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(63,224,208,.6)]" />
+      <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
       {label}
     </div>
   </div>

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
 import { spineStyle, SHELF_ROW_H, SHELF_PLANK_H } from "../../utils/bookshelf";
-import { RenderSlot, assignDividerLevels } from "../../utils/shelfLayout";
+import { RenderSlot, assignDividerPlacement } from "../../utils/shelfLayout";
 import { PlacedItem } from "../../utils/shelfPacking";
 import { BookSpine } from "./BookSpine";
 import { BookStack } from "./BookStack";
@@ -17,27 +17,30 @@ export const PLANK_STYLE: React.CSSProperties = {
 interface Props {
   row: PlacedItem[];
   slotByKey: Map<string, RenderSlot>;
+  /** Szerokość toru (well) — do wykrycia tabliczek wychodzących poza prawą krawędź. */
+  rowWidth: number;
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
 }
 
 /** Jeden rząd półki: woluminy na pozycjach z fizyki + drewniana deska pod spodem. */
-export const ShelfRow: React.FC<Props> = ({ row, slotByKey, onDragStart, onDragEnd }) => {
-  // Poziom tabliczek dekad (góra/dół) — wąskie dekady zderzałyby napisy u góry.
-  const plateLevels = assignDividerLevels(row, (k) => {
+export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, onDragStart, onDragEnd }) => {
+  // Rozmieszczenie tabliczek dekad (góra/dół + lewo/prawo) — unika kolizji i wyjścia poza półkę.
+  const placement = assignDividerPlacement(row, (k) => {
     const s = slotByKey.get(k);
     return s && s.kind === "divider" ? s.label : undefined;
-  });
+  }, rowWidth);
   return (
   <div>
     <div className="relative" style={{ height: SHELF_ROW_H }}>
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
         if (slot.kind === "divider") {
-          // z-15: tabliczka + deseczka malują się PONAD granicznymi grzbietami.
+          // z-30: tabliczka + deseczka malują się PONAD grzbietami i deską półki.
+          const pl = placement.get(p.key);
           return (
-            <div key={p.key} className="absolute bottom-0" style={{ left: p.x, zIndex: 15 }}>
-              <ShelfDivider label={slot.label} width={p.w} plate={plateLevels.get(p.key) ?? "top"} />
+            <div key={p.key} className="absolute bottom-0" style={{ left: p.x, zIndex: 30 }}>
+              <ShelfDivider label={slot.label} width={p.w} plate={pl?.level ?? "top"} dir={pl?.dir ?? "right"} />
             </div>
           );
         }

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,20 @@ body {
   --sk-room-flame: radial-gradient(circle at 50% 72%, #cffafe, #22d3ee 55%, #0e7490);
 }
 
+/* Przekładki dekad w Holo+ = amber (kolor oprawy Regału), spójnie z ramką/HUD.
+   Lokalny override na `.shelf-divider`: --noo-glow → akcent ramki (żyła/smużka/
+   poświata sygila), deseczka/tabliczka/sygil przemalowane na amber. Tylko Holo+ —
+   w Relikwiarzu przekładki zostają mosiężno-teal (brak reguły). */
+.skin-holo .shelf-divider {
+  --noo-glow: var(--sk-frame-accent);
+  --sk-board-bg: linear-gradient(180deg, #fcd34d, #f59e0b 42%, #b45309);
+  --sk-plate-text: #fde68a;
+  --sk-plate-edge: #a16207;
+  --sk-cog-ring: #fbbf24;
+  --sk-cog-skull: #2a1e06;
+  --sk-cog-disc: #140e02;
+}
+
 .skin-noospheric .book-spine {
   background: linear-gradient(90deg, rgba(0,0,0,.35), var(--spine-muted) 22%, var(--spine-muted) 78%, rgba(0,0,0,.28));
   box-shadow: inset 1.5px 0 0 rgba(var(--noo-glow),.22), inset -2px 0 4px rgba(0,0,0,.45), 0 6px 10px -6px rgba(0,0,0,.6);

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -7,6 +7,13 @@ export type RenderSlot = ShelfSlot | { kind: "divider"; label: string };
 
 /** Poziom, na którym maluje się pozioma tabliczka dekady: u góry (domyślnie) albo u dołu. */
 export type DividerLevel = "top" | "bottom";
+/** Kierunek rozwijania tabliczki od deseczki: w prawo (domyślnie) albo w lewo (przy prawej krawędzi). */
+export type DividerDir = "right" | "left";
+/** Rozmieszczenie tabliczki przekładki: poziom (góra/dół) + kierunek (lewo/prawo). */
+export interface DividerPlacement { level: DividerLevel; dir: DividerDir; }
+
+/** Footprint deseczki na półce (px) — spójny z `DIVIDER_W` / `ShelfDivider width`. */
+const PLATE_BOARD_W = 10;
 
 /**
  * Estymowana szerokość poziomej tabliczki rocznika (px) — do wykrywania kolizji.
@@ -19,32 +26,41 @@ export function plateWidth(label: string): number {
 }
 
 /**
- * Rozdziela tabliczki dekad w JEDNYM rzędzie na dwa poziomy (góra/dół), tak by
- * sąsiednie nie nachodziły na siebie, gdy dekada jest wąska (mało książek → następna
- * przekładka blisko). Zachłannie od lewej: tabliczka zostaje na górze, jeśli nie
- * zderza się z prawą krawędzią ostatniej górnej; inaczej ląduje na dole; a gdy i dół
- * zajęty (rzadka potrójna kolizja) — wraca na górę (akceptujemy). Zwraca mapę
- * `key→poziom` TYLKO dla przekładek, które muszą zjechać na dół (reszta = góra).
+ * Rozmieszcza tabliczki dekad w JEDNYM rzędzie, tak by nie nachodziły na siebie ani
+ * nie wychodziły poza półkę:
+ *  - **kierunek**: tabliczka rozwija się w prawo od deseczki; jeśli sięgnęłaby poza
+ *    prawą krawędź półki (`rowWidth`), rozwija się w lewo (prawy brzeg przy deseczce);
+ *  - **poziom**: zachłannie od lewej — tabliczka zostaje na górze, o ile jej przedział
+ *    poziomy nie zderza się z ostatnią górną; inaczej ląduje na dole; a gdy i dół zajęty
+ *    (rzadka potrójna kolizja) — wraca na górę (akceptujemy).
+ * Zwraca mapę `key→{level,dir}` dla KAŻDEJ przekładki (domyślnie `{top,right}`).
+ * `rowWidth ≤ 0` (nieznana szerokość) wyłącza detekcję krawędzi — wszystko w prawo.
  */
-export function assignDividerLevels(
+export function assignDividerPlacement(
   row: PlacedItem[],
   labelOf: (key: string) => string | undefined,
+  rowWidth: number,
   gap = 6,
-): Map<string, DividerLevel> {
-  const dividers = row.filter((p) => p.kind === "divider").sort((a, b) => a.x - b.x);
-  const out = new Map<string, DividerLevel>();
+): Map<string, DividerPlacement> {
+  const dividers = row.filter((p) => p.kind === "divider");
+  // Kierunek + przedział poziomy [left,right] każdej tabliczki (uwzględnia zawinięcie w lewo).
+  const spans = dividers.map((d) => {
+    const w = plateWidth(labelOf(d.key) ?? "");
+    const overflow = rowWidth > 0 && d.x + w > rowWidth;
+    const right = overflow ? d.x + PLATE_BOARD_W : d.x + w;
+    return { key: d.key, left: right - w, right, dir: (overflow ? "left" : "right") as DividerDir };
+  });
+  spans.sort((a, b) => a.left - b.left);
+
+  const out = new Map<string, DividerPlacement>();
   let topRight = -Infinity;
   let botRight = -Infinity;
-  for (const d of dividers) {
-    const right = d.x + plateWidth(labelOf(d.key) ?? "");
-    if (d.x >= topRight) {
-      topRight = right + gap;               // góra (domyślna) — nie zapisujemy
-    } else if (d.x >= botRight) {
-      out.set(d.key, "bottom");
-      botRight = right + gap;
-    } else {
-      topRight = right + gap;               // potrójna kolizja → góra
-    }
+  for (const s of spans) {
+    let level: DividerLevel;
+    if (s.left >= topRight) { level = "top"; topRight = s.right + gap; }
+    else if (s.left >= botRight) { level = "bottom"; botRight = s.right + gap; }
+    else { level = "top"; topRight = s.right + gap; } // potrójna kolizja → góra
+    out.set(s.key, { level, dir: s.dir });
   }
   return out;
 }


### PR DESCRIPTION
Follow-up polish on the decade dividers (after the top/bottom collision fix), from four requests.

## Changes
- **Shelf boundary awareness** — a nameplate near the right edge used to run past the shelf. When `x + plateWidth > rowWidth` it now extends **leftward** (right edge anchored at the board). `assignDividerLevels` → **`assignDividerPlacement(row, labelOf, rowWidth)`** returning `{level, dir}`; `ShelfRow` receives `rowWidth` from `Shelf` (the well width).
- **Amber dividers in Holo+** — new rule `.skin-holo .shelf-divider` locally overrides `--noo-glow` → `--sk-frame-accent` and repaints board / plate / sigil in amber, matching the Regał frame chrome. Relikwiarz stays teal/brass (scoped to Holo+ only).
- **Bottom plates on the shelf line** — dropped to `bottom:-12` so they overlap the plank instead of covering book titles; divider `z-index` **15 → 30** so plates always paint above spines and the plank.
- **Bottom sigil** — a second cog-finial added at the bottom of every divider (at the plank line).

Purely a render-layer change — physics/packing untouched.

## Verification
- `npm run lint` clean · `npm test` **313/313** green (+2 new) · `npm run build` OK.
- Headless-Chromium screenshots of both skins: amber dividers + bottom sigils + plates on the plank in Holo+; Relikwiarz unchanged. Left-extension is covered by a deterministic unit test.
- Version bump `1.24.0` → `1.25.0` (minor); backlog changelog updated.

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_