### PR TITLE
Stats: Publishers / Series / Cycles card

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.29.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.30.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.30.0** — **Statystyki: Wydawnictwa / Serie / Cykle (STAT-PR2).** Nowe bloki w `getStats`
+  z pól, które wypełniają rytuały publisher/series/cycles, a statystyki dotąd ignorowały:
+  `publisherStats` (top 15 oficyn: liczba tytułów + read-rate), `seriesStats` (top 15 serii:
+  posiadane/total → luki), `cycleStats` (udział „część cyklu" w kolekcji). Karta `PublishingCard`
+  (pasek cykli + top oficyny z read-rate + serie z „luki/komplet", zielony = komplet). Testy +1 → 333.
 - **1.29.0** — **Statystyki: zagregowana dostępność + dług libraryStats (STAT-PR1).** `StatsService`
   dostaje `ConfigService`. `libraryStats` iteruje teraz `config.library.branches` (koniec hardcode
   Felin/Bronowice — 3. filia z Kalibracji od razu w statystykach; `id` = `sourceTag`, zachowana

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.29.0",
+  "version": "1.30.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/statsService.test.ts
+++ b/services/__tests__/statsService.test.ts
@@ -84,6 +84,24 @@ describe('StatsService', () => {
     expect(a).toEqual({ totalUnread: 5, owned: 2, library: 1, vinted: 1, none: 1 });
   });
 
+  it('aggregates publishers / series / cycles from their fields', async () => {
+    const mk = (id: string, over: Partial<NotionBook>): NotionBook => ({
+      id, plTitle: `T${id}`, origTitle: "", author: "A", year: "1970", zrodlo: [], awards: [],
+      currentWydawnictwo: "", currentSeria: "", currentCzesccyklu: false, lp: id,
+      plTitleRichText: [], origTitleRichText: [], ...over,
+    });
+    mockNotion.getBooksForStats.mockResolvedValue([
+      mk("1", { currentWydawnictwo: "MAG", currentSeria: "Uczta Wyobraźni", currentCzesccyklu: true, zrodlo: ["Posiadam", "Przeczytane"] }),
+      mk("2", { currentWydawnictwo: "MAG", currentSeria: "Uczta Wyobraźni", currentCzesccyklu: true, zrodlo: ["Posiadam"] }),
+      mk("3", { currentWydawnictwo: "Rebis", currentSeria: "", currentCzesccyklu: false }),
+    ]);
+    const { publisherStats, seriesStats, cycleStats } = await service.getStats();
+    expect(publisherStats[0]).toEqual({ name: "MAG", count: 2, read: 1 });
+    expect(publisherStats.find(p => p.name === "Rebis")).toEqual({ name: "Rebis", count: 1, read: 0 });
+    expect(seriesStats[0]).toEqual({ name: "Uczta Wyobraźni", count: 2, owned: 2, read: 1 });
+    expect(cycleStats).toEqual({ partOfCycle: 2, standalone: 1, total: 3 });
+  });
+
   it('builds libraryStats from config branches (id = sourceTag)', async () => {
     mockNotion.getBooksForStats.mockResolvedValue([
       { id: "1", plTitle: "X", origTitle: "", author: "A", year: "1970", zrodlo: ["Biblioteka"], awards: [], currentWydawnictwo: "", currentSeria: "", currentCzesccyklu: false, lp: "1", plTitleRichText: [], origTitleRichText: [] } as NotionBook,

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -83,6 +83,44 @@ export class StatsService {
     });
     const availabilityStats = { totalUnread, ...availability };
 
+    // 5c. Wydawnictwa / Serie / Cykle — dane z rytuałów publisher/series/cycles, dotąd
+    // nietknięte przez statystyki. Wszystkie liczą się per książka z niepustym polem.
+    const isReadBook = (b: typeof books[number]) => (b.zrodlo || []).includes("Przeczytane");
+    const isOwnedBook = (b: typeof books[number]) => (b.zrodlo || []).includes("Posiadam");
+
+    // Top wydawnictwa: liczba tytułów + ile przeczytanych.
+    const publisherMap: Record<string, { count: number; read: number }> = {};
+    books.forEach(book => {
+      const pub = (book.currentWydawnictwo || "").trim();
+      if (!pub) return;
+      if (!publisherMap[pub]) publisherMap[pub] = { count: 0, read: 0 };
+      publisherMap[pub].count++;
+      if (isReadBook(book)) publisherMap[pub].read++;
+    });
+    const publisherStats = Object.entries(publisherMap)
+      .map(([name, s]) => ({ name, ...s }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
+      .slice(0, 15);
+
+    // Serie: ile tytułów w serii, ile posiadasz (luki = count − owned).
+    const seriesMap: Record<string, { count: number; owned: number; read: number }> = {};
+    books.forEach(book => {
+      const ser = (book.currentSeria || "").trim();
+      if (!ser) return;
+      if (!seriesMap[ser]) seriesMap[ser] = { count: 0, owned: 0, read: 0 };
+      seriesMap[ser].count++;
+      if (isOwnedBook(book)) seriesMap[ser].owned++;
+      if (isReadBook(book)) seriesMap[ser].read++;
+    });
+    const seriesStats = Object.entries(seriesMap)
+      .map(([name, s]) => ({ name, ...s }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
+      .slice(0, 15);
+
+    // Cykle: udział książek będących częścią cyklu (currentCzesccyklu) w kolekcji.
+    const cyclePart = books.filter(b => b.currentCzesccyklu === true).length;
+    const cycleStats = { partOfCycle: cyclePart, standalone: books.length - cyclePart, total: books.length };
+
     // 6. Yearly progress
     const yearlyStats: Record<string, { read: number; total: number; books: any[] }> = {};
     books.forEach(book => {
@@ -124,6 +162,9 @@ export class StatsService {
         .map(([year, stats]) => ({ year, ...stats }))
         .sort((a, b) => parseInt(a.year) - parseInt(b.year)),
       availabilityStats,
+      publisherStats,
+      seriesStats,
+      cycleStats,
       // Filie z konfiguracji (`library.branches`) — dopisanie 3. filii w Kalibracji od razu
       // pojawia się w statystykach. `id` = tag „Źródło" filii (dopasowanie po znaczniku).
       libraryStats: branches.map(branch => ({

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -12,6 +12,7 @@ import { IdentifiedLibraryItem } from "./stats/IdentifiedLibraryItem";
 import { OwnedUnreadItem } from "./stats/OwnedUnreadItem";
 import { AwardCoverageGrid } from "./stats/AwardCoverageGrid";
 import { AvailabilityCard } from "./stats/AvailabilityCard";
+import { PublishingCard } from "./stats/PublishingCard";
 import { useEffectiveConfig } from "../hooks/useAppConfig";
 
 export const StatsSection: React.FC = () => {
@@ -132,6 +133,9 @@ export const StatsSection: React.FC = () => {
 
         {/* Aggregate Availability */}
         <AvailabilityCard stats={stats.availabilityStats} />
+
+        {/* Publishers / Series / Cycles */}
+        <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} />
 
         {/* Yearly Progress */}
         <motion.div

--- a/src/components/stats/PublishingCard.tsx
+++ b/src/components/stats/PublishingCard.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Building2, Layers, Repeat } from "lucide-react";
+import { PublisherStat, SeriesStat, CycleStats } from "../../hooks/useStats";
+
+/**
+ * Wydawnictwa / Serie / Cykle — dane z rytuałów publisher/series/cycles, dotąd
+ * niepokazywane. Wydawnictwa: liczba tytułów + read-rate. Serie: posiadane/total
+ * (luki). Cykle: udział „części cyklu" w kolekcji (donut-bar).
+ */
+
+const barRow = (label: string, value: number, max: number, sub: string, color: string) => (
+  <div key={label} className="space-y-1">
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-xs text-slate-300 truncate">{label}</span>
+      <span className="text-[10px] text-slate-500 tabular-nums shrink-0">{sub}</span>
+    </div>
+    <div className="h-1.5 w-full rounded-full bg-slate-950 overflow-hidden">
+      <div className={`h-full rounded-full ${color}`} style={{ width: `${max > 0 ? (value / max) * 100 : 0}%` }} />
+    </div>
+  </div>
+);
+
+export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: SeriesStat[]; cycles: CycleStats }> = ({ publishers, series, cycles }) => {
+  const maxPub = Math.max(1, ...publishers.map((p) => p.count));
+  const maxSer = Math.max(1, ...series.map((s) => s.count));
+  const cyclePct = cycles.total > 0 ? Math.round((cycles.partOfCycle / cycles.total) * 100) : 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.18 }}
+      className="glass-card p-6 rounded-3xl border-indigo-500/10 space-y-6"
+    >
+      <h3 className="text-sm font-bold font-display uppercase tracking-widest text-indigo-400 flex items-center gap-2 mb-4">
+        <Building2 className="w-4 h-4" />
+        Oficyny, Serie i Cykle
+      </h3>
+
+      {/* Cykle — pasek udziału */}
+      <div className="p-3 rounded-2xl bg-slate-950/40 border border-white/5 space-y-2">
+        <div className="flex items-center gap-2 text-xs text-slate-400">
+          <Repeat className="w-3.5 h-3.5 text-purple-400" />
+          <span className="flex-1">Część cyklu</span>
+          <span className="font-bold text-purple-300 tabular-nums">{cycles.partOfCycle}</span>
+          <span className="text-slate-500">/ {cycles.total}</span>
+          <span className="text-[10px] text-slate-500 tabular-nums w-9 text-right">{cyclePct}%</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-slate-950 overflow-hidden border border-slate-800">
+          <div className="h-full rounded-full bg-gradient-to-r from-purple-500 to-indigo-600" style={{ width: `${cyclePct}%` }} />
+        </div>
+      </div>
+
+      {/* Top wydawnictwa */}
+      <div className="space-y-3">
+        <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Building2 className="w-3 h-3" /> Top oficyny</h4>
+        {publishers.length === 0 ? (
+          <p className="text-slate-500 text-xs italic">Brak danych — uruchom Rytuał Wydania.</p>
+        ) : (
+          <div className="space-y-2.5 max-h-[200px] overflow-y-auto pr-1 custom-scrollbar">
+            {publishers.slice(0, 8).map((p) => barRow(p.name, p.count, maxPub, `${p.read}/${p.count} przecz.`, "bg-indigo-500"))}
+          </div>
+        )}
+      </div>
+
+      {/* Serie z lukami */}
+      <div className="space-y-3">
+        <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Layers className="w-3 h-3" /> Serie (posiadane/total)</h4>
+        {series.length === 0 ? (
+          <p className="text-slate-500 text-xs italic">Brak danych — uruchom Rytuał Seryjny.</p>
+        ) : (
+          <div className="space-y-2.5 max-h-[200px] overflow-y-auto pr-1 custom-scrollbar">
+            {series.slice(0, 8).map((s) => barRow(s.name, s.owned, s.count, `${s.owned}/${s.count}${s.owned < s.count ? " · luki" : " · komplet"}`, s.owned >= s.count ? "bg-emerald-500" : "bg-blue-500"))}
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+};

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -49,6 +49,10 @@ export interface AvailabilityStats {
   none: number;
 }
 
+export interface PublisherStat { name: string; count: number; read: number }
+export interface SeriesStat { name: string; count: number; owned: number; read: number }
+export interface CycleStats { partOfCycle: number; standalone: number; total: number }
+
 export interface Stats {
   authorStats: AuthorStat[];
   awardBooksStats: { read: number; total: number };
@@ -57,6 +61,9 @@ export interface Stats {
   allAwardsStats: { read: number; total: number };
   yearlyStats: YearlyStat[];
   availabilityStats: AvailabilityStats;
+  publisherStats: PublisherStat[];
+  seriesStats: SeriesStat[];
+  cycleStats: CycleStats;
   libraryStats: LibraryStat[];
 }
 


### PR DESCRIPTION
Second of four new stat cards. Surfaces data the publisher/series/cycles rituals already fill (`currentWydawnictwo` / `currentSeria` / `currentCzesccyklu`) but stats never touched — zero new scanning.

## Changes
- `publisherStats` — top 15 imprints by title count, with read-rate.
- `seriesStats` — top 15 series by title count, with owned/total (collection gaps).
- `cycleStats` — share of "part of a cycle" books in the whole collection.
- `PublishingCard` — cycle-share bar + top imprints (read-rate) + series with „luki/komplet" (green bar = complete set).

## Verification
- `npm run lint` clean · `npm test` **333/333** green (+1: publisher/series/cycle aggregation) · `npm run build` OK.
- Card rendered + screenshotted (headless Chromium) with sample data.
- Version bump `1.29.0` → `1.30.0`; backlog updated.

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_