### PR TITLE
Stats: masonry layout — koniec dziur od wymuszonej równej wysokości pary

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.35.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.35.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.35.1** — **Statystyki: masonry zamiast siatki (koniec dziur od wysokości pary).**
+  Kontener `columns-1 md:columns-2` + karty `break-inside-avoid mb-8` — każda kolumna pakuje się
+  niezależnie, więc krótsza karta nie rozciąga się do wysokości wyższego sąsiada i nie zostawia
+  pustego miejsca ani nie przesuwa kafelka niżej. Karta pełnej szerokości (histogram dekad) rozpina
+  się przez `md:[column-span:all]`. Usunięto `h-full`/`items-stretch` (equal-height już zbędne).
 - **1.35.0** — **Statystyki: drag&drop kolejności kart.** Nagłówek „Analizy Zasobów" ma przełącznik
   trybu układania (ikona `LayoutGrid` → `Check`) + reset (`RotateCcw`). W trybie: karty `draggable`
   (native HTML5 DnD), inner `pointer-events-none`, dashed amber ring, badge „przeciągnij", drop-target

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.35.0",
+      "version": "1.35.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.35.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -75,7 +75,7 @@ export const StatsSection: React.FC = () => {
     {
       id: "authors",
       node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6 h-full">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-cyan-500 flex items-center gap-2 mb-4">
             <User className="w-4 h-4" />
             Indeks Autorów
@@ -91,7 +91,7 @@ export const StatsSection: React.FC = () => {
     {
       id: "awards",
       node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6 h-full">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-purple-500 flex items-center gap-2 mb-4">
             <Award className="w-4 h-4" />
             Progres Archiwum Nagród
@@ -111,7 +111,7 @@ export const StatsSection: React.FC = () => {
     {
       id: "yearly",
       node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6 h-full">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-orange-500 flex items-center gap-2 mb-4">
             <Calendar className="w-4 h-4" />
             Chronologia Przeczytanych
@@ -127,7 +127,7 @@ export const StatsSection: React.FC = () => {
     {
       id: "ownedUnread",
       node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }} className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6 h-full">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }} className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-emerald-500 flex items-center gap-2 mb-4">
             <Package className="w-4 h-4" />
             Zasoby Oczekujące (Posiadane)
@@ -147,7 +147,7 @@ export const StatsSection: React.FC = () => {
     {
       id: "library",
       node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6 h-full">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-500 flex items-center gap-2 mb-4">
             <Library className="w-4 h-4" />
             Książki dostępne w bibliotekach
@@ -163,7 +163,7 @@ export const StatsSection: React.FC = () => {
     {
       id: "identified",
       node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6 h-full">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-400 flex items-center gap-2">
               <Search className="w-4 h-4" />
@@ -276,14 +276,17 @@ export const StatsSection: React.FC = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-stretch">
+      {/* Masonry (multi-column): każda kolumna pakuje się niezależnie, więc krótsza
+          karta nie rozciąga się do wysokości sąsiada i nie zostawia dziury pod sobą.
+          Karta pełnej szerokości (histogram dekad) rozpina się przez `column-span:all`. */}
+      <div className="columns-1 md:columns-2 gap-8">
         {ordered.map((card) => {
           const dragging = dragId === card.id;
           const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
           return (
             <div
               key={card.id}
-              className={`relative ${card.span2 ? "md:col-span-2" : ""} ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
+              className={`relative mb-8 break-inside-avoid ${card.span2 ? "md:[column-span:all]" : ""} ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
               draggable={arranging}
               onDragStart={(e) => {
                 if (!arranging) return;


### PR DESCRIPTION
## Problem

W siatce `md:grid-cols-2` wiersz miał wysokość wyższej z pary kart. Krótka karta (np. „Zagregowana dostępność" obok wysokiego „Rynku") rozciągała komórkę i zostawiała puste miejsce, a kolejny kafelek w kolumnie nie mógł zacząć się przed końcem wysokiego sąsiada → dziura + przesunięty kafelek.

## Rozwiązanie

Masonry przez CSS multi-column:
- kontener `columns-1 md:columns-2 gap-8`,
- każda karta `mb-8 break-inside-avoid` — kolumny pakują się niezależnie, bez sprzężenia wysokości,
- histogram dekad pełnej szerokości przez `md:[column-span:all]`,
- usunięto zbędne `h-full` / `items-stretch` (equal-height już niepotrzebny).

Drag&drop kolejności działa bez zmian — reorder operuje na kolejności DOM, niezależnie od layoutu.

## Weryfikacja

Zrzut harnessa masonry (karty o różnej wysokości, tryb normalny i układania): kolumny pakują się ciasno, brak rozciągniętych pustych kafelków, karta pełnej szerokości poprawnie rozpięta, dashed ramki trybu układania opinają karty 1:1. `npm run lint` czysty, `npm test` zielony (357), `npm run build` OK. Wersja `1.35.1`.

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_