### PR TITLE
Stats: drag&drop reordering of cards in „Analiza Zasobów"

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.34.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.35.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.35.0** — **Statystyki: drag&drop kolejności kart.** Nagłówek „Analizy Zasobów" ma przełącznik
+  trybu układania (ikona `LayoutGrid` → `Check`) + reset (`RotateCcw`). W trybie: karty `draggable`
+  (native HTML5 DnD), inner `pointer-events-none`, dashed amber ring, badge „przeciągnij", drop-target
+  podświetlony cyan. Kolejność = lista id sekcji w `ui.statsOrder` (nowy knob, default `[]` = kolejność
+  z kodu); zapis optymistyczny przez `persistStatsOrder` (PUT /api/app-config, nie klobruje innych
+  knobów). Czyste helpery `orderByIds`/`moveId` w `utils/statsLayout.ts` (nowe karty dopisywane na końcu,
+  martwe id ignorowane) + testy. Karty dostały `id` + `h-full`; grid `items-stretch`.
 - **1.34.1** — **Podgląd cyklu: linki do Encyklopedii.** Każdy tom w `CyclePanel` ma ikonę
   „otwórz w Encyklopedii" (nowa karta) — URL `index.php?title=<tytuł z _>` (wzorzec jak w parserze),
   `stopPropagation` by nie zamykać modala. Wygodny podgląd tomu bez ręcznego szukania.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.34.1",
+  "version": "1.35.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.34.1",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.34.1",
+      "version": "1.35.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.34.1",
+  "version": "1.35.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/statsLayout.test.ts
+++ b/src/__tests__/statsLayout.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { orderByIds, moveId } from "../utils/statsLayout";
+
+describe("orderByIds", () => {
+  const all = ["a", "b", "c", "d"];
+
+  it("zwraca kolejność kodu, gdy brak zapisu", () => {
+    expect(orderByIds(all, [])).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("respektuje zapisaną kolejność", () => {
+    expect(orderByIds(all, ["c", "a", "d", "b"])).toEqual(["c", "a", "d", "b"]);
+  });
+
+  it("dopisuje nowe karty (spoza zapisu) na końcu w kolejności kodu", () => {
+    expect(orderByIds(all, ["b", "a"])).toEqual(["b", "a", "c", "d"]);
+  });
+
+  it("ignoruje id, których już nie ma w kodzie", () => {
+    expect(orderByIds(all, ["z", "c", "y", "a"])).toEqual(["c", "a", "b", "d"]);
+  });
+
+  it("odrzuca duplikaty w zapisie", () => {
+    expect(orderByIds(all, ["a", "a", "b"])).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("moveId", () => {
+  const order = ["a", "b", "c", "d"];
+
+  it("przenosi element w przód (przed cel)", () => {
+    expect(moveId(order, "d", "b")).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("przenosi element w tył (wstawia przed cel na jego bieżącej pozycji)", () => {
+    expect(moveId(order, "a", "c")).toEqual(["b", "a", "c", "d"]);
+  });
+
+  it("no-op gdy drag == target", () => {
+    expect(moveId(order, "b", "b")).toEqual(order);
+  });
+
+  it("no-op gdy id nie istnieje", () => {
+    expect(moveId(order, "x", "b")).toEqual(order);
+    expect(moveId(order, "b", "x")).toEqual(order);
+  });
+
+  it("nie mutuje wejścia", () => {
+    const copy = order.slice();
+    moveId(order, "a", "d");
+    expect(order).toEqual(copy);
+  });
+});

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { motion } from "motion/react";
-import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search } from "lucide-react";
+import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search, GripVertical, LayoutGrid, RotateCcw, Check } from "lucide-react";
 import { useStats } from "../hooks/useStats";
 import { useLibraryCheck } from "../hooks/useLibraryCheck";
 import { useMarkAsRead } from "../hooks/useMarkAsRead";
@@ -15,19 +15,33 @@ import { AvailabilityCard } from "./stats/AvailabilityCard";
 import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
 import { MarketCard } from "./stats/MarketCard";
-import { useEffectiveConfig } from "../hooks/useAppConfig";
+import { useEffectiveConfig, persistStatsOrder } from "../hooks/useAppConfig";
+import { orderByIds, moveId } from "../utils/statsLayout";
+
+interface StatCard {
+  id: string;
+  /** Karta na pełną szerokość siatki (md:col-span-2). */
+  span2?: boolean;
+  node: React.ReactNode;
+}
 
 export const StatsSection: React.FC = () => {
   // Filie biblioteczne z konfiguracji (fallback: defaulty do czasu pobrania).
-  const branches = useEffectiveConfig().library.branches;
+  const cfg = useEffectiveConfig();
+  const branches = cfg.library.branches;
   const { stats, loading, error, fetchStats, addBookToLibrarySection } = useStats();
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
   const { markingId, markedIds, markAsRead } = useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats });
 
+  // Tryb układania kart (drag&drop) + stan bieżącego przeciągania.
+  const [arranging, setArranging] = useState(false);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+
   if (loading && !stats) {
     return (
       <div className="flex flex-col items-center justify-center p-12 space-y-4">
-        <motion.div 
+        <motion.div
           animate={{ rotate: 360 }}
           transition={{ repeat: Infinity, duration: 2, ease: "linear" }}
           className="text-cyan-500"
@@ -43,7 +57,7 @@ export const StatsSection: React.FC = () => {
     return (
       <div className="p-8 glass-card border-red-500/30 text-center">
         <p className="text-red-400 font-bold mb-4">Błąd Odczytu Danych: {error}</p>
-        <button 
+        <button
           onClick={fetchStats}
           className="px-6 py-2 bg-red-900/40 hover:bg-red-800/60 text-red-200 rounded-xl border border-red-700/30 transition-all"
         >
@@ -55,42 +69,13 @@ export const StatsSection: React.FC = () => {
 
   if (!stats) return null;
 
-  return (
-    <div className="space-y-12">
-      <div className="flex items-center gap-6 mb-12">
-        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
-        <div className="flex items-center gap-4">
-          <BarChart3 className="w-6 h-6 text-cyan-400" />
-          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-cyan-100/90 whitespace-nowrap">
-            Analiza Zasobów Wiedzy
-          </h2>
-        </div>
-        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
-        
-        <button 
-          onClick={fetchStats}
-          disabled={loading}
-          className="p-2 hover:bg-slate-900 rounded-lg text-slate-500 hover:text-cyan-400 transition-colors disabled:opacity-50"
-          title="Odśwież Dane"
-          aria-label="Odśwież Dane Statystyczne"
-        >
-          <motion.div 
-            animate={loading ? { rotate: 360 } : {}} 
-            transition={loading ? { repeat: Infinity, duration: 1, ease: "linear" } : {}}
-            whileTap={!loading ? { scale: 0.9 } : {}}
-          >
-            <RefreshCw className={`w-5 h-5 ${loading ? 'text-cyan-400' : ''}`} />
-          </motion.div>
-        </button>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        {/* Author Progress */}
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6"
-        >
+  // Definicje kart w kolejności kodu (= domyślna). Każda ma stabilne `id`, po którym
+  // zapamiętujemy układ użytkownika (ui.statsOrder). Reorder nie zmienia treści kart.
+  const cards: StatCard[] = [
+    {
+      id: "authors",
+      node: (
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6 h-full">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-cyan-500 flex items-center gap-2 mb-4">
             <User className="w-4 h-4" />
             Indeks Autorów
@@ -101,59 +86,32 @@ export const StatsSection: React.FC = () => {
             ))}
           </div>
         </motion.div>
-
-        {/* Award Progress */}
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-          className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6"
-        >
+      ),
+    },
+    {
+      id: "awards",
+      node: (
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6 h-full">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-purple-500 flex items-center gap-2 mb-4">
             <Award className="w-4 h-4" />
             Progres Archiwum Nagród
           </h3>
           <div className="space-y-6">
-            <ProgressBar 
-              current={stats.awardBooksStats.read}
-              total={stats.awardBooksStats.total}
-              label="Polskie wydania z listy nagród"
-              icon={Book}
-              color="purple"
-            />
-            <ProgressBar 
-              current={stats.allAwardsStats.read}
-              total={stats.allAwardsStats.total}
-              label="Książki mające Wszystkie Nagrody"
-              icon={Award}
-              color="emerald"
-            />
-            
+            <ProgressBar current={stats.awardBooksStats.read} total={stats.awardBooksStats.total} label="Polskie wydania z listy nagród" icon={Book} color="purple" />
+            <ProgressBar current={stats.allAwardsStats.read} total={stats.allAwardsStats.total} label="Książki mające Wszystkie Nagrody" icon={Award} color="emerald" />
             <AwardCoverageGrid coverage={stats.awardCoverage} />
           </div>
         </motion.div>
-
-        {/* Aggregate Availability */}
-        <AvailabilityCard stats={stats.availabilityStats} />
-
-        {/* Market (Vinted) */}
-        <MarketCard market={stats.marketStats} />
-
-        {/* Publishers / Series / Cycles */}
-        <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} />
-
-        {/* Decade histogram — full width */}
-        <div className="md:col-span-2">
-          <DecadeHistogram decades={stats.decadeStats} />
-        </div>
-
-        {/* Yearly Progress */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}
-          className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6"
-        >
+      ),
+    },
+    { id: "availability", node: <AvailabilityCard stats={stats.availabilityStats} /> },
+    { id: "market", node: <MarketCard market={stats.marketStats} /> },
+    { id: "publishing", node: <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} /> },
+    { id: "decades", span2: true, node: <DecadeHistogram decades={stats.decadeStats} /> },
+    {
+      id: "yearly",
+      node: (
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6 h-full">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-orange-500 flex items-center gap-2 mb-4">
             <Calendar className="w-4 h-4" />
             Chronologia Przeczytanych
@@ -164,14 +122,12 @@ export const StatsSection: React.FC = () => {
             ))}
           </div>
         </motion.div>
-
-        {/* Owned but Unread */}
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.25 }}
-          className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6"
-        >
+      ),
+    },
+    {
+      id: "ownedUnread",
+      node: (
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }} className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6 h-full">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-emerald-500 flex items-center gap-2 mb-4">
             <Package className="w-4 h-4" />
             Zasoby Oczekujące (Posiadane)
@@ -181,54 +137,38 @@ export const StatsSection: React.FC = () => {
               <p className="text-slate-400 text-sm italic text-center py-8">Wszystkie posiadane zasoby zostały przyswojone.</p>
             ) : (
               stats.ownedUnread.map((book, idx) => (
-                <OwnedUnreadItem
-                  key={idx}
-                  book={book}
-                  marking={markingId === book.id}
-                  disabled={markingId !== null}
-                  onMarkAsRead={markAsRead}
-                />
+                <OwnedUnreadItem key={idx} book={book} marking={markingId === book.id} disabled={markingId !== null} onMarkAsRead={markAsRead} />
               ))
             )}
           </div>
         </motion.div>
-
-        {/* Library Progress */}
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3 }}
-          className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6"
-        >
+      ),
+    },
+    {
+      id: "library",
+      node: (
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6 h-full">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-500 flex items-center gap-2 mb-4">
             <Library className="w-4 h-4" />
             Książki dostępne w bibliotekach
           </h3>
           <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
             {stats.libraryStats.map((library) => (
-              <LibraryProgressItem 
-                key={library.id} 
-                library={library} 
-                onMarkAsRead={markAsRead}
-                markingId={markingId}
-              />
+              <LibraryProgressItem key={library.id} library={library} onMarkAsRead={markAsRead} markingId={markingId} />
             ))}
           </div>
         </motion.div>
-
-        {/* Identified in Libraries */}
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.35 }}
-          className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6"
-        >
+      ),
+    },
+    {
+      id: "identified",
+      node: (
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6 h-full">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-400 flex items-center gap-2">
               <Search className="w-4 h-4" />
               Zidentyfikowane w bibliotekach
             </h3>
-            
             <button
               onClick={() => checkAllLibraries(branches)}
               disabled={checkingLibrary !== null}
@@ -244,16 +184,14 @@ export const StatsSection: React.FC = () => {
               Skanuj Wszystkie
             </button>
           </div>
-          
           {libraryError && (
             <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-xs text-red-400 font-bold mb-4">
               Błąd skanowania: {libraryError}
             </div>
           )}
-
           <div className="space-y-6 max-h-[500px] overflow-y-auto pr-2 custom-scrollbar">
             {branches.map((library) => (
-              <IdentifiedLibraryItem 
+              <IdentifiedLibraryItem
                 key={library.id}
                 library={library}
                 books={identifiedBooks[library.id] || []}
@@ -268,6 +206,109 @@ export const StatsSection: React.FC = () => {
             ))}
           </div>
         </motion.div>
+      ),
+    },
+  ];
+
+  // Kolejność efektywna (zapis użytkownika + nowe karty na końcu) i wyszukiwanie po id.
+  const order = orderByIds(cards.map((c) => c.id), cfg.ui.statsOrder);
+  const byId = new Map(cards.map((c) => [c.id, c]));
+  const ordered = order.map((id) => byId.get(id)).filter((c): c is StatCard => Boolean(c));
+
+  const commitReorder = (target: string) => {
+    if (!dragId || dragId === target) return;
+    persistStatsOrder(moveId(order, dragId, target));
+  };
+  const exitArrange = () => { setArranging(false); setDragId(null); setOverId(null); };
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center gap-6">
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
+        <div className="flex items-center gap-4">
+          <BarChart3 className="w-6 h-6 text-cyan-400" />
+          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-cyan-100/90 whitespace-nowrap">
+            Analiza Zasobów Wiedzy
+          </h2>
+        </div>
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
+
+        {arranging && (
+          <button
+            onClick={() => persistStatsOrder([])}
+            className="p-2 rounded-lg text-slate-500 hover:text-amber-300 hover:bg-slate-900 transition-colors"
+            title="Przywróć domyślną kolejność kart"
+            aria-label="Przywróć domyślną kolejność kart"
+          >
+            <RotateCcw className="w-5 h-5" />
+          </button>
+        )}
+        <button
+          onClick={() => (arranging ? exitArrange() : setArranging(true))}
+          className={`p-2 rounded-lg transition-colors border ${arranging ? "bg-amber-500/15 text-amber-300 border-amber-500/40" : "border-transparent text-slate-500 hover:text-cyan-400 hover:bg-slate-900"}`}
+          title={arranging ? "Zakończ układanie kart" : "Ułóż karty (przeciągnij i upuść)"}
+          aria-label="Przełącz tryb układania kart"
+        >
+          {arranging ? <Check className="w-5 h-5" /> : <LayoutGrid className="w-5 h-5" />}
+        </button>
+
+        <button
+          onClick={fetchStats}
+          disabled={loading}
+          className="p-2 hover:bg-slate-900 rounded-lg text-slate-500 hover:text-cyan-400 transition-colors disabled:opacity-50"
+          title="Odśwież Dane"
+          aria-label="Odśwież Dane Statystyczne"
+        >
+          <motion.div
+            animate={loading ? { rotate: 360 } : {}}
+            transition={loading ? { repeat: Infinity, duration: 1, ease: "linear" } : {}}
+            whileTap={!loading ? { scale: 0.9 } : {}}
+          >
+            <RefreshCw className={`w-5 h-5 ${loading ? 'text-cyan-400' : ''}`} />
+          </motion.div>
+        </button>
+      </div>
+
+      {arranging && (
+        <div className="flex items-center justify-center gap-2 text-[11px] text-amber-300/80 uppercase tracking-widest font-bold">
+          <GripVertical className="w-3.5 h-3.5" />
+          Przeciągnij karty, aby ustalić kolejność — zapis jest automatyczny
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+        {ordered.map((card) => {
+          const dragging = dragId === card.id;
+          const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
+          return (
+            <div
+              key={card.id}
+              className={`relative ${card.span2 ? "md:col-span-2" : ""} ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
+              draggable={arranging}
+              onDragStart={(e) => {
+                if (!arranging) return;
+                setDragId(card.id);
+                e.dataTransfer.effectAllowed = "move";
+                try { e.dataTransfer.setData("text/plain", card.id); } catch { /* Safari */ }
+              }}
+              onDragEnter={() => { if (arranging) setOverId(card.id); }}
+              onDragOver={(e) => { if (arranging) e.preventDefault(); }}
+              onDrop={(e) => { if (arranging) { e.preventDefault(); commitReorder(card.id); } }}
+              onDragEnd={() => { setDragId(null); setOverId(null); }}
+            >
+              <div className={arranging ? "pointer-events-none" : ""}>{card.node}</div>
+
+              {arranging && (
+                <div className={`absolute inset-0 rounded-3xl border-2 border-dashed pointer-events-none transition-colors ${isOver ? "border-cyan-400/70 bg-cyan-500/5" : "border-amber-500/40"}`} />
+              )}
+              {arranging && !dragging && (
+                <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 rounded-lg bg-slate-950/85 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-widest pointer-events-none">
+                  <GripVertical className="w-3 h-3" /> przeciągnij
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -76,6 +76,8 @@ export interface AppConfig {
     shelfRowsPerPage: number;
     /** Precyzyjny drag&drop na regale (wstawianie w szczelinę w obrębie dekady). */
     preciseShelfDrop: boolean;
+    /** Kolejność kart w „Analizie Zasobów" (id sekcji). Puste = domyślna kolejność z kodu. */
+    statsOrder: string[];
   };
 }
 
@@ -132,6 +134,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   ui: {
     shelfRowsPerPage: 5,
     preciseShelfDrop: true,
+    statsOrder: [],
   },
 };
 
@@ -159,6 +162,20 @@ const cleanStringList = (v: unknown, dflt: string[], maxItems = 30, maxLen = 400
     .filter((x) => x.length > 0 && x.length <= maxLen)
     .slice(0, maxItems);
   return out.length > 0 ? out : [...dflt];
+};
+
+/** Lista identyfikatorów (np. kolejność kart) — dozwolona pusta, dedup, przycięcie. */
+const cleanIdList = (v: unknown, maxItems = 40, maxLen = 40): string[] => {
+  if (!Array.isArray(v)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of v) {
+    if (typeof x !== "string") continue;
+    const s = x.trim();
+    if (s && s.length <= maxLen && !seen.has(s)) { seen.add(s); out.push(s); }
+    if (out.length >= maxItems) break;
+  }
+  return out;
 };
 
 const cleanBranches = (v: unknown, dflt: LibraryBranch[]): LibraryBranch[] => {
@@ -237,6 +254,7 @@ export function mergeConfig(overrides?: unknown): AppConfig {
     ui: {
       shelfRowsPerPage: clampInt(u.shelfRowsPerPage, 1, 12, d.ui.shelfRowsPerPage),
       preciseShelfDrop: cleanBool(u.preciseShelfDrop, d.ui.preciseShelfDrop),
+      statsOrder: cleanIdList(u.statsOrder),
     },
   };
 }

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -43,6 +43,28 @@ export function publishEffectiveConfig(cfg: AppConfig): void {
   listeners.forEach((l) => l(cfg));
 }
 
+/**
+ * Utrwala kolejność kart statystyk (`ui.statsOrder`) bez otwierania panelu.
+ * Optymistycznie publikuje nową kolejność od razu (płynny reorder), a zapis do
+ * Notion leci w tle — błąd sieci nie cofa układu na tę sesję. Nie klobruje innych
+ * knobów: bierze bieżącą efektywną konfigurację i podmienia tylko to pole.
+ */
+export async function persistStatsOrder(order: string[]): Promise<void> {
+  const current = await loadShared();
+  const next: AppConfig = { ...current, ui: { ...current.ui, statsOrder: order } };
+  publishEffectiveConfig(next);
+  try {
+    const res = await fetch("/api/app-config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(next),
+    });
+    if (res.ok) publishEffectiveConfig(mergeConfig(await res.json()));
+  } catch {
+    /* zostaje wersja optymistyczna na tę sesję */
+  }
+}
+
 /** Efektywna konfiguracja dla konsumentów — defaulty do czasu pobrania, potem live. */
 export function useEffectiveConfig(): AppConfig {
   const [cfg, setCfg] = useState<AppConfig>(cachedConfig ?? DEFAULT_CONFIG);

--- a/src/utils/statsLayout.ts
+++ b/src/utils/statsLayout.ts
@@ -1,0 +1,42 @@
+/**
+ * Czyste helpery kolejności kart statystyk (drag&drop w „Analizie Zasobów").
+ *
+ * Kolejność użytkownika trzymamy jako listę id sekcji (`ui.statsOrder`). Kod jest
+ * odporny na dryf: nowe karty dodane w kodzie, których nie ma w zapisanej liście,
+ * dopisujemy na końcu w kolejności kodu; id z zapisu, których już nie ma w kodzie,
+ * ignorujemy. Dzięki temu zapisany blob nigdy nie „gubi" ani nie duplikuje karty.
+ */
+
+/**
+ * Ustala finalną kolejność id: najpierw zapisane (przefiltrowane do istniejących,
+ * bez duplikatów), potem pozostałe z `allIds` w kolejności kodu.
+ */
+export function orderByIds(allIds: string[], savedOrder: string[]): string[] {
+  const known = new Set(allIds);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of savedOrder) {
+    if (known.has(id) && !seen.has(id)) { seen.add(id); out.push(id); }
+  }
+  for (const id of allIds) {
+    if (!seen.has(id)) { seen.add(id); out.push(id); }
+  }
+  return out;
+}
+
+/**
+ * Przenosi `dragId` na pozycję `targetId` (wstawienie przed elementem docelowym w
+ * jego bieżącym miejscu). Zwraca nową listę; wejście pozostaje nietknięte.
+ * No-op gdy któreś id nie istnieje lub są równe.
+ */
+export function moveId(order: string[], dragId: string, targetId: string): string[] {
+  if (dragId === targetId) return order.slice();
+  const from = order.indexOf(dragId);
+  const to = order.indexOf(targetId);
+  if (from === -1 || to === -1) return order.slice();
+  const next = order.slice();
+  next.splice(from, 1);
+  const insertAt = next.indexOf(targetId);
+  next.splice(insertAt, 0, dragId);
+  return next;
+}


### PR DESCRIPTION
## Co i po co

Sekcja statystyk rośnie i sztywna kolejność kart przestała pasować do każdego układu pracy. Ten PR dodaje **tryb układania** kart drag&dropem z zapamiętaniem preferencji.

## Zmiany

- **`StatsSection.tsx`** — karty wydzielone do tablicy z stabilnym `id` (`authors`, `awards`, `availability`, `market`, `publishing`, `decades`, `yearly`, `ownedUnread`, `library`, `identified`). Nagłówek dostał przełącznik trybu (`LayoutGrid` → `Check`) i reset (`RotateCcw`). W trybie: karty `draggable` (native HTML5 DnD), inner `pointer-events-none` (brak przypadkowych klików), dashed amber ring, badge „przeciągnij", drop-target podświetlony cyan. Poza trybem — zachowanie bez zmian.
- **`utils/statsLayout.ts`** (nowy, czysty) — `orderByIds` (zapis + nowe karty na końcu + ignorowanie martwych id) oraz `moveId` (insert-before-target, bez mutacji). Testy w `src/__tests__/statsLayout.test.ts`.
- **`configSchema.ts`** — nowy knob `ui.statsOrder: string[]` (default `[]` = kolejność z kodu) + clamp `cleanIdList` (dozwolona pusta lista, dedup, przycięcie). Propaguje się automatycznie na backend (współdzielony `mergeConfig`/`diffFromDefaults`).
- **`hooks/useAppConfig.ts`** — `persistStatsOrder`: optymistyczny zapis kolejności (PUT `/api/app-config`) bez klobrowania innych knobów; błąd sieci nie cofa układu na sesję.

## Trwałość

Kolejność ląduje w blobie konfiguracji w Notion (opis kolumny `AppConfig`) — spójnie z resztą `ui.*`, więc preferencja podąża za użytkownikiem między urządzeniami. Zapis leci raz na upuszczenie karty.

## Testy

`npm run lint` czysty, `npm test` zielony (357, +10 dla `statsLayout`), `npm run build` OK. Wersja `1.35.0`.

Fixes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_