### PR TITLE
Cycle panel: per-volume link to the Encyclopedia (new tab)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.34.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.34.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,9 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.34.1** — **Podgląd cyklu: linki do Encyklopedii.** Każdy tom w `CyclePanel` ma ikonę
+  „otwórz w Encyklopedii" (nowa karta) — URL `index.php?title=<tytuł z _>` (wzorzec jak w parserze),
+  `stopPropagation` by nie zamykać modala. Wygodny podgląd tomu bez ręcznego szukania.
 - **1.34.0** — **Podgląd cyklu — Skryptorium (CYC-PR2).** Badge „cykl" w `BookResultCard` jest
   teraz KLIKALNY → modal `CyclePanel`. `useCycle` (GET /api/cycle, cache per title+author w ref).
   Panel: nazwa cyklu, ostrzeżenie „przed tą pozycją N nieprzeczytanych tomów — nadrób dla fabuły"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.34.0",
+      "version": "1.34.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.34.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/search/CyclePanel.tsx
+++ b/src/components/search/CyclePanel.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Layers, X, Loader2, Check, Package, Award, CircleDashed, MapPin, AlertTriangle } from "lucide-react";
+import { Layers, X, Loader2, Check, Package, Award, CircleDashed, MapPin, AlertTriangle, ExternalLink } from "lucide-react";
 import { useCycle } from "../../hooks/useCycle";
+
+/** Link do strony tomu w Archiwum Encyklopedii Fantastyki (ten sam wzorzec co parser). */
+const encyclopediaUrl = (title: string) =>
+  `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent(title.replace(/ /g, "_"))}`;
 
 /**
  * Modal podglądu cyklu (Skryptorium). Pobiera na żądanie uporządkowaną listę tomów
@@ -104,6 +108,17 @@ export const CyclePanel: React.FC<Props> = ({ title, author, onClose }) => {
                         </div>
                         {v.awarded && <Award className="w-3.5 h-3.5 text-amber-400 shrink-0" aria-label="nagrodzona" />}
                         <span className={`text-[10px] uppercase tracking-wider font-bold shrink-0 ${s.cls}`}>{s.label}</span>
+                        <a
+                          href={encyclopediaUrl(v.title)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="shrink-0 p-1 rounded-md text-slate-500 hover:text-amber-300 hover:bg-amber-500/10 transition-colors"
+                          title="Otwórz w Encyklopedii (nowa karta)"
+                          aria-label={`Otwórz „${v.title}" w Encyklopedii`}
+                        >
+                          <ExternalLink className="w-3.5 h-3.5" />
+                        </a>
                       </li>
                     );
                   })}


### PR DESCRIPTION
Small follow-up to the cycle preview: each volume row in `CyclePanel` now has an "open in Encyclopedia" external-link icon.

- URL pattern `index.php?title=<title with underscores>` — the same one the wiki parser already uses for book links.
- Opens in a new tab (`target="_blank"`, `rel="noopener noreferrer"`); `stopPropagation` so the click doesn't close the modal.

Lets you preview any volume of a cycle in one click, without hunting for it manually.

## Verification
- `npm run lint` clean · `npm run build` OK · `npm test` unaffected (347/347).
- Screenshotted (headless Chromium, mocked API): link icon sits next to each volume's status label.
- Version bump `1.34.0` → `1.34.1`; backlog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_