### PR TITLE
Vinted resume: widen the "Kontynuuj" window from 12h to 24h

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.25.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.25.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.25.3** — **Vinted „Kontynuuj": okno 12 h → 24 h.** Audyt potwierdził, że mechanizm wznowienia
+  jest nienaruszony (bloki celowo nie zapisują `scannedAt`, stąd pozorne „189 co przebieg" w czasie
+  fali wykryć). Przy skanach raz dziennie 12 h zawsze wygasało — teraz `RESUME_HOURS = 24`,
+  zdeduplikowane do JEDNEGO eksportu w `VintedScanControls.tsx` (import w `VintedCheckItem`;
+  wcześniej stała była zdublowana w dwóch plikach i mogła się rozjechać).
 - **1.25.2** — **Skanery: odświeżona pula User-Agentów (sierpień 2026).** Audyt regresji po
   refaktorze god-object/god-hook wykazał, że CAŁA konfiguracja skanera Vinted (URL, nagłówki,
   agent, timeout 30 s, retry 3×4 s bez ponawiania 403, throttle 3–5 s, `looksBlocked`, watchdog

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.25.2",
+      "version": "1.25.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.25.2",
+  "version": "1.25.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
 import { useVintedResolveSellers } from "../../hooks/useVintedResolveSellers";
 import { useVintedStored } from "../../hooks/useVintedStored";
-import { VintedScanControls } from "./vinted/VintedScanControls";
+import { VintedScanControls, RESUME_HOURS } from "./vinted/VintedScanControls";
 import { VintedScanProgress } from "./vinted/VintedScanProgress";
 import { VintedDebugLog } from "./vinted/VintedDebugLog";
 import { VintedResolveStatus } from "./vinted/VintedResolveStatus";
@@ -17,8 +17,6 @@ interface VintedCheckItemProps {
   isChecking: boolean;
   progress: any;
 }
-
-const RESUME_HOURS = 12;
 
 export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
   const [showLogs, setShowLogs] = React.useState(false);

--- a/src/components/stats/vinted/VintedScanControls.tsx
+++ b/src/components/stats/vinted/VintedScanControls.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Loader2, Search, Bug, Database, HardDriveDownload, Trash2 } from "lucide-react";
 import { RitualButton } from "../RitualButton";
 
-const RESUME_HOURS = 12;
+/** Okno „Kontynuuj": pomiń książki skanowane w ostatnich N h. Jedno źródło — importuje je też VintedCheckItem. */
+export const RESUME_HOURS = 24;
 
 interface Props {
   isChecking: boolean;


### PR DESCRIPTION
With daily scans the 12h resume window always lapsed, so "Kontynuuj" had nothing to skip and every run did the full pass. (The audit confirmed the resume mechanism itself is intact — blocked/errored books intentionally don't get a `scannedAt`.)

## Changes
- `RESUME_HOURS` **12 → 24**.
- Deduplicated the constant to a single export in `VintedScanControls.tsx`, imported by `VintedCheckItem.tsx` — it was defined in both files, risking the tooltip drifting from the actual window.

## Verification
- `npm run lint` clean · `npm test` **313/313** green · `npm run build` OK.
- Version bump `1.25.2` → `1.25.3` (patch); backlog updated.

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_