### PR TITLE
Audyt „cykle jako wiersze" + fix: promocja tomu do nagrody

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.40.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.40.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.40.1** — **Audyt „cykle jako wiersze" + fix promocji.** Przegląd wszystkich konsumentów wierszy.
+  FIX (korektność): `bookSyncService` — gdy rytuał nagród trafi na istniejący wiersz `Tom cyklu`
+  (tom, który JEDNAK zdobył nagrodę), promuje go do `Kategoria=Nagroda` (inaczej zostałby ukryty w
+  statystykach nagród; zapobiega też duplikatowi). Stała `AWARD_CATEGORY`. Audyt potwierdził poprawne
+  filtry (staty/integralność/Regał/Skryptorium/duplikaty/Lp). ODNOTOWANE (nie-bug, decyzje na później):
+  (a) brak w-appowego oznaczania tomów przeczytane/posiadane — Archiwum jest read-only, widoki nagród
+  je wykluczają → oznaczasz w Notion; kandydat do CV-PR3b; (b) skan biblioteki i Vinted CELOWO obejmują
+  tomy (Vinted zbiera dane pod UC1, ale nic ich jeszcze nie wyświetla); (c) cyclesSync/publisher/series/
+  purify/wikiField iterują też tomy — nieszkodliwe wzbogacanie, dodatkowy ruch wiki.
 - **1.40.0** — **Cykle jako wiersze — CV-PR3a (tomy poza numeracją Lp i duplikatami).** Na życzenie:
   poboczne tomy cykli NIE uczestniczą w globalnym numerze porządkowym — `lpSyncService` filtruje
   `isAwardBook` (numery nagród zostają czyste 1..N, tomy się nie wciskają; ich kolejność wewnątrz cyklu

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.40.0",
+  "version": "1.40.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/bookCategory.ts
+++ b/services/bookCategory.ts
@@ -7,6 +7,7 @@
  * `isAwardBook`; skaner Vinted celowo bierze WSZYSTKO (tomy cykli też chcemy skanować).
  */
 export const CYCLE_VOLUME_CATEGORY = "Tom cyklu";
+export const AWARD_CATEGORY = "Nagroda";
 
 export function isCycleVolume(b: { kategoria?: string }): boolean {
   return b.kategoria === CYCLE_VOLUME_CATEGORY;

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -6,6 +6,7 @@ import { calculateSimilarity, countCommonWords, cleanTitle } from "../utils";
 import { Book, NotionBook, SyncEvent, SyncParams } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
 import { buildBookUpdates, buildNewBookProperties } from "./bookDiff";
+import { isCycleVolume, AWARD_CATEGORY } from "./bookCategory";
 import { createLogger } from "../logger";
 import { ConfigService } from "./configService";
 
@@ -134,6 +135,12 @@ export class BookSyncService {
 
           if (existingBook) {
             const updates = buildBookUpdates(existingBook, book);
+            // Promocja: rytuał nagród przetwarza laureatów, więc jeśli trafił na wiersz
+            // oznaczony jako „Tom cyklu", ten tom JEDNAK jest nagrodzony — przenosimy go
+            // do Kategoria=Nagroda (inaczej zostałby ukryty w statystykach nagród).
+            if (isCycleVolume(existingBook)) {
+              updates["Kategoria"] = { select: { name: AWARD_CATEGORY } };
+            }
             if (Object.keys(updates).length > 0) {
               await this.notion.updatePage(existingBook.id, updates);
               updated++;


### PR DESCRIPTION
Audyt całości „cykle jako wiersze" przed dalszymi krokami. Przejrzane wszystkie miejsca iterujące wiersze bazy.

## Fix (korektność)

`bookSyncService` dopasowuje laureatów do **wszystkich** istniejących wierszy. Jeśli laureat istniał już jako wiersz `Tom cyklu` (tom, który jednak zdobył nagrodę), był aktualizowany w miejscu z nagrodą, ale zostawał `Kategoria=Tom cyklu` → **ukryty w statystykach nagród**. Teraz przy dopasowaniu wiersza-tomu rytuał **promuje go do `Kategoria=Nagroda`** (stała `AWARD_CATEGORY`). Zapobiega też duplikatowi (tytuł już istnieje jako wiersz).

## Audyt — reszta OK

Filtry `isAwardBook` są we właściwych miejscach: statystyki, integralność, Regał/Skryptorium, duplikaty, Lp. Vinted i cycleLookup CELOWO widzą tomy.

Odnotowane (nie-bug, decyzje na później — w backlogu):
- brak w-appowego oznaczania tomów przeczytane/posiadane (Archiwum read-only, widoki nagród je wykluczają) → oznaczasz w Notion; kandydat do CV-PR3b,
- skan biblioteki i Vinted obejmują tomy (Vinted zbiera dane pod UC1, jeszcze niewyświetlane),
- cyclesSync/publisher/series/purify/wikiField iterują też tomy — nieszkodliwe wzbogacanie, dodatkowy ruch wiki.

## Testy

`npm run lint` czysty, `npm test` zielony (371), `npm run build` OK. Wersja `1.40.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_