### PR TITLE
Shelf dividers: render plates above all boards; dim the Holo+ amber

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.25.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.25.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.25.1** — **Przekładki: tabliczki zawsze nad deseczkami + przytłumiony amber.** (1) Render dwuwarstwowy
+  w `ShelfRow`: najpierw wszystkie deseczki (`ShelfDivider part="board"`, z-20), potem wszystkie tabliczki
+  (`part="plate"`, z-40) — tabliczka nie chowa się już pod deseczką sąsiada (ani własną). `ShelfDivider`
+  dostał prop `part`. (2) Amber dividera przygaszony: deseczka `#cda24c→#b07d2e→#6b3d12` (było `#fcd34d→#f59e0b`),
+  `--noo-glow` przekładki `214,168,92` zamiast pełnego `--sk-frame-accent`, tabliczka/sygil w łagodniejszym tonie.
 - **1.25.0** — **Przekładki dekad: krawędź półki, amber w Holo+, plakietki na deskę, sygil u dołu.**
   (1) **Granica półki**: `assignDividerLevels` → `assignDividerPlacement(row, labelOf, rowWidth)` — zwraca
   `{level, dir}`; gdy tabliczka wyszłaby poza prawą krawędź (`x + plateWidth > rowWidth`), rozwija się

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -11,77 +11,84 @@ interface Props {
   plate?: DividerLevel;
   /** Kierunek rozwijania tabliczki: „right" (domyślnie) lub „left" przy prawej krawędzi półki. */
   dir?: DividerDir;
+  /** Warstwa renderu: „board" (deseczka+sygile+żyła) albo „plate" (sama tabliczka).
+   *  `ShelfRow` maluje wszystkie deseczki, a POTEM wszystkie tabliczki, wyżej — dzięki
+   *  temu tabliczka nigdy nie chowa się pod deseczką sąsiada. */
+  part?: "board" | "plate";
 }
 
 /** Wysokość widocznej deseczki — spójna z `DIVIDER_H` w `shelfLayout` (podpora fizyki). */
 export const BOARD_H = 168;
 
 /**
- * Generyczna **przekładka sekcji** w stylu noosferycznym: cienka **deseczka** z
- * mosiądzu ze świecącą żyłą danych + sygilami koła u góry i u dołu + pozioma
- * **tabliczka-runa** rocznika przy początku zakresu (wariant A: tylko przy pierwszym
- * pojawieniu dekady) z projekcyjną smużką światła do deseczki. Rozmieszczenie liczy
- * `assignDividerPlacement`: tabliczka domyślnie u góry i w prawo, ale gdy dekada jest
- * wąska i górna kolidowałaby z sąsiednią → `plate="bottom"` (siada na krawędzi półki,
- * by nie zasłaniać tytułów), a przy prawej krawędzi półki → `dir="left"` (rozwija się
- * w lewo). Klasa `shelf-divider` pozwala skórze przemalować całą przekładkę (Holo+ =
- * amber, w kolorze oprawy Regału). Etykieta to zwykły string — ten sam komponent
- * obsłuży literę alfabetu / nazwisko autora itp. Nieprzeciągalna.
+ * Generyczna **przekładka sekcji** w stylu noosferycznym: cienka **deseczka** z żyłą
+ * danych i sygilami koła u góry i u dołu (`part="board"`) + pozioma **tabliczka-runa**
+ * rocznika (`part="plate"`). Warstwy są rozdzielone, bo `ShelfRow` maluje najpierw
+ * wszystkie deseczki, a potem wszystkie tabliczki wyżej (tabliczka zawsze na wierzchu).
+ * Rozmieszczenie liczy `assignDividerPlacement`: tabliczka domyślnie u góry i w prawo,
+ * przy wąskiej dekadzie → `plate="bottom"` (siada na krawędzi półki, by nie zasłaniać
+ * tytułów), a przy prawej krawędzi półki → `dir="left"`. Klasa `shelf-divider` pozwala
+ * skórze przemalować przekładkę (Holo+ = przytłumiony amber, w tonie oprawy Regału).
+ * Nieprzeciągalna.
  */
-export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H, plate = "top", dir = "right" }) => {
+export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H, plate = "top", dir = "right", part = "board" }) => {
   const atBottom = plate === "bottom";
   const toLeft = dir === "left";
   return (
-  <div className="shelf-divider relative select-none" style={{ width, height }} title={label} aria-hidden>
-    {/* cienka deseczka rozgraniczająca (dół toru) */}
-    <div
-      className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
-      style={{
-        width, height: BOARD_H,
-        background: "var(--sk-board-bg)",
-        boxShadow: "inset 1px 0 0 rgba(var(--noo-glow),.35), inset -1px 0 2px rgba(0,0,0,.6), 0 6px 10px -6px rgba(0,0,0,.6)",
-      }}
-    >
-      {/* cog-finial na szczycie deseczki */}
-      <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
-      {/* cog-finial u dołu deseczki (na linii półki) */}
-      <CogSigil className="absolute -bottom-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
-      {/* świecąca żyła danych */}
-      <div
-        className="noo-data absolute left-1/2 -translate-x-1/2 rounded-[2px]"
-        style={{ top: 14, bottom: 8, width: 2, background: "linear-gradient(180deg, rgba(var(--noo-glow),.9), rgba(var(--noo-glow),.15))", boxShadow: "0 0 6px rgba(var(--noo-glow),.8)" }}
-      />
-    </div>
+    <div className="shelf-divider relative select-none" style={{ width, height }} title={label} aria-hidden>
+      {part === "board" ? (
+        <>
+          {/* cienka deseczka rozgraniczająca (dół toru) */}
+          <div
+            className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
+            style={{
+              width, height: BOARD_H,
+              background: "var(--sk-board-bg)",
+              boxShadow: "inset 1px 0 0 rgba(var(--noo-glow),.35), inset -1px 0 2px rgba(0,0,0,.6), 0 6px 10px -6px rgba(0,0,0,.6)",
+            }}
+          >
+            {/* cog-finial na szczycie deseczki */}
+            <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
+            {/* cog-finial u dołu deseczki (na linii półki) */}
+            <CogSigil className="absolute -bottom-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
+            {/* świecąca żyła danych */}
+            <div
+              className="noo-data absolute left-1/2 -translate-x-1/2 rounded-[2px]"
+              style={{ top: 14, bottom: 8, width: 2, background: "linear-gradient(180deg, rgba(var(--noo-glow),.9), rgba(var(--noo-glow),.15))", boxShadow: "0 0 6px rgba(var(--noo-glow),.8)" }}
+            />
+          </div>
 
-    {/* projekcyjna smużka światła łącząca tabliczkę z deseczką (kierunek zależny od poziomu) */}
-    <div
-      className="noo-data absolute"
-      style={{
-        left: 4, width: 2, height: 150,
-        boxShadow: "0 0 6px rgba(var(--noo-glow),.5)",
-        ...(atBottom
-          ? { bottom: 30, background: "linear-gradient(0deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }
-          : { top: 22, background: "linear-gradient(180deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }),
-      }}
-    />
-
-    {/* tabliczka-runa rocznika, krawędzią przy deseczce; u góry domyślnie, u dołu (na
-        linii półki, nachodzi na deskę) gdy górna kolidowałaby z sąsiadem; rozwija się
-        w prawo, a przy prawej krawędzi półki w lewo. z-2 → zawsze nad grzbietami. */}
-    <div
-      className="absolute z-[2] flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
-      style={{
-        ...(atBottom ? { bottom: -12 } : { top: 0 }),
-        ...(toLeft ? { right: 0 } : { left: 0 }),
-        color: "var(--sk-plate-text)", fontSize: 11, letterSpacing: "0.06em",
-        background: "var(--sk-plate-bg)",
-        boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), 0 5px 9px -4px #000, 0 0 12px rgba(var(--noo-glow),.25)",
-        textShadow: "0 0 6px rgba(var(--noo-glow),.45)",
-      }}
-    >
-      <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
-      {label}
+          {/* projekcyjna smużka światła łącząca tabliczkę z deseczką (kierunek zależny od poziomu) */}
+          <div
+            className="noo-data absolute"
+            style={{
+              left: 4, width: 2, height: 150,
+              boxShadow: "0 0 6px rgba(var(--noo-glow),.5)",
+              ...(atBottom
+                ? { bottom: 30, background: "linear-gradient(0deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }
+                : { top: 22, background: "linear-gradient(180deg, rgba(var(--noo-glow),.55), rgba(var(--noo-glow),0))" }),
+            }}
+          />
+        </>
+      ) : (
+        /* tabliczka-runa rocznika, krawędzią przy deseczce; u góry domyślnie, u dołu
+           (na linii półki, nachodzi na deskę) gdy górna kolidowałaby z sąsiadem;
+           rozwija się w prawo, a przy prawej krawędzi półki w lewo */
+        <div
+          className="absolute flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
+          style={{
+            ...(atBottom ? { bottom: -12 } : { top: 0 }),
+            ...(toLeft ? { right: 0 } : { left: 0 }),
+            color: "var(--sk-plate-text)", fontSize: 11, letterSpacing: "0.06em",
+            background: "var(--sk-plate-bg)",
+            boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), 0 5px 9px -4px #000, 0 0 12px rgba(var(--noo-glow),.25)",
+            textShadow: "0 0 6px rgba(var(--noo-glow),.45)",
+          }}
+        >
+          <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
+          {label}
+        </div>
+      )}
     </div>
-  </div>
   );
 };

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -33,14 +33,14 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, onDragStar
   return (
   <div>
     <div className="relative" style={{ height: SHELF_ROW_H }}>
+      {/* Warstwa 1: grzbiety/kupki + deseczki przekładek (z-20, nad tłem i deską). */}
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
         if (slot.kind === "divider") {
-          // z-30: tabliczka + deseczka malują się PONAD grzbietami i deską półki.
           const pl = placement.get(p.key);
           return (
-            <div key={p.key} className="absolute bottom-0" style={{ left: p.x, zIndex: 30 }}>
-              <ShelfDivider label={slot.label} width={p.w} plate={pl?.level ?? "top"} dir={pl?.dir ?? "right"} />
+            <div key={p.key} className="absolute bottom-0" style={{ left: p.x, zIndex: 20 }}>
+              <ShelfDivider part="board" label={slot.label} width={p.w} plate={pl?.level ?? "top"} dir={pl?.dir ?? "right"} />
             </div>
           );
         }
@@ -60,6 +60,17 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, onDragStar
               : { left: p.x }}
           >
             <BookSpine book={slot.book} style={{ ...spineStyle(slot.book), width: p.w }} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+          </div>
+        );
+      })}
+      {/* Warstwa 2: same tabliczki dekad — ZAWSZE na wierzchu (z-40), nigdy pod deseczką sąsiada. */}
+      {row.map((p) => {
+        const slot = slotByKey.get(p.key)!;
+        if (slot.kind !== "divider") return null;
+        const pl = placement.get(p.key);
+        return (
+          <div key={`plate-${p.key}`} className="absolute bottom-0" style={{ left: p.x, zIndex: 40 }}>
+            <ShelfDivider part="plate" label={slot.label} width={p.w} plate={pl?.level ?? "top"} dir={pl?.dir ?? "right"} />
           </div>
         );
       })}

--- a/src/index.css
+++ b/src/index.css
@@ -101,13 +101,13 @@ body {
    poświata sygila), deseczka/tabliczka/sygil przemalowane na amber. Tylko Holo+ —
    w Relikwiarzu przekładki zostają mosiężno-teal (brak reguły). */
 .skin-holo .shelf-divider {
-  --noo-glow: var(--sk-frame-accent);
-  --sk-board-bg: linear-gradient(180deg, #fcd34d, #f59e0b 42%, #b45309);
-  --sk-plate-text: #fde68a;
-  --sk-plate-edge: #a16207;
-  --sk-cog-ring: #fbbf24;
-  --sk-cog-skull: #2a1e06;
-  --sk-cog-disc: #140e02;
+  --noo-glow: 214, 168, 92;   /* przytłumiony amber (żyła/smużka/poświata sygila) */
+  --sk-board-bg: linear-gradient(180deg, #cda24c, #b07d2e 42%, #6b3d12);
+  --sk-plate-text: #f0d69a;
+  --sk-plate-edge: #7d5210;
+  --sk-cog-ring: #d9a83f;
+  --sk-cog-skull: #241a06;
+  --sk-cog-disc: #120c02;
 }
 
 .skin-noospheric .book-spine {


### PR DESCRIPTION
Two small follow-ups on the decade dividers.

## Changes
- **Plate-under-board fix** — a bottom nameplate could be partly hidden by a divider board (its sigil vanished under the amber post). `ShelfRow` now renders in **two passes**: every divider board first (`part="board"`, z-20), then every nameplate (`part="plate"`, z-40), so a plate never hides under a neighbouring — or its own — board. `ShelfDivider` gains a `part: "board" | "plate"` prop.
- **Dimmer Holo+ amber** — muted brass board (`#cda24c→#b07d2e→#6b3d12`, was `#fcd34d→#f59e0b`), divider `--noo-glow` `214,168,92` instead of the full frame accent, softer plate text/sigil.

Render/colour only — logic and geometry unchanged.

## Verification
- `npm run lint` clean · `npm test` **313/313** green · `npm run build` OK.
- Headless-Chromium screenshot: the "1940–1949" / "1970–1979" bottom plates now paint fully above the boards (sigil no longer clipped); amber is visibly muted.
- Version bump `1.25.0` → `1.25.1` (patch); backlog updated.

Fixes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_