### PR TITLE
Cykle jako wiersze — CV-PR1: infrastruktura separacji Kategoria

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.37.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.38.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.38.0** — **Cykle jako wiersze — decyzja + CV-PR1 (infrastruktura separacji `Kategoria`).**
+  DECYZJA użytkownika: poboczne tomy cykli będą REALNYMI wierszami bazy (opcja A: te same wiersze +
+  `Kategoria`), żeby dało się je oznaczać przeczytane/posiadane i żeby Vinted je skanował. Gap w blobach:
+  tom „nieprzeczytany" = brak wiersza, nie dało się oznaczyć. CV-PR1 (bezpieczny fundament, no-op dopóki
+  nie ma takich wierszy): mapper czyta `Kategoria` (select; pusto = „Nagroda"), `NotionBook.kategoria`,
+  helper `isAwardBook`/`isCycleVolume` (`services/bookCategory.ts`). Filtr `isAwardBook` w choke-pointach
+  nagrodowych: `statsService.getStats` (1 linia → wszystkie staty), `integrityService` (rok/Lp vs wiki),
+  `toSearchIndex` (Regał + Skryptorium). Vinted CELOWO bez filtra (ma skanować też tomy cykli). Testy.
+  NASTĘPNE: CV-PR2 (Żniwa robią idempotentny upsert wierszy `Kategoria=Tom cyklu` zamiast blobów; Archiwum
+  czyta wiersze), CV-PR3 (opcjonalne włączanie cykli w Regale/Skryptorium, sprzątanie blobów, duplikaty).
 - **1.37.1** — **Żniwa Cykli: poprawki po testach.** (1) Podsumowanie liczyło „1" — bo `summary.updated`
   było jednym zdaniem, a UI liczy count z długości listy; teraz `result.updated = liczba zapisanych`
   + `summary.updated` to RZECZYWISTA lista tytułów (skipped = tytuły bez sąsiednich tomów; pusty 0-case

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notionMapper.ts
+++ b/notionMapper.ts
@@ -64,6 +64,9 @@ export function mapPageToBook(page: NotionPage): NotionBook {
   const currentWydawnictwo = getPlainText(getProp(props, "Wydawnictwo"));
   const currentSeria = getPlainText(getProp(props, "Seria"));
   const currentCzesccyklu = getProp(props, "Część cyklu")?.checkbox || false;
+  // Kategoria wiersza: „Nagroda" (domyślnie, gdy pusto) vs „Tom cyklu" (poboczny tom
+  // cyklu dodany rytuałem żniw). Rozdziela pozycje nagrodowe od reszty.
+  const kategoria = getProp(props, "Kategoria")?.select?.name || undefined;
   const lp = getPlainText(getProp(props, "Lp"));
 
   const awards = multiSelectNames(getProp(props, "Nagroda"));
@@ -88,6 +91,7 @@ export function mapPageToBook(page: NotionPage): NotionBook {
     currentWydawnictwo,
     currentSeria,
     currentCzesccyklu,
+    kategoria,
     lp,
     awards,
     zrodlo,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.37.1",
+      "version": "1.38.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.37.1",
+  "version": "1.38.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/bookCategory.test.ts
+++ b/services/__tests__/bookCategory.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { isAwardBook, isCycleVolume, CYCLE_VOLUME_CATEGORY } from "../bookCategory";
+import { toSearchIndex } from "../bookSearchIndex";
+import { NotionBook } from "../../src/types";
+
+describe("bookCategory", () => {
+  it("brak kategorii = nagrodowa (zgodność wstecz)", () => {
+    expect(isAwardBook({})).toBe(true);
+    expect(isCycleVolume({})).toBe(false);
+    expect(isAwardBook({ kategoria: "Nagroda" })).toBe(true);
+  });
+
+  it("Tom cyklu = nie-nagrodowa", () => {
+    expect(isCycleVolume({ kategoria: CYCLE_VOLUME_CATEGORY })).toBe(true);
+    expect(isAwardBook({ kategoria: CYCLE_VOLUME_CATEGORY })).toBe(false);
+  });
+});
+
+describe("toSearchIndex — wyklucza tomy cykli", () => {
+  const mk = (id: string, kategoria?: string): NotionBook => ({
+    id, plTitle: `Tytuł ${id}`, origTitle: "", awards: [], kategoria,
+  } as NotionBook);
+
+  it("indeks (Regał/Skryptorium) pomija Kategoria=Tom cyklu", () => {
+    const idx = toSearchIndex([mk("a"), mk("b", CYCLE_VOLUME_CATEGORY), mk("c", "Nagroda")]);
+    expect(idx.map((e) => e.id)).toEqual(["a", "c"]);
+  });
+});

--- a/services/__tests__/statsService.test.ts
+++ b/services/__tests__/statsService.test.ts
@@ -64,6 +64,19 @@ describe('StatsService', () => {
     expect(stats.ownedUnread[0].title).toBe('Cyberiada');
   });
 
+  it('excludes cycle-volume rows (Kategoria=Tom cyklu) from award stats', async () => {
+    const base = { origTitle: '', author: 'Autor X', year: '1980', currentWydawnictwo: '', currentSeria: '', currentCzesccyklu: false, plTitleRichText: [], origTitleRichText: [] };
+    mockNotion.getBooksForStats.mockResolvedValue([
+      { ...base, id: '1', plTitle: 'Nagrodzona', zrodlo: ['Przeczytane'], awards: ['Nagroda Hugo'], lp: '1' },
+      { ...base, id: '2', plTitle: 'Poboczny tom', zrodlo: ['Przeczytane'], awards: [], lp: '2', kategoria: 'Tom cyklu' },
+    ] as NotionBook[]);
+
+    const stats = await service.getStats();
+    // Tylko pozycja nagrodowa liczona; tom cyklu pominięty w awardBooks i autorach.
+    expect(stats.awardBooksStats).toEqual({ read: 1, total: 1 });
+    expect(stats.authorStats).toEqual([expect.objectContaining({ name: 'Autor X', total: 1 })]);
+  });
+
   it('partitions unread availability by priority (owned > library > vinted > none)', async () => {
     const vintedBlob = JSON.stringify({ scannedAt: "2026-01-01", offers: [{ id: "o", url: "https://vinted.pl/items/1", price: 10 }] });
     const mk = (id: string, zrodlo: string[], vintedData?: string): NotionBook => ({

--- a/services/bookCategory.ts
+++ b/services/bookCategory.ts
@@ -1,0 +1,17 @@
+/**
+ * Kategoria wiersza w bazie — rozdziela pozycje nagrodowe od pobocznych tomów cykli
+ * dodanych rytuałem żniw. Wiersze bez ustawionej „Kategorii" traktujemy jako nagrodowe
+ * (zgodność wstecz — istniejące pozycje nie mają tego pola).
+ *
+ * Konsumenci nagrodowi (statystyki, integralność, indeks Skryptorium/Regału) filtrują
+ * `isAwardBook`; skaner Vinted celowo bierze WSZYSTKO (tomy cykli też chcemy skanować).
+ */
+export const CYCLE_VOLUME_CATEGORY = "Tom cyklu";
+
+export function isCycleVolume(b: { kategoria?: string }): boolean {
+  return b.kategoria === CYCLE_VOLUME_CATEGORY;
+}
+
+export function isAwardBook(b: { kategoria?: string }): boolean {
+  return !isCycleVolume(b);
+}

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -1,4 +1,5 @@
 import { NotionBook, BookIndexEntry } from "../src/types";
+import { isAwardBook } from "./bookCategory";
 
 /**
  * Czysta projekcja pełnych rekordów Notion → odchudzony indeks wyszukiwarki.
@@ -9,6 +10,9 @@ import { NotionBook, BookIndexEntry } from "../src/types";
  */
 export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
   return books
+    // Regał i Skryptorium pozostają nagrodowe — poboczne tomy cykli wykluczamy
+    // (mają własny widok „Archiwum Cykli"); włączenie opcjonalne dojdzie później.
+    .filter((b) => isAwardBook(b))
     .filter((b) => (b.plTitle && b.plTitle.trim().length > 0) || (b.origTitle && b.origTitle.trim().length > 0))
     .map((b) => ({
       id: b.id,

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -4,6 +4,7 @@ import { WikiAdapter } from "../wiki.adapter";
 import { BookSyncService } from "./bookSyncService";
 import { SyncEvent, NotionBook, Book, IntegrityCheckResult } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
+import { isAwardBook } from "./bookCategory";
 
 export type { IntegrityCheckResult };
 
@@ -33,10 +34,13 @@ export class IntegrityService {
       await this.notion.init();
 
       sendEvent({ type: "status", message: "Pobieranie wszystkich danych z Notion..." });
-      const notionBooks = await this.notion.queryAllBooks(
+      const allNotionRows = await this.notion.queryAllBooks(
         (count) => sendEvent({ type: "status", message: `Pobrano ${count} rekordów z Notion...` }),
         checkCancellation
       );
+      // Integralność dotyczy pozycji NAGRODOWYCH — poboczne tomy cykli (Kategoria=Tom
+      // cyklu) nie są na listach nagród wiki, więc wykluczamy je z porównań (rok/Lp).
+      const notionBooks = allNotionRows.filter(isAwardBook);
       if (checkCancellation()) return;
 
       sendEvent({ type: "status", message: "Pobieranie danych z Archiwum Encyklopedii (Nagrody)..." });

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -2,6 +2,7 @@ import { NotionAdapter } from "../notion.adapter";
 import { ConfigService } from "./configService";
 import { parseVintedData } from "./vintedStore";
 import { computeMarketStats } from "./marketStats";
+import { isAwardBook } from "./bookCategory";
 
 export class StatsService {
   constructor(private notion: NotionAdapter, private config: ConfigService) {}
@@ -10,8 +11,9 @@ export class StatsService {
     let books = await this.notion.getBooksForStats();
     const branches = (await this.config.getConfig()).library.branches;
 
-    // Global filter: only books with a non-empty Polish title
-    books = books.filter(b => b.plTitle && b.plTitle.trim() !== "");
+    // Global filter: tylko pozycje NAGRODOWE (poboczne tomy cykli mają własny widok
+    // w „Archiwum Cykli") oraz z niepustym tytułem polskim.
+    books = books.filter(b => isAwardBook(b) && b.plTitle && b.plTitle.trim() !== "");
     
     // 1. Author progress
     const authorStats: Record<string, { read: number; total: number; books: any[] }> = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export interface NotionBook {
   currentWydawnictwo?: string;
   currentSeria?: string;
   currentCzesccyklu?: boolean;
+  /** Kategoria wiersza: „Nagroda" (domyślnie/pusto) vs „Tom cyklu" (poboczny tom cyklu). */
+  kategoria?: string;
   lp?: string;
   zrodlo?: string[];
   plTitleRichText?: NotionRichTextItem[];


### PR DESCRIPTION
Fundament pod przechowywanie pobocznych tomów cykli jako REALNE wiersze bazy (wybrana opcja A: te same wiersze + `Kategoria`) — żeby dało się je oznaczać przeczytane/posiadane i żeby Vinted je skanował. Rozwiązuje gap: w blobach tom „nieprzeczytany" = brak wiersza, nie dało się oznaczyć.

## Co robi

- **Mapper** czyta `Kategoria` (select; puste = „Nagroda" — zgodność wstecz) → `NotionBook.kategoria`.
- **`services/bookCategory.ts`**: `isAwardBook` / `isCycleVolume` (`CYCLE_VOLUME_CATEGORY = "Tom cyklu"`).
- **Filtr nagrodowy** w choke-pointach:
  - `statsService.getStats` — jedna linia u źródła → wszystkie statystyki pomijają tomy cykli,
  - `integrityService` — porównania rok/Lp vs wiki tylko dla pozycji nagrodowych,
  - `toSearchIndex` — Regał i Skryptorium zostają nagrodowe.
- **Skaner Vinted CELOWO bez filtra** — tomy cykli mają być skanowane (sedno opcji A).

## Bezpieczeństwo wdrożenia

To zmiana **no-op na dziś**: żadne wiersze `Tom cyklu` jeszcze nie istnieją (powstaną w CV-PR2), więc każdy filtr jest chwilowo bez efektu. Kładziemy separację NAJPIERW, żeby po pojawieniu się wierszy widoki nagród od razu były czyste.

## Testy

`bookCategory` + `toSearchIndex` (wyklucza tom cyklu) + `statsService` (tom cyklu poza licznikami nagród). `npm run lint` czysty, `npm test` zielony (375, +4), `npm run build` OK. Wersja `1.38.0`.

## Następne

CV-PR2: Żniwa robią idempotentny upsert wierszy `Kategoria=Tom cyklu` zamiast blobów, Archiwum czyta wiersze. CV-PR3: opcjonalne włączanie cykli w Regale/Skryptorium, sprzątanie blobów/duplikaty.

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_