### PR TITLE
Żniwa Cykli: realne liczniki podsumowania + wygaszanie ukończonych cykli

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.37.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.37.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.37.1** — **Żniwa Cykli: poprawki po testach.** (1) Podsumowanie liczyło „1" — bo `summary.updated`
+  było jednym zdaniem, a UI liczy count z długości listy; teraz `result.updated = liczba zapisanych`
+  + `summary.updated` to RZECZYWISTA lista tytułów (skipped = tytuły bez sąsiednich tomów; pusty 0-case
+  bez summary → widok „Rytuał Zakończony"). (2) „Archiwum Cykli": cykle przeczytane w całości
+  (`read === total`) są wygaszone (opacity-45) + badge „Ukończony" (cyan), bright tylko gdy rozwinięte.
 - **1.37.0** — **Cykle: karta „Archiwum Cykli" (UC2) — Etap 1 frontend (CYH-PR2).** Czysty
   `mergeCycleCaches(books)` scala bloby `CycleCache` z wszystkich pozycji w listę cykli (grupa po
   nazwie, dedup tomów po tytule, statusy OR-owane, sort malejąco po `missing`) → `getCyclesHarvest()`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.37.0",
+  "version": "1.37.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/cycleHarvestService.ts
+++ b/services/cycleHarvestService.ts
@@ -35,7 +35,8 @@ export class CycleHarvestService {
 
       sendEvent({ type: "status", message: `Znaleziono ${cycleBooks.length} pozycji oznaczonych jako część cyklu. Odpytywanie Archiwum...` });
       if (cycleBooks.length === 0) {
-        sendEvent({ type: "complete", result: { success: true, found: 0, written: 0, skipped: 0, noSiblings: 0, summary: { note: "Brak pozycji z zaznaczonym polem Część cyklu — uruchom najpierw Rytuał Oznaczania Cykli." } } });
+        // Bez summary → widok „Rytuał Zakończony" (found/updated), nie karty liczników.
+        sendEvent({ type: "complete", result: { success: true, found: 0, updated: 0 } });
         return;
       }
 
@@ -43,7 +44,11 @@ export class CycleHarvestService {
       // trzymamy niską współbieżność (max 3), niezależnie od writeConcurrency.
       const limit = pLimit(Math.min(3, Math.max(1, (await this.config.getConfig()).sync.writeConcurrency)));
 
-      let processed = 0, written = 0, unchanged = 0, noSiblings = 0;
+      // Zbieramy RZECZYWISTE listy tytułów — UI liczy count z długości list, więc
+      // pojedyncze zdanie podsumowania dawało błędne „1" (policzone jako 1 element).
+      let processed = 0, unchanged = 0;
+      const updatedTitles: string[] = [];
+      const noSiblingTitles: string[] = [];
       const errors: { book: string; error: string }[] = [];
 
       const tasks = cycleBooks.map((book) => limit(async () => {
@@ -53,7 +58,7 @@ export class CycleHarvestService {
           const view = await this.cycleLookup.lookup(title, book.author || "");
           // <=1 tom = brak sąsiadów do zebrania (albo strona bez danych cyklu).
           if (!view || view.volumes.length <= 1) {
-            noSiblings++;
+            noSiblingTitles.push(title);
           } else {
             const blob = buildCycleBlob(view, Date.now());
             const existing = parseCycleBlob(book.cycleCache);
@@ -61,7 +66,7 @@ export class CycleHarvestService {
               unchanged++;
             } else {
               await this.notion.saveCycleCache(book.id, serializeCycleBlob(blob));
-              written++;
+              updatedTitles.push(`${title} (${view.volumes.length} tomów: ${view.cycleName})`);
             }
           }
         } catch (err: any) {
@@ -76,21 +81,18 @@ export class CycleHarvestService {
 
       await Promise.all(tasks);
 
-      log.info("Żniwa cykli zakończone", { found: cycleBooks.length, written, unchanged, noSiblings, errors: errors.length });
+      const written = updatedTitles.length;
+      log.info("Żniwa cykli zakończone", { found: cycleBooks.length, written, unchanged, noSiblings: noSiblingTitles.length, errors: errors.length });
       sendEvent({
         type: "complete",
         result: {
           success: !checkCancellation(),
           found: cycleBooks.length,
-          written,
-          unchanged,
-          noSiblings,
+          updated: written,   // liczba realnie zapisanych pozycji (UI czyta to pole)
+          unchanged,          // bez zmian struktury (nie zapisano) — informacyjnie
           summary: {
-            updated: [`Zapisano tomy cyklu dla ${written} pozycji`],
-            skipped: [
-              `${unchanged} bez zmian`,
-              `${noSiblings} bez sąsiednich tomów`,
-            ],
+            updated: updatedTitles,      // panel „Zaktualizowane" + poprawny licznik
+            skipped: noSiblingTitles,    // „Pominięto — nie oceniono" (brak sąsiednich tomów)
           },
           errors: errors.length > 0 ? errors : undefined,
         },

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { motion } from "motion/react";
-import { Layers, ChevronDown, Check, Package, CircleDashed, AlertTriangle, Award, ExternalLink, Loader2 } from "lucide-react";
+import { Layers, ChevronDown, Check, CheckCheck, Package, CircleDashed, AlertTriangle, Award, ExternalLink, Loader2 } from "lucide-react";
 import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
 
 /** Link do tomu w Archiwum Encyklopedii Fantastyki (ten sam wzorzec co parser/panel). */
@@ -57,15 +57,21 @@ export const CyclesHarvestCard: React.FC = () => {
         <div className="space-y-2 max-h-[460px] overflow-y-auto pr-2 custom-scrollbar">
           {view.cycles.map((c) => {
             const isOpen = open === c.cycle;
+            // Cykl przeczytany w całości → wygaszony (nic nie zostało do nadrobienia).
+            const done = c.total > 0 && c.read === c.total;
             return (
-              <div key={c.cycle} className="rounded-2xl border border-white/5 bg-slate-950/40 overflow-hidden">
+              <div key={c.cycle} className={`rounded-2xl border border-white/5 bg-slate-950/40 overflow-hidden transition-opacity ${done && !isOpen ? "opacity-45" : ""}`}>
                 <button
                   onClick={() => setOpen(isOpen ? null : c.cycle)}
                   className="w-full flex items-center gap-2.5 p-3 text-left hover:bg-white/5 transition-colors"
                 >
                   <ChevronDown className={`w-4 h-4 shrink-0 text-slate-500 transition-transform ${isOpen ? "rotate-180" : ""}`} />
-                  <span className="flex-1 min-w-0 text-sm font-bold text-slate-200 truncate">{c.cycle}</span>
-                  {c.missing > 0 && (
+                  <span className={`flex-1 min-w-0 text-sm font-bold truncate ${done ? "text-slate-400" : "text-slate-200"}`}>{c.cycle}</span>
+                  {done ? (
+                    <span className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full border border-cyan-500/25 bg-cyan-500/10 text-cyan-300/90 text-[9px] font-bold uppercase tracking-wider">
+                      <CheckCheck className="w-2.5 h-2.5" /> ukończony
+                    </span>
+                  ) : c.missing > 0 && (
                     <span className="shrink-0 px-2 py-0.5 rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-300 text-[9px] font-bold uppercase tracking-wider">
                       {c.missing} do zdobycia
                     </span>


### PR DESCRIPTION
Poprawki po testach Rytuału Żniw (#208).

## 1. Podsumowanie liczyło „1"

UI wyprowadza licznik „Zaktualizowano" z `result.updated`, a w fallbacku z **długości** `summary.updated`. Rytuał wstawiał tam jedno zdanie → count = 1. Teraz:
- `result.updated` = realna liczba zapisanych pozycji,
- `summary.updated` = lista tytułów (z liczbą tomów i nazwą cyklu),
- `summary.skipped` = tytuły bez sąsiednich tomów (panel „Pominięto — nie oceniono"),
- pusty 0-case bez `summary` → widok „Rytuał Zakończony" zamiast wyzerowanych kart.

## 2. Archiwum Cykli — wygaszanie ukończonych

Cykle przeczytane w całości (`read === total`) renderują się wygaszone (`opacity-45`) z badge **„Ukończony"** (cyan zamiast „N do zdobycia"); rozjaśniają się po rozwinięciu. Są już na dole listy (sort po `missing`).

## Weryfikacja

Zrzut karty: Hyperion (2/2 przeczytane) wygaszony z badge „Ukończony" na dole; Mistborn „1 do zdobycia" u góry. `npm run lint` czysty, `npm test` zielony (371), `npm run build` OK. Wersja `1.37.1`.

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_