### PR TITLE
Tomy cykli: etykieta Lp „Nazwa (nr)" zamiast tytułu

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.40.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.40.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.40.2** — **Tomy cykli: etykieta Lp = „Nazwa (nr)".** Po teście użytkownika (tomy miały w Lp
+  polski tytuł, niespójnie z numerami nagród): kolumna tytułowa `Lp` tomu cyklu = „Mistborn (3)"
+  (`cycleLpLabel(cykl, nr)`; tytuł żyje w „Tytuł polski"). Stabilne, nie zależy od przenumerowań.
+  Rytuał żniw MIGRUJE istniejące wiersze tomów do nowej etykiety (aktualizuje Lp gdy różne); kotwic
+  nagrodowych (numer w Lp) NIE dotyka. Testy.
 - **1.40.1** — **Audyt „cykle jako wiersze" + fix promocji.** Przegląd wszystkich konsumentów wierszy.
   FIX (korektność): `bookSyncService` — gdy rytuał nagród trafi na istniejący wiersz `Tom cyklu`
   (tom, który JEDNAK zdobył nagrodę), promuje go do `Kategoria=Nagroda` (inaczej zostałby ukryty w

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.40.1",
+      "version": "1.40.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.40.1",
+  "version": "1.40.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/cycleRows.test.ts
+++ b/services/__tests__/cycleRows.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { buildCycleVolumeProperties, aggregateCycleRows } from "../cycleRows";
+import { buildCycleVolumeProperties, aggregateCycleRows, cycleLpLabel } from "../cycleRows";
 import { NotionBook } from "../../src/types";
 
 describe("buildCycleVolumeProperties", () => {
@@ -10,8 +10,15 @@ describe("buildCycleVolumeProperties", () => {
     expect(p["Cykl"].rich_text[0].text.content).toBe("Mistborn");
     expect(p["CyklNr"]).toEqual({ number: 3 });
     expect(p["Część cyklu"]).toEqual({ checkbox: true });
-    expect(p["Lp"].title[0].text.content).toBe("Bohater Wieków");
+    // Lp (kolumna tytułowa) = etykieta cyklu, tytuł żyje w „Tytuł polski".
+    expect(p["Lp"].title[0].text.content).toBe("Mistborn (3)");
+    expect(p["Tytuł polski"].rich_text[0].text.content).toBe("Bohater Wieków");
     expect(p["Autor"].multi_select).toEqual([{ name: "Brandon Sanderson" }]);
+  });
+
+  it("cycleLpLabel: 'Nazwa (nr)', fallback gdy brak nazwy", () => {
+    expect(cycleLpLabel("Mistborn", 2)).toBe("Mistborn (2)");
+    expect(cycleLpLabel("", 1)).toBe("Cykl (1)");
   });
 
   it("pomija Autora gdy brak", () => {

--- a/services/cycleHarvestService.ts
+++ b/services/cycleHarvestService.ts
@@ -3,7 +3,7 @@ import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent, NotionBook } from "../src/types";
 import { ConfigService } from "./configService";
 import { CycleLookupService } from "./cycleLookupService";
-import { buildCycleVolumeProperties } from "./cycleRows";
+import { buildCycleVolumeProperties, cycleLpLabel } from "./cycleRows";
 import { isCycleVolume } from "./bookCategory";
 import { createLogger } from "../logger";
 
@@ -79,14 +79,23 @@ export class CycleHarvestService {
             const nr = i + 1;
             const existing = byTitle.get(normKey(vol.title));
             if (existing) {
-              // Istnieje jako wiersz — dotaguj Cykl/CyklNr, jeśli brak (nie duplikuj).
+              // Istnieje jako wiersz — dotaguj Cykl/CyklNr (nie duplikuj). Dla wierszy
+              // tomów cykli ujednolić też etykietę Lp; kotwic nagrodowych (numer w Lp)
+              // NIE dotykamy.
+              const props: Record<string, any> = {};
               if (existing.cykl !== view.cycleName || existing.cyklNr !== nr) {
-                await this.notion.updatePage(existing.id, {
-                  "Cykl": { rich_text: [{ text: { content: view.cycleName } }] },
-                  "CyklNr": { number: nr },
-                });
+                props["Cykl"] = { rich_text: [{ text: { content: view.cycleName } }] };
+                props["CyklNr"] = { number: nr };
+              }
+              if (isCycleVolume(existing)) {
+                const label = cycleLpLabel(view.cycleName, nr);
+                if (existing.lp !== label) props["Lp"] = { title: [{ text: { content: label } }] };
+              }
+              if (Object.keys(props).length > 0) {
+                await this.notion.updatePage(existing.id, props);
                 tagged++;
                 existing.cykl = view.cycleName; existing.cyklNr = nr;
+                if (isCycleVolume(existing)) existing.lp = cycleLpLabel(view.cycleName, nr);
               }
             } else {
               // Brak wiersza — utwórz poboczny tom cyklu (autor z kotwicy).

--- a/services/cycleRows.ts
+++ b/services/cycleRows.ts
@@ -37,11 +37,19 @@ export interface CyclesHarvest {
   harvestedAt: number | null;
 }
 
+/**
+ * Etykieta kolumny „Lp" (tytułowej) dla tomu cyklu: „Nazwa cyklu (nr)", np. „Mistborn (3)".
+ * Stabilna (nie zależy od przenumerowań Lp), czytelna, jasno odróżnia tom od numeru nagrody.
+ */
+export function cycleLpLabel(cycleName: string, nr: number): string {
+  return `${(cycleName || "Cykl").trim()} (${nr})`;
+}
+
 /** Payload nowego wiersza pobocznego tomu cyklu. */
 export function buildCycleVolumeProperties(input: { title: string; author?: string; cycleName: string; nr: number }): Record<string, any> {
   const title = sanitizeNotionString(input.title || "");
   const properties: Record<string, any> = {
-    "Lp": { title: [{ text: { content: title || "Tom cyklu" } }] },
+    "Lp": { title: [{ text: { content: sanitizeNotionString(cycleLpLabel(input.cycleName, input.nr)) } }] },
     "Tytuł polski": { rich_text: [{ text: { content: title } }] },
     "Kategoria": { select: { name: CYCLE_VOLUME_CATEGORY } },
     "Cykl": { rich_text: [{ text: { content: sanitizeNotionString(input.cycleName || "") } }] },


### PR DESCRIPTION
Po teście: wiersze tomów cykli miały w kolumnie `Lp` (tytułowej) polski tytuł — niespójnie z pozycjami nagrodowymi, które mają tam numer.

## Zmiana

- Kolumna `Lp` tomu cyklu = **stabilna etykieta „Nazwa cyklu (nr)"**, np. „Mistborn (3)" (`cycleLpLabel`); prawdziwy tytuł żyje w „Tytuł polski". Nie zależy od przenumerowań Lp, jasno odróżnia tom od numeru nagrody.
- **Rytuał żniw MIGRUJE** istniejące wiersze tomów do nowej etykiety (aktualizuje `Lp`, gdy różne) — więc pozycje z Twojego testu poprawią się przy ponownym uruchomieniu. Kotwic nagrodowych (numer w Lp) **nie dotyka**.

## Testy

`cycleRows` (Lp = „Mistborn (3)", `cycleLpLabel`). `npm run lint` czysty, `npm test` zielony (372), `npm run build` OK. Wersja `1.40.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_