### PR TITLE
Shelf precise DnD: insertion caret, decade validation, order persistence

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.27.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.28.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.27.1** — **Precyzyjny drag&drop na regale — plumbing (DND-PR1).** Kolumna `ShelfOrder`
+- **1.28.0** — **Precyzyjny drag&drop na regale (DND-PR2).** Sort półek: `byShelfPosition`
+  (dekada → `effShelfKey` → tytuł); `effShelfKey` = `shelfOrder` o ile mieści się w dekadzie książki
+  (klucz STALE spoza dekady ignorowany → powrót do roku). Czysty planer `shelfInsertion.ts`:
+  `canInsertAt` (walidacja: szczelina musi sąsiadować z dekadą książki; „bez daty" wykluczone) +
+  `planInsertion` (klucz-środek między sąsiadami = 1 zapis; remis rocznika → renumeracja TYLKO
+  związanego przedziału, limit 40). UI: `ShelfRow` liczy granice szczelin (kupka = 1 slot) i rysuje
+  neonowy kursor wstawienia (cyan = OK, róż = zła dekada); `Shelf` mapuje granice na cel
+  (`beforeId`/koniec półki, no-op przy sobie samej) i waliduje; `BookshelfSection.handlePreciseDrop`
+  = optymistyczne `orderOverrides` + POST `/api/shelf-order` z rollbackiem + (przy zmianie półki)
+  standardowa zmiana „przeczytane" (wydzielone `applyReadChange`). Globalny drop na ramę bez zmian;
+  szczelina ma priorytet (stopPropagation tylko przy walidnym trafieniu). Knob `ui.preciseShelfDrop`
+  (default on, sekcja Zaawansowane). Testy: +10 (planer/sort/walidacja) → 330. Screeny: caret OK/odmowa. Kolumna `ShelfOrder`
   (number, tworzona przy pierwszym zapisie): rzadki, ręczny klucz porządku w skali ułamkowych lat —
   utrwalamy TYLKO ręcznie wstawione książki, reszta zostaje na deterministycznym auto-układzie
   (rok → dekada → fizyka). Mapper/typy (`NotionBook.shelfOrder`, `BookIndexEntry.shelfOrder`),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.27.1",
+      "version": "1.28.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.27.1",
+  "version": "1.28.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/shelfInsertion.test.ts
+++ b/src/__tests__/shelfInsertion.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { BookIndexEntry } from "../types";
+import { canInsertAt, planInsertion } from "../utils/shelfInsertion";
+import { effShelfKey, byShelfPosition } from "../utils/bookshelf";
+
+const mk = (id: string, year: string, shelfOrder?: number): BookIndexEntry => ({
+  id, plTitle: `T-${id}`, origTitle: "", author: "", year,
+  awards: [], zrodlo: [], series: "", partOfCycle: false, shelfOrder,
+});
+
+describe("bookshelf.effShelfKey / byShelfPosition", () => {
+  it("uses shelfOrder within the book's decade, falls back to year otherwise", () => {
+    expect(effShelfKey(mk("a", "1954"))).toBe(1954);
+    expect(effShelfKey(mk("a", "1954", 1955.5))).toBe(1955.5);
+    // Klucz STALE (spoza dekady książki) — ignorowany.
+    expect(effShelfKey(mk("a", "1964", 1955.5))).toBe(1964);
+  });
+
+  it("sorts by decade, then manual key interleaved with years, then title", () => {
+    const a = mk("a", "1954");            // klucz 1954
+    const b = mk("b", "1957", 1954.5);    // ręcznie między 1954 a 1955
+    const c = mk("c", "1955");
+    const d = mk("d", "1949");            // inna dekada — zawsze przed
+    const sorted = [a, b, c, d].sort(byShelfPosition).map((x) => x.id);
+    expect(sorted).toEqual(["d", "a", "b", "c"]);
+  });
+});
+
+describe("shelfInsertion.canInsertAt", () => {
+  const seq = [mk("a", "1948"), mk("b", "1952"), mk("c", "1955"), mk("d", "1969")];
+
+  it("allows gaps inside and at the edges of the book's decade section", () => {
+    const dragged = mk("x", "1953");
+    expect(canInsertAt(seq, dragged, "b")).toBe(true);  // przed 1952 (start sekcji 1950s — lewy sąsiad 1948)
+    expect(canInsertAt(seq, dragged, "c")).toBe(true);  // między 1952 a 1955
+    expect(canInsertAt(seq, dragged, "d")).toBe(true);  // koniec sekcji 1950s (lewy sąsiad 1955)
+  });
+
+  it("rejects gaps in a foreign decade and unknown targets", () => {
+    const dragged = mk("x", "1953");
+    expect(canInsertAt(seq, dragged, "a")).toBe(false); // przed 1948 — sąsiedzi 1940s/undefined
+    expect(canInsertAt(seq, dragged, null)).toBe(false); // koniec półki — lewy sąsiad 1969 (1960s)
+    expect(canInsertAt(seq, dragged, "zzz")).toBe(false);
+  });
+
+  it("rejects dateless books and accepts drops onto an empty shelf", () => {
+    expect(canInsertAt(seq, mk("x", ""), "b")).toBe(false);
+    expect(canInsertAt([], mk("x", "1953"), null)).toBe(true);
+  });
+});
+
+describe("shelfInsertion.planInsertion", () => {
+  it("midpoint between distinct keys — a single write", () => {
+    const seq = [mk("a", "1952"), mk("b", "1956")];
+    const plan = planInsertion(seq, mk("x", "1954"), "b");
+    expect(plan?.orders).toEqual([{ pageId: "x", order: 1954 }]);
+  });
+
+  it("edge of the decade section: start and end land inside the decade scale", () => {
+    const seq = [mk("a", "1948"), mk("b", "1952"), mk("c", "1969")];
+    const start = planInsertion(seq, mk("x", "1951"), "b")!.orders[0];
+    expect(start.pageId).toBe("x");
+    expect(start.order).toBeGreaterThanOrEqual(1950);
+    expect(start.order).toBeLessThan(1952);
+    const end = planInsertion(seq, mk("y", "1953"), "c")!.orders[0];
+    expect(end.order).toBeGreaterThan(1952);
+    expect(end.order).toBeLessThan(1960);
+  });
+
+  it("tie of same-year keys renumbers only the tied run, preserving final order", () => {
+    const seq = [mk("a", "1954"), mk("b", "1954"), mk("c", "1957")];
+    const plan = planInsertion(seq, mk("x", "1954"), "b")!;
+    // renumeracja: a, x, b (+x) — 3 wpisy; c nietknięte
+    expect(plan.orders.map((o) => o.pageId)).toEqual(["a", "x", "b"]);
+    const byId = Object.fromEntries(plan.orders.map((o) => [o.pageId, o.order]));
+    expect(byId.a).toBeLessThan(byId.x);
+    expect(byId.x).toBeLessThan(byId.b);
+    expect(byId.b).toBeLessThan(1955); // poniżej następnego rocznika
+    for (const o of plan.orders) expect(o.order).toBeGreaterThanOrEqual(1954);
+  });
+
+  it("returns null for invalid gaps and empty orders for an empty shelf", () => {
+    const seq = [mk("a", "1969")];
+    expect(planInsertion(seq, mk("x", "1953"), null)).toBeNull();
+    expect(planInsertion([], mk("x", "1953"), null)).toEqual({ orders: [] });
+  });
+
+  it("applied plan actually sorts into the intended position", () => {
+    const seq = [mk("a", "1954"), mk("b", "1954"), mk("c", "1957")];
+    const dragged = mk("x", "1954");
+    const plan = planInsertion(seq, dragged, "b")!;
+    const byId = Object.fromEntries(plan.orders.map((o) => [o.pageId, o.order]));
+    const applied = [...seq, dragged].map((b) => (byId[b.id] !== undefined ? { ...b, shelfOrder: byId[b.id] } : b));
+    expect(applied.sort(byShelfPosition).map((b) => b.id)).toEqual(["a", "x", "b", "c"]);
+  });
+});

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -4,6 +4,7 @@ import { BookIndexEntry } from "../types";
 import { useBooks } from "../hooks/useBooks";
 import { useMarkRead } from "../hooks/useMarkRead";
 import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
+import { planInsertion } from "../utils/shelfInsertion";
 import { ShelfSkin, SHELF_SKINS, skinClass, loadSkin, saveSkin } from "../utils/shelfSkin";
 import { useEffectiveConfig } from "../hooks/useAppConfig";
 import { Shelf } from "./shelf/Shelf";
@@ -19,8 +20,11 @@ export const BookshelfSection: React.FC = () => {
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
   const [skin, setSkin] = useState<ShelfSkin>(loadSkin);
-  // Liczba rzędów regału na stronę — knob `ui.shelfRowsPerPage`.
-  const rowsPerPage = useEffectiveConfig().ui.shelfRowsPerPage;
+  // Knoby UI: liczba rzędów regału na stronę + precyzyjny drop.
+  const uiCfg = useEffectiveConfig().ui;
+  const rowsPerPage = uiCfg.shelfRowsPerPage;
+  // Optymistyczne nadpisania ręcznych kluczy porządku (precyzyjny drop) do czasu refetch.
+  const [orderOverrides, setOrderOverrides] = useState<Record<string, number>>({});
   useEffect(() => { saveSkin(skin); }, [skin]);
 
   // Zapis stanu „przeczytane" jest SERIALIZOWANY per książka (latest-wins). Backend
@@ -30,20 +34,16 @@ export const BookshelfSection: React.FC = () => {
   const pendingRef = useRef<Record<string, boolean>>({});
   const runningRef = useRef<Set<string>>(new Set());
 
-  const all = books ?? [];
+  // Księgozbiór z nadpisanymi kluczami porządku (optymistycznie, do czasu refetch).
+  const all = useMemo(() => {
+    const src = books ?? [];
+    return src.map((b) => (orderOverrides[b.id] !== undefined ? { ...b, shelfOrder: orderOverrides[b.id] } : b));
+  }, [books, orderOverrides]);
   const { read, toRead } = useMemo(() => splitShelves(all, overrides), [all, overrides]);
   const featured = useMemo(() => featuredReads(all, overrides), [all, overrides]);
 
-  const handleDrop = useCallback((target: ShelfId) => {
-    const book = dragging;
-    setDragging(null);
-    if (!book) return;
-
-    const targetRead = target === "read";
-    const wasRead = isRead(book, overrides);
-    if (wasRead === targetRead) return; // upuszczono na tę samą półkę — nic
-
-    // Optymistyczny ruch od razu.
+  /** Optymistyczna zmiana „przeczytane" + serializowany zapis (latest-wins per książka). */
+  const applyReadChange = useCallback((book: BookIndexEntry, targetRead: boolean) => {
     setOverrides((prev) => ({ ...prev, [book.id]: targetRead }));
     setMoveError(null);
 
@@ -67,7 +67,64 @@ export const BookshelfSection: React.FC = () => {
         runningRef.current.delete(book.id);
       }
     })();
-  }, [dragging, overrides, setRead]);
+  }, [setRead]);
+
+  const handleDrop = useCallback((target: ShelfId) => {
+    const book = dragging;
+    setDragging(null);
+    if (!book) return;
+
+    const targetRead = target === "read";
+    if (isRead(book, overrides) === targetRead) return; // upuszczono na tę samą półkę — nic
+    applyReadChange(book, targetRead);
+  }, [dragging, overrides, applyReadChange]);
+
+  /**
+   * Precyzyjny drop: wstaw książkę przed `insertBeforeId` (null = koniec półki).
+   * Klucze liczy czysty `planInsertion` (zwykle 1 wpis; remis roku → mała renumeracja);
+   * zapis optymistyczny + POST /api/shelf-order z rollbackiem. Przy zmianie półki
+   * dokłada się standardowa zmiana „przeczytane".
+   */
+  const handlePreciseDrop = useCallback((target: ShelfId, insertBeforeId: string | null) => {
+    const book = dragging;
+    setDragging(null);
+    if (!book) return;
+
+    const targetRead = target === "read";
+    const wasRead = isRead(book, overrides);
+    const seq = (targetRead ? read : toRead).filter((b) => b.id !== book.id);
+    const plan = planInsertion(seq, book, insertBeforeId);
+
+    if (plan && plan.orders.length > 0) {
+      setOrderOverrides((prev) => {
+        const next = { ...prev };
+        for (const o of plan.orders) next[o.pageId] = o.order;
+        return next;
+      });
+      void (async () => {
+        try {
+          const res = await fetch("/api/shelf-order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ orders: plan.orders }),
+          });
+          if (!res.ok) {
+            const j = await res.json().catch(() => null);
+            throw new Error(j?.error || `Błąd serwera: ${res.status}`);
+          }
+        } catch (e: any) {
+          setOrderOverrides((prev) => {
+            const next = { ...prev };
+            for (const o of plan.orders) delete next[o.pageId];
+            return next;
+          });
+          setMoveError(`Nie udało się zapisać pozycji „${book.plTitle || book.origTitle}": ${e.message}`);
+        }
+      })();
+    }
+
+    if (wasRead !== targetRead) applyReadChange(book, targetRead);
+  }, [dragging, overrides, read, toRead, applyReadChange]);
 
   return (
     <div className="space-y-8">
@@ -152,13 +209,15 @@ export const BookshelfSection: React.FC = () => {
             <Shelf
               shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={rowsPerPage}
               icon={<BookOpen className="w-4 h-4" />}
-              books={toRead} dragging={!!dragging}
+              books={toRead} draggingBook={dragging}
+              preciseEnabled={uiCfg.preciseShelfDrop} onPreciseDrop={handlePreciseDrop}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
             <Shelf
               shelfId="read" title="Przeczytane" accent="emerald" pageSize={rowsPerPage}
               icon={<CheckCircle2 className="w-4 h-4" />}
-              books={read} dragging={!!dragging}
+              books={read} draggingBook={dragging}
+              preciseEnabled={uiCfg.preciseShelfDrop} onPreciseDrop={handlePreciseDrop}
               onDragStart={setDragging} onDragEnd={() => setDragging(null)} onDropBook={handleDrop}
             />
           </div>

--- a/src/components/ConfigSection.tsx
+++ b/src/components/ConfigSection.tsx
@@ -214,6 +214,12 @@ export const ConfigSection: React.FC = () => {
               <NumberField label="Biblioteka: równoległość" hint="Jednoczesne zapytania OPAC." value={draft.library.concurrency} onChange={(v) => upd("library", { concurrency: v })} />
               <NumberField label="Sync: równoległość zapisów" hint="pLimit zapisów do Notion (nagrody/cykle)." value={draft.sync.writeConcurrency} onChange={(v) => upd("sync", { writeConcurrency: v })} />
               <NumberField label="Regał: rzędy na stronę" value={draft.ui.shelfRowsPerPage} onChange={(v) => upd("ui", { shelfRowsPerPage: v })} />
+              <Field label="Regał: precyzyjny drop" hint="Wstawianie woluminu w konkretną szczelinę (w obrębie dekady). Wyłączony = tylko globalny drag&drop między półkami.">
+                <label className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 cursor-pointer select-none">
+                  <input type="checkbox" checked={draft.ui.preciseShelfDrop} onChange={(e) => upd("ui", { preciseShelfDrop: e.target.checked })} className="accent-cyan-500 w-4 h-4" />
+                  Włączony
+                </label>
+              </Field>
               <NumberField label="Duplikaty: próg autora" hint="0.5–1; wyżej = mniej czułe." value={draft.sync.dupAuthorThreshold} step={0.01} onChange={(v) => upd("sync", { dupAuthorThreshold: v })} />
               <NumberField label="Duplikaty: próg tytułu" hint="0.5–1; dotyczy tytułu PL i oryginalnego." value={draft.sync.dupTitleThreshold} step={0.01} onChange={(v) => upd("sync", { dupTitleThreshold: v })} />
             </div>

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -1,10 +1,11 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { BookIndexEntry } from "../../types";
 import { ShelfId, SHELF_ROW_GAP, SHELF_PLANK_H } from "../../utils/bookshelf";
 import { packAndLayout } from "../../utils/shelfPacking";
 import { buildShelfItems, chunk } from "../../utils/shelfLayout";
-import { ShelfRow, EmptyShelfRow } from "./ShelfRow";
+import { canInsertAt } from "../../utils/shelfInsertion";
+import { ShelfRow, EmptyShelfRow, GapBoundary, GapCaret } from "./ShelfRow";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
 
 interface Props {
@@ -16,17 +17,59 @@ interface Props {
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
   onDropBook: (target: ShelfId) => void;
-  dragging: boolean;
+  /** Precyzyjny drop: wstaw przeciąganą książkę przed `insertBeforeId` (null = koniec półki). */
+  onPreciseDrop?: (target: ShelfId, insertBeforeId: string | null) => void;
+  /** Przeciągana książka (do walidacji dekady precyzyjnego dropu); null = brak przeciągania. */
+  draggingBook: BookIndexEntry | null;
+  /** Knob `ui.preciseShelfDrop` — wyłączony = tylko globalny drop na ramę. */
+  preciseEnabled?: boolean;
   /** Gdy podane: regał ma STAŁĄ wysokość tylu rzędów i dzieli się na segmenty „Regał I/N". */
   pageSize?: number;
 }
 
 /** Jeden regał: drewniany korpus + FIZYCZNE rozłożenie woluminów (wypełnione półki, oparte pochyły). */
-export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, dragging, pageSize }) => {
+export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, onPreciseDrop, draggingBook, preciseEnabled = true, pageSize }) => {
+  const dragging = draggingBook !== null;
   const [over, setOver] = useState(false);
   const [page, setPage] = useState(0);
   const wellRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
+
+  // Kursor wstawienia + rozstrzygnięty cel (beforeId) — czyszczone z końcem przeciągania.
+  const [caret, setCaret] = useState<(GapCaret & { beforeId: string | null }) | null>(null);
+  useEffect(() => { if (!dragging) setCaret(null); }, [dragging]);
+
+  const preciseActive = preciseEnabled && dragging && !!onPreciseDrop;
+  // Sekwencja półki bez przeciąganej książki (przy przeciąganiu w obrębie tej samej półki).
+  const seqSans = draggingBook ? books.filter((b) => b.id !== draggingBook.id) : books;
+
+  /** Granica szczeliny → cel wstawienia; undefined = no-op (szczelina przy samej przeciąganej). */
+  const resolveBoundary = (b: GapBoundary): string | null | undefined => {
+    if (b.beforeId) return b.beforeId === draggingBook?.id ? undefined : b.beforeId;
+    if (b.afterId) {
+      if (b.afterId === draggingBook?.id) return undefined;
+      const i = seqSans.findIndex((x) => x.id === b.afterId);
+      if (i < 0) return undefined;
+      return seqSans[i + 1]?.id ?? null;
+    }
+    return undefined;
+  };
+
+  const handleGapOver = (rowIndex: number, b: GapBoundary) => {
+    if (!draggingBook) return;
+    const beforeId = resolveBoundary(b);
+    if (beforeId === undefined) { setCaret(null); return; }
+    setCaret({ row: rowIndex, x: b.x, beforeId, valid: canInsertAt(seqSans, draggingBook, beforeId) });
+  };
+
+  const handleGapDrop = (): boolean => {
+    if (!caret?.valid || !onPreciseDrop) return false;
+    const beforeId = caret.beforeId;
+    setCaret(null);
+    setOver(false);
+    onPreciseDrop(shelfId, beforeId);
+    return true;
+  };
 
   useLayoutEffect(() => {
     const el = wellRef.current;
@@ -95,7 +138,12 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
         ) : (
           <div ref={wellRef} className="flex flex-col" style={{ rowGap: SHELF_ROW_GAP - SHELF_PLANK_H }}>
             {shown.map((row, ri) => (
-              <ShelfRow key={cur * 1000 + ri} row={row} slotByKey={slotByKey} rowWidth={width} onDragStart={onDragStart} onDragEnd={onDragEnd} />
+              <ShelfRow
+                key={cur * 1000 + ri} row={row} slotByKey={slotByKey} rowWidth={width}
+                rowIndex={ri} preciseActive={preciseActive} caret={caret}
+                onGapOver={handleGapOver} onGapLeave={() => setCaret(null)} onGapDrop={handleGapDrop}
+                onDragStart={onDragStart} onDragEnd={onDragEnd}
+              />
             ))}
             {Array.from({ length: pad }).map((_, i) => <EmptyShelfRow key={`pad${i}`} />)}
           </div>

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { BookIndexEntry } from "../../types";
 import { spineStyle, SHELF_ROW_H, SHELF_PLANK_H } from "../../utils/bookshelf";
 import { RenderSlot, assignDividerPlacement } from "../../utils/shelfLayout";
@@ -14,25 +14,93 @@ export const PLANK_STYLE: React.CSSProperties = {
   borderRadius: 2,
 };
 
+/**
+ * Szczelina precyzyjnego dropu: `beforeId` = wstaw przed tą książką; `afterId`
+ * (ostatnia granica rzędu) = wstaw za tą książką — Shelf mapuje ją na `beforeId`
+ * następnika w globalnej sekwencji (lub koniec półki).
+ */
+export interface GapBoundary {
+  x: number;
+  beforeId?: string;
+  afterId?: string;
+}
+
+/** Kursor wstawienia (stan trzymany w Shelf; rząd rysuje swój fragment). */
+export interface GapCaret {
+  row: number;
+  x: number;
+  valid: boolean;
+}
+
 interface Props {
   row: PlacedItem[];
   slotByKey: Map<string, RenderSlot>;
   /** Szerokość toru (well) — do wykrycia tabliczek wychodzących poza prawą krawędź. */
   rowWidth: number;
+  /** Indeks rzędu na stronie (adresowanie kursora wstawienia). */
+  rowIndex: number;
+  /** Precyzyjny drop aktywny (knob włączony + trwa przeciąganie). */
+  preciseActive: boolean;
+  /** Kursor wstawienia, jeśli wskazuje ten rząd. */
+  caret: GapCaret | null;
+  /** Najechanie na szczelinę (rząd, granica) / opuszczenie rzędu / drop w kursor. */
+  onGapOver: (rowIndex: number, boundary: GapBoundary) => void;
+  onGapLeave: () => void;
+  onGapDrop: () => boolean; // true = obsłużone precyzyjnie (zatrzymaj propagację)
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
 }
 
 /** Jeden rząd półki: woluminy na pozycjach z fizyki + drewniana deska pod spodem. */
-export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, onDragStart, onDragEnd }) => {
+export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, preciseActive, caret, onGapOver, onGapLeave, onGapDrop, onDragStart, onDragEnd }) => {
   // Rozmieszczenie tabliczek dekad (góra/dół + lewo/prawo) — unika kolizji i wyjścia poza półkę.
   const placement = assignDividerPlacement(row, (k) => {
     const s = slotByKey.get(k);
     return s && s.kind === "divider" ? s.label : undefined;
   }, rowWidth);
+
+  // Granice szczelin: start każdego slotu-książki (wstaw przed pierwszym woluminem
+  // slotu; kupka = jeden slot) + prawa krawędź ostatniego slotu (wstaw za ostatnim).
+  const boundaries = useMemo<GapBoundary[]>(() => {
+    const items = row.filter((p) => p.kind !== "divider").slice().sort((a, b) => a.x - b.x);
+    const out: GapBoundary[] = [];
+    for (const p of items) {
+      const slot = slotByKey.get(p.key)!;
+      const firstId = slot.kind === "stack" ? slot.books[0]?.id : slot.kind === "spine" ? slot.book.id : undefined;
+      if (firstId) out.push({ x: p.x, beforeId: firstId });
+    }
+    const last = items[items.length - 1];
+    if (last) {
+      const slot = slotByKey.get(last.key)!;
+      const lastId = slot.kind === "stack" ? slot.books[slot.books.length - 1]?.id : slot.kind === "spine" ? slot.book.id : undefined;
+      if (lastId) out.push({ x: last.x + last.w, afterId: lastId });
+    }
+    return out;
+  }, [row, slotByKey]);
+
+  const rowCaret = caret && caret.row === rowIndex ? caret : null;
+
+  const dragHandlers = preciseActive ? {
+    onDragOver: (e: React.DragEvent<HTMLDivElement>) => {
+      if (boundaries.length === 0) return;
+      e.preventDefault(); // szczeliny przyjmują drop (bez stopPropagation — rama dalej podświetla cel)
+      const x = e.clientX - e.currentTarget.getBoundingClientRect().left;
+      let nearest = boundaries[0];
+      for (const b of boundaries) if (Math.abs(b.x - x) < Math.abs(nearest.x - x)) nearest = b;
+      onGapOver(rowIndex, nearest);
+    },
+    onDragLeave: (e: React.DragEvent<HTMLDivElement>) => {
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) onGapLeave();
+    },
+    onDrop: (e: React.DragEvent<HTMLDivElement>) => {
+      // Obsłużone precyzyjnie → zatrzymaj (inaczej rama zrobi globalny drop drugi raz).
+      if (onGapDrop()) { e.preventDefault(); e.stopPropagation(); }
+    },
+  } : {};
+
   return (
   <div>
-    <div className="relative" style={{ height: SHELF_ROW_H }}>
+    <div className="relative" style={{ height: SHELF_ROW_H }} {...dragHandlers}>
       {/* Warstwa 1: grzbiety/kupki + deseczki przekładek (z-20, nad tłem i deską). */}
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
@@ -74,6 +142,20 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, onDragStar
           </div>
         );
       })}
+      {/* Kursor wstawienia — neonowa kreska w najbliższej szczelinie (cyan = OK, róż = zła dekada). */}
+      {rowCaret && (
+        <div
+          className="absolute pointer-events-none rounded-[2px]"
+          style={{
+            left: rowCaret.x - 1.5, width: 3, top: 4, bottom: 0, zIndex: 50,
+            background: rowCaret.valid
+              ? "linear-gradient(180deg, rgba(34,211,238,.95), rgba(34,211,238,.25))"
+              : "linear-gradient(180deg, rgba(244,63,94,.9), rgba(244,63,94,.2))",
+            boxShadow: rowCaret.valid ? "0 0 10px rgba(34,211,238,.8)" : "0 0 10px rgba(244,63,94,.7)",
+          }}
+          aria-hidden
+        />
+      )}
     </div>
     <div style={PLANK_STYLE} />
   </div>

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -74,6 +74,8 @@ export interface AppConfig {
   ui: {
     /** Liczba rzędów regału na stronę (Regał N/M). */
     shelfRowsPerPage: number;
+    /** Precyzyjny drag&drop na regale (wstawianie w szczelinę w obrębie dekady). */
+    preciseShelfDrop: boolean;
   };
 }
 
@@ -129,6 +131,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   },
   ui: {
     shelfRowsPerPage: 5,
+    preciseShelfDrop: true,
   },
 };
 
@@ -140,6 +143,8 @@ const clamp = (v: unknown, min: number, max: number, dflt: number): number => {
 };
 const clampInt = (v: unknown, min: number, max: number, dflt: number): number =>
   Math.round(clamp(v, min, max, dflt));
+
+const cleanBool = (v: unknown, dflt: boolean): boolean => (typeof v === "boolean" ? v : dflt);
 
 const cleanString = (v: unknown, dflt: string, maxLen = 120): string => {
   const s = typeof v === "string" ? v.trim() : "";
@@ -231,6 +236,7 @@ export function mergeConfig(overrides?: unknown): AppConfig {
     },
     ui: {
       shelfRowsPerPage: clampInt(u.shelfRowsPerPage, 1, 12, d.ui.shelfRowsPerPage),
+      preciseShelfDrop: cleanBool(u.preciseShelfDrop, d.ui.preciseShelfDrop),
     },
   };
 }

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -323,24 +323,45 @@ export function parseYear(year: string): number | null {
 }
 
 /** Rok wydania jako liczba do sortowania; brak → na koniec. */
-function pubYear(b: BookIndexEntry): number {
+export function pubYear(b: BookIndexEntry): number {
   return parseYear(b.year) ?? Infinity;
 }
 
-/** Porządek wg daty wydania (rosnąco, chronologicznie), remis → tytuł. */
-const byYearTitle = (a: BookIndexEntry, b: BookIndexEntry) =>
-  pubYear(a) - pubYear(b) || displayTitle(a).localeCompare(displayTitle(b), "pl");
+/** Klucz dekady książki (1950, 1960, …); brak roku → Infinity (sekcja „bez daty" na końcu). */
+export function decadeKeyOf(b: BookIndexEntry): number {
+  const y = parseYear(b.year);
+  return y === null ? Infinity : Math.floor(y / 10) * 10;
+}
+
+/**
+ * Efektywny klucz porządku na półce: ręczny `shelfOrder` (precyzyjny drag&drop),
+ * o ile mieści się w dekadzie książki — klucz spoza dekady jest STALE (rok książki
+ * zmienił dekadę po nadaniu klucza) i wraca do sortu po roku. Skala: ułamkowe lata.
+ */
+export function effShelfKey(b: BookIndexEntry): number {
+  const dec = decadeKeyOf(b);
+  const so = b.shelfOrder;
+  if (typeof so === "number" && isFinite(so) && isFinite(dec) && so >= dec && so < dec + 10) return so;
+  return pubYear(b);
+}
+
+/**
+ * Porządek na regale: dekada → efektywny klucz (ręczny lub rok) → tytuł.
+ * Bez ręcznych kluczy równoważny dawnemu sortowi po roku (dekada rośnie z rokiem).
+ */
+export const byShelfPosition = (a: BookIndexEntry, b: BookIndexEntry) =>
+  decadeKeyOf(a) - decadeKeyOf(b) || effShelfKey(a) - effShelfKey(b) || displayTitle(a).localeCompare(displayTitle(b), "pl");
 
 /**
  * Dzieli księgozbiór na dwie półki wg stanu „przeczytane" (z nadpisaniami),
- * każda posortowana wg **daty wydania** (rosnąco), remis → tytuł.
+ * każda posortowana porządkiem regału (`byShelfPosition`).
  */
 export function splitShelves(books: BookIndexEntry[], overrides: ReadOverrides = {}): Record<ShelfId, BookIndexEntry[]> {
   const read: BookIndexEntry[] = [];
   const toRead: BookIndexEntry[] = [];
   for (const b of books) (isRead(b, overrides) ? read : toRead).push(b);
-  read.sort(byYearTitle);
-  toRead.sort(byYearTitle);
+  read.sort(byShelfPosition);
+  toRead.sort(byShelfPosition);
   return { read, toRead };
 }
 

--- a/src/utils/shelfInsertion.ts
+++ b/src/utils/shelfInsertion.ts
@@ -1,0 +1,85 @@
+import { BookIndexEntry } from "../types";
+import { decadeKeyOf, effShelfKey } from "./bookshelf";
+
+/**
+ * Czysty planer precyzyjnego wstawienia na regał.
+ *
+ * Wejście: posortowana sekwencja półki docelowej BEZ przeciąganej książki,
+ * przeciągana książka i cel (`insertBeforeId` — id książki, przed którą wstawiamy;
+ * null = na sam koniec półki). Wyjście: partia zapisów `ShelfOrder` (skala
+ * ułamkowych lat) — zwykle 1 wpis (klucz-środek między sąsiadami); przy remisie
+ * kluczy (książki z tego samego roku bez ręcznych kluczy) renumerowany jest tylko
+ * ZWIĄZANY przedział, nie cała dekada.
+ *
+ * Walidacja rocznikowa: wstawić można wyłącznie w szczelinę, której sąsiad (lewy
+ * lub prawy) należy do dekady przeciąganej książki — czyli wewnątrz jej sekcji
+ * albo na jej brzegach. Książki „bez daty" nie mają skali → precyzyjny drop off.
+ */
+
+export interface InsertionPlan {
+  /** Zapisy ShelfOrder do wysłania (id → klucz). Zawsze zawiera przeciąganą książkę. */
+  orders: { pageId: string; order: number }[];
+}
+
+/** Maks. partia zapisów (spójna z limitem POST /api/shelf-order). */
+const MAX_ORDERS = 40;
+
+/** Czy szczelina PRZED książką `insertBeforeId` (null = koniec) przyjmie tę książkę (dekada się zgadza)? */
+export function canInsertAt(seq: BookIndexEntry[], dragged: BookIndexEntry, insertBeforeId: string | null): boolean {
+  const dec = decadeKeyOf(dragged);
+  if (!isFinite(dec)) return false; // „bez daty" — brak skali porządku
+  const idx = insertBeforeId === null ? seq.length : seq.findIndex((b) => b.id === insertBeforeId);
+  if (insertBeforeId !== null && idx < 0) return false;
+  const L = idx > 0 ? seq[idx - 1] : undefined;
+  const R = idx < seq.length ? seq[idx] : undefined;
+  if (!L && !R) return true; // pusta półka — zwykły drop, bez klucza
+  return (L !== undefined && decadeKeyOf(L) === dec) || (R !== undefined && decadeKeyOf(R) === dec);
+}
+
+/**
+ * Plan zapisów dla wstawienia. `null` gdy szczelina nieprawidłowa (zła dekada /
+ * nieznany cel / partia ponad limit) — wołający robi fallback do zwykłego dropu.
+ */
+export function planInsertion(seq: BookIndexEntry[], dragged: BookIndexEntry, insertBeforeId: string | null): InsertionPlan | null {
+  if (!canInsertAt(seq, dragged, insertBeforeId)) return null;
+  const dec = decadeKeyOf(dragged);
+  const idx = insertBeforeId === null ? seq.length : seq.findIndex((b) => b.id === insertBeforeId);
+  const L = idx > 0 ? seq[idx - 1] : undefined;
+  const R = idx < seq.length ? seq[idx] : undefined;
+
+  if (!L && !R) return { orders: [] }; // pusta półka — pozycja wynika z roku
+
+  // Granice tylko z sąsiadów WEWNĄTRZ dekady; sąsiad z innej dekady = otwarty brzeg sekcji.
+  const kL = L && decadeKeyOf(L) === dec ? effShelfKey(L) : null;
+  const kR = R && decadeKeyOf(R) === dec ? effShelfKey(R) : null;
+
+  const lo = dec;            // dolna krawędź skali dekady
+  const hi = dec + 9.99;     // górna krawędź (klucz musi zostać < dec+10)
+
+  if (kL !== null && kR !== null) {
+    if (kL < kR) return { orders: [{ pageId: dragged.id, order: (kL + kR) / 2 }] };
+    // Remis kluczy (ten sam rok bez ręcznych kluczy): renumeruj związany przedział
+    // [wszystkie kolejne wpisy o kluczu == kL wokół szczeliny] + wstawiana.
+    const tie = kL;
+    let start = idx - 1;
+    while (start - 1 >= 0 && decadeKeyOf(seq[start - 1]) === dec && effShelfKey(seq[start - 1]) === tie) start--;
+    let end = idx; // pierwszy indeks ZA przedziałem
+    while (end < seq.length && decadeKeyOf(seq[end]) === dec && effShelfKey(seq[end]) === tie) end++;
+    const run = seq.slice(start, end);
+    const insertPos = idx - start;
+    const finalRun: BookIndexEntry[] = [...run.slice(0, insertPos), dragged, ...run.slice(insertPos)];
+    if (finalRun.length > MAX_ORDERS) return null;
+    // Rozłóż klucze w [tie, min(tie+0.98, hi)] — poniżej następnego rocznika.
+    const top = Math.min(tie + 0.98, hi);
+    const stepSpan = top - tie;
+    const orders = finalRun.map((b, i) => ({ pageId: b.id, order: tie + (stepSpan * (i + 1)) / (finalRun.length + 1) }));
+    return { orders };
+  }
+
+  if (kL !== null) {
+    // Koniec sekcji dekady — klucz między kL a górną krawędzią.
+    return { orders: [{ pageId: dragged.id, order: kL + (hi - kL) / 2 }] };
+  }
+  // kR !== null: początek sekcji — klucz między dolną krawędzią a kR.
+  return { orders: [{ pageId: dragged.id, order: lo + ((kR as number) - lo) / 2 }] };
+}


### PR DESCRIPTION
Stage 2/2 of precise shelf drag&drop (plumbing landed in #182). A book can now be dropped into a **chosen gap within its decade section**; the existing global frame drop stays as the fallback.

## Changes
- **Sorting** — `byShelfPosition` (decade → `effShelfKey` → title). `effShelfKey` honours `shelfOrder` only when it lies inside the book's decade — a stale key (the book's year moved decades) silently falls back to the year sort.
- **Pure planner** (`utils/shelfInsertion.ts`) — `canInsertAt` validates that a gap borders the dragged book's decade (dateless books excluded); `planInsertion` emits a midpoint key (**single Notion write** in the common case) or, on same-year key ties, renumbers **only the tied run** (respects the 40-entry API cap).
- **UI** — `ShelfRow` computes gap boundaries per row (a stack counts as one slot) and renders a neon **insertion caret**: cyan = valid spot, rose = wrong decade. `Shelf` maps row-edge boundaries onto the global sequence (before-id / end of shelf; a gap next to the dragged book itself is a no-op) and validates against the target shelf minus the dragged book.
- **Persistence** — optimistic `orderOverrides` + `POST /api/shelf-order` with rollback on failure; a cross-shelf precise drop also runs the standard read-state change (extracted `applyReadChange`, shared with the global drop).
- **Precedence** — the gap intercepts the drop only on a valid hit (`stopPropagation`); otherwise the frame's global drop behaves exactly as before.
- **Config knob** — `ui.preciseShelfDrop` (default on, „Zaawansowane" section of Sanktuarium Kalibracji).

## Verification
- `npm run lint` clean · `npm test` **330/330** green (+10: planner midpoints, tie renumbering, decade validation, sort round-trip, stale-key guard) · `npm run build` OK.
- Headless-Chromium screenshots: cyan caret lit in the dragged book's own 1950s section; rose refusal caret in the foreign 1970s section; frame's global „upuść tutaj" highlight unaffected.
- Version bump `1.27.1` → `1.28.0` (minor); backlog updated.

Fixes #183 · Refs #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_