### PR TITLE
Stats: Market panel (Vinted) — completion cost, deals, drops, sellers

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.31.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.32.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.32.0** — **Statystyki: panel „Rynek" (STAT-PR4, ostatnia z 4 kart).** Czysty helper
+  `services/marketStats.ts` (`computeMarketStats`) z blobu `VintedData`: koszt skompletowania
+  (suma najtańszych ofert po jednej na CHCIANĄ książkę — nieprzeczytana i nieposiadana),
+  najtańsze okazje (top 8), świeże spadki cen (cena < prevPrice, największe pierwsze),
+  ranking sprzedawców z paczką (≥2 chcianych książek, suma min-per-book). Waluta = dominująca
+  w ofertach. Karta `MarketCard` (actionable — linki wprost do ofert/profili). Reuse
+  `parseVintedData`. Testy +5 (osobny plik) → 339. **KOMPLET 4 kart statystyk** (Rynek /
+  Wydawnictwa-Serie-Cykle / Dekady / Dostępność) — wszystkie z danych, które już mamy.
 - **1.31.0** — **Statystyki: Oś czasu / dekady (STAT-PR3).** `decadeStats` w `getStats` — rollup
   roczników do dekad (pierwszy 4-cyfrowy rok; wielodatowe → pierwszy; brak roku pominięty),
   total/read/owned per dekada. Karta `DecadeHistogram` (pełna szerokość, `md:col-span-2`):

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.31.0",
+  "version": "1.32.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/marketStats.test.ts
+++ b/services/__tests__/marketStats.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { computeMarketStats } from "../marketStats";
+import { NotionBook } from "../../src/types";
+
+const blob = (offers: any[], extra: any = {}) => JSON.stringify({ scannedAt: "2026-01-01", offers, ...extra });
+const mk = (id: string, over: Partial<NotionBook>): NotionBook => ({
+  id, plTitle: `T${id}`, origTitle: "", author: "A", year: "1970", zrodlo: [], awards: [],
+  currentWydawnictwo: "", currentSeria: "", currentCzesccyklu: false, lp: id,
+  plTitleRichText: [], origTitleRichText: [], ...over,
+});
+
+describe("marketStats.computeMarketStats", () => {
+  it("sums the cheapest wanted-book offers into completion cost", () => {
+    const books = [
+      mk("1", { vintedData: blob([{ url: "u1", price: 20, currency: "PLN" }, { url: "u2", price: 12, currency: "PLN" }]) }),
+      mk("2", { vintedData: blob([{ url: "u3", price: 30, currency: "PLN" }]) }),
+    ];
+    const m = computeMarketStats(books);
+    expect(m.completionCost).toBe(42); // 12 + 30
+    expect(m.booksWithOffers).toBe(2);
+    expect(m.totalOffers).toBe(3);
+    expect(m.currency).toBe("PLN");
+    expect(m.cheapest[0]).toMatchObject({ price: 12, bookId: "1" });
+  });
+
+  it("excludes owned and read books (already have / don't want)", () => {
+    const books = [
+      mk("1", { zrodlo: ["Posiadam"], vintedData: blob([{ url: "u", price: 10, currency: "PLN" }]) }),
+      mk("2", { zrodlo: ["Przeczytane"], vintedData: blob([{ url: "u", price: 10, currency: "PLN" }]) }),
+      mk("3", { vintedData: blob([{ url: "u", price: 15, currency: "PLN" }]) }),
+    ];
+    const m = computeMarketStats(books);
+    expect(m.booksWithOffers).toBe(1);
+    expect(m.completionCost).toBe(15);
+  });
+
+  it("captures price drops (price < prevPrice), biggest first", () => {
+    const books = [
+      mk("1", { vintedData: blob([{ url: "u", price: 18, prevPrice: 25, currency: "PLN" }]) }),
+      mk("2", { vintedData: blob([{ url: "u", price: 40, prevPrice: 100, currency: "PLN" }]) }),
+      mk("3", { vintedData: blob([{ url: "u", price: 10, prevPrice: 8, currency: "PLN" }]) }), // wzrost — pomijany
+    ];
+    const m = computeMarketStats(books);
+    expect(m.priceDrops.map((d) => d.bookId)).toEqual(["2", "1"]);
+    expect(m.priceDrops[0]).toMatchObject({ prevPrice: 100, price: 40 });
+  });
+
+  it("ranks sellers by distinct wanted books (>=2), summing per-book minimums", () => {
+    const seller = (id: string, login: string) => ({ id, login, url: `https://vinted.pl/member/${id}` });
+    const books = [
+      mk("1", { vintedData: blob([{ url: "u", price: 20, currency: "PLN", seller: seller("s1", "ala") }]) }),
+      mk("2", { vintedData: blob([{ url: "u", price: 30, currency: "PLN", seller: seller("s1", "ala") }]) }),
+      mk("3", { vintedData: blob([{ url: "u", price: 15, currency: "PLN", seller: seller("s2", "bob") }]) }), // tylko 1 książka
+    ];
+    const m = computeMarketStats(books);
+    expect(m.topSellers).toHaveLength(1);
+    expect(m.topSellers[0]).toMatchObject({ id: "s1", login: "ala", books: 2, total: 50 });
+  });
+
+  it("ignores books without offers / without prices / without blob", () => {
+    const books = [
+      mk("1", {}),                                                   // brak blobu
+      mk("2", { vintedData: blob([]) }),                             // pusto
+      mk("3", { vintedData: blob([{ url: "u", price: null, currency: "PLN" }]) }), // bez ceny
+    ];
+    const m = computeMarketStats(books);
+    expect(m).toMatchObject({ completionCost: 0, booksWithOffers: 0, totalOffers: 0 });
+    expect(m.cheapest).toEqual([]);
+  });
+});

--- a/services/marketStats.ts
+++ b/services/marketStats.ts
@@ -1,0 +1,92 @@
+import { NotionBook } from "../src/types";
+import { parseVintedData } from "./vintedStore";
+
+/**
+ * „Rynek" — statystyki z blobu `VintedData` (składowane oferty). Czysta funkcja
+ * (bez I/O): liczy z pól, które skaner już zebrał. „Chciane" = nieprzeczytane
+ * i nieposiadane (te faktycznie warto kupić). Zob. docs/stats-service.md.
+ */
+
+export interface CheapOffer { bookId: string; bookTitle: string; price: number; currency: string; url: string }
+export interface PriceDrop extends CheapOffer { prevPrice: number }
+export interface TopSeller { id: string; login: string; url: string; books: number; total: number }
+
+export interface MarketStats {
+  currency: string;
+  /** Suma najtańszych ofert po jednej na chcianą książkę z ofertami — koszt skompletowania. */
+  completionCost: number;
+  /** Ile chcianych książek ma ≥1 ofertę z ceną. */
+  booksWithOffers: number;
+  /** Łączna liczba ofert z ceną wśród chcianych książek. */
+  totalOffers: number;
+  /** Najtańsze pojedyncze oferty (top). */
+  cheapest: CheapOffer[];
+  /** Świeże spadki cen (cena < poprzednia). */
+  priceDrops: PriceDrop[];
+  /** Sprzedawcy z największą liczbą chcianych książek (naturalne paczki). */
+  topSellers: TopSeller[];
+}
+
+const isWanted = (b: NotionBook) => {
+  const zr = b.zrodlo || [];
+  return !zr.includes("Przeczytane") && !zr.includes("Posiadam");
+};
+
+export function computeMarketStats(books: NotionBook[]): MarketStats {
+  let completionCost = 0;
+  let booksWithOffers = 0;
+  let totalOffers = 0;
+  const cheapestAll: CheapOffer[] = [];
+  const drops: PriceDrop[] = [];
+  const currencyCount: Record<string, number> = {};
+  // seller.id → { login, url, books:Set, total(min-per-book) }
+  const sellers: Record<string, { login: string; url: string; books: Set<string>; perBookMin: Record<string, number> }> = {};
+
+  for (const book of books) {
+    if (!isWanted(book)) continue;
+    const data = parseVintedData(book.vintedData);
+    if (!data) continue;
+    const title = book.plTitle || book.origTitle || "—";
+    const priced = data.offers.filter((o) => typeof o.price === "number" && o.price! > 0);
+    if (priced.length === 0) continue;
+
+    booksWithOffers++;
+    totalOffers += priced.length;
+
+    let bookMin = Infinity;
+    for (const o of priced) {
+      const price = o.price as number;
+      currencyCount[o.currency] = (currencyCount[o.currency] || 0) + 1;
+      if (price < bookMin) bookMin = price;
+      cheapestAll.push({ bookId: book.id, bookTitle: title, price, currency: o.currency, url: o.url });
+      if (typeof o.prevPrice === "number" && o.prevPrice > price) {
+        drops.push({ bookId: book.id, bookTitle: title, price, prevPrice: o.prevPrice, currency: o.currency, url: o.url });
+      }
+      // Sprzedawca (dociągnięty w etapie 2) — grupowanie chcianych książek.
+      if (o.seller?.id) {
+        const s = (sellers[o.seller.id] ||= { login: o.seller.login, url: o.seller.url, books: new Set(), perBookMin: {} });
+        s.books.add(book.id);
+        s.perBookMin[book.id] = Math.min(s.perBookMin[book.id] ?? Infinity, price);
+      }
+    }
+    completionCost += bookMin;
+  }
+
+  const currency = Object.entries(currencyCount).sort((a, b) => b[1] - a[1])[0]?.[0] || "PLN";
+
+  const topSellers: TopSeller[] = Object.entries(sellers)
+    .map(([id, s]) => ({ id, login: s.login, url: s.url, books: s.books.size, total: Object.values(s.perBookMin).reduce((a, b) => a + b, 0) }))
+    .filter((s) => s.books >= 2) // paczka ma sens od 2 książek
+    .sort((a, b) => b.books - a.books || a.total - b.total)
+    .slice(0, 6);
+
+  return {
+    currency,
+    completionCost: Math.round(completionCost * 100) / 100,
+    booksWithOffers,
+    totalOffers,
+    cheapest: cheapestAll.sort((a, b) => a.price - b.price).slice(0, 8),
+    priceDrops: drops.sort((a, b) => (b.prevPrice - b.price) - (a.prevPrice - a.price)).slice(0, 8),
+    topSellers,
+  };
+}

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -1,6 +1,7 @@
 import { NotionAdapter } from "../notion.adapter";
 import { ConfigService } from "./configService";
 import { parseVintedData } from "./vintedStore";
+import { computeMarketStats } from "./marketStats";
 
 export class StatsService {
   constructor(private notion: NotionAdapter, private config: ConfigService) {}
@@ -137,6 +138,9 @@ export class StatsService {
       .map(([decade, s]) => ({ decade: parseInt(decade, 10), ...s }))
       .sort((a, b) => a.decade - b.decade);
 
+    // 5e. Rynek — statystyki z blobu VintedData (koszt skompletowania, okazje, spadki, sprzedawcy).
+    const marketStats = computeMarketStats(books);
+
     // 6. Yearly progress
     const yearlyStats: Record<string, { read: number; total: number; books: any[] }> = {};
     books.forEach(book => {
@@ -182,6 +186,7 @@ export class StatsService {
       seriesStats,
       cycleStats,
       decadeStats,
+      marketStats,
       // Filie z konfiguracji (`library.branches`) — dopisanie 3. filii w Kalibracji od razu
       // pojawia się w statystykach. `id` = tag „Źródło" filii (dopasowanie po znaczniku).
       libraryStats: branches.map(branch => ({

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -14,6 +14,7 @@ import { AwardCoverageGrid } from "./stats/AwardCoverageGrid";
 import { AvailabilityCard } from "./stats/AvailabilityCard";
 import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
+import { MarketCard } from "./stats/MarketCard";
 import { useEffectiveConfig } from "../hooks/useAppConfig";
 
 export const StatsSection: React.FC = () => {
@@ -134,6 +135,9 @@ export const StatsSection: React.FC = () => {
 
         {/* Aggregate Availability */}
         <AvailabilityCard stats={stats.availabilityStats} />
+
+        {/* Market (Vinted) */}
+        <MarketCard market={stats.marketStats} />
 
         {/* Publishers / Series / Cycles */}
         <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} />

--- a/src/components/stats/MarketCard.tsx
+++ b/src/components/stats/MarketCard.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Coins, Tag, TrendingDown, Users, ExternalLink } from "lucide-react";
+import { MarketStats } from "../../hooks/useStats";
+
+/**
+ * „Rynek" — statystyki z blobu VintedData: koszt skompletowania kolekcji (suma
+ * najtańszych ofert chcianych książek), najtańsze okazje, świeże spadki cen,
+ * sprzedawcy z największą liczbą chcianych książek (naturalne paczki). Actionable —
+ * linki wiodą wprost do ofert.
+ */
+
+const money = (n: number, cur: string) => `${n.toLocaleString("pl-PL", { maximumFractionDigits: 0 })} ${cur}`;
+
+const OfferRow: React.FC<{ title: string; url: string; children: React.ReactNode }> = ({ title, url, children }) => (
+  <a href={url} target="_blank" rel="noopener noreferrer"
+    className="flex items-center gap-2 p-2 rounded-xl bg-slate-950/40 border border-white/5 hover:border-rose-500/30 hover:bg-rose-500/5 transition-all group">
+    <span className="text-xs text-slate-300 flex-1 truncate group-hover:text-rose-200">{title}</span>
+    {children}
+    <ExternalLink className="w-3 h-3 text-slate-600 group-hover:text-rose-400 shrink-0" />
+  </a>
+);
+
+export const MarketCard: React.FC<{ market: MarketStats }> = ({ market }) => {
+  const { currency: cur } = market;
+  const hasData = market.booksWithOffers > 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.12 }}
+      className="glass-card p-6 rounded-3xl border-rose-500/10 space-y-6"
+    >
+      <h3 className="text-sm font-bold font-display uppercase tracking-widest text-rose-400 flex items-center gap-2 mb-4">
+        <Coins className="w-4 h-4" />
+        Rynek Reliktów (Vinted)
+      </h3>
+
+      {!hasData ? (
+        <p className="text-slate-400 text-sm italic text-center py-8">Brak składowanych ofert — uruchom Rytuał Skanowania Vinted.</p>
+      ) : (
+        <>
+          {/* Koszt skompletowania */}
+          <div className="p-4 rounded-2xl bg-gradient-to-br from-rose-500/10 to-slate-950/40 border border-rose-500/20">
+            <div className="flex items-baseline gap-2">
+              <span className="text-3xl font-bold font-display text-rose-200 tabular-nums">{money(market.completionCost, cur)}</span>
+            </div>
+            <p className="text-[11px] text-slate-400 mt-1">
+              koszt skompletowania — najtańsza oferta dla każdej z <span className="text-rose-300 font-bold">{market.booksWithOffers}</span> chcianych książek ({market.totalOffers} ofert łącznie)
+            </p>
+          </div>
+
+          {/* Najtańsze okazje */}
+          <div className="space-y-2">
+            <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Tag className="w-3 h-3" /> Najtańsze okazje</h4>
+            <div className="space-y-1.5 max-h-[160px] overflow-y-auto pr-1 custom-scrollbar">
+              {market.cheapest.map((o, i) => (
+                <OfferRow key={i} title={o.bookTitle} url={o.url}>
+                  <span className="text-xs font-bold text-emerald-300 tabular-nums shrink-0">{money(o.price, o.currency)}</span>
+                </OfferRow>
+              ))}
+            </div>
+          </div>
+
+          {/* Świeże spadki cen */}
+          {market.priceDrops.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><TrendingDown className="w-3 h-3 text-emerald-400" /> Spadki cen</h4>
+              <div className="space-y-1.5 max-h-[140px] overflow-y-auto pr-1 custom-scrollbar">
+                {market.priceDrops.map((d, i) => (
+                  <OfferRow key={i} title={d.bookTitle} url={d.url}>
+                    <span className="text-[10px] text-slate-500 line-through tabular-nums shrink-0">{money(d.prevPrice, d.currency)}</span>
+                    <span className="text-xs font-bold text-emerald-300 tabular-nums shrink-0">{money(d.price, d.currency)}</span>
+                    <span className="text-[10px] font-bold text-emerald-400 tabular-nums shrink-0">−{Math.round(d.prevPrice - d.price)}</span>
+                  </OfferRow>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Sprzedawcy z paczką */}
+          {market.topSellers.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Users className="w-3 h-3" /> Sprzedawcy z paczką</h4>
+              <div className="space-y-1.5">
+                {market.topSellers.map((s) => (
+                  <a key={s.id} href={s.url} target="_blank" rel="noopener noreferrer"
+                    className="flex items-center gap-2 p-2 rounded-xl bg-slate-950/40 border border-white/5 hover:border-purple-500/30 hover:bg-purple-500/5 transition-all group">
+                    <span className="text-xs text-slate-300 flex-1 truncate group-hover:text-purple-200">{s.login}</span>
+                    <span className="text-[10px] text-slate-500 tabular-nums shrink-0">~{money(s.total, cur)}</span>
+                    <span className="px-1.5 py-0.5 rounded-md bg-purple-500/15 text-purple-300 text-[10px] font-bold tabular-nums shrink-0">{s.books} książki</span>
+                    <ExternalLink className="w-3 h-3 text-slate-600 group-hover:text-purple-400 shrink-0" />
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </motion.div>
+  );
+};

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -54,6 +54,19 @@ export interface SeriesStat { name: string; count: number; owned: number; read: 
 export interface CycleStats { partOfCycle: number; standalone: number; total: number }
 export interface DecadeStat { decade: number; total: number; read: number; owned: number }
 
+export interface CheapOffer { bookId: string; bookTitle: string; price: number; currency: string; url: string }
+export interface PriceDrop extends CheapOffer { prevPrice: number }
+export interface TopSeller { id: string; login: string; url: string; books: number; total: number }
+export interface MarketStats {
+  currency: string;
+  completionCost: number;
+  booksWithOffers: number;
+  totalOffers: number;
+  cheapest: CheapOffer[];
+  priceDrops: PriceDrop[];
+  topSellers: TopSeller[];
+}
+
 export interface Stats {
   authorStats: AuthorStat[];
   awardBooksStats: { read: number; total: number };
@@ -66,6 +79,7 @@ export interface Stats {
   seriesStats: SeriesStat[];
   cycleStats: CycleStats;
   decadeStats: DecadeStat[];
+  marketStats: MarketStats;
   libraryStats: LibraryStat[];
 }
 


### PR DESCRIPTION
Fourth and last of the new stat cards — the most actionable one. All from the stored `VintedData` blob (prices/sellers), zero new scanning.

## Changes
- **Pure `services/marketStats.ts`** (`computeMarketStats`). "Wanted" = unread & unowned.
  - `completionCost` — sum of the cheapest offer per wanted book that has offers ("brakuje N tomów za ~X zł").
  - `cheapest` — top 8 individual offers.
  - `priceDrops` — offers with `price < prevPrice`, biggest drop first.
  - `topSellers` — sellers holding ≥2 wanted books (bundle opportunity), with the sum of per-book minimums; dominant currency picked from the offers.
- **`MarketCard`** — completion-cost hero + deals + drops (struck-through old price + delta) + bundle sellers, each row linking straight to the offer/profile.

## Verification
- `npm run lint` clean · `npm test` **339/339** green (+5: cheapest sum, owned/read exclusion, drops ordering, seller ranking, empty-blob guard) · `npm run build` OK.
- Card rendered + screenshotted (headless Chromium) with sample data.
- Version bump `1.31.0` → `1.32.0`; backlog updated.

Completes the 4-card stats set (Market / Publishers-Series-Cycles / Decades / Availability), all built from data the app already stores.

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_