### PR TITLE
Stats: decade histogram (Oś czasu)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.30.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.31.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.31.0** — **Statystyki: Oś czasu / dekady (STAT-PR3).** `decadeStats` w `getStats` — rollup
+  roczników do dekad (pierwszy 4-cyfrowy rok; wielodatowe → pierwszy; brak roku pominięty),
+  total/read/owned per dekada. Karta `DecadeHistogram` (pełna szerokość, `md:col-span-2`):
+  pionowe słupki total z cyanowym wypełnieniem = przeczytane, złoty highlight „złotej ery"
+  (najliczniejsza dekada), legenda + łączny licznik przeczytań. GOTCHA: kolumny słupków
+  wymagają `h-full` (row `items-end` nie rozciąga wysokości → słupki 0px). Testy +1 → 334.
 - **1.30.0** — **Statystyki: Wydawnictwa / Serie / Cykle (STAT-PR2).** Nowe bloki w `getStats`
   z pól, które wypełniają rytuały publisher/series/cycles, a statystyki dotąd ignorowały:
   `publisherStats` (top 15 oficyn: liczba tytułów + read-rate), `seriesStats` (top 15 serii:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.31.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/statsService.test.ts
+++ b/services/__tests__/statsService.test.ts
@@ -102,6 +102,25 @@ describe('StatsService', () => {
     expect(cycleStats).toEqual({ partOfCycle: 2, standalone: 1, total: 3 });
   });
 
+  it('rolls years up into decades (read/owned, first 4-digit year)', async () => {
+    const mk = (id: string, year: string, zrodlo: string[] = []): NotionBook => ({
+      id, plTitle: `T${id}`, origTitle: "", author: "A", year, zrodlo, awards: [],
+      currentWydawnictwo: "", currentSeria: "", currentCzesccyklu: false, lp: id,
+      plTitleRichText: [], origTitleRichText: [],
+    });
+    mockNotion.getBooksForStats.mockResolvedValue([
+      mk("1", "1954", ["Przeczytane"]),
+      mk("2", "1959", ["Posiadam"]),
+      mk("3", "1965/1966"),        // wielodatowe → 1960
+      mk("4", "brak"),             // bez roku → pominięta
+    ]);
+    const { decadeStats } = await service.getStats();
+    expect(decadeStats).toEqual([
+      { decade: 1950, total: 2, read: 1, owned: 1 },
+      { decade: 1960, total: 1, read: 0, owned: 0 },
+    ]);
+  });
+
   it('builds libraryStats from config branches (id = sourceTag)', async () => {
     mockNotion.getBooksForStats.mockResolvedValue([
       { id: "1", plTitle: "X", origTitle: "", author: "A", year: "1970", zrodlo: ["Biblioteka"], awards: [], currentWydawnictwo: "", currentSeria: "", currentCzesccyklu: false, lp: "1", plTitleRichText: [], origTitleRichText: [] } as NotionBook,

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -121,6 +121,22 @@ export class StatsService {
     const cyclePart = books.filter(b => b.currentCzesccyklu === true).length;
     const cycleStats = { partOfCycle: cyclePart, standalone: books.length - cyclePart, total: books.length };
 
+    // 5d. Rozkład dekad — rollup roczników do dekad (aplikacja już myśli dekadami przez
+    // regał). Pierwszy 4-cyfrowy rok z pola; wielodatowe → pierwszy rok. Brak roku pomijany.
+    const decadeMap: Record<number, { total: number; read: number; owned: number }> = {};
+    books.forEach(book => {
+      const m = (book.year || "").toString().match(/\d{4}/);
+      if (!m) return;
+      const dec = Math.floor(parseInt(m[0], 10) / 10) * 10;
+      if (!decadeMap[dec]) decadeMap[dec] = { total: 0, read: 0, owned: 0 };
+      decadeMap[dec].total++;
+      if (isReadBook(book)) decadeMap[dec].read++;
+      if (isOwnedBook(book)) decadeMap[dec].owned++;
+    });
+    const decadeStats = Object.entries(decadeMap)
+      .map(([decade, s]) => ({ decade: parseInt(decade, 10), ...s }))
+      .sort((a, b) => a.decade - b.decade);
+
     // 6. Yearly progress
     const yearlyStats: Record<string, { read: number; total: number; books: any[] }> = {};
     books.forEach(book => {
@@ -165,6 +181,7 @@ export class StatsService {
       publisherStats,
       seriesStats,
       cycleStats,
+      decadeStats,
       // Filie z konfiguracji (`library.branches`) — dopisanie 3. filii w Kalibracji od razu
       // pojawia się w statystykach. `id` = tag „Źródło" filii (dopasowanie po znaczniku).
       libraryStats: branches.map(branch => ({

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -13,6 +13,7 @@ import { OwnedUnreadItem } from "./stats/OwnedUnreadItem";
 import { AwardCoverageGrid } from "./stats/AwardCoverageGrid";
 import { AvailabilityCard } from "./stats/AvailabilityCard";
 import { PublishingCard } from "./stats/PublishingCard";
+import { DecadeHistogram } from "./stats/DecadeHistogram";
 import { useEffectiveConfig } from "../hooks/useAppConfig";
 
 export const StatsSection: React.FC = () => {
@@ -136,6 +137,11 @@ export const StatsSection: React.FC = () => {
 
         {/* Publishers / Series / Cycles */}
         <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} />
+
+        {/* Decade histogram — full width */}
+        <div className="md:col-span-2">
+          <DecadeHistogram decades={stats.decadeStats} />
+        </div>
 
         {/* Yearly Progress */}
         <motion.div

--- a/src/components/stats/DecadeHistogram.tsx
+++ b/src/components/stats/DecadeHistogram.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { motion } from "motion/react";
+import { BarChart3, Crown } from "lucide-react";
+import { DecadeStat } from "../../hooks/useStats";
+
+/**
+ * Oś czasu / dekady — histogram rozkładu kolekcji po dekadach wydania (aplikacja
+ * już myśli dekadami przez regał). Słupek = total; wypełnienie = przeczytane.
+ * Wyróżniona „złota era" (najliczniejsza dekada).
+ */
+export const DecadeHistogram: React.FC<{ decades: DecadeStat[] }> = ({ decades }) => {
+  const max = Math.max(1, ...decades.map((d) => d.total));
+  const peak = decades.reduce<DecadeStat | null>((best, d) => (!best || d.total > best.total ? d : best), null);
+  const totalRead = decades.reduce((s, d) => s + d.read, 0);
+  const totalAll = decades.reduce((s, d) => s + d.total, 0);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.22 }}
+      className="glass-card p-6 rounded-3xl border-amber-500/10 space-y-6"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-bold font-display uppercase tracking-widest text-amber-400 flex items-center gap-2">
+          <BarChart3 className="w-4 h-4" />
+          Oś Czasu Archiwum
+        </h3>
+        {peak && (
+          <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-amber-300/80">
+            <Crown className="w-3.5 h-3.5" /> Złota era: {peak.decade}.
+          </span>
+        )}
+      </div>
+
+      {decades.length === 0 ? (
+        <p className="text-slate-400 text-sm italic text-center py-8">Brak dat wydania w kolekcji.</p>
+      ) : (
+        <>
+          {/* Histogram — słupki pionowe, wypełnienie = przeczytane */}
+          <div className="flex items-end gap-1.5 h-[160px] pt-2">
+            {decades.map((d) => {
+              const h = (d.total / max) * 100;
+              const readH = d.total > 0 ? (d.read / d.total) * 100 : 0;
+              const isPeak = peak?.decade === d.decade;
+              return (
+                <div key={d.decade} className="flex-1 h-full flex flex-col items-center gap-1.5 min-w-0 group">
+                  <span className="text-[9px] text-slate-500 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity">{d.total}</span>
+                  <div className="w-full flex-1 flex items-end" style={{ minHeight: 1 }}>
+                    <div
+                      className={`w-full rounded-t-[3px] relative overflow-hidden ${isPeak ? "bg-amber-500/25" : "bg-slate-700/40"}`}
+                      style={{ height: `${Math.max(h, 2)}%` }}
+                      title={`${d.decade}–${d.decade + 9}: ${d.total} (przecz. ${d.read}, posiad. ${d.owned})`}
+                    >
+                      {/* Wypełnienie = przeczytane (od dołu) */}
+                      <div
+                        className={`absolute bottom-0 inset-x-0 ${isPeak ? "bg-gradient-to-t from-amber-500 to-amber-400" : "bg-gradient-to-t from-cyan-500 to-cyan-400"}`}
+                        style={{ height: `${readH}%` }}
+                      />
+                    </div>
+                  </div>
+                  <span className="text-[9px] text-slate-500 tabular-nums whitespace-nowrap">{`'${String(d.decade % 100).padStart(2, "0")}`}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Legenda */}
+          <div className="flex items-center justify-center gap-5 text-[10px] text-slate-500 uppercase tracking-widest font-bold">
+            <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-cyan-400" /> Przeczytane</span>
+            <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-slate-700/60" /> Pozostałe</span>
+            <span className="text-slate-400 tabular-nums normal-case tracking-normal">{totalRead}/{totalAll} łącznie</span>
+          </div>
+        </>
+      )}
+    </motion.div>
+  );
+};

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -52,6 +52,7 @@ export interface AvailabilityStats {
 export interface PublisherStat { name: string; count: number; read: number }
 export interface SeriesStat { name: string; count: number; owned: number; read: number }
 export interface CycleStats { partOfCycle: number; standalone: number; total: number }
+export interface DecadeStat { decade: number; total: number; read: number; owned: number }
 
 export interface Stats {
   authorStats: AuthorStat[];
@@ -64,6 +65,7 @@ export interface Stats {
   publisherStats: PublisherStat[];
   seriesStats: SeriesStat[];
   cycleStats: CycleStats;
+  decadeStats: DecadeStat[];
   libraryStats: LibraryStat[];
 }
 


### PR DESCRIPTION
Third of four new stat cards. Rolls publication years up into decades — the app already thinks in decades via the shelf, this brings it into stats.

## Changes
- `decadeStats` in `getStats`: total/read/owned per decade (first 4-digit year; multi-date → first; no year → skipped).
- `DecadeHistogram` (full width, `md:col-span-2`): total bars with a cyan read-fill, a golden highlight on the "golden era" (busiest decade), legend + overall read counter.

Pure read of `year` + `zrodlo`, zero new scanning.

## Verification
- `npm run lint` clean · `npm test` **334/334** green (+1: decade rollup) · `npm run build` OK.
- Histogram rendered + screenshotted (headless Chromium). Note in code: bar columns need `h-full` (row `items-end` doesn't stretch height, else bars collapse to 0px) — caught in visual check.
- Version bump `1.30.0` → `1.31.0`; backlog updated.

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_