### PR TITLE
Cycle preview UI: clickable badge in Skryptorium + volume panel

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.33.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.34.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.34.0** — **Podgląd cyklu — Skryptorium (CYC-PR2).** Badge „cykl" w `BookResultCard` jest
+  teraz KLIKALNY → modal `CyclePanel`. `useCycle` (GET /api/cycle, cache per title+author w ref).
+  Panel: nazwa cyklu, ostrzeżenie „przed tą pozycją N nieprzeczytanych tomów — nadrób dla fabuły"
+  (unreadBefore), uporządkowana lista tomów ze statusem (przeczytana/posiadana/w bazie/brak +
+  ikona nagrody), wyróżniony bieżący (pin), adnotacja „nie zapisujemy w bazie". Esc/klik-tło zamyka.
+  Rozwiązuje przypadek „nagrodzony jest tom 2 — którego tomu 1 nie mam/nie przeczytałem".
 - **1.33.0** — **Podgląd cyklu — backend (CYC-PR1).** Na żądanie, BEZ zapisu do Notion (zgodnie z
   preferencją: nie zaśmiecamy bazy). `WikiParser.extractCycleInfo` (nazwa `|cykl=`, łańcuch
   `|poprzednia=`/`|następna=` — potwierdzony format; oba warianty ogonka „następna/nastepna"; +
@@ -580,8 +586,11 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 - **Ewentualnie później**: odświeżanie pojedynczej książki/oferty z bazy (re-check
   świeżości), natywna baza „Vinted Offers" (jeśli blob przestanie wystarczać), proxy
   rezydencjalne dla ominięcia 403.
-- **Cykle: sąsiednie tomy** (pomysł, analiza 1.11.1) — dla książek „Część cyklu"
-  pokazywać/szukać wcześniejszych/późniejszych tomów; sąsiednie tomy mogą NIE być w bazie.
+- **Cykle: sąsiednie tomy — ZREALIZOWANE (1.33.0/1.34.0), wariant on-demand bez persystencji.**
+  Zamiast blobu `CycleData` + rytuału (poniższy plan): lazy `GET /api/cycle` na klik badge'a
+  „cykl" w Skryptorium → panel tomów krzyżowany z bazą. NIC nie zapisujemy do Notion (zgodnie z
+  preferencją użytkownika). Poniższy plan persystencji ZOSTAWIONY jako referencja, gdyby kiedyś
+  potrzebny był offline/statystyki cykli. Oryginalny pomysł/analiza 1.11.1:
   - **Kluczowy finding**: `cyclesSyncService` już parsuje `|cykl=` / `{{Cykl|…}}` z wikitekstu,
     ale zapisuje TYLKO boolean „Część cyklu" (linie 41–131) — nazwę cyklu i listę tomów
     z szablonu `{{Cykl}}` wyrzucamy. Tu jest źródło danych: rozszerzyć ten sam rytuał,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.34.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { motion } from "motion/react";
 import { Layers, BookMarked, Award, Tag } from "lucide-react";
 import { BookIndexEntry } from "../../types";
 import { HighlightedText } from "./HighlightedText";
+import { CyclePanel } from "./CyclePanel";
 
 /** Kolor tagu źródła — spójny język wizualny z resztą aplikacji. */
 function zrodloTheme(tag: string): string {
@@ -30,8 +31,11 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
   // Tytuł główny = polski, a gdy go brak — oryginalny (książki nieprzetłumaczone).
   const primaryTitle = book.plTitle?.trim() ? book.plTitle : book.origTitle;
   const showOrig = book.origTitle && book.origTitle.trim() && book.origTitle !== primaryTitle;
+  const [showCycle, setShowCycle] = useState(false);
 
   return (
+    <>
+    {showCycle && <CyclePanel title={primaryTitle} author={book.author || ""} onClose={() => setShowCycle(false)} />}
     <motion.div
       layout
       initial={{ opacity: 0, scale: 0.97 }}
@@ -52,12 +56,14 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
               className="text-base font-bold text-slate-100 leading-tight"
             />
             {book.partOfCycle && (
-              <span
-                className="shrink-0 flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-amber-500/15 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-wider"
-                title="Część cyklu — może być kolejnym tomem w kolekcji"
+              <button
+                type="button"
+                onClick={() => setShowCycle(true)}
+                className="shrink-0 flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-amber-500/15 border border-amber-500/30 text-amber-300 hover:bg-amber-500/25 hover:border-amber-400/50 text-[9px] font-bold uppercase tracking-wider transition-all cursor-pointer"
+                title="Pokaż tomy cyklu — sprawdź kolejność czytania"
               >
                 <Layers className="w-2.5 h-2.5" /> cykl
-              </span>
+              </button>
             )}
           </div>
 
@@ -103,5 +109,6 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
         </div>
       </div>
     </motion.div>
+    </>
   );
 };

--- a/src/components/search/CyclePanel.tsx
+++ b/src/components/search/CyclePanel.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Layers, X, Loader2, Check, Package, Award, CircleDashed, MapPin, AlertTriangle } from "lucide-react";
+import { useCycle } from "../../hooks/useCycle";
+
+/**
+ * Modal podglądu cyklu (Skryptorium). Pobiera na żądanie uporządkowaną listę tomów
+ * i pokazuje status każdego względem bazy (masz / przeczytana / nagrodzona / brak) +
+ * wyróżnia bieżącą pozycję i licznik „ile tomów do nadrobienia przed fabułą".
+ */
+
+const STATUS = (v: { read: boolean; owned: boolean; inBase: boolean }) => {
+  if (v.read) return { icon: Check, cls: "text-cyan-400", label: "przeczytana" };
+  if (v.owned) return { icon: Package, cls: "text-emerald-400", label: "posiadana" };
+  if (v.inBase) return { icon: CircleDashed, cls: "text-slate-400", label: "w bazie" };
+  return { icon: AlertTriangle, cls: "text-amber-400", label: "brak w bazie" };
+};
+
+interface Props {
+  title: string;
+  author: string;
+  onClose: () => void;
+}
+
+export const CyclePanel: React.FC<Props> = ({ title, author, onClose }) => {
+  const { view, loading, error, fetchCycle } = useCycle();
+
+  useEffect(() => { fetchCycle(title, author); }, [title, author, fetchCycle]);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+        className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-950/70 backdrop-blur-sm"
+        onClick={onClose}
+      >
+        <motion.div
+          initial={{ opacity: 0, scale: 0.96, y: 10 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96 }}
+          transition={{ duration: 0.18 }}
+          className="glass-card rounded-3xl border-amber-500/20 w-full max-w-lg max-h-[80vh] flex flex-col overflow-hidden"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Nagłówek */}
+          <div className="flex items-start gap-3 p-5 border-b border-white/5">
+            <div className="shrink-0 p-2 rounded-xl bg-amber-500/15 border border-amber-500/25 text-amber-300">
+              <Layers className="w-4 h-4" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-bold font-display uppercase tracking-widest text-amber-300 truncate">
+                {view?.cycleName || "Cykl"}
+              </h3>
+              <p className="text-[11px] text-slate-500 truncate">{title}</p>
+            </div>
+            <button onClick={onClose} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-200 hover:bg-white/5 transition-colors" aria-label="Zamknij">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Treść */}
+          <div className="flex-1 overflow-y-auto custom-scrollbar p-5 space-y-3">
+            {loading && (
+              <div className="flex items-center justify-center gap-3 py-12 text-slate-400">
+                <Loader2 className="w-5 h-5 animate-spin text-amber-400" />
+                <span className="text-sm uppercase tracking-widest font-bold">Odpytywanie Archiwum Cyklu...</span>
+              </div>
+            )}
+
+            {error && !loading && (
+              <p className="text-sm text-slate-400 italic text-center py-10">{error}</p>
+            )}
+
+            {view && !loading && (
+              <>
+                {view.unreadBefore > 0 && (
+                  <div className="flex items-center gap-2.5 p-3 rounded-2xl bg-amber-500/10 border border-amber-500/20 text-amber-200 text-xs">
+                    <AlertTriangle className="w-4 h-4 shrink-0" />
+                    <span>Przed tą pozycją masz <b>{view.unreadBefore}</b> {view.unreadBefore === 1 ? "nieprzeczytany tom" : "nieprzeczytane tomy"} — warto nadrobić dla fabuły.</span>
+                  </div>
+                )}
+
+                <ol className="space-y-1.5">
+                  {view.volumes.map((v, i) => {
+                    const s = STATUS(v);
+                    const Icon = s.icon;
+                    return (
+                      <li
+                        key={i}
+                        className={`flex items-center gap-2.5 p-2.5 rounded-xl border transition-colors ${
+                          v.isCurrent ? "bg-cyan-500/10 border-cyan-500/30" : "bg-slate-950/40 border-white/5"
+                        }`}
+                      >
+                        <span className="text-[10px] font-bold tabular-nums text-slate-500 w-5 text-right shrink-0">{i + 1}.</span>
+                        <Icon className={`w-4 h-4 shrink-0 ${s.cls}`} />
+                        <div className="flex-1 min-w-0">
+                          <span className={`text-sm truncate block ${v.isCurrent ? "text-cyan-200 font-bold" : v.inBase ? "text-slate-200" : "text-slate-400"}`}>
+                            {v.title}
+                            {v.isCurrent && <MapPin className="inline w-3 h-3 ml-1 text-cyan-400" />}
+                          </span>
+                        </div>
+                        {v.awarded && <Award className="w-3.5 h-3.5 text-amber-400 shrink-0" aria-label="nagrodzona" />}
+                        <span className={`text-[10px] uppercase tracking-wider font-bold shrink-0 ${s.cls}`}>{s.label}</span>
+                      </li>
+                    );
+                  })}
+                </ol>
+
+                <p className="text-[10px] text-slate-600 text-center pt-1">
+                  Dane pobrane z Encyklopedii na żądanie — nie zapisujemy ich w bazie.
+                </p>
+              </>
+            )}
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/src/hooks/useCycle.ts
+++ b/src/hooks/useCycle.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback, useRef } from "react";
+
+export interface CycleVolume {
+  title: string;
+  isCurrent: boolean;
+  inBase: boolean;
+  read: boolean;
+  owned: boolean;
+  awarded: boolean;
+  awards: string[];
+}
+export interface CycleView {
+  cycleName: string;
+  volumes: CycleVolume[];
+  unreadBefore: number;
+  source: "chain" | "template" | "mixed" | "single";
+}
+
+/**
+ * Podgląd cyklu na żądanie (GET /api/cycle). Cache per (tytuł|autor) w ref — ponowne
+ * otwarcie panelu dla tej samej książki nie odpytuje serwera. Backend też cache'uje.
+ */
+export function useCycle() {
+  const [view, setView] = useState<CycleView | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cache = useRef<Map<string, CycleView | null>>(new Map());
+
+  const fetchCycle = useCallback(async (title: string, author: string) => {
+    const key = `${title}|${author}`;
+    setError(null);
+    if (cache.current.has(key)) { setView(cache.current.get(key)!); return; }
+    setLoading(true);
+    setView(null);
+    try {
+      const res = await fetch(`/api/cycle?title=${encodeURIComponent(title)}&author=${encodeURIComponent(author || "")}`);
+      if (res.status === 404) { cache.current.set(key, null); setView(null); setError("Nie znaleziono danych cyklu dla tej pozycji."); return; }
+      if (!res.ok) { const j = await res.json().catch(() => null); throw new Error(j?.error || `Błąd serwera: ${res.status}`); }
+      const data: CycleView = await res.json();
+      cache.current.set(key, data);
+      setView(data);
+    } catch (e: any) {
+      setError(e?.message || "Nie udało się pobrać cyklu.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => { setView(null); setError(null); setLoading(false); }, []);
+
+  return { view, loading, error, fetchCycle, reset };
+}


### PR DESCRIPTION
Stage 2/2 of the on-demand cycle preview (backend landed in #194). The "cykl" badge in Skryptorium results becomes clickable → a modal with the cycle's volumes.

## Changes
- **`useCycle`** — `GET /api/cycle` with a per-(title+author) ref cache; reopening the same book's panel doesn't re-hit the server.
- **`CyclePanel`** modal — cycle name, an "N unread volumes before this one — catch up for the plot" warning (`unreadBefore`), an ordered volume list with per-volume status (read / owned / in-base / missing + an award icon), the current volume highlighted with a pin, and a footer noting nothing is stored. Closes on Esc / backdrop click.
- **`BookResultCard`** — the existing "cykl" badge is now a button that opens the panel.

Solves the exact pain: "the awarded book is vol 2 — and I don't have / haven't read the un-awarded vol 1" — without digging through the base or the encyclopedia.

## Verification
- `npm run lint` clean · `npm test` **347/347** green · `npm run build` OK.
- Panel rendered + screenshotted (headless Chromium, mocked API): ordered Dune-cycle volumes with statuses, the unread-before warning, current-volume highlight, and the "not stored" footer.
- Version bump `1.33.0` → `1.34.0`; backlog updated (the old "Cykle: sąsiednie tomy" open item is marked done in this simpler on-demand form).

Fixes #195 · Refs #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_