### PR TITLE
App config backend: schema, Notion-stored overrides, API, knob consumers

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.25.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.26.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.26.0** — **Konfiguracja aplikacji (backend, CFG-PR1).** Nowy współdzielony schemat
+  `src/configSchema.ts` (AppConfig + DEFAULT_CONFIG + mergeConfig z clampami + diffFromDefaults +
+  parseStoredConfig; defaulty = dotychczasowe zachowanie 1:1). **Składowanie: diff od defaultów
+  jako JSON w OPISIE kolumny `AppConfig`** (adapter `get/saveAppConfigRaw`; opis, nie wiersz —
+  sentinel wyciekałby do rytuałów iterujących wiersze). `services/configService.ts` (cache 30 s,
+  limit blobu 1900 zn., odporny odczyt → defaulty). REST: `GET/PUT /api/app-config`. Konsumenci:
+  vinted (URL katalogu/timeout/retry/throttle/UA/wykluczenia/cap sprzedawców), library (concurrency/
+  wykluczenia/UA), bookSync+syncManager-diagnostyka (nagrody z cfg — skasowane 2 z 3 kopii listy),
+  duplicates (progi 0.85/0.9), bookSync+cycles (writeConcurrency). Testy: +7 (configSchema) → 320.
+  Uwaga: listy wykluczeń Vinted i biblioteki celowo OSOBNE (różnią się Audioteką).
 - **1.25.3** — **Vinted „Kontynuuj": okno 12 h → 24 h.** Audyt potwierdził, że mechanizm wznowienia
   jest nienaruszony (bloki celowo nie zapisują `scannedAt`, stąd pozorne „189 co przebieg" w czasie
   fali wykryć). Przy skanach raz dziennie 12 h zawsze wygasało — teraz `RESUME_HOURS = 24`,

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { syncManager, SyncTaskName } from "../syncManager";
+import { syncManager, SyncTaskName, configService } from "../syncManager";
 import { SyncParams } from "../src/types";
 import { createLogger } from "../logger";
 import { executeSyncTask } from "./sseStream";
@@ -61,6 +61,24 @@ export const getConfig = (req: Request, res: Response) => {
     hasNotionKey: !!process.env.NOTION_API_KEY,
     hasDatabaseId: !!process.env.NOTION_DATABASE_ID,
   });
+};
+
+/** Efektywna konfiguracja aplikacji (defaulty + nadpisania z Notion) — zakładka „Konfiguracja". */
+export const getAppConfig = async (req: Request, res: Response) => {
+  try {
+    res.json(await configService.getConfig(req.query.force === "1"));
+  } catch (error: any) {
+    res.status(500).json({ error: error.message || "Nie udało się odczytać konfiguracji." });
+  }
+};
+
+/** Zapis konfiguracji: wejście przechodzi clampy w configSchema; składowany jest diff od defaultów. */
+export const updateAppConfig = async (req: Request, res: Response) => {
+  try {
+    res.json(await configService.saveConfig(req.body));
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || "Nie udało się zapisać konfiguracji." });
+  }
 };
 
 export const getNotionSchema = async (req: Request, res: Response) => {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.25.3",
+  "version": "1.26.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -113,6 +113,29 @@ export class NotionAdapter {
     }
   }
 
+  /** Nazwa kolumny-nośnika konfiguracji aplikacji (blob JSON żyje w jej OPISIE, nie w wierszach). */
+  private static readonly APP_CONFIG_COLUMN = "AppConfig";
+
+  /**
+   * Odczyt blobu konfiguracji z opisu kolumny `AppConfig`. Brak kolumny/opisu → null
+   * (aplikacja działa na defaultach z `configSchema`). Opis kolumny wybrano zamiast
+   * wiersza-sentinela, bo rytuały (puryfikacja/integralność/LP) iterują po wszystkich
+   * wierszach i sentinel by w nie wyciekał.
+   */
+  async getAppConfigRaw(): Promise<string | null> {
+    const schema = await this.getSchema();
+    const desc = schema?.[NotionAdapter.APP_CONFIG_COLUMN]?.description;
+    return typeof desc === "string" && desc.trim() ? desc : null;
+  }
+
+  /** Zapis blobu konfiguracji do opisu kolumny `AppConfig` (tworzy kolumnę przy pierwszym zapisie). */
+  async saveAppConfigRaw(json: string): Promise<void> {
+    await this.init();
+    await this.updateSource(this.actualDataSourceId!, {
+      [NotionAdapter.APP_CONFIG_COLUMN]: { rich_text: {}, description: json },
+    });
+  }
+
   async queryAllBooks(onProgress?: (count: number) => void, checkCancellation?: () => boolean): Promise<NotionBook[]> {
     await this.init();
     const allBooks: NotionBook[] = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.25.3",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.25.3",
+      "version": "1.26.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.25.3",
+  "version": "1.26.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -9,6 +9,8 @@ router.get("/wiki/last-update", syncController.getWikiLastUpdate);
 router.get("/health", syncController.getHealth);
 router.get("/diagnostics", syncController.getDiagnostics);
 router.get("/config", syncController.getConfig);
+router.get("/app-config", syncController.getAppConfig);
+router.put("/app-config", syncController.updateAppConfig);
 router.get("/notion/schema", syncController.getNotionSchema);
 router.patch("/notion/schema", syncController.updateNotionSchema);
 router.post("/sync/reset", syncController.resetSyncState);

--- a/scrapingClient.ts
+++ b/scrapingClient.ts
@@ -22,7 +22,11 @@ const USER_AGENTS = [
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15'
 ];
 
-export const getRandomUserAgent = () => USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
+/** Losowy UA z przekazanej puli (konfig `scraping.userAgents`); bez argumentu — z wbudowanej. */
+export const getRandomUserAgent = (pool?: string[]) => {
+  const list = pool && pool.length > 0 ? pool : USER_AGENTS;
+  return list[Math.floor(Math.random() * list.length)];
+};
 
 export interface ScrapingAgentOptions {
   /** Maks. równoległych połączeń do jednego hosta (domyślnie 5). */

--- a/services/__tests__/bookSyncService.test.ts
+++ b/services/__tests__/bookSyncService.test.ts
@@ -1,3 +1,4 @@
+import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BookSyncService } from '../bookSyncService';
 import { NotionAdapter } from '../../notion.adapter';
@@ -23,7 +24,7 @@ describe('BookSyncService', () => {
 
     mockSendEvent = vi.fn();
 
-    service = new BookSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+    service = new BookSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter, fakeConfig);
   });
 
   describe('fetchBooksFromMediaWiki', () => {

--- a/services/__tests__/cyclesSyncService.test.ts
+++ b/services/__tests__/cyclesSyncService.test.ts
@@ -1,3 +1,4 @@
+import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CyclesSyncService } from '../cyclesSyncService';
 import { NotionAdapter } from '../../notion.adapter';
@@ -26,7 +27,7 @@ describe('CyclesSyncService', () => {
 
     mockSendEvent = vi.fn();
 
-    service = new CyclesSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+    service = new CyclesSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter, fakeConfig);
   });
 
   it('updates cycle checkbox when it differs', async () => {

--- a/services/__tests__/duplicateSyncService.test.ts
+++ b/services/__tests__/duplicateSyncService.test.ts
@@ -1,3 +1,4 @@
+import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DuplicateSyncService } from '../duplicateSyncService';
 import { NotionAdapter } from '../../notion.adapter';
@@ -20,7 +21,7 @@ describe('DuplicateSyncService', () => {
 
     mockSendEvent = vi.fn();
 
-    service = new DuplicateSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+    service = new DuplicateSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter, fakeConfig);
   });
 
   it('detects duplicates with identical titles', async () => {

--- a/services/__tests__/integrityService.test.ts
+++ b/services/__tests__/integrityService.test.ts
@@ -1,3 +1,4 @@
+import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IntegrityService } from '../integrityService';
 import { NotionAdapter } from '../../notion.adapter';
@@ -22,7 +23,7 @@ describe('IntegrityService', () => {
 
     mockSendEvent = vi.fn();
 
-    service = new IntegrityService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter);
+    service = new IntegrityService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter, fakeConfig);
   });
 
   it('detects duplicate Lp values', async () => {

--- a/services/__tests__/libraryCheckService.test.ts
+++ b/services/__tests__/libraryCheckService.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('axios', () => ({
@@ -46,7 +47,7 @@ describe('LibraryCheckService', () => {
     ]);
     mockedGet.mockResolvedValue({ data: OPAC_MISS });
 
-    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, never);
+    await new LibraryCheckService(notion, fakeConfig).runLibraryCheck('48', sendEvent, never);
 
     expect(mockedGet).toHaveBeenCalledTimes(1); // only book #1 is a valid candidate
     const complete = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'complete');
@@ -64,7 +65,7 @@ describe('LibraryCheckService', () => {
       ),
     });
 
-    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, never);
+    await new LibraryCheckService(notion, fakeConfig).runLibraryCheck('48', sendEvent, never);
 
     const match = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'match');
     expect(match).toBeDefined();
@@ -83,7 +84,7 @@ describe('LibraryCheckService', () => {
       ),
     });
 
-    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, never);
+    await new LibraryCheckService(notion, fakeConfig).runLibraryCheck('48', sendEvent, never);
 
     const match = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'match');
     expect(match).toBeUndefined();
@@ -95,7 +96,7 @@ describe('LibraryCheckService', () => {
     const notion = makeNotion([{ id: '1', plTitle: 'Solaris', author: 'Stanisław Lem', zrodlo: [] }]);
     mockedGet.mockResolvedValue({ data: OPAC_MISS });
 
-    await new LibraryCheckService(notion).runLibraryCheck('48', sendEvent, () => true);
+    await new LibraryCheckService(notion, fakeConfig).runLibraryCheck('48', sendEvent, () => true);
 
     expect(mockedGet).not.toHaveBeenCalled();
     const complete = sendEvent.mock.calls.map((c: any) => c[0]).find((e: any) => e.type === 'complete');

--- a/services/__tests__/testConfig.ts
+++ b/services/__tests__/testConfig.ts
@@ -1,0 +1,5 @@
+import { ConfigService } from "../configService";
+import { mergeConfig } from "../../src/configSchema";
+
+/** Fake ConfigService dla testów serwisów — zawsze zwraca defaulty (bez Notion). */
+export const fakeConfig = { getConfig: async () => mergeConfig(undefined) } as unknown as ConfigService;

--- a/services/__tests__/vintedSyncService.test.ts
+++ b/services/__tests__/vintedSyncService.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('axios', () => ({
@@ -52,7 +53,7 @@ describe('VintedSyncService', () => {
       }),
     });
 
-    const svc = new VintedSyncService(notion);
+    const svc = new VintedSyncService(notion, fakeConfig);
     await svc.runVintedCheck(sendEvent, never);
 
     const events = sendEvent.mock.calls.map((c: any) => c[0]);
@@ -73,7 +74,7 @@ describe('VintedSyncService', () => {
     ]);
     mockedGet.mockResolvedValue({ data: NO_RESULTS_HTML });
 
-    const svc = new VintedSyncService(notion);
+    const svc = new VintedSyncService(notion, fakeConfig);
     await svc.runVintedCheck(sendEvent, never);
 
     const events = sendEvent.mock.calls.map((c: any) => c[0]);
@@ -90,7 +91,7 @@ describe('VintedSyncService', () => {
     ]);
     mockedGet.mockResolvedValue({ data: NO_RESULTS_HTML });
 
-    const svc = new VintedSyncService(notion);
+    const svc = new VintedSyncService(notion, fakeConfig);
     await svc.runVintedCheck(sendEvent, never);
 
     expect(mockedGet).not.toHaveBeenCalled();

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -7,11 +7,12 @@ import { Book, NotionBook, SyncEvent, SyncParams } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
 import { buildBookUpdates, buildNewBookProperties } from "./bookDiff";
 import { createLogger } from "../logger";
+import { ConfigService } from "./configService";
 
 const log = createLogger("BookSync");
 
 export class BookSyncService {
-  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
 
   async fetchBooksFromMediaWiki(pageTitle: string, awardName: string, sendEvent: (data: SyncEvent) => void): Promise<Book[]> {
     sendEvent({ type: "status", message: `Inicjacja ekstrakcji danych z Archiwum Encyklopedii: ${awardName}...` });
@@ -34,12 +35,9 @@ export class BookSyncService {
       await this.notion.init();
       let allBooksToSync: Book[] = [];
       if (params.syncAll) {
-        const PREDEFINED_AWARDS = [
-          { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
-          { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
-          { name: "Nagroda Locus", title: "Locus nagroda powieść" }
-        ];
-        for (const aw of PREDEFINED_AWARDS) {
+        // Lista stron nagród z konfiguracji (knob `sync.awards`) — bez kopii w kodzie.
+        const awards = (await this.config.getConfig()).sync.awards;
+        for (const aw of awards) {
           if (checkCancellation()) break;
           const books = await this.fetchBooksFromMediaWiki(aw.title, aw.name, sendEvent);
           allBooksToSync = allBooksToSync.concat(books);
@@ -91,7 +89,7 @@ export class BookSyncService {
       const syncSummary = { added: [] as string[], updated: [] as string[], skipped: [] as string[], duplicates: [] as string[] };
       const errors: any[] = [];
       
-      const limit = pLimit(3);
+      const limit = pLimit((await this.config.getConfig()).sync.writeConcurrency);
       let processedCount = 0;
 
       const syncTasks = booksToSync.map((book) => limit(async () => {

--- a/services/configService.ts
+++ b/services/configService.ts
@@ -1,0 +1,54 @@
+import { NotionAdapter } from "../notion.adapter";
+import { AppConfig, mergeConfig, diffFromDefaults, parseStoredConfig } from "../src/configSchema";
+import { createLogger } from "../logger";
+
+const log = createLogger("Config");
+
+/** Krótki cache efektywnej konfiguracji — rytuały czytają ją na starcie przebiegu. */
+const CONFIG_CACHE_TTL_MS = 30 * 1000;
+
+/** Twardy limit rozmiaru blobu w opisie kolumny (diff od defaultów jest zwykle < 1 KB). */
+const MAX_BLOB_CHARS = 1900;
+
+/**
+ * Serwis konfiguracji: efektywna konfiguracja = defaulty z `configSchema` + diff
+ * składowany w Notion (opis kolumny `AppConfig`). Odczyt jest odporny: uszkodzony
+ * blob / brak kolumny / błąd Notion → defaulty (aplikacja nigdy nie pada od configu).
+ */
+export class ConfigService {
+  private cached: { cfg: AppConfig; expiresAt: number } | null = null;
+
+  constructor(private notion: NotionAdapter) {}
+
+  /** Efektywna konfiguracja (defaulty + nadpisania). `force` pomija cache. */
+  async getConfig(force = false): Promise<AppConfig> {
+    if (!force && this.cached && this.cached.expiresAt > Date.now()) return this.cached.cfg;
+    let cfg: AppConfig;
+    try {
+      const raw = await this.notion.getAppConfigRaw();
+      cfg = mergeConfig(parseStoredConfig(raw));
+    } catch (e: any) {
+      log.warn("Nie udało się odczytać konfiguracji z Notion — używam defaultów", { error: e?.message });
+      cfg = mergeConfig(undefined);
+    }
+    this.cached = { cfg, expiresAt: Date.now() + CONFIG_CACHE_TTL_MS };
+    return cfg;
+  }
+
+  /**
+   * Zapis: wejście przechodzi przez mergeConfig (clampy/typy), składujemy TYLKO diff
+   * od defaultów. Zwraca efektywną konfigurację po zapisie.
+   */
+  async saveConfig(input: unknown): Promise<AppConfig> {
+    const cfg = mergeConfig(input);
+    const overrides = diffFromDefaults(cfg);
+    const json = Object.keys(overrides).length > 0 ? JSON.stringify(overrides) : "";
+    if (json.length > MAX_BLOB_CHARS) {
+      throw new Error(`Konfiguracja po zserializowaniu ma ${json.length} znaków (limit ${MAX_BLOB_CHARS}). Zmniejsz liczbę nadpisań (np. wpisów User-Agent).`);
+    }
+    await this.notion.saveAppConfigRaw(json);
+    this.cached = { cfg, expiresAt: Date.now() + CONFIG_CACHE_TTL_MS };
+    log.info("Zapisano konfigurację", { overrideSections: Object.keys(overrides), chars: json.length });
+    return cfg;
+  }
+}

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -4,9 +4,10 @@ import { WikiAdapter } from "../wiki.adapter";
 import { WikiParser } from "../wiki.parser";
 import { NotionBook, SyncEvent } from "../src/types";
 import { isWikiAuthorMatch } from "./dataNormalizer";
+import { ConfigService } from "./configService";
 
 export class CyclesSyncService {
-  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
 
   async runCyclesSync(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
     try {
@@ -34,7 +35,7 @@ export class CyclesSyncService {
       if (failedTitles.length > 0) {
         errors.push({ book: `${failedTitles.length} stron`, error: `Nie udało się pobrać treści z encyklopedii (fallback przez wyszukiwarkę): ${failedTitles.slice(0, 5).join(", ")}${failedTitles.length > 5 ? "…" : ""}` });
       }
-      const limit = pLimit(3);
+      const limit = pLimit((await this.config.getConfig()).sync.writeConcurrency);
       
       const isAuthorMatch = isWikiAuthorMatch;
 

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -2,13 +2,16 @@ import { NotionAdapter } from "../notion.adapter";
 import { WikiAdapter } from "../wiki.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
 import { countCommonWords, calculateSimilarity } from "../utils";
+import { ConfigService } from "./configService";
 
 export class DuplicateSyncService {
-  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
 
   async runDuplicateCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
     console.log("DuplicateSyncService runDuplicateCheck started");
     try {
+      // Progi podobieństwa z konfiguracji (knoby `sync.dup*Threshold`).
+      const { dupAuthorThreshold, dupTitleThreshold } = (await this.config.getConfig()).sync;
       sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
       await this.notion.init();
       console.log("Notion initialized");
@@ -36,7 +39,7 @@ export class DuplicateSyncService {
           let isDuplicate = false;
           let reason = "";
           
-          const sameAuthor = authorA && authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > 0.85);
+          const sameAuthor = authorA && authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > dupAuthorThreshold);
           const differentAuthor = authorA && authorB && !sameAuthor && calculateSimilarity(authorA, authorB) < 0.5; // Clearly different
 
           if (differentAuthor) continue; 
@@ -52,12 +55,12 @@ export class DuplicateSyncService {
             reason = "identyczny tytuł oryg.";
           }
           // 3. High similarity for Polish title
-          else if (titleA && titleB && calculateSimilarity(titleA, titleB) > 0.9) {
+          else if (titleA && titleB && calculateSimilarity(titleA, titleB) > dupTitleThreshold) {
             isDuplicate = true;
             reason = "wysokie podobieństwo PL";
           }
           // 4. High similarity for Original title
-          else if (origA && origB && calculateSimilarity(origA, origB) > 0.9) {
+          else if (origA && origB && calculateSimilarity(origA, origB) > dupTitleThreshold) {
             isDuplicate = true;
             reason = "wysokie podobieństwo oryg.";
           }

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -1,4 +1,5 @@
 import { NotionAdapter } from "../notion.adapter";
+import { ConfigService } from "./configService";
 import { WikiAdapter } from "../wiki.adapter";
 import { BookSyncService } from "./bookSyncService";
 import { SyncEvent, NotionBook, Book, IntegrityCheckResult } from "../src/types";
@@ -22,8 +23,8 @@ interface BookEntry { keys: string[]; years: string[]; display: string }
 export class IntegrityService {
   private bookSyncService: BookSyncService;
 
-  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {
-    this.bookSyncService = new BookSyncService(notion, wiki);
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, config: ConfigService) {
+    this.bookSyncService = new BookSyncService(notion, wiki, config);
   }
 
   async runIntegrityCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {

--- a/services/libraryCheckService.ts
+++ b/services/libraryCheckService.ts
@@ -6,10 +6,10 @@ import { withRetry } from "../retry";
 import { createLogger } from "../logger";
 import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
 import { parseOpacResults, findBookMatch } from "./opacParser";
+import { ConfigService } from "./configService";
 
 const log = createLogger("LibraryCheck");
 
-const CONCURRENCY = 6;
 const REQUEST_TIMEOUT = 20000;
 
 /**
@@ -19,13 +19,16 @@ const REQUEST_TIMEOUT = 20000;
  * pomijane). Zob. docs/library-check.md i services/opacParser.ts.
  */
 export class LibraryCheckService {
-  constructor(private notion: NotionAdapter) {}
+  constructor(private notion: NotionAdapter, private config: ConfigService) {}
 
   async runLibraryCheck(
     libraryCode: string,
     sendEvent: (data: SyncEvent) => void,
     checkCancellation: () => boolean,
   ) {
+    // Knoby skanera (równoległość / wykluczenia / pula UA) czytane raz na przebieg.
+    const cfg = await this.config.getConfig();
+    const concurrency = cfg.library.concurrency;
     sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
     // cache: kolejne filie w „Skanuj wszystkie" współdzielą jedno pobranie z Notion.
     const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
@@ -33,8 +36,7 @@ export class LibraryCheckService {
     // Kandydaci: mają polski tytuł i NIE są już przeczytane/posiadane/w bibliotece.
     const candidates = allBooks.filter((b) => {
       const zrodlo = b.zrodlo || [];
-      const excluded = ["Przeczytane", "Biblioteka", "Biblioteka 9", "Posiadam"];
-      return !zrodlo.some((z) => excluded.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
+      return !zrodlo.some((z) => cfg.library.excludedSources.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
     });
 
     sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia...` });
@@ -43,8 +45,8 @@ export class LibraryCheckService {
     // OPAC MBP Lublin nie wysyła certyfikatu pośredniego → Node zgłasza „unable to
     // verify the first certificate" i każde żądanie leci wyjątkiem. Wyłączamy
     // weryfikację TLS tylko dla tego agenta (czytamy publiczny katalog, bez sekretów).
-    const httpsAgent = createScrapingAgent({ rejectUnauthorized: false, maxSockets: CONCURRENCY });
-    const limit = pLimit(CONCURRENCY);
+    const httpsAgent = createScrapingAgent({ rejectUnauthorized: false, maxSockets: concurrency });
+    const limit = pLimit(concurrency);
     let processed = 0;
 
     const tasks = candidates.map((book) =>
@@ -54,7 +56,7 @@ export class LibraryCheckService {
         const title = book.plTitle;
         const url = `https://opac.mbp.lublin.pl/search/description?q=${encodeURIComponent(title)}&index=1&scope=full&f2%5B0%5D=${encodeURIComponent(libraryCode)}`;
         const headers = {
-          "User-Agent": getRandomUserAgent(),
+          "User-Agent": getRandomUserAgent(cfg.scraping.userAgents),
           "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
           "Accept-Language": "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7",
           "Cache-Control": "no-cache",

--- a/services/vintedHttp.ts
+++ b/services/vintedHttp.ts
@@ -1,9 +1,9 @@
 import { getRandomUserAgent } from "../scrapingClient";
 
-/** Nagłówki żądania Vinted (świeży User-Agent na wywołanie). Wspólne dla skanu i grupowania. */
-export function vintedRequestHeaders() {
+/** Nagłówki żądania Vinted (świeży User-Agent na wywołanie; pula z konfiguracji). */
+export function vintedRequestHeaders(uaPool?: string[]) {
   return {
-    'User-Agent': getRandomUserAgent(),
+    'User-Agent': getRandomUserAgent(uaPool),
     'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
     'Referer': 'https://www.vinted.pl/',

--- a/services/vintedScanPlanner.ts
+++ b/services/vintedScanPlanner.ts
@@ -22,16 +22,17 @@ export interface ScanPlan {
  * (2) opcjonalnie pomiń skanowane w ostatnich `skipScannedWithinHours` (bieżąca partia),
  * (3) posortuj OD NAJSTARSZYCH (nigdy-skanowane pierwsze) — przerwany przebieg zawsze
  * posuwa najbardziej nieaktualne dane, a „Kontynuuj" domyka partię zamiast dublować świeże.
- * `now` wstrzykiwalny dla testów.
+ * `now` wstrzykiwalny dla testów; `excludedSources` z konfiguracji (default = dotychczasowa lista).
  */
 export function selectAndOrderCandidates(
   books: NotionBook[],
   skipScannedWithinHours?: number,
   now: number = Date.now(),
+  excludedSources: string[] = EXCLUDED_SOURCES,
 ): ScanPlan {
   const base = books.filter((b) => {
     const zrodlo = b.zrodlo || [];
-    return !zrodlo.some((z) => EXCLUDED_SOURCES.includes(z)) && !!b.plTitle && b.plTitle.trim() !== "";
+    return !zrodlo.some((z) => excludedSources.includes(z)) && !!b.plTitle && b.plTitle.trim() !== "";
   });
 
   let withDates = base.map((b) => ({ book: b, at: scannedMs(b) }));

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -9,8 +9,15 @@ import { NotionBook } from "../src/types";
 import { offerFromItem, parseVintedData, mergeAndDiff, serializeVintedData, computeChangedAt, toStoredBookView, StoredVintedData, StoredOffer, StoredBookView, OfferDiff, EMPTY_DIFF } from "./vintedStore";
 import { selectAndOrderCandidates } from "./vintedScanPlanner";
 import { vintedRequestHeaders, memMb, throttle, classifyVintedError } from "./vintedHttp";
+import { ConfigService } from "./configService";
+import { AppConfig } from "../src/configSchema";
 
 const log = createLogger("VintedScan");
+
+/** URL katalogu Vinted zbudowany z knobów konfiguracji (kategoria/język/cena/waluta/sortowanie). */
+function buildCatalogUrl(v: AppConfig["vinted"], searchText: string): string {
+  return `https://www.vinted.pl/catalog?catalog[]=${v.catalogId}&language_book_ids[]=${v.languageId}&page=1&order=${encodeURIComponent(v.order)}&price_from=${v.priceFrom}&currency=${v.currency}&search_text=${encodeURIComponent(searchText)}`;
+}
 
 /**
  * Skaner ofert na Vinted (bezpośredni scraper HTML — NIE AI). Dla każdej książki,
@@ -20,7 +27,7 @@ const log = createLogger("VintedScan");
  * (`vintedStore`) żyją w czystych helperach. Zob. docs/vinted-scanner.md.
  */
 export class VintedSyncService {
-  constructor(private notion: NotionAdapter) {}
+  constructor(private notion: NotionAdapter, private config: ConfigService) {}
 
   /**
    * Etap 3: czyta składowane wyniki Vinted ze wszystkich książek (blob VintedData) do
@@ -76,12 +83,15 @@ export class VintedSyncService {
     params?: { skipScannedWithinHours?: number },
   ) {
     try {
+      // Knoby skanera (throttle/URL/retry/UA/wykluczenia) czytane raz na przebieg.
+      const cfg = await this.config.getConfig();
+      const v = cfg.vinted;
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       // cache: współdziel pobranie z sąsiadującymi skanami (biblioteka/Vinted).
       const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
       const skipHours = params?.skipScannedWithinHours;
-      const { candidates, skipped } = selectAndOrderCandidates(allBooks, skipHours);
+      const { candidates, skipped } = selectAndOrderCandidates(allBooks, skipHours, Date.now(), v.excludedSources);
       if (skipHours && skipHours > 0 && skipped > 0) {
         sendEvent({ type: "status", message: `Wznawianie: pominięto ${skipped} skanowanych < ${skipHours} h. Do sprawdzenia: ${candidates.length}.` });
       }
@@ -116,12 +126,12 @@ export class VintedSyncService {
           total: candidates.length,
         });
 
-        const url = `https://www.vinted.pl/catalog?catalog[]=2319&language_book_ids[]=6440&page=1&order=price_low_to_high&price_from=2&currency=PLN&search_text=${encodeURIComponent(searchText)}`;
+        const url = buildCatalogUrl(v, searchText);
 
         sendEvent({ type: "search_attempt", result: { id: book.id, title: book.plTitle, author: book.author, url, status: "pending", itemCount: 0 } });
 
         try {
-          const response = await withRetry(async () => axios.get(url, { httpsAgent, headers: vintedRequestHeaders(), timeout: 30000 }), 3, 4000);
+          const response = await withRetry(async () => axios.get(url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents), timeout: v.requestTimeoutMs }), v.retryAttempts, v.retryBackoffMs);
 
           const html = response.data;
           log.info(`Odpowiedź Vinted`, { title, chars: html.length, ...memMb() });
@@ -132,7 +142,7 @@ export class VintedSyncService {
             sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
             sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } } });
             // Blok to NIE „brak ofert": nie zapisujemy pustki ani scannedAt, by wznowienie ponowiło tę książkę.
-            await throttle();
+            await throttle(v.throttleMinMs, v.throttleJitterMs);
             continue;
           }
 
@@ -140,7 +150,7 @@ export class VintedSyncService {
             log.info(`Brak wyników na Vinted`, { searchText });
             sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } } });
             await this.persistEmptyIfNew(book, scannedAt, persistEnabled, "Marker 'Brak wyników' mimo zapisanych ofert — pomijam zapis (możliwy fałszywy marker)");
-            await throttle();
+            await throttle(v.throttleMinMs, v.throttleJitterMs);
             continue;
           }
 
@@ -176,7 +186,7 @@ export class VintedSyncService {
         }
 
         // Odstęp między żądaniami (z jitterem) — na KAŻDEJ ścieżce, by nie wywołać bloku.
-        await throttle();
+        await throttle(v.throttleMinMs, v.throttleJitterMs);
       }
 
       const wasCancelled = checkCancellation();
@@ -199,7 +209,11 @@ export class VintedSyncService {
     checkCancellation: () => boolean,
     params?: { cap?: number },
   ) {
-    const CAP = params?.cap && params.cap > 0 ? params.cap : Infinity;
+    // Cap: parametr żądania > knob konfiguracji (`sellerResolveCap`; 0 = bez limitu).
+    const cfg = await this.config.getConfig();
+    const v = cfg.vinted;
+    const capKnob = params?.cap && params.cap > 0 ? params.cap : v.sellerResolveCap;
+    const CAP = capKnob > 0 ? capKnob : Infinity;
     try {
       sendEvent({ type: "status", message: "Wczytywanie składowanych ofert z Notion..." });
       const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
@@ -238,7 +252,7 @@ export class VintedSyncService {
           fetched++;
           sendEvent({ type: "progress", message: `Sprzedawca: ${p.book.plTitle} (${fetched}/${target})`, current: fetched, total: target });
           try {
-            const response = await withRetry(async () => axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(), timeout: 30000 }), 3, 4000);
+            const response = await withRetry(async () => axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents), timeout: v.requestTimeoutMs }), v.retryAttempts, v.retryBackoffMs);
             const html = response.data;
             if (looksBlocked(html)) {
               log.warn("Vinted zablokował stronę oferty (sprzedawca, baza)", { url: offer.url });
@@ -254,7 +268,7 @@ export class VintedSyncService {
           } catch (err: any) {
             log.warn("Błąd ustalania sprzedawcy (baza)", { url: offer.url, error: err.message });
           }
-          await throttle();
+          await throttle(v.throttleMinMs, v.throttleJitterMs);
         }
         // Zapisz książkę raz, po ustaleniu jej ofert (mniej zapisów do Notion).
         if (dirty) {

--- a/src/__tests__/configSchema.test.ts
+++ b/src/__tests__/configSchema.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_CONFIG, mergeConfig, diffFromDefaults, parseStoredConfig } from "../configSchema";
+
+describe("configSchema.mergeConfig", () => {
+  it("returns exact defaults for empty/undefined/garbage input", () => {
+    expect(mergeConfig(undefined)).toEqual(DEFAULT_CONFIG);
+    expect(mergeConfig({})).toEqual(DEFAULT_CONFIG);
+    expect(mergeConfig("nonsense")).toEqual(DEFAULT_CONFIG);
+    expect(mergeConfig(null)).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("applies overrides and keeps the rest at defaults", () => {
+    const cfg = mergeConfig({ vinted: { resumeHours: 48, priceFrom: 5 } });
+    expect(cfg.vinted.resumeHours).toBe(48);
+    expect(cfg.vinted.priceFrom).toBe(5);
+    expect(cfg.vinted.throttleMinMs).toBe(DEFAULT_CONFIG.vinted.throttleMinMs);
+    expect(cfg.library).toEqual(DEFAULT_CONFIG.library);
+  });
+
+  it("clamps out-of-range numbers and rejects wrong types back to defaults", () => {
+    const cfg = mergeConfig({
+      vinted: { resumeHours: 999999, throttleMinMs: 1, retryAttempts: "trzy" as any, currency: "zloty" },
+      library: { concurrency: -5 },
+      sync: { dupAuthorThreshold: 2 },
+      ui: { shelfRowsPerPage: 0 },
+    });
+    expect(cfg.vinted.resumeHours).toBe(8760);
+    expect(cfg.vinted.throttleMinMs).toBe(500);
+    expect(cfg.vinted.retryAttempts).toBe(DEFAULT_CONFIG.vinted.retryAttempts);
+    expect(cfg.vinted.currency).toBe("PLN");
+    expect(cfg.library.concurrency).toBe(1);
+    expect(cfg.sync.dupAuthorThreshold).toBe(1);
+    expect(cfg.ui.shelfRowsPerPage).toBe(1);
+  });
+
+  it("cleans list overrides: drops junk entries, falls back to defaults when empty", () => {
+    const cfg = mergeConfig({
+      scraping: { userAgents: ["  UA-1  ", "", 42 as any] },
+      library: { branches: [{ id: "x", name: "Filia X", code: "9", sourceTag: "Tag" }, { id: "x", name: "dubel", code: "1", sourceTag: "T" }, { name: "bez id" } as any] },
+      sync: { awards: [] },
+    });
+    expect(cfg.scraping.userAgents).toEqual(["UA-1"]);
+    expect(cfg.library.branches).toEqual([{ id: "x", name: "Filia X", code: "9", sourceTag: "Tag" }]);
+    expect(cfg.sync.awards).toEqual(DEFAULT_CONFIG.sync.awards); // pusta lista → defaulty
+  });
+});
+
+describe("configSchema.diffFromDefaults", () => {
+  it("is empty for pure defaults and minimal for single overrides", () => {
+    expect(diffFromDefaults(mergeConfig(undefined))).toEqual({});
+    const diff = diffFromDefaults(mergeConfig({ vinted: { resumeHours: 48 } }));
+    expect(diff).toEqual({ vinted: { resumeHours: 48 } });
+  });
+
+  it("round-trips: merge(diff(cfg)) === cfg", () => {
+    const cfg = mergeConfig({
+      vinted: { resumeHours: 48, excludedSources: ["Posiadam"] },
+      library: { concurrency: 3 },
+      ui: { shelfRowsPerPage: 7 },
+    });
+    expect(mergeConfig(diffFromDefaults(cfg))).toEqual(cfg);
+  });
+});
+
+describe("configSchema.parseStoredConfig", () => {
+  it("parses valid JSON, tolerates empty/corrupt blobs", () => {
+    expect(parseStoredConfig('{"vinted":{"resumeHours":48}}')).toEqual({ vinted: { resumeHours: 48 } });
+    expect(parseStoredConfig("")).toBeNull();
+    expect(parseStoredConfig(null)).toBeNull();
+    expect(parseStoredConfig("{zepsuty json")).toBeNull();
+    expect(parseStoredConfig('"string"')).toBeNull();
+  });
+});

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -1,0 +1,267 @@
+/**
+ * Schemat konfiguracji aplikacji (knoby z zakładki „Konfiguracja").
+ *
+ * Moduł WSPÓŁDZIELONY frontend/backend (czysty TS, zero zależności Node) — frontend
+ * bierze stąd typy i DEFAULT_CONFIG (formularz + reset), backend merge/clamp/diff.
+ * Zasada przechowywania: w Notion (opis kolumny `AppConfig`) ląduje wyłącznie
+ * **diff od defaultów** — mały blob, a nowe knoby w kodzie dostają defaulty bez
+ * migracji. Wartości domyślne = dokładnie dotychczasowe zachowanie aplikacji.
+ */
+
+export interface LibraryBranch {
+  id: string;
+  name: string;
+  code: string;
+  /** Tag „Źródło" dopisywany po oznaczeniu książki jako dostępnej w tej filii. */
+  sourceTag: string;
+}
+
+export interface AwardPage {
+  name: string;
+  /** Tytuł strony w Archiwum Encyklopedii Fantastyki. */
+  title: string;
+}
+
+export interface AppConfig {
+  vinted: {
+    /** Okno „Kontynuuj": pomiń książki skanowane w ostatnich N h. */
+    resumeHours: number;
+    /** Minimalny odstęp między żądaniami (ms). */
+    throttleMinMs: number;
+    /** Losowy jitter dokładany do odstępu (ms). */
+    throttleJitterMs: number;
+    /** Timeout pojedynczego żądania HTTP (ms). NIE skracaj pochopnie — patrz backlog. */
+    requestTimeoutMs: number;
+    /** Liczba prób withRetry. */
+    retryAttempts: number;
+    /** Bazowy backoff między próbami (ms). */
+    retryBackoffMs: number;
+    /** Kategoria katalogu Vinted (2319 = beletrystyka). */
+    catalogId: number;
+    /** Filtr języka ofert (6440 = polski). */
+    languageId: number;
+    /** Dolny próg ceny (odcina oferty-śmieci). */
+    priceFrom: number;
+    currency: string;
+    /** Sortowanie wyników katalogu. */
+    order: string;
+    /** Limit ustaleń sprzedawców na przebieg; 0 = bez limitu. */
+    sellerResolveCap: number;
+    /** Tagi „Źródło" wykluczające książkę ze skanu Vinted. */
+    excludedSources: string[];
+  };
+  scraping: {
+    /** Pula User-Agentów (rotacja per żądanie). Odświeżaj co kilka miesięcy. */
+    userAgents: string[];
+  };
+  library: {
+    branches: LibraryBranch[];
+    /** Równoległość zapytań OPAC. */
+    concurrency: number;
+    /** Tagi wykluczające ze skanu bibliotecznego (celowo osobna lista — bez „Audioteka"). */
+    excludedSources: string[];
+  };
+  sync: {
+    /** Strony nagród na wiki (Hugo/Nebula/Locus) — źródło pełnej synchronizacji i diagnostyki. */
+    awards: AwardPage[];
+    /** Równoległość zapisów do Notion (bookSync / cycles). */
+    writeConcurrency: number;
+    /** Próg podobieństwa autorów przy wykrywaniu duplikatów (0–1). */
+    dupAuthorThreshold: number;
+    /** Próg podobieństwa tytułów (PL i oryginalnego) przy duplikatach (0–1). */
+    dupTitleThreshold: number;
+  };
+  ui: {
+    /** Liczba rzędów regału na stronę (Regał N/M). */
+    shelfRowsPerPage: number;
+  };
+}
+
+/** Głęboki partial konfiguracji (kształt nadpisań składowanych w Notion). */
+export type ConfigOverrides = {
+  [S in keyof AppConfig]?: Partial<AppConfig[S]>;
+};
+
+export const DEFAULT_CONFIG: AppConfig = {
+  vinted: {
+    resumeHours: 24,
+    throttleMinMs: 3000,
+    throttleJitterMs: 2000,
+    requestTimeoutMs: 30000,
+    retryAttempts: 3,
+    retryBackoffMs: 4000,
+    catalogId: 2319,
+    languageId: 6440,
+    priceFrom: 2,
+    currency: "PLN",
+    order: "price_low_to_high",
+    sellerResolveCap: 0,
+    excludedSources: ["Posiadam", "Przeczytane", "Audioteka", "Biblioteka", "Biblioteka 9"],
+  },
+  scraping: {
+    userAgents: [
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:154.0) Gecko/20100101 Firefox/154.0',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15',
+    ],
+  },
+  library: {
+    branches: [
+      { id: "felin", name: "Biblioteka Felin", code: "48", sourceTag: "Biblioteka" },
+      { id: "bronowice", name: "Biblioteka Bronowice", code: "7", sourceTag: "Biblioteka 9" },
+    ],
+    concurrency: 6,
+    excludedSources: ["Przeczytane", "Biblioteka", "Biblioteka 9", "Posiadam"],
+  },
+  sync: {
+    awards: [
+      { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
+      { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
+      { name: "Nagroda Locus", title: "Locus nagroda powieść" },
+    ],
+    writeConcurrency: 3,
+    dupAuthorThreshold: 0.85,
+    dupTitleThreshold: 0.9,
+  },
+  ui: {
+    shelfRowsPerPage: 5,
+  },
+};
+
+/* ==================== Normalizacja / clampy ==================== */
+
+const clamp = (v: unknown, min: number, max: number, dflt: number): number => {
+  const n = typeof v === "number" && isFinite(v) ? v : NaN;
+  return isNaN(n) ? dflt : Math.min(max, Math.max(min, n));
+};
+const clampInt = (v: unknown, min: number, max: number, dflt: number): number =>
+  Math.round(clamp(v, min, max, dflt));
+
+const cleanString = (v: unknown, dflt: string, maxLen = 120): string => {
+  const s = typeof v === "string" ? v.trim() : "";
+  return s.length > 0 && s.length <= maxLen ? s : dflt;
+};
+
+const cleanStringList = (v: unknown, dflt: string[], maxItems = 30, maxLen = 400): string[] => {
+  if (!Array.isArray(v)) return [...dflt];
+  const out = v
+    .filter((x): x is string => typeof x === "string")
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0 && x.length <= maxLen)
+    .slice(0, maxItems);
+  return out.length > 0 ? out : [...dflt];
+};
+
+const cleanBranches = (v: unknown, dflt: LibraryBranch[]): LibraryBranch[] => {
+  if (!Array.isArray(v)) return dflt.map((b) => ({ ...b }));
+  const out: LibraryBranch[] = [];
+  for (const raw of v.slice(0, 20)) {
+    if (!raw || typeof raw !== "object") continue;
+    const b = raw as Record<string, unknown>;
+    const id = cleanString(b.id, "", 40);
+    const name = cleanString(b.name, "", 80);
+    const code = cleanString(b.code, "", 20);
+    const sourceTag = cleanString(b.sourceTag, "", 60);
+    if (id && name && code && sourceTag && !out.some((x) => x.id === id)) {
+      out.push({ id, name, code, sourceTag });
+    }
+  }
+  return out.length > 0 ? out : dflt.map((b) => ({ ...b }));
+};
+
+const cleanAwards = (v: unknown, dflt: AwardPage[]): AwardPage[] => {
+  if (!Array.isArray(v)) return dflt.map((a) => ({ ...a }));
+  const out: AwardPage[] = [];
+  for (const raw of v.slice(0, 20)) {
+    if (!raw || typeof raw !== "object") continue;
+    const a = raw as Record<string, unknown>;
+    const name = cleanString(a.name, "", 80);
+    const title = cleanString(a.title, "", 120);
+    if (name && title && !out.some((x) => x.name === name)) out.push({ name, title });
+  }
+  return out.length > 0 ? out : dflt.map((a) => ({ ...a }));
+};
+
+/**
+ * Scala nadpisania z defaultami i clampuje każdą wartość do bezpiecznego zakresu.
+ * Nieznane pola są ignorowane, złe typy wracają do defaultu — funkcja NIGDY nie
+ * rzuca (uszkodzony blob w Notion nie może zabić aplikacji).
+ */
+export function mergeConfig(overrides?: unknown): AppConfig {
+  const o = (overrides && typeof overrides === "object" ? overrides : {}) as ConfigOverrides;
+  const d = DEFAULT_CONFIG;
+  const v = o.vinted ?? {};
+  const s = o.scraping ?? {};
+  const l = o.library ?? {};
+  const y = o.sync ?? {};
+  const u = o.ui ?? {};
+  return {
+    vinted: {
+      resumeHours: clampInt(v.resumeHours, 1, 8760, d.vinted.resumeHours),
+      throttleMinMs: clampInt(v.throttleMinMs, 500, 60000, d.vinted.throttleMinMs),
+      throttleJitterMs: clampInt(v.throttleJitterMs, 0, 60000, d.vinted.throttleJitterMs),
+      requestTimeoutMs: clampInt(v.requestTimeoutMs, 5000, 120000, d.vinted.requestTimeoutMs),
+      retryAttempts: clampInt(v.retryAttempts, 1, 6, d.vinted.retryAttempts),
+      retryBackoffMs: clampInt(v.retryBackoffMs, 500, 60000, d.vinted.retryBackoffMs),
+      catalogId: clampInt(v.catalogId, 1, 999999, d.vinted.catalogId),
+      languageId: clampInt(v.languageId, 1, 999999, d.vinted.languageId),
+      priceFrom: clamp(v.priceFrom, 0, 10000, d.vinted.priceFrom),
+      currency: /^[A-Z]{3}$/.test(String(v.currency ?? "")) ? String(v.currency) : d.vinted.currency,
+      order: cleanString(v.order, d.vinted.order, 60),
+      sellerResolveCap: clampInt(v.sellerResolveCap, 0, 10000, d.vinted.sellerResolveCap),
+      excludedSources: cleanStringList(v.excludedSources, d.vinted.excludedSources, 30, 64),
+    },
+    scraping: {
+      userAgents: cleanStringList(s.userAgents, d.scraping.userAgents, 30, 400),
+    },
+    library: {
+      branches: cleanBranches(l.branches, d.library.branches),
+      concurrency: clampInt(l.concurrency, 1, 12, d.library.concurrency),
+      excludedSources: cleanStringList(l.excludedSources, d.library.excludedSources, 30, 64),
+    },
+    sync: {
+      awards: cleanAwards(y.awards, d.sync.awards),
+      writeConcurrency: clampInt(y.writeConcurrency, 1, 10, d.sync.writeConcurrency),
+      dupAuthorThreshold: clamp(y.dupAuthorThreshold, 0.5, 1, d.sync.dupAuthorThreshold),
+      dupTitleThreshold: clamp(y.dupTitleThreshold, 0.5, 1, d.sync.dupTitleThreshold),
+    },
+    ui: {
+      shelfRowsPerPage: clampInt(u.shelfRowsPerPage, 1, 12, d.ui.shelfRowsPerPage),
+    },
+  };
+}
+
+const eq = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+
+/**
+ * Diff pełnej konfiguracji względem defaultów — do składowania trzymamy tylko to,
+ * co user faktycznie zmienił (mały blob + nowe knoby dziedziczą defaulty z kodu).
+ */
+export function diffFromDefaults(cfg: AppConfig): ConfigOverrides {
+  const out: ConfigOverrides = {};
+  for (const section of Object.keys(DEFAULT_CONFIG) as (keyof AppConfig)[]) {
+    const overrides: Record<string, unknown> = {};
+    const defSection = DEFAULT_CONFIG[section] as Record<string, unknown>;
+    const curSection = cfg[section] as Record<string, unknown>;
+    for (const key of Object.keys(defSection)) {
+      if (!eq(curSection[key], defSection[key])) overrides[key] = curSection[key];
+    }
+    if (Object.keys(overrides).length > 0) (out as Record<string, unknown>)[section] = overrides;
+  }
+  return out;
+}
+
+/** Parsuje blob z Notion; pusty/uszkodzony → null (mergeConfig dostanie undefined = same defaulty). */
+export function parseStoredConfig(raw: string | null | undefined): ConfigOverrides | null {
+  if (!raw || !raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as ConfigOverrides) : null;
+  } catch {
+    return null;
+  }
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -13,6 +13,7 @@ import { IntegrityService } from "./services/integrityService";
 import { LibraryCheckService } from "./services/libraryCheckService";
 import { VintedSyncService } from "./services/vintedSyncService";
 import { toSearchIndex } from "./services/bookSearchIndex";
+import { ConfigService } from "./services/configService";
 import { createLogger, classifyHttpError } from "./logger";
 import { SyncEvent } from "./src/types";
 
@@ -27,18 +28,20 @@ const log = createLogger("SyncManager");
 
 const notionAdapter = new NotionAdapter(process.env.NOTION_API_KEY!, process.env.NOTION_DATABASE_ID!);
 const wikiAdapter = new WikiAdapter();
-const duplicateSyncService = new DuplicateSyncService(notionAdapter, wikiAdapter);
-const bookSyncService = new BookSyncService(notionAdapter, wikiAdapter);
+/** Konfiguracja aplikacji (knoby) — defaulty + nadpisania z Notion; wstrzykiwana do serwisów. */
+export const configService = new ConfigService(notionAdapter);
+const duplicateSyncService = new DuplicateSyncService(notionAdapter, wikiAdapter, configService);
+const bookSyncService = new BookSyncService(notionAdapter, wikiAdapter, configService);
 const publisherSyncService = new PublisherSyncService(notionAdapter, wikiAdapter);
 const seriesSyncService = new SeriesSyncService(notionAdapter, wikiAdapter);
-const cyclesSyncService = new CyclesSyncService(notionAdapter, wikiAdapter);
+const cyclesSyncService = new CyclesSyncService(notionAdapter, wikiAdapter, configService);
 const lpSyncService = new LpSyncService(notionAdapter);
 const statsService = new StatsService(notionAdapter);
 const purificationService = new PurificationService(notionAdapter);
 const schemaValidationService = new SchemaValidationService(notionAdapter);
-const integrityService = new IntegrityService(notionAdapter, wikiAdapter);
-const libraryCheckService = new LibraryCheckService(notionAdapter);
-const vintedSyncService = new VintedSyncService(notionAdapter);
+const integrityService = new IntegrityService(notionAdapter, wikiAdapter, configService);
+const libraryCheckService = new LibraryCheckService(notionAdapter, configService);
+const vintedSyncService = new VintedSyncService(notionAdapter, configService);
 
 interface SyncTask {
   name: string;
@@ -193,12 +196,8 @@ class SyncManager {
       log.error("Diagnostics: Notion FAILED", report.notion);
     }
 
-    // 2. Wiki — pobranie każdej strony nagrody z osobna
-    const AWARDS = [
-      { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
-      { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
-      { name: "Nagroda Locus", title: "Locus nagroda powieść" },
-    ];
+    // 2. Wiki — pobranie każdej strony nagrody z osobna (lista z konfiguracji `sync.awards`)
+    const AWARDS = (await configService.getConfig()).sync.awards;
     for (const aw of AWARDS) {
       const t0 = Date.now();
       try {


### PR DESCRIPTION
Stage 1/2 of the logo-click "Konfiguracja" tab: hardcoded parameters become configurable knobs served from one store. Stage 2 (the tab UI) follows in a separate PR.

## Design
- **`src/configSchema.ts`** (shared FE/BE, pure TS): `AppConfig` types, `DEFAULT_CONFIG` (defaults = current behaviour 1:1), `mergeConfig` with per-knob clamps — never throws, corrupt input degrades to defaults; `diffFromDefaults`; `parseStoredConfig`.
- **Storage** — only the *diff from defaults*, as JSON in the **description of a dedicated `AppConfig` column**. A sentinel row was rejected: purification/integrity/LP iterate all rows and would touch it. Survives redeploys (Render's disk is ephemeral), zero new infrastructure.
- **`services/configService.ts`** — 30 s cache, 1900-char blob guard, resilient reads (Notion error / corrupt blob → defaults).
- **REST**: `GET /api/app-config`, `PUT /api/app-config` (input passes the clamps; effective config returned).

## Knobs wired
| Obszar | Knoby |
|---|---|
| Vinted scan + seller resolve | catalog URL (kategoria/język/cena od/waluta/sortowanie), request timeout, retry (próby/backoff), throttle (min/jitter), pula UA, wykluczone źródła, cap sprzedawców |
| Biblioteka | concurrency, wykluczone źródła, pula UA |
| Sync | strony nagród (usuwa 2 z 3 zduplikowanych kopii listy), writeConcurrency (bookSync/cycles), progi duplikatów (autor/tytuł) |
| UI | shelfRowsPerPage (konsument w PR-2) |

Excluded-source lists for Vinted and library stay deliberately separate (they differ by „Audioteka" — merging would silently change library-scan behaviour).

## Verification
- `npm run lint` clean · `npm test` **320/320** green (+7 configSchema: merge/clamp/diff round-trip/parse) · `npm run build` OK.
- Version bump `1.25.3` → `1.26.0` (minor); backlog updated.

Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_