### PR TITLE
Config tab UI: logo-click "Sanktuarium Kalibracji" + config-driven consumers

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.26.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.27.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.27.0** — **Zakładka „Sanktuarium Kalibracji" (frontend, CFG-PR2).** Klik w LOGO (nagłówek)
+  otwiera ukrytą zakładkę `admin` (ponowny klik wraca do statystyk; logo amber gdy aktywna).
+  `ConfigSection`: sekcje Vinted / pula UA / filie OPAC (edytor wierszy) / strony nagród (edytor)
+  / Zaawansowane (zwijane: timeout/retry, równoległości, progi duplikatów, rzędy regału, wykluczenia
+  biblioteki). Zapisz → PUT `/api/app-config`; „Domyślne" resetuje draft. `useAppConfig` (panel,
+  świeży GET) + `useEffectiveConfig` (konsumenci: cache modułowy, defaulty do czasu pobrania,
+  publish po zapisie). Konsumenci cfg: dropdown nagród (useSyncManager.awardOptions → SyncAwards),
+  filie w StatsSection, `pageSize` regału, `resumeHours` Vinted (checkbox + tooltip via prop).
+  `constants.ts` = fallbacki derywowane z DEFAULT_CONFIG (+`SYNC_ALL_AWARD`). UWAGA JSX: polskie
+  cudzysłowy „" w atrybutach stringowych psują parser — używać `{'...'}`.
 - **1.26.0** — **Konfiguracja aplikacji (backend, CFG-PR1).** Nowy współdzielony schemat
   `src/configSchema.ts` (AppConfig + DEFAULT_CONFIG + mergeConfig z clampami + diffFromDefaults +
   parseStoredConfig; defaulty = dotychczasowe zachowanie 1:1). **Składowanie: diff od defaultów

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.26.0",
+  "version": "1.27.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,12 @@ import { SearchSection } from "./components/SearchSection";
 import { BookshelfSection } from "./components/BookshelfSection";
 import { VintedSection } from "./components/VintedSection";
 import { LiturgySection } from "./components/LiturgySection";
+import { ConfigSection } from "./components/ConfigSection";
 import { TabNav, TabDef } from "./components/TabNav";
 import { ParticleBackground } from "./components/ParticleBackground";
 import { useSyncManager } from "./hooks/useSyncManager";
 
-type TabId = 'stats' | 'shelf' | 'search' | 'config' | 'vinted';
+type TabId = 'stats' | 'shelf' | 'search' | 'config' | 'vinted' | 'admin';
 
 const tabTransition = { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y: 0 }, exit: { opacity: 0, y: -20 }, transition: { duration: 0.3 } };
 
@@ -48,12 +49,19 @@ export default function App() {
           animate={{ opacity: 1, y: 0 }}
           className="flex flex-col md:flex-row items-center gap-8 text-center md:text-left"
         >
-          <motion.div
+          {/* Logo = wejście do Sanktuarium Kalibracji (zakładka admin, poza paskiem). */}
+          <motion.button
             whileHover={{ scale: 1.05, rotate: 5 }}
-            className="p-5 bg-slate-900/80 rounded-2xl border border-cyan-500/30 shadow-2xl shadow-cyan-500/20 backdrop-blur-xl"
+            whileTap={{ scale: 0.95 }}
+            onClick={() => setActiveTab(activeTab === 'admin' ? 'stats' : 'admin')}
+            className={`p-5 bg-slate-900/80 rounded-2xl border shadow-2xl backdrop-blur-xl cursor-pointer transition-colors ${
+              activeTab === 'admin' ? 'border-amber-500/50 shadow-amber-500/20' : 'border-cyan-500/30 shadow-cyan-500/20'
+            }`}
+            title="Sanktuarium Kalibracji (konfiguracja)"
+            aria-label="Otwórz konfigurację"
           >
-            <Database className="w-12 h-12 text-cyan-400" />
-          </motion.div>
+            <Database className={`w-12 h-12 ${activeTab === 'admin' ? 'text-amber-400' : 'text-cyan-400'}`} />
+          </motion.button>
           <div className="flex-1">
             <h1 className="text-4xl md:text-5xl font-bold tracking-tighter font-display mb-2 flex items-center justify-center md:justify-start gap-3 flex-wrap">
               <span className="bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]">
@@ -120,6 +128,8 @@ export default function App() {
             <motion.div key="search" {...tabTransition}><SearchSection /></motion.div>
           ) : activeTab === 'config' ? (
             <motion.div key="config" {...tabTransition} className="space-y-12"><LiturgySection sm={sm} /></motion.div>
+          ) : activeTab === 'admin' ? (
+            <motion.div key="admin" {...tabTransition}><ConfigSection /></motion.div>
           ) : (
             <motion.div key="vinted" {...tabTransition}><VintedSection /></motion.div>
           )}

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -5,6 +5,7 @@ import { useBooks } from "../hooks/useBooks";
 import { useMarkRead } from "../hooks/useMarkRead";
 import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
 import { ShelfSkin, SHELF_SKINS, skinClass, loadSkin, saveSkin } from "../utils/shelfSkin";
+import { useEffectiveConfig } from "../hooks/useAppConfig";
 import { Shelf } from "./shelf/Shelf";
 import { CoverCard } from "./shelf/CoverCard";
 import { ShelfFrame } from "./shelf/ShelfFrame";
@@ -18,6 +19,8 @@ export const BookshelfSection: React.FC = () => {
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
   const [skin, setSkin] = useState<ShelfSkin>(loadSkin);
+  // Liczba rzędów regału na stronę — knob `ui.shelfRowsPerPage`.
+  const rowsPerPage = useEffectiveConfig().ui.shelfRowsPerPage;
   useEffect(() => { saveSkin(skin); }, [skin]);
 
   // Zapis stanu „przeczytane" jest SERIALIZOWANY per książka (latest-wins). Backend
@@ -147,13 +150,13 @@ export const BookshelfSection: React.FC = () => {
               „Przeczytane" — drag&drop między nimi. Każdy paginowany (Regał N/M). */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <Shelf
-              shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={5}
+              shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={rowsPerPage}
               icon={<BookOpen className="w-4 h-4" />}
               books={toRead} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
             <Shelf
-              shelfId="read" title="Przeczytane" accent="emerald" pageSize={5}
+              shelfId="read" title="Przeczytane" accent="emerald" pageSize={rowsPerPage}
               icon={<CheckCircle2 className="w-4 h-4" />}
               books={read} dragging={!!dragging}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}

--- a/src/components/ConfigSection.tsx
+++ b/src/components/ConfigSection.tsx
@@ -1,0 +1,227 @@
+import React, { useState } from "react";
+import { motion } from "motion/react";
+import { Loader2, Save, RotateCcw, Wrench, ShoppingCart, Globe, LibraryBig, Trophy, ChevronDown, ChevronUp, Plus, Trash2, CheckCircle2 } from "lucide-react";
+import { AppConfig, DEFAULT_CONFIG, LibraryBranch, AwardPage } from "../configSchema";
+import { useAppConfig } from "../hooks/useAppConfig";
+
+/**
+ * Zakładka „Kalibracja" (wejście: klik w logo) — knoby konfiguracji aplikacji.
+ * Draft edytowany lokalnie; „Zapisz" wysyła PUT /api/app-config (backend clampuje
+ * i składuje diff od defaultów w Notion). Sekcja „Zaawansowane" zwijana.
+ */
+
+const inputCls = "w-full px-3 py-2 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-xl focus:outline-none focus:border-cyan-500/50 focus:ring-2 focus:ring-cyan-500/10 transition-all font-medium";
+const labelCls = "text-[11px] font-bold text-slate-400 uppercase tracking-widest";
+const hintCls = "text-[10px] text-slate-500 leading-snug";
+
+const Field: React.FC<{ label: string; hint?: string; children: React.ReactNode }> = ({ label, hint, children }) => (
+  <div className="space-y-1.5">
+    <label className={labelCls}>{label}</label>
+    {children}
+    {hint && <p className={hintCls}>{hint}</p>}
+  </div>
+);
+
+const NumberField: React.FC<{ label: string; hint?: string; value: number; step?: number; onChange: (v: number) => void }> = ({ label, hint, value, step, onChange }) => (
+  <Field label={label} hint={hint}>
+    <input type="number" step={step ?? 1} value={value} className={inputCls}
+      onChange={(e) => onChange(e.target.value === "" ? 0 : Number(e.target.value))} />
+  </Field>
+);
+
+const TextField: React.FC<{ label: string; hint?: string; value: string; onChange: (v: string) => void }> = ({ label, hint, value, onChange }) => (
+  <Field label={label} hint={hint}>
+    <input type="text" value={value} className={inputCls} onChange={(e) => onChange(e.target.value)} />
+  </Field>
+);
+
+/** Lista tekstowa (jeden wpis na linię) — wykluczone źródła, pula UA. */
+const ListField: React.FC<{ label: string; hint?: string; rows?: number; value: string[]; onChange: (v: string[]) => void }> = ({ label, hint, rows = 4, value, onChange }) => (
+  <Field label={label} hint={hint}>
+    <textarea
+      rows={rows}
+      className={`${inputCls} font-mono text-xs leading-relaxed resize-y custom-scrollbar`}
+      value={value.join("\n")}
+      onChange={(e) => onChange(e.target.value.split("\n"))}
+      onBlur={(e) => onChange(e.target.value.split("\n").map((s) => s.trim()).filter(Boolean))}
+    />
+  </Field>
+);
+
+const SectionCard: React.FC<{ icon: React.ReactNode; title: string; accent: string; children: React.ReactNode }> = ({ icon, title, accent, children }) => (
+  <div className="glass-card rounded-3xl p-6 space-y-5">
+    <h3 className={`flex items-center gap-2.5 text-sm font-display font-bold uppercase tracking-[0.2em] ${accent}`}>
+      {icon}{title}
+    </h3>
+    {children}
+  </div>
+);
+
+export const ConfigSection: React.FC = () => {
+  const { draft, setDraft, loading, saving, error, savedAt, save } = useAppConfig();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  if (loading || !draft) {
+    return (
+      <div className="glass-card rounded-3xl p-16 flex items-center justify-center gap-3 text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin text-cyan-400" />
+        <span className="text-sm uppercase tracking-widest font-bold">Wczytywanie kalibracji Cogitatora...</span>
+      </div>
+    );
+  }
+
+  // Pojedyncze settery per sekcja — draft jest zawsze pełnym AppConfig.
+  const upd = <S extends keyof AppConfig>(section: S, patch: Partial<AppConfig[S]>) =>
+    setDraft({ ...draft, [section]: { ...draft[section], ...patch } });
+
+  const setBranch = (i: number, patch: Partial<LibraryBranch>) => {
+    const branches = draft.library.branches.map((b, j) => (j === i ? { ...b, ...patch } : b));
+    upd("library", { branches });
+  };
+  const setAward = (i: number, patch: Partial<AwardPage>) => {
+    const awards = draft.sync.awards.map((a, j) => (j === i ? { ...a, ...patch } : a));
+    upd("sync", { awards });
+  };
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
+      {/* Nagłówek + akcje */}
+      <div className="glass-card rounded-3xl p-6 flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex-1">
+          <h2 className="text-xl font-bold font-display uppercase tracking-widest text-cyan-400 flex items-center gap-3">
+            <Wrench className="w-5 h-5" />
+            Sanktuarium Kalibracji
+          </h2>
+          <p className="text-xs text-slate-400 mt-1">
+            Knoby Machine Spirit. Wartości poza zakresem są przycinane; zapis trafia do Notion (opis kolumny <span className="font-mono text-cyan-300/80">AppConfig</span>) i przeżywa redeploy.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {savedAt && !saving && !error && (
+            <span className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-emerald-400">
+              <CheckCircle2 className="w-4 h-4" /> Zapisano
+            </span>
+          )}
+          <button
+            onClick={() => setDraft(JSON.parse(JSON.stringify(DEFAULT_CONFIG)))}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-xl border border-slate-700 text-slate-300 hover:border-amber-500/50 hover:text-amber-300 transition-all text-xs font-bold uppercase tracking-widest"
+            title="Przywróć wszystkie knoby do wartości domyślnych (zapisz, by utrwalić)"
+          >
+            <RotateCcw className="w-4 h-4" /> Domyślne
+          </button>
+          <button
+            onClick={save} disabled={saving}
+            className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-cyan-500/15 border border-cyan-500/40 text-cyan-300 hover:bg-cyan-500/25 disabled:opacity-50 transition-all text-xs font-bold uppercase tracking-widest shadow-[0_0_15px_rgba(34,211,238,0.15)]"
+          >
+            {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+            Zapisz
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="glass-card rounded-2xl p-4 border-red-500/30 bg-red-500/5 text-sm text-red-400 font-medium">{error}</div>
+      )}
+
+      {/* Vinted */}
+      <SectionCard icon={<ShoppingCart className="w-4 h-4" />} title="Skaner Vinted" accent="text-rose-400">
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <NumberField label={'Okno „Kontynuuj” (h)'} hint={'Pomiń książki skanowane w ostatnich N godzinach.'} value={draft.vinted.resumeHours} onChange={(v) => upd("vinted", { resumeHours: v })} />
+          <NumberField label="Odstęp min. (ms)" hint="Minimalna przerwa między żądaniami." value={draft.vinted.throttleMinMs} onChange={(v) => upd("vinted", { throttleMinMs: v })} />
+          <NumberField label="Jitter odstępu (ms)" hint="Losowy dodatek do przerwy (min + 0…jitter)." value={draft.vinted.throttleJitterMs} onChange={(v) => upd("vinted", { throttleJitterMs: v })} />
+          <NumberField label="Cena od" hint="Dolny próg ceny w katalogu (odcina śmieci)." value={draft.vinted.priceFrom} step={0.5} onChange={(v) => upd("vinted", { priceFrom: v })} />
+          <NumberField label="Kategoria katalogu" hint="2319 = beletrystyka." value={draft.vinted.catalogId} onChange={(v) => upd("vinted", { catalogId: v })} />
+          <NumberField label="ID języka" hint="6440 = polski." value={draft.vinted.languageId} onChange={(v) => upd("vinted", { languageId: v })} />
+          <TextField label="Waluta" value={draft.vinted.currency} onChange={(v) => upd("vinted", { currency: v.toUpperCase() })} />
+          <Field label="Sortowanie">
+            <select className={inputCls} value={draft.vinted.order} onChange={(e) => upd("vinted", { order: e.target.value })}>
+              <option value="price_low_to_high">Cena rosnąco</option>
+              <option value="price_high_to_low">Cena malejąco</option>
+              <option value="newest_first">Najnowsze</option>
+              <option value="relevance">Trafność</option>
+            </select>
+          </Field>
+          <NumberField label="Limit sprzedawców / przebieg" hint={'0 = bez limitu (rytuał „Ustal sprzedawców”).'} value={draft.vinted.sellerResolveCap} onChange={(v) => upd("vinted", { sellerResolveCap: v })} />
+        </div>
+        <ListField label="Źródła wykluczające ze skanu" hint={'Tag „Źródło” = książka pomijana. Jeden tag na linię.'}
+          value={draft.vinted.excludedSources} onChange={(v) => upd("vinted", { excludedSources: v })} />
+      </SectionCard>
+
+      {/* Pula UA */}
+      <SectionCard icon={<Globe className="w-4 h-4" />} title="Kamuflaż noosferyczny (User-Agent)" accent="text-cyan-400">
+        <ListField label="Pula User-Agentów" rows={7}
+          hint={'Rotacja per żądanie (Vinted + biblioteka). Odświeżaj co ~kwartał do bieżących wersji przeglądarek — przestarzałe UA ściągają wykrycie bota. Jeden wpis na linię.'}
+          value={draft.scraping.userAgents} onChange={(v) => upd("scraping", { userAgents: v })} />
+      </SectionCard>
+
+      {/* Filie biblioteczne */}
+      <SectionCard icon={<LibraryBig className="w-4 h-4" />} title="Filie biblioteczne (OPAC)" accent="text-indigo-400">
+        <div className="space-y-3">
+          {draft.library.branches.map((b, i) => (
+            <div key={i} className="grid grid-cols-[1fr_1.4fr_0.6fr_1fr_auto] gap-2 items-end">
+              <TextField label={i === 0 ? "ID" : ""} value={b.id} onChange={(v) => setBranch(i, { id: v })} />
+              <TextField label={i === 0 ? "Nazwa" : ""} value={b.name} onChange={(v) => setBranch(i, { name: v })} />
+              <TextField label={i === 0 ? "Kod f2" : ""} value={b.code} onChange={(v) => setBranch(i, { code: v })} />
+              <TextField label={i === 0 ? "Tag Źródło" : ""} value={b.sourceTag} onChange={(v) => setBranch(i, { sourceTag: v })} />
+              <button onClick={() => upd("library", { branches: draft.library.branches.filter((_, j) => j !== i) })}
+                className="p-2.5 mb-0.5 rounded-xl text-slate-500 hover:text-red-400 hover:bg-red-500/10 transition-all" title="Usuń filię">
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+          <button onClick={() => upd("library", { branches: [...draft.library.branches, { id: "", name: "", code: "", sourceTag: "" }] })}
+            className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-widest text-indigo-300 hover:text-indigo-200 transition-colors">
+            <Plus className="w-4 h-4" /> Dodaj filię
+          </button>
+          <p className={hintCls}>Kod f2 = wartość filtra filii w OPAC MBP Lublin. Tag „Źródło" jest dopisywany po oznaczeniu książki i wyklucza ją z kolejnych skanów.</p>
+        </div>
+      </SectionCard>
+
+      {/* Nagrody */}
+      <SectionCard icon={<Trophy className="w-4 h-4" />} title="Strony nagród (Archiwum Encyklopedii)" accent="text-amber-400">
+        <div className="space-y-3">
+          {draft.sync.awards.map((a, i) => (
+            <div key={i} className="grid grid-cols-[1fr_1.6fr_auto] gap-2 items-end">
+              <TextField label={i === 0 ? "Nazwa nagrody" : ""} value={a.name} onChange={(v) => setAward(i, { name: v })} />
+              <TextField label={i === 0 ? "Tytuł strony wiki" : ""} value={a.title} onChange={(v) => setAward(i, { title: v })} />
+              <button onClick={() => upd("sync", { awards: draft.sync.awards.filter((_, j) => j !== i) })}
+                className="p-2.5 mb-0.5 rounded-xl text-slate-500 hover:text-red-400 hover:bg-red-500/10 transition-all" title="Usuń nagrodę">
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+          <button onClick={() => upd("sync", { awards: [...draft.sync.awards, { name: "", title: "" }] })}
+            className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-widest text-amber-300 hover:text-amber-200 transition-colors">
+            <Plus className="w-4 h-4" /> Dodaj nagrodę
+          </button>
+          <p className={hintCls}>Lista zasila dropdown „Liturgie Synchronizacji", pełną synchronizację („Wszystkie Nagrody") i diagnostykę.</p>
+        </div>
+      </SectionCard>
+
+      {/* Zaawansowane */}
+      <div className="glass-card rounded-3xl p-6 space-y-5">
+        <button onClick={() => setShowAdvanced(!showAdvanced)}
+          className="w-full flex items-center justify-between text-sm font-display font-bold uppercase tracking-[0.2em] text-purple-400">
+          <span className="flex items-center gap-2.5"><Wrench className="w-4 h-4" />Zaawansowane</span>
+          {showAdvanced ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+        </button>
+        {showAdvanced && (
+          <div className="space-y-5">
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              <NumberField label="Vinted: timeout (ms)" hint="NIE skracaj pochopnie — ucinanie wolnych odpowiedzi Cloudflare = zero trafień." value={draft.vinted.requestTimeoutMs} onChange={(v) => upd("vinted", { requestTimeoutMs: v })} />
+              <NumberField label="Vinted: liczba prób" value={draft.vinted.retryAttempts} onChange={(v) => upd("vinted", { retryAttempts: v })} />
+              <NumberField label="Vinted: backoff (ms)" value={draft.vinted.retryBackoffMs} onChange={(v) => upd("vinted", { retryBackoffMs: v })} />
+              <NumberField label="Biblioteka: równoległość" hint="Jednoczesne zapytania OPAC." value={draft.library.concurrency} onChange={(v) => upd("library", { concurrency: v })} />
+              <NumberField label="Sync: równoległość zapisów" hint="pLimit zapisów do Notion (nagrody/cykle)." value={draft.sync.writeConcurrency} onChange={(v) => upd("sync", { writeConcurrency: v })} />
+              <NumberField label="Regał: rzędy na stronę" value={draft.ui.shelfRowsPerPage} onChange={(v) => upd("ui", { shelfRowsPerPage: v })} />
+              <NumberField label="Duplikaty: próg autora" hint="0.5–1; wyżej = mniej czułe." value={draft.sync.dupAuthorThreshold} step={0.01} onChange={(v) => upd("sync", { dupAuthorThreshold: v })} />
+              <NumberField label="Duplikaty: próg tytułu" hint="0.5–1; dotyczy tytułu PL i oryginalnego." value={draft.sync.dupTitleThreshold} step={0.01} onChange={(v) => upd("sync", { dupTitleThreshold: v })} />
+            </div>
+            <ListField label="Biblioteka: źródła wykluczające" hint={'Osobna lista od Vinted (celowo bez „Audioteka” — audiobook nie wyklucza wypożyczenia papieru).'}
+              value={draft.library.excludedSources} onChange={(v) => upd("library", { excludedSources: v })} />
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/LiturgySection.tsx
+++ b/src/components/LiturgySection.tsx
@@ -47,6 +47,7 @@ export const LiturgySection: React.FC<{ sm: ReturnType<typeof useSyncManager> }>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <SyncAwards
           sync={sync}
+          awardOptions={sm.awardOptions}
           integritySync={integritySync}
           handleAwardChange={handleAwardChange}
           handleSync={handleSync}

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -11,9 +11,11 @@ import { AuthorProgressItem } from "./stats/AuthorProgressItem";
 import { IdentifiedLibraryItem } from "./stats/IdentifiedLibraryItem";
 import { OwnedUnreadItem } from "./stats/OwnedUnreadItem";
 import { AwardCoverageGrid } from "./stats/AwardCoverageGrid";
-import { LIBRARY_BRANCHES } from "../constants";
+import { useEffectiveConfig } from "../hooks/useAppConfig";
 
 export const StatsSection: React.FC = () => {
+  // Filie biblioteczne z konfiguracji (fallback: defaulty do czasu pobrania).
+  const branches = useEffectiveConfig().library.branches;
   const { stats, loading, error, fetchStats, addBookToLibrarySection } = useStats();
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
   const { markingId, markedIds, markAsRead } = useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats });
@@ -210,7 +212,7 @@ export const StatsSection: React.FC = () => {
             </h3>
             
             <button
-              onClick={() => checkAllLibraries(LIBRARY_BRANCHES)}
+              onClick={() => checkAllLibraries(branches)}
               disabled={checkingLibrary !== null}
               className="px-4 py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-xl border border-blue-500/30 text-xs font-bold uppercase tracking-widest transition-all disabled:opacity-50 flex items-center gap-2"
             >
@@ -232,7 +234,7 @@ export const StatsSection: React.FC = () => {
           )}
 
           <div className="space-y-6 max-h-[500px] overflow-y-auto pr-2 custom-scrollbar">
-            {LIBRARY_BRANCHES.map((library) => (
+            {branches.map((library) => (
               <IdentifiedLibraryItem 
                 key={library.id}
                 library={library}

--- a/src/components/SyncAwards.tsx
+++ b/src/components/SyncAwards.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { BookOpen, Loader2, RefreshCw } from "lucide-react";
 import { motion } from "motion/react";
 import { useSync } from "../hooks/useSync";
-import { PREDEFINED_AWARDS } from "../constants";
+import { AwardPage } from "../configSchema";
 import { IntegrityCheckCard } from "./IntegrityCheckCard";
 
 interface SyncAwardsProps {
   sync: ReturnType<typeof useSync>;
+  /** Lista nagród z konfiguracji (+ „Wszystkie Nagrody") — dropdown. */
+  awardOptions: AwardPage[];
   integritySync: ReturnType<typeof useSync>;
   handleAwardChange: (name: string) => void;
   handleSync: () => void;
@@ -16,6 +18,7 @@ interface SyncAwardsProps {
 
 export const SyncAwards: React.FC<SyncAwardsProps> = ({ 
   sync, 
+  awardOptions,
   integritySync,
   handleAwardChange, 
   handleSync, 
@@ -46,7 +49,7 @@ export const SyncAwards: React.FC<SyncAwardsProps> = ({
             disabled={syncState.loading}
             className="w-full bg-slate-950 border border-slate-800 rounded-2xl px-4 py-3 text-slate-200 focus:ring-2 focus:ring-cyan-500/50 focus:border-cyan-500/50 outline-none transition-all disabled:opacity-50 font-medium"
           >
-            {PREDEFINED_AWARDS.map(a => (
+            {awardOptions.map(a => (
               <option key={a.name} value={a.name}>{a.name}</option>
             ))}
             <option value="Inna">Inna (wpisz poniżej)</option>

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { VintedResult, VintedSearchAttempt } from "../../hooks/useVintedCheck";
 import { useVintedResolveSellers } from "../../hooks/useVintedResolveSellers";
 import { useVintedStored } from "../../hooks/useVintedStored";
-import { VintedScanControls, RESUME_HOURS } from "./vinted/VintedScanControls";
+import { VintedScanControls } from "./vinted/VintedScanControls";
+import { useEffectiveConfig } from "../../hooks/useAppConfig";
 import { VintedScanProgress } from "./vinted/VintedScanProgress";
 import { VintedDebugLog } from "./vinted/VintedDebugLog";
 import { VintedResolveStatus } from "./vinted/VintedResolveStatus";
@@ -20,6 +21,8 @@ interface VintedCheckItemProps {
 
 export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
   const [showLogs, setShowLogs] = React.useState(false);
+  // Okno „Kontynuuj" z konfiguracji (knob `vinted.resumeHours`).
+  const resumeHours = useEffectiveConfig().vinted.resumeHours;
   // Wznawianie: domyślnie pomijamy książki skanowane < RESUME_HOURS h (bieżąca partia),
   // resztę skanujemy od najstarszych — kontynuacja przerwanego przebiegu, nie od zera.
   const [resumeScan, setResumeScan] = React.useState(true);
@@ -36,13 +39,14 @@ export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searc
     if (isChecking) { onStop(); return; }
     // Wyjdź z widoku bazy, żeby świeże wyniki skanu były widoczne (nie pinowane do stored).
     clearStored();
-    onCheck(resumeScan ? { skipScannedWithinHours: RESUME_HOURS } : undefined);
+    onCheck(resumeScan ? { skipScannedWithinHours: resumeHours } : undefined);
   };
   const onResolveToggle = () => { if (isResolving) { stopResolve(); return; } clearStored(); runResolve(); };
 
   return (
     <div className="space-y-8">
       <VintedScanControls
+        resumeHours={resumeHours}
         isChecking={isChecking} isResolving={isResolving} isLoadingStored={isLoadingStored}
         usingStored={usingStored} hasAttempts={searchAttempts.length > 0}
         resumeScan={resumeScan} setResumeScan={setResumeScan}

--- a/src/components/stats/vinted/VintedScanControls.tsx
+++ b/src/components/stats/vinted/VintedScanControls.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { Loader2, Search, Bug, Database, HardDriveDownload, Trash2 } from "lucide-react";
 import { RitualButton } from "../RitualButton";
 
-/** Okno „Kontynuuj": pomiń książki skanowane w ostatnich N h. Jedno źródło — importuje je też VintedCheckItem. */
-export const RESUME_HOURS = 24;
 
 interface Props {
+  /** Okno „Kontynuuj" (h) z konfiguracji — tylko do tooltipa. */
+  resumeHours: number;
   isChecking: boolean;
   isResolving: boolean;
   isLoadingStored: boolean;
@@ -23,6 +23,7 @@ interface Props {
 
 /** Nagłówek skanera + rytuały (skan / identyfikacja handlarzy / przywołanie z bazy). */
 export const VintedScanControls: React.FC<Props> = ({
+  resumeHours,
   isChecking, isResolving, isLoadingStored, usingStored, hasAttempts,
   resumeScan, setResumeScan, showLogs, setShowLogs,
   onScanToggle, onResolveToggle, onLoadStored, onClearStored,
@@ -38,7 +39,7 @@ export const VintedScanControls: React.FC<Props> = ({
         {!isChecking && (
           <label
             className="flex items-center gap-1.5 text-[11px] font-bold text-slate-400 cursor-pointer select-none"
-            title={`Pomiń książki skanowane w ostatnich ${RESUME_HOURS} h (bieżąca partia); resztę skanuj OD NAJSTARSZYCH — kontynuuje przerwany przebieg i odświeża najstarsze. Odznacz, by skanować wszystko od nowa (też od najstarszych).`}
+            title={`Pomiń książki skanowane w ostatnich ${resumeHours} h (bieżąca partia); resztę skanuj OD NAJSTARSZYCH — kontynuuje przerwany przebieg i odświeża najstarsze. Odznacz, by skanować wszystko od nowa (też od najstarszych).`}
           >
             <input type="checkbox" checked={resumeScan} onChange={(e) => setResumeScan(e.target.checked)} className="accent-cyan-500 w-3.5 h-3.5" />
             Kontynuuj

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,15 +1,14 @@
-export const PREDEFINED_AWARDS = [
-  { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
-  { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
-  { name: "Nagroda Locus", title: "Locus nagroda powieść" },
-  { name: "Wszystkie Nagrody", title: "Wszystkie" },
-];
+import { DEFAULT_CONFIG } from "./configSchema";
 
-// sourceTag = znacznik „Źródło" dopisywany po kliknięciu na znalezionej pozycji.
-// Jest to zarazem tag wykluczający pozycję z kolejnych skanów (zob.
-// services/libraryCheckService.ts — lista `excluded`), więc oznaczenie książki
-// jednocześnie usuwa ją z puli kandydatów danej filii.
-export const LIBRARY_BRANCHES = [
-  { id: "felin", name: "Biblioteka Felin", code: "48", sourceTag: "Biblioteka" },
-  { id: "bronowice", name: "Biblioteka Bronowice", code: "7", sourceTag: "Biblioteka 9" }
-];
+/**
+ * Stałe-fallbacki DERYWOWANE z DEFAULT_CONFIG (jedno źródło prawdy w configSchema).
+ * Żywe wartości pochodzą z konfiguracji (`useEffectiveConfig` → GET /api/app-config);
+ * te listy służą jako stan początkowy zanim odpowiedź dotrze.
+ */
+
+/** Pseudo-nagroda pełnej synchronizacji — opcja UI, nie strona wiki. */
+export const SYNC_ALL_AWARD = { name: "Wszystkie Nagrody", title: "Wszystkie" };
+
+export const PREDEFINED_AWARDS = [...DEFAULT_CONFIG.sync.awards, SYNC_ALL_AWARD];
+
+export const LIBRARY_BRANCHES = DEFAULT_CONFIG.library.branches;

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from "react";
+import { AppConfig, DEFAULT_CONFIG, mergeConfig } from "../configSchema";
+
+/**
+ * Konfiguracja aplikacji po stronie frontu.
+ *
+ * - `useEffectiveConfig` — dla KONSUMENTÓW (regał, skanery, nagrody): jedno pobranie
+ *   na sesję (cache modułowy współdzielony między hookami), `DEFAULT_CONFIG` do czasu
+ *   odpowiedzi, brak stanów błędu (konsument zawsze dostaje działającą konfigurację).
+ * - `useAppConfig` — dla PANELU (zakładka Konfiguracja): świeże pobranie, edycja
+ *   lokalna, zapis PUT; po zapisie unieważnia cache konsumentów.
+ */
+
+let cachedConfig: AppConfig | null = null;
+let inflight: Promise<AppConfig> | null = null;
+const listeners = new Set<(cfg: AppConfig) => void>();
+
+async function fetchConfig(force = false): Promise<AppConfig> {
+  const res = await fetch(`/api/app-config${force ? "?force=1" : ""}`);
+  if (!res.ok) throw new Error(`Błąd serwera: ${res.status}`);
+  // mergeConfig = pas bezpieczeństwa po stronie klienta (i clamp starych odpowiedzi).
+  return mergeConfig(await res.json());
+}
+
+function loadShared(): Promise<AppConfig> {
+  if (cachedConfig) return Promise.resolve(cachedConfig);
+  if (!inflight) {
+    inflight = fetchConfig()
+      .then((cfg) => {
+        cachedConfig = cfg;
+        listeners.forEach((l) => l(cfg));
+        return cfg;
+      })
+      .catch(() => DEFAULT_CONFIG) // sieć/500 → defaulty; nie zapisujemy do cache, kolejny mount spróbuje znów
+      .finally(() => { inflight = null; });
+  }
+  return inflight;
+}
+
+/** Po zapisie w panelu: podmień cache i powiadom zamontowanych konsumentów. */
+export function publishEffectiveConfig(cfg: AppConfig): void {
+  cachedConfig = cfg;
+  listeners.forEach((l) => l(cfg));
+}
+
+/** Efektywna konfiguracja dla konsumentów — defaulty do czasu pobrania, potem live. */
+export function useEffectiveConfig(): AppConfig {
+  const [cfg, setCfg] = useState<AppConfig>(cachedConfig ?? DEFAULT_CONFIG);
+  useEffect(() => {
+    const listener = (c: AppConfig) => setCfg(c);
+    listeners.add(listener);
+    loadShared().then((c) => setCfg(c));
+    return () => { listeners.delete(listener); };
+  }, []);
+  return cfg;
+}
+
+/** Stan panelu konfiguracji: draft do edycji + load/save. */
+export function useAppConfig() {
+  const [draft, setDraft] = useState<AppConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setDraft(await fetchConfig(true));
+    } catch (e: any) {
+      setError(e?.message || "Nie udało się pobrać konfiguracji.");
+      setDraft(mergeConfig(undefined));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const save = useCallback(async () => {
+    if (!draft) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/app-config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(draft),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(body?.error || `Błąd serwera: ${res.status}`);
+      const effective = mergeConfig(body);
+      setDraft(effective);
+      publishEffectiveConfig(effective);
+      setSavedAt(Date.now());
+    } catch (e: any) {
+      setError(e?.message || "Nie udało się zapisać konfiguracji.");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft]);
+
+  return { draft, setDraft, loading, saving, error, savedAt, load, save };
+}

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useSync } from "./useSync";
-import { PREDEFINED_AWARDS } from "../constants";
+import { PREDEFINED_AWARDS, SYNC_ALL_AWARD } from "../constants";
+import { useEffectiveConfig } from "./useAppConfig";
 
 /**
  * Orkiestracja wszystkich rytuałów synchronizacji po stronie frontendu.
@@ -12,6 +13,11 @@ import { PREDEFINED_AWARDS } from "../constants";
  */
 export function useSyncManager() {
   const [fullSyncResults, setFullSyncResults] = useState<any[] | null>(null);
+
+  // Lista nagród z konfiguracji (+ pseudo-opcja pełnej synchronizacji);
+  // PREDEFINED_AWARDS służy tylko jako stan początkowy do czasu pobrania.
+  const cfg = useEffectiveConfig();
+  const awardOptions = [...cfg.sync.awards, SYNC_ALL_AWARD];
 
   const sync = useSync("/api/sync", "/api/sync/stop", {
     awardName: PREDEFINED_AWARDS[0].name,
@@ -48,7 +54,7 @@ export function useSyncManager() {
   // Przyjmuje samą NAZWĘ nagrody (nie zdarzenie DOM) — manager pozostaje
   // niezależny od prezentacji (parsowanie <select> zostaje w komponencie).
   const handleAwardChange = (selectedName: string) => {
-    const predefined = PREDEFINED_AWARDS.find(a => a.name === selectedName);
+    const predefined = awardOptions.find(a => a.name === selectedName);
 
     sync.setState(prev => ({
       ...prev,
@@ -129,6 +135,8 @@ export function useSyncManager() {
   return {
     // Instancje rytuałów (przekazywane do komponentów prezentacyjnych)
     sync, publisherSync, seriesSync, cyclesSync, lpSync, integritySync, duplicatesSync, purifySync, schemaSync,
+    // Lista nagród z konfiguracji (dropdown w SyncAwards)
+    awardOptions,
     // Stan zbiorczy
     syncs, anyError, isAnySyncLoading,
     fullSyncResults, clearFullSyncResults: () => setFullSyncResults(null),


### PR DESCRIPTION
Stage 2/2 of the app-config feature (backend landed in #178). The logo is now the door to the knobs.

## Changes
- **Entry** — clicking the header logo opens a hidden `admin` tab („Sanktuarium Kalibracji"); clicking again returns to stats. The logo glows amber while active. The tab is not in the tab strip (admin-only surface).
- **`ConfigSection`** — glass-card sections: Skaner Vinted (okno Kontynuuj, throttle, cena od, kategoria/język, waluta, sortowanie, cap sprzedawców, wykluczenia), Kamuflaż noosferyczny (pula UA, jeden wpis na linię), Filie biblioteczne (edytor wierszy: id / nazwa / kod f2 / tag Źródło, dodawanie i usuwanie), Strony nagród (edytor wierszy), Zaawansowane (zwijane: timeout/retry Vinted z ostrzeżeniem, równoległości, progi duplikatów, rzędy regału, wykluczenia biblioteki). Zapisz → `PUT /api/app-config`; Domyślne → reset draftu.
- **Hooks** — `useAppConfig` (panel: fresh GET + save) and `useEffectiveConfig` (consumers: module-level cache, `DEFAULT_CONFIG` until fetched, live update published after a save).
- **Config-driven consumers** — award dropdown (`useSyncManager.awardOptions` → `SyncAwards` prop), library branches (`StatsSection`), shelf `pageSize` (`BookshelfSection`), Vinted `resumeHours` (constant → prop into `VintedScanControls`).
- `constants.ts` now derives fallbacks from `DEFAULT_CONFIG` (single source of truth).

## Verification
- Visual: headless-Chromium screenshot of the full tab (all sections + advanced expanded) — renders correctly in the app's glassmorphism style.
- `npm run lint` clean · `npm test` **320/320** green · `npm run build` OK.
- Version bump `1.26.0` → `1.27.0` (minor); backlog updated.

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_