### PR TITLE
Stats: masonry „wiersz po wierszu" (round-robin)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.35.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.35.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.35.2** — **Statystyki: masonry „wiersz po wierszu" (round-robin).** CSS `columns` czytało
+  się kolumnami (cała lewa, potem prawa) — nieintuicyjne przy drag&drop kolejności. Teraz karty
+  rozkładane round-robin `distributeColumns(items, cols)` (i % cols) do osobnych kolumn flex:
+  0,2,4 w lewej, 1,3,5 w prawej → odczyt lewo→prawo pozostaje 0,1,2,3,..., a kolumny pakują się
+  niezależnie (bez dziur). `cols` z `matchMedia('(min-width:768px)')` (1/2). Karty pełnej szerokości
+  (span2) przerywają blok i renderują się na całą szerokość (segmentacja `full`/`block`). Helper
+  `renderCard` (DRY DnD). Test round-robin. Zastąpiło `columns`/`column-span:all` z 1.35.1.
 - **1.35.1** — **Statystyki: masonry zamiast siatki (koniec dziur od wysokości pary).**
   Kontener `columns-1 md:columns-2` + karty `break-inside-avoid mb-8` — każda kolumna pakuje się
   niezależnie, więc krótsza karta nie rozciąga się do wysokości wyższego sąsiada i nie zostawia

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.35.1",
+      "version": "1.35.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.35.1",
+  "version": "1.35.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/statsLayout.test.ts
+++ b/src/__tests__/statsLayout.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { orderByIds, moveId } from "../utils/statsLayout";
+import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
 
 describe("orderByIds", () => {
   const all = ["a", "b", "c", "d"];
@@ -50,5 +50,26 @@ describe("moveId", () => {
     const copy = order.slice();
     moveId(order, "a", "d");
     expect(order).toEqual(copy);
+  });
+});
+
+describe("distributeColumns", () => {
+  it("round-robin do 2 kolumn (wiersz po wierszu)", () => {
+    expect(distributeColumns(["a", "b", "c", "d", "e"], 2)).toEqual([
+      ["a", "c", "e"],
+      ["b", "d"],
+    ]);
+  });
+
+  it("1 kolumna = wszystko w kolejności", () => {
+    expect(distributeColumns(["a", "b", "c"], 1)).toEqual([["a", "b", "c"]]);
+  });
+
+  it("cols < 1 traktuje jak 1", () => {
+    expect(distributeColumns(["a", "b"], 0)).toEqual([["a", "b"]]);
+  });
+
+  it("puste wejście → puste kolumny", () => {
+    expect(distributeColumns([], 2)).toEqual([[], []]);
   });
 });

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { motion } from "motion/react";
 import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search, GripVertical, LayoutGrid, RotateCcw, Check } from "lucide-react";
 import { useStats } from "../hooks/useStats";
@@ -16,7 +16,7 @@ import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
 import { MarketCard } from "./stats/MarketCard";
 import { useEffectiveConfig, persistStatsOrder } from "../hooks/useAppConfig";
-import { orderByIds, moveId } from "../utils/statsLayout";
+import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
 
 interface StatCard {
   id: string;
@@ -37,6 +37,17 @@ export const StatsSection: React.FC = () => {
   const [arranging, setArranging] = useState(false);
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
+
+  // Liczba kolumn masonry zależna od breakpointu md (768px) — round-robin trzyma
+  // czytanie „wiersz po wierszu", więc kolumny muszą odpowiadać temu, co widać.
+  const [cols, setCols] = useState(2);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const apply = () => setCols(mq.matches ? 2 : 1);
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, []);
 
   if (loading && !stats) {
     return (
@@ -221,6 +232,55 @@ export const StatsSection: React.FC = () => {
   };
   const exitArrange = () => { setArranging(false); setDragId(null); setOverId(null); };
 
+  // Jedna karta z opakowaniem DnD + nakładkami trybu układania (reużywalna w blokach
+  // round-robin i w kartach pełnej szerokości).
+  const renderCard = (card: StatCard) => {
+    const dragging = dragId === card.id;
+    const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
+    return (
+      <div
+        key={card.id}
+        className={`relative ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
+        draggable={arranging}
+        onDragStart={(e) => {
+          if (!arranging) return;
+          setDragId(card.id);
+          e.dataTransfer.effectAllowed = "move";
+          try { e.dataTransfer.setData("text/plain", card.id); } catch { /* Safari */ }
+        }}
+        onDragEnter={() => { if (arranging) setOverId(card.id); }}
+        onDragOver={(e) => { if (arranging) e.preventDefault(); }}
+        onDrop={(e) => { if (arranging) { e.preventDefault(); commitReorder(card.id); } }}
+        onDragEnd={() => { setDragId(null); setOverId(null); }}
+      >
+        <div className={arranging ? "pointer-events-none" : ""}>{card.node}</div>
+        {arranging && (
+          <div className={`absolute inset-0 rounded-3xl border-2 border-dashed pointer-events-none transition-colors ${isOver ? "border-cyan-400/70 bg-cyan-500/5" : "border-amber-500/40"}`} />
+        )}
+        {arranging && !dragging && (
+          <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 rounded-lg bg-slate-950/85 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-widest pointer-events-none">
+            <GripVertical className="w-3 h-3" /> przeciągnij
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Segmentacja: karty pełnej szerokości (span2) przerywają blok round-robin i renderują
+  // się na całą szerokość; pozostałe idą w kolumny (i % cols) z niezależnym pakowaniem.
+  type Segment = { kind: "full"; card: StatCard } | { kind: "block"; cards: StatCard[] };
+  const segments: Segment[] = [];
+  let run: StatCard[] = [];
+  for (const c of ordered) {
+    if (c.span2) {
+      if (run.length) { segments.push({ kind: "block", cards: run }); run = []; }
+      segments.push({ kind: "full", card: c });
+    } else {
+      run.push(c);
+    }
+  }
+  if (run.length) segments.push({ kind: "block", cards: run });
+
   return (
     <div className="space-y-8">
       <div className="flex items-center gap-6">
@@ -276,42 +336,24 @@ export const StatsSection: React.FC = () => {
         </div>
       )}
 
-      {/* Masonry (multi-column): każda kolumna pakuje się niezależnie, więc krótsza
-          karta nie rozciąga się do wysokości sąsiada i nie zostawia dziury pod sobą.
-          Karta pełnej szerokości (histogram dekad) rozpina się przez `column-span:all`. */}
-      <div className="columns-1 md:columns-2 gap-8">
-        {ordered.map((card) => {
-          const dragging = dragId === card.id;
-          const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
-          return (
-            <div
-              key={card.id}
-              className={`relative mb-8 break-inside-avoid ${card.span2 ? "md:[column-span:all]" : ""} ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
-              draggable={arranging}
-              onDragStart={(e) => {
-                if (!arranging) return;
-                setDragId(card.id);
-                e.dataTransfer.effectAllowed = "move";
-                try { e.dataTransfer.setData("text/plain", card.id); } catch { /* Safari */ }
-              }}
-              onDragEnter={() => { if (arranging) setOverId(card.id); }}
-              onDragOver={(e) => { if (arranging) e.preventDefault(); }}
-              onDrop={(e) => { if (arranging) { e.preventDefault(); commitReorder(card.id); } }}
-              onDragEnd={() => { setDragId(null); setOverId(null); }}
-            >
-              <div className={arranging ? "pointer-events-none" : ""}>{card.node}</div>
-
-              {arranging && (
-                <div className={`absolute inset-0 rounded-3xl border-2 border-dashed pointer-events-none transition-colors ${isOver ? "border-cyan-400/70 bg-cyan-500/5" : "border-amber-500/40"}`} />
-              )}
-              {arranging && !dragging && (
-                <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 rounded-lg bg-slate-950/85 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-widest pointer-events-none">
-                  <GripVertical className="w-3 h-3" /> przeciągnij
+      {/* Masonry „wiersz po wierszu": karty rozłożone round-robin (i % cols) na osobne
+          kolumny, każda pakuje się niezależnie (brak sprzężenia wysokości = brak dziur),
+          a odczyt lewo→prawo/góra→dół pozostaje 0,1,2,3,... Karta pełnej szerokości
+          (histogram dekad) przerywa blok i zajmuje całą szerokość. */}
+      <div className="space-y-8">
+        {segments.map((seg, si) =>
+          seg.kind === "full" ? (
+            <div key={`full-${si}`}>{renderCard(seg.card)}</div>
+          ) : (
+            <div key={`block-${si}`} className="flex gap-8">
+              {distributeColumns(seg.cards, cols).map((col, ci) => (
+                <div key={ci} className="flex-1 min-w-0 flex flex-col gap-8">
+                  {col.map((card) => renderCard(card))}
                 </div>
-              )}
+              ))}
             </div>
-          );
-        })}
+          )
+        )}
       </div>
     </div>
   );

--- a/src/utils/statsLayout.ts
+++ b/src/utils/statsLayout.ts
@@ -25,6 +25,19 @@ export function orderByIds(allIds: string[], savedOrder: string[]): string[] {
 }
 
 /**
+ * Rozkłada elementy na `cols` kolumn round-robin (element i → kolumna i % cols),
+ * zachowując czytanie „wiersz po wierszu": 0 i 2 i 4 w lewej, 1 i 3 i 5 w prawej.
+ * Każda kolumna pakuje się potem niezależnie (brak sprzężenia wysokości = brak dziur),
+ * a kolejność odczytu lewo→prawo, góra→dół pozostaje 0,1,2,3,... Zwraca `cols` list.
+ */
+export function distributeColumns<T>(items: T[], cols: number): T[][] {
+  const n = Math.max(1, Math.floor(cols));
+  const out: T[][] = Array.from({ length: n }, () => []);
+  items.forEach((it, i) => out[i % n].push(it));
+  return out;
+}
+
+/**
  * Przenosi `dragId` na pozycję `targetId` (wstawienie przed elementem docelowym w
  * jego bieżącym miejscu). Zwraca nową listę; wejście pozostaje nietknięte.
  * No-op gdy któreś id nie istnieje lub są równe.


### PR DESCRIPTION
## Problem

Masonry z CSS `columns` (1.35.1) pakował ciasno, ale czytał się **kolumnami** (cała lewa, potem prawa). Przy drag&drop kolejności nieintuicyjne — karta upuszczona na „pozycję 2" lądowała na dole lewej kolumny.

## Rozwiązanie

Round-robin masonry, zachowujący czytanie **wiersz po wierszu**:
- `distributeColumns(items, cols)` rozkłada karty `i % cols` do osobnych kolumn flex: 0,2,4 w lewej, 1,3,5 w prawej → odczyt lewo→prawo/góra→dół to 0,1,2,3,...
- każda kolumna to `flex flex-col gap-8` i pakuje się **niezależnie** (brak sprzężenia wysokości = brak dziur),
- liczba kolumn z `matchMedia('(min-width:768px)')` (1 na mobile, 2 na desktop) — musi odpowiadać temu, co widać, by round-robin czytał się poprawnie,
- karty pełnej szerokości (histogram dekad) przerywają blok i renderują się na całą szerokość (segmentacja `full`/`block`),
- wspólny helper `renderCard` (DRY dla DnD + nakładek trybu układania).

Zastępuje `columns`/`column-span:all` z 1.35.1. Drag&drop kolejności bez zmian (reorder działa na kolejności DOM).

## Weryfikacja

Zrzut harnessa (10 kart różnej wysokości, w tym pełna szerokość): odczyt 1,2,3,4,... lewo→prawo, kolumny pakują się ciasno bez dziur, krótka karta nie czeka na wysokiego sąsiada, karta pełnej szerokości poprawnie przerywa blok. `npm run lint` czysty, `npm test` zielony (361, +4 dla `distributeColumns`), `npm run build` OK. Wersja `1.35.2`.

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_