### PR TITLE
Shelf precise DnD plumbing: ShelfOrder column, mapper, API endpoint

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.27.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.27.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.27.1** — **Precyzyjny drag&drop na regale — plumbing (DND-PR1).** Kolumna `ShelfOrder`
+  (number, tworzona przy pierwszym zapisie): rzadki, ręczny klucz porządku w skali ułamkowych lat —
+  utrwalamy TYLKO ręcznie wstawione książki, reszta zostaje na deterministycznym auto-układzie
+  (rok → dekada → fizyka). Mapper/typy (`NotionBook.shelfOrder`, `BookIndexEntry.shelfOrder`),
+  indeks wyszukiwarki, adapter `setShelfOrders` (sekwencyjnie, partie małe), `POST /api/shelf-order`
+  (limit 40 wpisów, walidacja). Bez zmiany zachowania — sort i UI dropu w następnym PR.
 - **1.27.0** — **Zakładka „Sanktuarium Kalibracji" (frontend, CFG-PR2).** Klik w LOGO (nagłówek)
   otwiera ukrytą zakładkę `admin` (ponowny klik wraca do statystyk; logo amber gdy aktywna).
   `ConfigSection`: sekcje Vinted / pula UA / filie OPAC (edytor wierszy) / strony nagród (edytor)

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -206,6 +206,30 @@ export const markAsRead = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ * Zapis ręcznych kluczy porządku regału (precyzyjny drag&drop). Partia mała
+ * (1 wpis + ewentualna renumeracja remisów roku) — twardy limit 40 chroni Notion.
+ */
+export const updateShelfOrders = async (req: Request, res: Response) => {
+  try {
+    const raw = req.body?.orders;
+    if (!Array.isArray(raw) || raw.length === 0) return res.status(400).json({ error: "Brak wpisów orders." });
+    if (raw.length > 40) return res.status(400).json({ error: "Za duża partia (limit 40 wpisów)." });
+    const entries: { pageId: string; order: number }[] = [];
+    for (const e of raw) {
+      if (!e || typeof e.pageId !== "string" || !e.pageId || typeof e.order !== "number" || !isFinite(e.order)) {
+        return res.status(400).json({ error: "Każdy wpis wymaga pageId (string) i skończonego order (number)." });
+      }
+      entries.push({ pageId: e.pageId, order: e.order });
+    }
+    await syncManager.setShelfOrders(entries);
+    res.json({ success: true, updated: entries.length });
+  } catch (error: any) {
+    log.error("Shelf order error", { message: error.message });
+    res.status(500).json({ error: error.message || "Nie udało się zapisać porządku regału." });
+  }
+};
+
 export const unmarkAsRead = async (req: Request, res: Response) => {
   try {
     const { pageId, tag } = req.body;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -113,6 +113,24 @@ export class NotionAdapter {
     }
   }
 
+  /**
+   * Zapis ręcznych kluczy porządku regału (kolumna „ShelfOrder", number) dla partii
+   * książek — precyzyjny drag&drop wysyła 1 wpis (wstawiona), a przy renumeracji
+   * remisów kilka. Kolumna tworzona przy pierwszym zapisie. Sekwencyjnie (nie
+   * równolegle) — partie są małe, a rate-limit Notion wrażliwy na bursty.
+   */
+  async setShelfOrders(entries: { pageId: string; order: number }[]): Promise<void> {
+    await this.init();
+    await this.createColumnIfNeeded("ShelfOrder", "number");
+    for (const e of entries) {
+      await withRetry(() => this.notion.pages.update({
+        page_id: e.pageId,
+        properties: { "ShelfOrder": { number: e.order } },
+      }));
+    }
+    this.invalidateBooksCache();
+  }
+
   /** Nazwa kolumny-nośnika konfiguracji aplikacji (blob JSON żyje w jej OPISIE, nie w wierszach). */
   private static readonly APP_CONFIG_COLUMN = "AppConfig";
 

--- a/notionMapper.ts
+++ b/notionMapper.ts
@@ -72,6 +72,10 @@ export function mapPageToBook(page: NotionPage): NotionBook {
   // Blob składowanych wyników Vinted (rich_text; wiele segmentów jest sklejanych w getPlainText).
   const vintedData = getPlainText(getProp(props, "VintedData")) || undefined;
 
+  // Ręczny klucz porządku na regale (number; brak/null → undefined = sort po roku).
+  const shelfOrderProp = getProp(props, "ShelfOrder");
+  const shelfOrder = shelfOrderProp?.type === "number" && typeof shelfOrderProp.number === "number" ? shelfOrderProp.number : undefined;
+
   return {
     id: page.id,
     plTitle,
@@ -86,6 +90,7 @@ export function mapPageToBook(page: NotionPage): NotionBook {
     zrodlo,
     plTitleRichText,
     origTitleRichText,
-    vintedData
+    vintedData,
+    shelfOrder
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.27.0",
+      "version": "1.27.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.27.0",
+  "version": "1.27.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -35,6 +35,7 @@ router.post("/sync-duplicates", syncController.runDuplicateCheck);
 router.post("/sync-integrity", syncController.runIntegrityCheck);
 router.post("/mark-as-read", syncController.markAsRead);
 router.post("/unmark-as-read", syncController.unmarkAsRead);
+router.post("/shelf-order", syncController.updateShelfOrders);
 router.post("/vinted-check", syncController.checkVintedAvailability);
 router.post("/vinted-check/stop", syncController.stopVintedCheck);
 router.post("/vinted-resolve-sellers", syncController.resolveVintedSellers);

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -20,5 +20,6 @@ export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
       zrodlo: b.zrodlo || [],
       series: b.currentSeria || "",
       partOfCycle: b.currentCzesccyklu ?? false,
+      shelfOrder: b.shelfOrder,
     }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,8 @@ export interface NotionBook {
   origTitleRichText?: NotionRichTextItem[];
   /** Blob JSON składowanych wyników Vinted (pole „VintedData") — parsowany przez vintedStore. */
   vintedData?: string;
+  /** Ręczny klucz porządku na regale (kolumna „ShelfOrder"; skala ułamkowych lat). */
+  shelfOrder?: number;
 }
 
 /**
@@ -69,6 +71,8 @@ export interface BookIndexEntry {
   zrodlo: string[];
   series: string;
   partOfCycle: boolean;
+  /** Ręczny klucz porządku na regale (precyzyjny drag&drop); brak → sort po roku. */
+  shelfOrder?: number;
 }
 
 export interface SyncState {

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -161,6 +161,11 @@ class SyncManager {
     return await this.notion.removeTagFromMultiSelect(pageId, "Źródło", tag);
   }
 
+  /** Zapis ręcznych kluczy porządku regału (precyzyjny drag&drop). */
+  async setShelfOrders(entries: { pageId: string; order: number }[]) {
+    return await this.notion.setShelfOrders(entries);
+  }
+
   /** Odczyt składowanych wyników Vinted (kafelki/paczki z bazy — bez re-scrape). */
   async getVintedStored() {
     return await vintedSyncService.getStoredData();


### PR DESCRIPTION
Stage 1/2 of precise shelf drag&drop (insert at a chosen spot within a decade; the current global drop stays).

## Design
The shelf layout stays **fully derived from data** — no full-layout registration. We persist only a **sparse manual order key** (`ShelfOrder`, number, fractional-year scale) for books the user actually repositions. Insertion between neighbours = midpoint key (one Notion write); year ties will renumber a small group. Books without a key keep the deterministic year-sort auto-layout.

## Changes (plumbing only — no behaviour change)
- `NotionBook.shelfOrder` / `BookIndexEntry.shelfOrder`; mapper reads the „ShelfOrder" number column; search index passes it through.
- Adapter `setShelfOrders(entries)` — creates the column on first write; sequential updates (small batches, Notion's burst-sensitive rate limit).
- `POST /api/shelf-order { orders: [{pageId, order}] }` — validation + hard 40-entry cap.

Stage 2/2 (next PR): sort integration (decade → key → year), gap hit-testing with a neon insertion caret, decade validation highlight, config knob.

## Verification
- `npm run lint` clean · `npm test` **320/320** green · `npm run build` OK.
- Version bump `1.27.0` → `1.27.1`; backlog updated.

Refs #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_