### PR TITLE
Cycle preview backend: parser + on-demand lookup service + endpoint

### DIFF
--- a/__tests__/cycleLookup.test.ts
+++ b/__tests__/cycleLookup.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { WikiParser } from "../wiki.parser";
+import { CycleLookupService } from "../services/cycleLookupService";
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+
+describe("WikiParser.extractCycleInfo", () => {
+  it("reads cykl / poprzednia / następna from the {{Książka}} infobox", () => {
+    const wt = `{{Książka
+| tytuł = Gildia Orędowników
+| cykl = [[Childe]]
+| poprzednia = [[Młody Bleys]]
+| następna = Gra Endera
+}}`;
+    const info = WikiParser.extractCycleInfo(wt);
+    expect(info.cycleName).toBe("Childe");
+    expect(info.prev).toBe("Młody Bleys");
+    expect(info.next).toBe("Gra Endera");
+  });
+
+  it("tolerates the accent-less 'nastepna' spelling and empty fields", () => {
+    expect(WikiParser.extractCycleInfo("| nastepna = Tom 2").next).toBe("Tom 2");
+    expect(WikiParser.extractCycleInfo("| poprzednia = \n| cykl = X")).toMatchObject({ cycleName: "X", prev: null });
+  });
+
+  it("harvests wikilinks from a {{Cykl}} navigation template in order", () => {
+    const wt = `{{Cykl|[[Diuna]]|[[Mesjasz Diuny]]|[[Dzieci Diuny]]}}`;
+    expect(WikiParser.extractCycleInfo(wt).templateVolumes).toEqual(["Diuna", "Mesjasz Diuny", "Dzieci Diuny"]);
+  });
+
+  it("returns empty for a page with no cycle markers", () => {
+    expect(WikiParser.extractCycleInfo("{{Książka|tytuł=Solaris}}")).toEqual({ cycleName: "", prev: null, next: null, templateVolumes: [] });
+  });
+});
+
+describe("CycleLookupService.lookup", () => {
+  const page = (over: Record<string, string>) =>
+    "{{Książka\n" + Object.entries(over).map(([k, v]) => `| ${k} = ${v}`).join("\n") + "\n}}";
+
+  const makeWiki = (pages: Record<string, string>) => ({
+    fetchPageContent: vi.fn(async (t: string) => pages[t] || ""),
+    searchPage: vi.fn(async () => []),
+  }) as unknown as WikiAdapter;
+
+  const makeNotion = (books: any[]) => ({
+    getBooksForStats: vi.fn(async () => books),
+  }) as unknown as NotionAdapter;
+
+  it("walks the prev/next chain into an ordered volume list and cross-refs the base", async () => {
+    const wiki = makeWiki({
+      "Tom 1": page({ cykl: "Saga", następna: "Tom 2" }),
+      "Tom 2": page({ cykl: "Saga", poprzednia: "Tom 1", następna: "Tom 3" }),
+      "Tom 3": page({ cykl: "Saga", poprzednia: "Tom 2" }),
+    });
+    const notion = makeNotion([
+      { id: "a", plTitle: "Tom 1", origTitle: "", zrodlo: ["Posiadam"], awards: [] },
+      { id: "b", plTitle: "Tom 2", origTitle: "", zrodlo: ["Przeczytane", "Posiadam"], awards: ["Nagroda Hugo"] },
+      // Tom 3 poza bazą
+    ]);
+    const svc = new CycleLookupService(notion, wiki);
+    const view = await svc.lookup("Tom 2", "");
+    expect(view).not.toBeNull();
+    expect(view!.cycleName).toBe("Saga");
+    expect(view!.volumes.map((v) => v.title)).toEqual(["Tom 1", "Tom 2", "Tom 3"]);
+    const [v1, v2, v3] = view!.volumes;
+    expect(v1).toMatchObject({ owned: true, read: false, isCurrent: false, inBase: true });
+    expect(v2).toMatchObject({ read: true, awarded: true, isCurrent: true });
+    expect(v3).toMatchObject({ inBase: false, read: false });
+    expect(view!.source).toBe("chain");
+  });
+
+  it("counts unread volumes before the current one (reading order gap)", async () => {
+    const wiki = makeWiki({
+      "T1": page({ cykl: "S", następna: "T2" }),
+      "T2": page({ cykl: "S", poprzednia: "T1", następna: "T3" }),
+      "T3": page({ cykl: "S", poprzednia: "T2" }),
+    });
+    const notion = makeNotion([{ id: "1", plTitle: "T1", origTitle: "", zrodlo: [], awards: [] }]);
+    const svc = new CycleLookupService(notion, wiki);
+    const view = await svc.lookup("T3", "");
+    expect(view!.unreadBefore).toBe(2); // T1 i T2 nieprzeczytane
+  });
+
+  it("returns null when the book is not part of any cycle", async () => {
+    const wiki = makeWiki({ "X": page({ tytuł: "X" }) });
+    const svc = new CycleLookupService(makeNotion([]), wiki);
+    expect(await svc.lookup("X", "")).toBeNull();
+  });
+
+  it("caches the result (single resolve per title+author)", async () => {
+    const wiki = makeWiki({ "T1": page({ cykl: "S", następna: "T2" }), "T2": page({ cykl: "S", poprzednia: "T1" }) });
+    const svc = new CycleLookupService(makeNotion([]), wiki);
+    await svc.lookup("T1", "");
+    const calls = (wiki.fetchPageContent as any).mock.calls.length;
+    await svc.lookup("T1", "");
+    expect((wiki.fetchPageContent as any).mock.calls.length).toBe(calls); // brak nowych fetchy
+  });
+});

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.32.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.33.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.33.0** — **Podgląd cyklu — backend (CYC-PR1).** Na żądanie, BEZ zapisu do Notion (zgodnie z
+  preferencją: nie zaśmiecamy bazy). `WikiParser.extractCycleInfo` (nazwa `|cykl=`, łańcuch
+  `|poprzednia=`/`|następna=` — potwierdzony format; oba warianty ogonka „następna/nastepna"; +
+  oportunistyczne linki z `{{Cykl}}`). `services/cycleLookupService.ts`: rozwiązuje stronę książki
+  (direct+search+bramka autora), chodzi po łańcuchu prev/next (bounded MAX_HOPS=15, visited-set),
+  dołącza linki `{{Cykl}}`, krzyżuje każdy tom z bazą (inBase/read/owned/awarded), liczy `unreadBefore`
+  (ile tomów przed bieżącym nieprzeczytanych = koszt wejścia w fabułę). Cache w pamięci procesu
+  (title+author). `GET /api/cycle?title&author` (404 = brak cyklu). Testy +8 → 347. UWAGA: host
+  encyklopedii zablokowany przez proxy dev-kontenera (403) — format `{{Cykl}}` nieweryfikowalny lokalnie,
+  dlatego RDZEŃ = pewny łańcuch prev/next; działanie na żywo potwierdzić po deployu.
 - **1.32.0** — **Statystyki: panel „Rynek" (STAT-PR4, ostatnia z 4 kart).** Czysty helper
   `services/marketStats.ts` (`computeMarketStats`) z blobu `VintedData`: koszt skompletowania
   (suma najtańszych ofert po jednej na CHCIANĄ książkę — nieprzeczytana i nieposiadana),

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -297,6 +297,25 @@ export const getVintedStored = async (_req: Request, res: Response) => {
   }
 };
 
+/**
+ * Podgląd cyklu dla książki (Skryptorium) — pobiera stronę wiki na żądanie, buduje
+ * listę tomów i krzyżuje z bazą. NIE zapisuje niczego do Notion. 404 = książka nie
+ * jest w cyklu / brak danych na wiki.
+ */
+export const getCycle = async (req: Request, res: Response) => {
+  const title = typeof req.query.title === "string" ? req.query.title.trim() : "";
+  const author = typeof req.query.author === "string" ? req.query.author.trim() : "";
+  if (!title) return res.status(400).json({ error: "Brak parametru title." });
+  try {
+    const view = await syncManager.getCycle(title, author);
+    if (!view) return res.status(404).json({ error: "Nie znaleziono cyklu dla tej książki." });
+    res.json(view);
+  } catch (error: any) {
+    log.error("Cycle lookup error", { title, message: error?.message });
+    res.status(500).json({ error: error.message || "Błąd podglądu cyklu." });
+  }
+};
+
 export const checkLibraryAvailability = async (req: Request, res: Response) => {
   const { libraryCode } = req.body;
   if (!libraryCode) return res.status(400).json({ error: "Missing libraryCode parameter" });

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.33.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -41,6 +41,7 @@ router.post("/vinted-check/stop", syncController.stopVintedCheck);
 router.post("/vinted-resolve-sellers", syncController.resolveVintedSellers);
 router.post("/vinted-resolve-sellers/stop", syncController.stopVintedResolveSellers);
 router.get("/vinted-stored", syncController.getVintedStored);
+router.get("/cycle", syncController.getCycle);
 router.post("/library-check", syncController.checkLibraryAvailability);
 
 export default router;

--- a/services/cycleLookupService.ts
+++ b/services/cycleLookupService.ts
@@ -1,0 +1,153 @@
+import { NotionAdapter } from "../notion.adapter";
+import { WikiAdapter } from "../wiki.adapter";
+import { WikiParser } from "../wiki.parser";
+import { NotionBook } from "../src/types";
+import { isWikiAuthorMatch } from "./dataNormalizer";
+import { createLogger } from "../logger";
+
+const log = createLogger("CycleLookup");
+
+/** Status jednego tomu względem TWOJEJ bazy (krzyżowanie po znormalizowanym tytule). */
+export interface CycleVolume {
+  title: string;
+  /** Czy to książka, z której wyszedł podgląd. */
+  isCurrent: boolean;
+  /** Czy tom jest w bazie Notion. */
+  inBase: boolean;
+  read: boolean;
+  owned: boolean;
+  /** Czy tom jest nagrodzony (ma jakąkolwiek nagrodę w bazie). */
+  awarded: boolean;
+  awards: string[];
+}
+
+export interface CycleView {
+  cycleName: string;
+  volumes: CycleVolume[];
+  /** Ile tomów PRZED bieżącym nie jest przeczytanych (książki do nadrobienia przed fabułą). */
+  unreadBefore: number;
+  /** Źródło listy: „chain" (prev/next), „template" ({{Cykl}}), „mixed". */
+  source: "chain" | "template" | "mixed" | "single";
+}
+
+/** Normalizacja tytułu do krzyżowania: bez formatowania wiki, lowercase, bez interpunkcji brzegowej. */
+function normTitle(t: string): string {
+  return (t || "")
+    .replace(/''+/g, "")
+    .replace(/\[\[([^\]|]+\|)?([^\]]+)\]\]/g, "$2")
+    .toLowerCase()
+    .replace(/[.,:;!?'"„”»«()]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const MAX_HOPS = 15; // bezpiecznik chodzenia po łańcuchu w każdą stronę
+
+/**
+ * Podgląd cyklu dla pojedynczej książki — NA ŻĄDANIE, bez zapisu do Notion.
+ * Buduje uporządkowaną listę tomów z łańcucha `|poprzednia=`/`|następna=` (pewny,
+ * potwierdzony format), wzbogaca o linki z `{{Cykl}}`, i krzyżuje każdy tom z bazą.
+ * Cache w pamięci procesu (klucz: tytuł+autor) — powtórne kliknięcie jest natychmiastowe.
+ */
+export class CycleLookupService {
+  private cache = new Map<string, CycleView | null>();
+
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
+
+  /** Rozwiązuje stronę wiki dla (tytuł, autor): direct fetch + search, z bramką autora. */
+  private async resolvePage(title: string, author: string): Promise<string> {
+    // 1. Bezpośrednie pobranie po dokładnym tytule.
+    const direct = await this.wiki.fetchPageContent(title);
+    if (direct && (!author || isWikiAuthorMatch(WikiParser.extractAuthor(direct), author))) return direct;
+    // 2. Wyszukiwanie po „tytuł autor".
+    if (author) {
+      const hits = await this.wiki.searchPage(`${title} ${author}`, 3);
+      for (const h of hits) {
+        const c = await this.wiki.fetchPageContent(h);
+        if (c && isWikiAuthorMatch(WikiParser.extractAuthor(c), author)) return c;
+      }
+    }
+    return direct || "";
+  }
+
+  /** Fetch po dokładnym tytule sąsiada z łańcucha (bez bramki autora — tytuł z zaufanego pola). */
+  private async fetchNeighbor(title: string): Promise<string> {
+    try { return await this.wiki.fetchPageContent(title); } catch { return ""; }
+  }
+
+  async lookup(rawTitle: string, author: string): Promise<CycleView | null> {
+    const key = `${normTitle(rawTitle)}|${(author || "").toLowerCase().trim()}`;
+    if (this.cache.has(key)) return this.cache.get(key)!;
+    const result = await this.compute(rawTitle, author);
+    this.cache.set(key, result);
+    return result;
+  }
+
+  private async compute(rawTitle: string, author: string): Promise<CycleView | null> {
+    const wikitext = await this.resolvePage(rawTitle, author);
+    if (!wikitext) return null;
+    const info = WikiParser.extractCycleInfo(wikitext);
+    if (!info.cycleName && !info.prev && !info.next && info.templateVolumes.length === 0) return null;
+
+    // Uporządkowany łańcuch: ...prev(prev), prev, [current], next, next(next)...
+    const before: string[] = [];
+    const after: string[] = [];
+    const visited = new Set<string>([normTitle(rawTitle)]);
+
+    let cursor = info.prev;
+    for (let i = 0; i < MAX_HOPS && cursor; i++) {
+      const n = normTitle(cursor);
+      if (visited.has(n)) break;
+      visited.add(n);
+      before.unshift(cursor);
+      const c = await this.fetchNeighbor(cursor);
+      cursor = c ? WikiParser.extractCycleInfo(c).prev : null;
+    }
+    cursor = info.next;
+    for (let i = 0; i < MAX_HOPS && cursor; i++) {
+      const n = normTitle(cursor);
+      if (visited.has(n)) break;
+      visited.add(n);
+      after.push(cursor);
+      const c = await this.fetchNeighbor(cursor);
+      cursor = c ? WikiParser.extractCycleInfo(c).next : null;
+    }
+
+    const chain = [...before, rawTitle, ...after];
+    // Linki z {{Cykl}} — dołóż nieobecne w łańcuchu (dla cykli bez prev/next).
+    const extras = info.templateVolumes.filter((t) => !chain.some((c) => normTitle(c) === normTitle(t)));
+    const ordered = chain.length > 1 ? [...chain, ...extras] : (extras.length > 0 ? [rawTitle, ...extras] : chain);
+
+    const source: CycleView["source"] =
+      chain.length > 1 && extras.length > 0 ? "mixed" :
+      chain.length > 1 ? "chain" :
+      extras.length > 0 ? "template" : "single";
+
+    // Krzyżowanie z bazą (cache: współdzielone pobranie).
+    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
+    const byTitle = new Map<string, NotionBook>();
+    for (const b of books) {
+      for (const t of [b.plTitle, b.origTitle]) if (t) byTitle.set(normTitle(t), b);
+    }
+
+    const volumes: CycleVolume[] = ordered.map((title) => {
+      const b = byTitle.get(normTitle(title));
+      const zr = b?.zrodlo || [];
+      return {
+        title,
+        isCurrent: normTitle(title) === normTitle(rawTitle),
+        inBase: !!b,
+        read: zr.includes("Przeczytane"),
+        owned: zr.includes("Posiadam"),
+        awarded: (b?.awards || []).length > 0,
+        awards: b?.awards || [],
+      };
+    });
+
+    const currentIdx = volumes.findIndex((v) => v.isCurrent);
+    const unreadBefore = currentIdx > 0 ? volumes.slice(0, currentIdx).filter((v) => !v.read).length : 0;
+
+    log.info("Cykl", { title: rawTitle, cycle: info.cycleName, volumes: volumes.length, source });
+    return { cycleName: info.cycleName || "Cykl", volumes, unreadBefore, source };
+  }
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -12,6 +12,7 @@ import { SchemaValidationService } from "./services/schemaValidationService";
 import { IntegrityService } from "./services/integrityService";
 import { LibraryCheckService } from "./services/libraryCheckService";
 import { VintedSyncService } from "./services/vintedSyncService";
+import { CycleLookupService } from "./services/cycleLookupService";
 import { toSearchIndex } from "./services/bookSearchIndex";
 import { ConfigService } from "./services/configService";
 import { createLogger, classifyHttpError } from "./logger";
@@ -42,6 +43,7 @@ const schemaValidationService = new SchemaValidationService(notionAdapter);
 const integrityService = new IntegrityService(notionAdapter, wikiAdapter, configService);
 const libraryCheckService = new LibraryCheckService(notionAdapter, configService);
 const vintedSyncService = new VintedSyncService(notionAdapter, configService);
+const cycleLookupService = new CycleLookupService(notionAdapter, wikiAdapter);
 
 interface SyncTask {
   name: string;
@@ -169,6 +171,11 @@ class SyncManager {
   /** Odczyt składowanych wyników Vinted (kafelki/paczki z bazy — bez re-scrape). */
   async getVintedStored() {
     return await vintedSyncService.getStoredData();
+  }
+
+  /** Podgląd cyklu dla książki (na żądanie, bez zapisu do bazy). */
+  async getCycle(title: string, author: string) {
+    return await cycleLookupService.lookup(title, author);
   }
 
   /**

--- a/wiki.parser.ts
+++ b/wiki.parser.ts
@@ -238,4 +238,40 @@ export class WikiParser {
     return "";
   }
 
+  /**
+   * Wyciąga informacje o cyklu z infoboksu `{{Książka}}`: nazwę cyklu (`|cykl=`),
+   * sąsiednie tomy (`|poprzednia=` / `|następna=` — łańcuch prev/next, potwierdzony
+   * na realnym rawie) oraz — oportunistycznie — tytuły z linków w szablonie
+   * nawigacyjnym `{{Cykl…}}`. Wołane w podglądzie cyklu (bez zapisu do bazy).
+   * `|następna=`/`|nastepna=` oba warianty (encyklopedia bywa niespójna w ogonku).
+   */
+  static extractCycleInfo(wikitext: string): { cycleName: string; prev: string | null; next: string | null; templateVolumes: string[] } {
+    if (!wikitext) return { cycleName: "", prev: null, next: null, templateVolumes: [] };
+
+    // Pojedyncza wartość parametru infoboksu (całe [[...]]/{{...}} jako token, ucięcie na następnym `|`).
+    const field = (name: string): string => {
+      const re = new RegExp(`\\|\\s*${name}\\s*=\\s*((?:\\[\\[[^\\]]*\\]\\]|\\{\\{[^{}]*\\}\\}|[^\\n|])+)`, "i");
+      const m = wikitext.match(re);
+      return m ? this.cleanWikitext(m[1]) : "";
+    };
+
+    const cycleName = field("cykl") || field("cykle");
+    const prev = field("poprzednia") || field("poprzedni") || "";
+    const next = field("następna") || field("nastepna") || field("następny") || field("nastepny") || "";
+
+    // Szablon nawigacyjny {{Cykl…}} — zbierz cele wikilinków [[Tytuł]] w kolejności.
+    const templateVolumes: string[] = [];
+    const tplMatch = wikitext.match(/\{\{\s*cykl[^{}]*(?:\{\{[^{}]*\}\}[^{}]*)*\}\}/i);
+    if (tplMatch) {
+      const linkRe = /\[\[([^|\]]+)(?:\|[^\]]*)?\]\]/g;
+      let lm;
+      while ((lm = linkRe.exec(tplMatch[0])) !== null) {
+        const t = lm[1].trim();
+        if (t && !templateVolumes.includes(t)) templateVolumes.push(t);
+      }
+    }
+
+    return { cycleName, prev: prev || null, next: next || null, templateVolumes };
+  }
+
 }


### PR DESCRIPTION
Stage 1/2 of the on-demand cycle preview. For a "part of a cycle" book, show its sibling volumes to judge the reading-order gap — often the awarded book is vol 2, so vol 1 must be read first for the plot.

**Nothing is written to Notion** — by preference we don't collect sibling volumes in the base. This does **not** break the "don't fetch on render" rule: it's one lazy fetch per click, not a mass render (and the wiki host isn't the Vinted/Cloudflare problem).

## Changes
- **`WikiParser.extractCycleInfo`** — cycle name (`|cykl=`), the prev/next chain (`|poprzednia=` / `|następna=`, confirmed format, both accent spellings), and opportunistic `{{Cykl}}` template wikilinks.
- **`services/cycleLookupService.ts`** — resolves the book's page (direct + search + author gate), walks the prev/next chain (bounded `MAX_HOPS=15`, visited-set to stop loops), appends `{{Cykl}}` links, cross-refs every volume against the base (inBase / read / owned / awarded), counts `unreadBefore` (volumes to catch up on before the current one). In-process cache by title+author — re-clicking is instant.
- **`GET /api/cycle?title&author`** — 404 when the book isn't in a cycle.

## Verification
- `npm run lint` clean · `npm test` **347/347** green (+8: infobox parsing, accent-less spelling, `{{Cykl}}` links, chain walk + cross-ref, unread-before count, null case, caching) · `npm run build` OK.
- **Caveat**: the encyclopedia host is blocked by the dev-container proxy (403), so the `{{Cykl}}` format can't be verified locally — the reliable spine is the confirmed prev/next chain; `{{Cykl}}` links are a bonus. Confirm live after deploy.
- Version bump `1.32.0` → `1.33.0`; backlog updated.

Refs #193 (frontend panel in stage 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_