### PR TITLE
Cykle: karta „Archiwum Cykli" w Analizie Zasobów (CYH-PR2, UC2)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.36.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.37.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.37.0** — **Cykle: karta „Archiwum Cykli" (UC2) — Etap 1 frontend (CYH-PR2).** Czysty
+  `mergeCycleCaches(books)` scala bloby `CycleCache` z wszystkich pozycji w listę cykli (grupa po
+  nazwie, dedup tomów po tytule, statusy OR-owane, sort malejąco po `missing`) → `getCyclesHarvest()`
+  + `GET /api/cycles-harvest`. Front: `useCyclesHarvest` + `CyclesHarvestCard` (rozwijane cykle,
+  liczniki inBase/total + badge „N do zdobycia", statusy tomów jak Skryptorium, link do Encyklopedii,
+  ikona nagrody) wpięta jako karta „cyclesHarvest" w Analizie Zasobów. Testy agregacji. Zweryfikowane
+  zrzutem. NASTĘPNE: UC1 — skaner Vinted czyta bloby i szuka widmowych tomów do kupienia.
 - **1.36.0** — **Cykle: Rytuał Żniw (harvest struktury do blobu per-pozycja) — Etap 1 backend (CYH-PR1).**
   Nowy rytuał `cycles-harvest` (`CycleHarvestService`): iteruje książki z „Część cyklu", reużywa
   `CycleLookupService` (prev/next + {{Cykl}} + cross-ref) i zapisuje zebrane tomy w blobie `CycleCache`

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -318,6 +318,15 @@ export const getCycle = async (req: Request, res: Response) => {
   }
 };
 
+export const getCyclesHarvest = async (_req: Request, res: Response) => {
+  try {
+    res.json(await syncManager.getCyclesHarvest());
+  } catch (error: any) {
+    log.error("Cycles harvest read error", { message: error?.message });
+    res.status(500).json({ error: error.message || "Błąd odczytu zebranych cykli." });
+  }
+};
+
 export const checkLibraryAvailability = async (req: Request, res: Response) => {
   const { libraryCode } = req.body;
   if (!libraryCode) return res.status(400).json({ error: "Missing libraryCode parameter" });

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.36.0",
+      "version": "1.37.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.36.0",
+  "version": "1.37.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -44,6 +44,7 @@ router.post("/vinted-resolve-sellers", syncController.resolveVintedSellers);
 router.post("/vinted-resolve-sellers/stop", syncController.stopVintedResolveSellers);
 router.get("/vinted-stored", syncController.getVintedStored);
 router.get("/cycle", syncController.getCycle);
+router.get("/cycles-harvest", syncController.getCyclesHarvest);
 router.post("/library-check", syncController.checkLibraryAvailability);
 
 export default router;

--- a/services/__tests__/cycleHarvest.test.ts
+++ b/services/__tests__/cycleHarvest.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { buildCycleBlob, serializeCycleBlob, parseCycleBlob, sameCycleContent } from "../cycleHarvest";
+import { buildCycleBlob, serializeCycleBlob, parseCycleBlob, sameCycleContent, mergeCycleCaches } from "../cycleHarvest";
 import { CycleView } from "../cycleLookupService";
 
 const view: CycleView = {
@@ -71,5 +71,51 @@ describe("sameCycleContent", () => {
     const shorter = buildCycleBlob({ ...view, volumes: view.volumes.slice(0, 2) }, 1);
     expect(sameCycleContent(a, shorter)).toBe(false);
     expect(sameCycleContent(a, null)).toBe(false);
+  });
+});
+
+describe("mergeCycleCaches", () => {
+  const blob = (cycle: string, ts: number, vols: any[]) =>
+    ({ cycleCache: JSON.stringify({ v: 1, ts, cycle, src: "chain", vols }) });
+
+  it("grupuje po cyklu, dedupuje tomy i OR-uje statusy między pozycjami", () => {
+    const books = [
+      blob("Mistborn", 100, [
+        { t: "Tom 1", b: 1, r: 1, o: 1, a: 0 },
+        { t: "Tom 2", b: 1, r: 0, o: 0, a: 1 },
+      ]),
+      // druga pozycja z tego samego cyklu: Tom 2 posiadany + nowy Tom 3 spoza bazy
+      blob("Mistborn", 200, [
+        { t: "Tom 2", b: 1, r: 0, o: 1, a: 1 },
+        { t: "Tom 3", b: 0, r: 0, o: 0, a: 0 },
+      ]),
+    ];
+    const out = mergeCycleCaches(books);
+    expect(out.totalCycles).toBe(1);
+    expect(out.harvestedAt).toBe(200);
+    const c = out.cycles[0];
+    expect(c.cycle).toBe("Mistborn");
+    expect(c.volumes.map((v) => v.title)).toEqual(["Tom 1", "Tom 2", "Tom 3"]);
+    expect(c.volumes[1].owned).toBe(true); // OR z drugiej pozycji
+    expect(c.total).toBe(3);
+    expect(c.inBase).toBe(2);
+    expect(c.missing).toBe(1);
+    expect(c.owned).toBe(2);
+    expect(c.read).toBe(1);
+  });
+
+  it("sortuje cykle malejąco po liczbie brakujących tomów", () => {
+    const books = [
+      blob(" Mało braku", 1, [{ t: "A", b: 1 }, { t: "B", b: 0 }]),
+      blob("Dużo braku", 1, [{ t: "C", b: 0 }, { t: "D", b: 0 }, { t: "E", b: 0 }]),
+    ];
+    const out = mergeCycleCaches(books);
+    expect(out.cycles[0].missing).toBe(3);
+    expect(out.cycles[1].missing).toBe(1);
+  });
+
+  it("pomija książki bez/uszkodzonym blobem", () => {
+    const out = mergeCycleCaches([{}, { cycleCache: "" }, { cycleCache: "{bad" }]);
+    expect(out).toEqual({ cycles: [], totalCycles: 0, harvestedAt: null });
   });
 });

--- a/services/cycleHarvest.ts
+++ b/services/cycleHarvest.ts
@@ -29,6 +29,87 @@ export interface CycleBlob {
 
 const bit = (b: boolean): 0 | 1 => (b ? 1 : 0);
 
+/** Jeden tom w zagregowanym widoku cyklu (statusy scalone OR-em między pozycjami). */
+export interface HarvestVolume {
+  title: string;
+  inBase: boolean;
+  read: boolean;
+  owned: boolean;
+  awarded: boolean;
+}
+/** Jeden cykl w Archiwum: tomy w kolejności + liczniki. */
+export interface HarvestCycle {
+  cycle: string;
+  volumes: HarvestVolume[];
+  total: number;
+  /** Ile tomów jest w bazie (jako wiersz). */ inBase: number;
+  owned: number;
+  read: number;
+  /** Ile tomów NIE ma w bazie (kandydaci do zdobycia). */ missing: number;
+}
+export interface CyclesHarvest {
+  cycles: HarvestCycle[];
+  totalCycles: number;
+  /** Najświeższy znacznik zebrania spośród blobów (epoch ms), null gdy brak danych. */
+  harvestedAt: number | null;
+}
+
+const normKey = (s: string): string => (s || "").toLowerCase().replace(/\s+/g, " ").trim();
+
+/**
+ * Scala bloby `CycleCache` z wielu pozycji w listę cykli do Archiwum: grupuje po
+ * nazwie cyklu, dedupuje tomy po tytule (statusy OR-owane), kolejność bierze z
+ * pierwszego napotkanego blobu danego cyklu, dopisując brakujące tomy na końcu.
+ * Czyste — wejściem jest lista książek (tylko pole `cycleCache`).
+ */
+export function mergeCycleCaches(books: { cycleCache?: string }[]): CyclesHarvest {
+  const groups = new Map<string, { name: string; order: string[]; vols: Map<string, HarvestVolume> }>();
+  let harvestedAt: number | null = null;
+
+  for (const book of books) {
+    const blob = parseCycleBlob(book.cycleCache);
+    if (!blob || blob.vols.length === 0) continue;
+    if (blob.ts) harvestedAt = harvestedAt === null ? blob.ts : Math.max(harvestedAt, blob.ts);
+
+    const gKey = normKey(blob.cycle);
+    let g = groups.get(gKey);
+    if (!g) { g = { name: blob.cycle, order: [], vols: new Map() }; groups.set(gKey, g); }
+
+    for (const v of blob.vols) {
+      const vKey = normKey(v.t);
+      const existing = g.vols.get(vKey);
+      if (existing) {
+        // Scal statusy OR-em (posiadanie/przeczytanie/nagroda widoczne z dowolnej pozycji).
+        existing.inBase = existing.inBase || !!v.b;
+        existing.read = existing.read || !!v.r;
+        existing.owned = existing.owned || !!v.o;
+        existing.awarded = existing.awarded || !!v.a;
+      } else {
+        g.order.push(vKey);
+        g.vols.set(vKey, { title: v.t, inBase: !!v.b, read: !!v.r, owned: !!v.o, awarded: !!v.a });
+      }
+    }
+  }
+
+  const cycles: HarvestCycle[] = Array.from(groups.values()).map((g) => {
+    const volumes = g.order.map((k) => g.vols.get(k)!);
+    const inBase = volumes.filter((v) => v.inBase).length;
+    return {
+      cycle: g.name,
+      volumes,
+      total: volumes.length,
+      inBase,
+      owned: volumes.filter((v) => v.owned).length,
+      read: volumes.filter((v) => v.read).length,
+      missing: volumes.length - inBase,
+    };
+  });
+  // Najciekawsze na górze: najwięcej brakujących tomów (najwięcej do zdobycia).
+  cycles.sort((a, b) => b.missing - a.missing || b.total - a.total || a.cycle.localeCompare(b.cycle));
+
+  return { cycles, totalCycles: cycles.length, harvestedAt };
+}
+
 /** Buduje kompaktowy blob z widoku cyklu (znacznik czasu podajemy z zewnątrz — testowalność). */
 export function buildCycleBlob(view: CycleView, ts: number): CycleBlob {
   return {

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -15,6 +15,7 @@ import { AvailabilityCard } from "./stats/AvailabilityCard";
 import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
 import { MarketCard } from "./stats/MarketCard";
+import { CyclesHarvestCard } from "./stats/CyclesHarvestCard";
 import { useEffectiveConfig, persistStatsOrder } from "../hooks/useAppConfig";
 import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
 
@@ -118,6 +119,7 @@ export const StatsSection: React.FC = () => {
     { id: "availability", node: <AvailabilityCard stats={stats.availabilityStats} /> },
     { id: "market", node: <MarketCard market={stats.marketStats} /> },
     { id: "publishing", node: <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} /> },
+    { id: "cyclesHarvest", node: <CyclesHarvestCard /> },
     { id: "decades", span2: true, node: <DecadeHistogram decades={stats.decadeStats} /> },
     {
       id: "yearly",

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import { motion } from "motion/react";
+import { Layers, ChevronDown, Check, Package, CircleDashed, AlertTriangle, Award, ExternalLink, Loader2 } from "lucide-react";
+import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
+
+/** Link do tomu w Archiwum Encyklopedii Fantastyki (ten sam wzorzec co parser/panel). */
+const encyclopediaUrl = (title: string) =>
+  `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent(title.replace(/ /g, "_"))}`;
+
+const volStatus = (v: HarvestVolume) => {
+  if (v.read) return { icon: Check, cls: "text-cyan-400", label: "przeczytana" };
+  if (v.owned) return { icon: Package, cls: "text-emerald-400", label: "posiadana" };
+  if (v.inBase) return { icon: CircleDashed, cls: "text-slate-400", label: "w bazie" };
+  return { icon: AlertTriangle, cls: "text-amber-400", label: "brak w bazie" };
+};
+
+/**
+ * Archiwum Cykli — zbiorczy widok tomów cykli zebranych Rytuałem Żniw (bloby
+ * `CycleCache`). Pokazuje ile tomów masz / brakuje, bez dodawania ich do bazy.
+ */
+export const CyclesHarvestCard: React.FC = () => {
+  const { view, loading, error } = useCyclesHarvest();
+  const [open, setOpen] = useState<string | null>(null);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="glass-card p-6 rounded-3xl border-amber-500/10 space-y-4"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-bold font-display uppercase tracking-widest text-amber-400 flex items-center gap-2">
+          <Layers className="w-4 h-4" />
+          Archiwum Cykli
+        </h3>
+        {view && view.totalCycles > 0 && (
+          <span className="text-[10px] font-bold tabular-nums text-slate-500 uppercase tracking-wider">{view.totalCycles} cykli</span>
+        )}
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center gap-3 py-10 text-slate-400">
+          <Loader2 className="w-5 h-5 animate-spin text-amber-400" />
+          <span className="text-xs uppercase tracking-widest font-bold">Odczyt zebranych cykli...</span>
+        </div>
+      )}
+
+      {error && !loading && <p className="text-sm text-slate-400 italic text-center py-8">{error}</p>}
+
+      {view && !loading && view.totalCycles === 0 && (
+        <p className="text-slate-400 text-sm italic text-center py-8">
+          Brak zebranych cykli. Uruchom <span className="text-amber-300 not-italic font-bold">Rytuał Żniw Cykli</span> w Liturgiach, aby zebrać sąsiednie tomy z Encyklopedii.
+        </p>
+      )}
+
+      {view && !loading && view.totalCycles > 0 && (
+        <div className="space-y-2 max-h-[460px] overflow-y-auto pr-2 custom-scrollbar">
+          {view.cycles.map((c) => {
+            const isOpen = open === c.cycle;
+            return (
+              <div key={c.cycle} className="rounded-2xl border border-white/5 bg-slate-950/40 overflow-hidden">
+                <button
+                  onClick={() => setOpen(isOpen ? null : c.cycle)}
+                  className="w-full flex items-center gap-2.5 p-3 text-left hover:bg-white/5 transition-colors"
+                >
+                  <ChevronDown className={`w-4 h-4 shrink-0 text-slate-500 transition-transform ${isOpen ? "rotate-180" : ""}`} />
+                  <span className="flex-1 min-w-0 text-sm font-bold text-slate-200 truncate">{c.cycle}</span>
+                  {c.missing > 0 && (
+                    <span className="shrink-0 px-2 py-0.5 rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-300 text-[9px] font-bold uppercase tracking-wider">
+                      {c.missing} do zdobycia
+                    </span>
+                  )}
+                  <span className="shrink-0 text-[10px] tabular-nums text-slate-500 font-bold">{c.inBase}/{c.total}</span>
+                </button>
+
+                {isOpen && (
+                  <ol className="px-3 pb-3 space-y-1">
+                    {c.volumes.map((v, i) => {
+                      const s = volStatus(v);
+                      const Icon = s.icon;
+                      return (
+                        <li key={i} className="flex items-center gap-2.5 p-2 rounded-lg bg-slate-950/40">
+                          <span className="text-[10px] font-bold tabular-nums text-slate-500 w-4 text-right shrink-0">{i + 1}.</span>
+                          <Icon className={`w-3.5 h-3.5 shrink-0 ${s.cls}`} />
+                          <span className={`flex-1 min-w-0 text-sm truncate ${v.inBase ? "text-slate-200" : "text-slate-400"}`}>{v.title}</span>
+                          {v.awarded && <Award className="w-3.5 h-3.5 text-amber-400 shrink-0" aria-label="nagrodzona" />}
+                          <a
+                            href={encyclopediaUrl(v.title)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="shrink-0 p-1 rounded-md text-slate-500 hover:text-amber-300 hover:bg-amber-500/10 transition-colors"
+                            title="Otwórz w Encyklopedii (nowa karta)"
+                            aria-label={`Otwórz ${v.title} w Encyklopedii`}
+                          >
+                            <ExternalLink className="w-3.5 h-3.5" />
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ol>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </motion.div>
+  );
+};

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface HarvestVolume {
+  title: string;
+  inBase: boolean;
+  read: boolean;
+  owned: boolean;
+  awarded: boolean;
+}
+export interface HarvestCycle {
+  cycle: string;
+  volumes: HarvestVolume[];
+  total: number;
+  inBase: number;
+  owned: number;
+  read: number;
+  missing: number;
+}
+export interface CyclesHarvest {
+  cycles: HarvestCycle[];
+  totalCycles: number;
+  harvestedAt: number | null;
+}
+
+/**
+ * Zebrane cykle (GET /api/cycles-harvest) — z blobów `CycleCache` uzupełnionych
+ * Rytuałem Żniw. Odczyt jest lekki (agregacja po stronie serwera z cache książek).
+ */
+export function useCyclesHarvest() {
+  const [view, setView] = useState<CyclesHarvest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHarvest = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/cycles-harvest");
+      if (!res.ok) throw new Error(`Błąd serwera: ${res.status}`);
+      setView(await res.json());
+    } catch (e: any) {
+      setError(e?.message || "Nie udało się pobrać zebranych cykli.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchHarvest(); }, [fetchHarvest]);
+
+  return { view, loading, error, fetchHarvest };
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -14,6 +14,7 @@ import { LibraryCheckService } from "./services/libraryCheckService";
 import { VintedSyncService } from "./services/vintedSyncService";
 import { CycleLookupService } from "./services/cycleLookupService";
 import { CycleHarvestService } from "./services/cycleHarvestService";
+import { mergeCycleCaches } from "./services/cycleHarvest";
 import { toSearchIndex } from "./services/bookSearchIndex";
 import { ConfigService } from "./services/configService";
 import { createLogger, classifyHttpError } from "./logger";
@@ -178,6 +179,12 @@ class SyncManager {
   }
 
   /** Podgląd cyklu dla książki (na żądanie, bez zapisu do bazy). */
+  /** Zagregowany widok zebranych cykli (z blobów `CycleCache`) dla Archiwum. */
+  async getCyclesHarvest() {
+    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
+    return mergeCycleCaches(books);
+  }
+
   async getCycle(title: string, author: string) {
     return await cycleLookupService.lookup(title, author);
   }


### PR DESCRIPTION
Etap 1, część frontendowa (use case 2): przeglądanie zebranych cykli w Archiwum, jak w Skryptorium, bez dodawania tomów do bazy.

## Co robi

- **`mergeCycleCaches(books)`** (czyste): scala bloby `CycleCache` z wszystkich pozycji → lista cykli. Grupa po nazwie cyklu, tomy dedupowane po tytule (statusy `inBase/read/owned/awarded` scalone OR-em między pozycjami), sort malejąco po liczbie brakujących tomów (najwięcej do zdobycia na górze). `harvestedAt` = najświeższy `ts`.
- **`GET /api/cycles-harvest`** (`SyncManager.getCyclesHarvest` → agregacja z cache książek).
- **`useCyclesHarvest`** + **`CyclesHarvestCard`**: rozwijane cykle, liczniki `inBase/total` + badge „N do zdobycia", tomy ze statusem (przeczytana/posiadana/w bazie/brak), ikona nagrody, link do Encyklopedii (nowa karta). Wpięta jako karta `cyclesHarvest` w „Analizie Zasobów".

## Weryfikacja

Zrzut karty (Mistborn rozwinięty: 6 tomów, statusy, „4 do zdobycia", 2/6; Diuna/Hyperion zwinięte) — zgodnie z oczekiwaniem. `npm run lint` czysty, `npm test` zielony (371, +3), `npm run build` OK. Wersja `1.37.0`.

## Następny etap

UC1: skaner Vinted czyta bloby `CycleCache` i szuka widmowych (spoza bazy) tomów do kupienia; wynik dostępności dopisywany do blobu i pokazywany w tej karcie.

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_