### PR TITLE
Scrapers: refresh the User-Agent pool to current browser versions

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.25.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.25.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -62,6 +62,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.25.2** — **Skanery: odświeżona pula User-Agentów (sierpień 2026).** Audyt regresji po
+  refaktorze god-object/god-hook wykazał, że CAŁA konfiguracja skanera Vinted (URL, nagłówki,
+  agent, timeout 30 s, retry 3×4 s bez ponawiania 403, throttle 3–5 s, `looksBlocked`, watchdog
+  120 s) przetrwała bajt w bajt — bloki to eskalacja po stronie Vinted/Cloudflare, nie nasz kod.
+  Pierwszy krok mitygacji: pula UA z Chrome 120–122/FF 122 (początek 2024) → **Chrome 151/152,
+  Firefox 154, Edge 151, Safari 26.0** (formaty realne: Chrome x.0.0.0 zredukowane, Safari
+  zamrożone Version/26.0, tokeny platform zamrożone). Też hardcoded UA w `wiki.adapter.ts`.
+  UWAGA: odświeżać pulę co kilka miesięcy. Jeśli bloki nie ustąpią → dłuższy throttle / proxy
+  rezydencjalne (Cloudflare Worker NIE jest rezydencjalny — datacenter IP, nie zdejmie scoringu).
 - **1.25.1** — **Przekładki: tabliczki zawsze nad deseczkami + przytłumiony amber.** (1) Render dwuwarstwowy
   w `ShelfRow`: najpierw wszystkie deseczki (`ShelfDivider part="board"`, z-20), potem wszystkie tabliczki
   (`part="plate"`, z-40) — tabliczka nie chowa się już pod deseczką sąsiada (ani własną). `ShelfDivider`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.25.1",
+      "version": "1.25.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.25.1",
+  "version": "1.25.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/scrapingClient.ts
+++ b/scrapingClient.ts
@@ -6,14 +6,20 @@ import https from "https";
  * strony HTML, więc potrzebują rotacji User-Agent i keep-alive agenta HTTPS.
  */
 
+// Pula bieżących wersji przeglądarek (stan: sierpień 2026 — Chrome 151/152,
+// Firefox 154, Edge 151, Safari 26). Anty-boty punktują przestarzałe UA (rozjazd
+// z resztą fingerprintu), więc odświeżaj pulę co kilka miesięcy. Format ma znaczenie:
+// Chrome/Edge raportują zredukowane wersje x.0.0.0, Safari 26 zamrożone Version/26.0,
+// a tokeny platform (Windows NT 10.0, Mac OS X 10_15_7 / 10.15) są celowo zamrożone
+// przez przeglądarki — nie „unowocześniać" ich.
 const USER_AGENTS = [
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0',
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.0.0',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.1 Safari/605.1.15'
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:154.0) Gecko/20100101 Firefox/154.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15'
 ];
 
 export const getRandomUserAgent = () => USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];

--- a/wiki.adapter.ts
+++ b/wiki.adapter.ts
@@ -14,7 +14,7 @@ const wikiAxios = axios.create({
   httpsAgent,
   timeout: 30000,
   headers: {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
     'Accept': 'application/json, text/plain, */*',
     'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7'
   }


### PR DESCRIPTION
First mitigation step for the renewed Vinted bot-detection (the regression audit confirmed the scanner config survived the god-object/god-hook refactors byte-for-byte — the blocking is a Vinted/Cloudflare-side escalation).

## Changes
- **`scrapingClient.ts`** — the 7-entry UA pool advertised Chrome 120–122 / Firefox 122 / Safari 17.2 (early 2024); anti-bot scoring flags outdated UA versions against the rest of the fingerprint. Refreshed to August 2026 stables: **Chrome 151/152, Firefox 154, Edge 151, Safari 26.0**, keeping the real-world formats (reduced Chrome `x.0.0.0`, Safari frozen at `Version/26.0`, deliberately frozen platform tokens like `Windows NT 10.0` / `Mac OS X 10_15_7`).
- **`wiki.adapter.ts`** — hardcoded UA Chrome/120 → 152 for consistency.
- Added a comment: refresh the pool every few months; don't "modernize" the frozen platform tokens.

Both scanners (Vinted + Library OPAC) consume the shared pool, so they pick this up automatically. No behavioural change beyond the header value.

## Verification
- `npm run lint` clean · `npm test` **313/313** green · `npm run build` OK.
- Version bump `1.25.1` → `1.25.2` (patch); backlog updated (audit findings + next escalation steps recorded).

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_