### PR TITLE
Cykle jako wiersze — CV-PR3a: tomy poza numeracją Lp i duplikatami

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.39.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.40.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.40.0** — **Cykle jako wiersze — CV-PR3a (tomy poza numeracją Lp i duplikatami).** Na życzenie:
+  poboczne tomy cykli NIE uczestniczą w globalnym numerze porządkowym — `lpSyncService` filtruje
+  `isAwardBook` (numery nagród zostają czyste 1..N, tomy się nie wciskają; ich kolejność wewnątrz cyklu
+  daje `CyklNr`). `duplicateSyncService` też filtruje `isAwardBook` (tomy cykli to odrębne książki, nie
+  duplikaty). Testy. Uczciwa korekta: read-side (staty/integralność/Regał/Skryptorium) był już czysty
+  (CV-PR1), ale rytuały PISZĄCE iterują wszystkie wiersze — Vinted CELOWO skanuje tomy; publisher/series/
+  purify/biblioteka nieszkodliwie je wzbogacają. NASTĘPNE (CV-PR3b): opcjonalne włączanie cykli w Regale/
+  Skryptorium, sprzątanie kolumny `CycleCache`.
 - **1.39.0** — **Cykle jako wiersze — CV-PR2 (Żniwa tworzą wiersze, bloby wycofane).** Rytuał Żniw
   zamiast blobów robi **idempotentny upsert WIERSZY**: dla każdej kotwicy nagrodowej (`Część cyklu`)
   rozwija cykl (`CycleLookupService`) i dla brakujących tomów tworzy wiersz `Kategoria=Tom cyklu` +

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.39.0",
+  "version": "1.40.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/lpSyncService.test.ts
+++ b/services/__tests__/lpSyncService.test.ts
@@ -62,4 +62,18 @@ describe('LpSyncService', () => {
     expect(mockNotion.updateLp).toHaveBeenCalledWith('page-2', '2');
     expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
   });
+
+  it('does not number cycle-volume rows (Kategoria=Tom cyklu)', async () => {
+    const base = { author: 'A', origTitle: '', awards: [], zrodlo: [], currentWydawnictwo: '', currentSeria: '', currentCzesccyklu: false, plTitleRichText: [], origTitleRichText: [] };
+    mockNotion.queryAllBooks.mockResolvedValue([
+      { ...base, id: 'award', plTitle: 'Nagrodzona', year: '1990', lp: 'x' },
+      { ...base, id: 'vol', plTitle: 'Tom cyklu', year: '1991', lp: 'y', kategoria: 'Tom cyklu' },
+    ] as NotionBook[]);
+
+    await service.runLpSync(mockSendEvent, () => false);
+
+    // Tylko pozycja nagrodowa dostaje numer; tom cyklu pominięty w numeracji.
+    expect(mockNotion.updateLp).toHaveBeenCalledWith('award', '1');
+    expect(mockNotion.updateLp).not.toHaveBeenCalledWith('vol', expect.anything());
+  });
 });

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -3,6 +3,7 @@ import { WikiAdapter } from "../wiki.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
 import { countCommonWords, calculateSimilarity } from "../utils";
 import { ConfigService } from "./configService";
+import { isAwardBook } from "./bookCategory";
 
 export class DuplicateSyncService {
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
@@ -16,8 +17,11 @@ export class DuplicateSyncService {
       await this.notion.init();
       console.log("Notion initialized");
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-      const allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
-      console.log(`Fetched ${allBooks.length} books`);
+      const fetched: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      // Wykrywanie duplikatów dotyczy pozycji nagrodowych — poboczne tomy cykli to
+      // legalne odrębne książki, nie duplikaty (wykluczamy z porównań).
+      const allBooks: NotionBook[] = fetched.filter(isAwardBook);
+      console.log(`Fetched ${fetched.length} books (${allBooks.length} award after category filter)`);
       
       const duplicates: { bookA: string; bookB: string; reason: string }[] = [];
       for (let i = 0; i < allBooks.length; i++) {

--- a/services/lpSyncService.ts
+++ b/services/lpSyncService.ts
@@ -1,6 +1,7 @@
 import { NotionAdapter } from "../notion.adapter";
 import pLimit from "p-limit";
 import { NotionBook, SyncEvent } from "../src/types";
+import { isAwardBook } from "./bookCategory";
 
 export class LpSyncService {
   constructor(private notion: NotionAdapter) {}
@@ -10,8 +11,11 @@ export class LpSyncService {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       let allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
       
-      // Filter out empty books (ghost rows) to avoid assigning Lp to them
-      allBooks = allBooks.filter(b => b.plTitle || b.origTitle || b.author);
+      // Filter out empty books (ghost rows) to avoid assigning Lp to them.
+      // Numeracja Lp dotyczy TYLKO pozycji nagrodowych — poboczne tomy cykli nie
+      // uczestniczą w globalnym numerze porządkowym (nie przesuwają numerów nagród;
+      // ich kolejność wewnątrz cyklu daje pole CyklNr).
+      allBooks = allBooks.filter(b => isAwardBook(b) && (b.plTitle || b.origTitle || b.author));
 
       if (checkCancellation()) { sendEvent({ type: "error", error: "Przerwano aktualizację Lp." }); return; }
       sendEvent({ type: "status", message: "Sortowanie i aktualizacja kolumny Lp..." });


### PR DESCRIPTION
Odpowiedź na uwagę o numeracji: poboczne tomy cykli **nie uczestniczą** w globalnym numerze porządkowym nagród ani w wykrywaniu duplikatów.

## Zmiany

- **`lpSyncService`** — filtr `isAwardBook`: Rytuał Rekonstrukcji Liczb numeruje **tylko pozycje nagrodowe**, więc ich numery 1..N zostają czyste, a tomy cykli się nie wciskają. Kolejność tomów wewnątrz cyklu daje pole `CyklNr` (używane w Archiwum).
- **`duplicateSyncService`** — filtr `isAwardBook`: tomy cykli to odrębne książki, nie duplikaty pozycji nagrodowych.

## Kontekst (korekta wcześniejszej odpowiedzi)

Read-side był już czysty (CV-PR1: staty/integralność/Regał/Skryptorium filtrują tomy). Ale rytuały **piszące** iterują wszystkie wiersze: Vinted CELOWO skanuje tomy (sedno opcji A); publisher/series/purify/biblioteka nieszkodliwie je wzbogacają; Lp i duplikaty wymagały wykluczenia — tu naprawione.

## Testy

`lpSyncService` (tom cyklu pominięty w numeracji) + istniejące. `npm run lint` czysty, `npm test` zielony (371), `npm run build` OK. Wersja `1.40.0`.

## Następne (CV-PR3b, opcjonalne)

Przełącznik „pokaż cykle" w Regale/Skryptorium, sprzątanie kolumny `CycleCache`.

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_