### PR TITLE
Cykle jako wiersze — CV-PR3b: oznaczanie tomów w Archiwum

### DIFF
--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -133,15 +133,17 @@ describe("POST /api/mark-as-read", () => {
 
     await request(app).post("/api/mark-as-read").send({ pageId: "page-2", tag: "Biblioteka" });
     await request(app).post("/api/mark-as-read").send({ pageId: "page-3", tag: "Biblioteka 9" });
+    await request(app).post("/api/mark-as-read").send({ pageId: "page-5", tag: "Posiadam" });
 
     expect(spy).toHaveBeenNthCalledWith(1, "page-2", "Biblioteka");
     expect(spy).toHaveBeenNthCalledWith(2, "page-3", "Biblioteka 9");
+    expect(spy).toHaveBeenNthCalledWith(3, "page-5", "Posiadam");
   });
 
   it("rejects an unknown tag with 400 and never touches Notion", async () => {
     const spy = vi.spyOn(syncManager, "markAsRead").mockResolvedValue(undefined);
 
-    const res = await request(app).post("/api/mark-as-read").send({ pageId: "page-4", tag: "Posiadam" });
+    const res = await request(app).post("/api/mark-as-read").send({ pageId: "page-4", tag: "Nagroda" });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/Niedozwolony znacznik/);

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.40.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.41.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.41.0** — **Cykle jako wiersze — CV-PR3b (oznaczanie tomów w Archiwum).** Karta „Archiwum Cykli"
+  ma teraz per-tom przełączniki **posiadane** (Posiadam) i **przeczytane** (Przeczytane) — klik dopisuje/
+  usuwa znacznik Źródło na wierszu i odświeża widok (silent refetch, bez migania kartą; per-wiersz spinner
+  `busyId`). Backend: „Posiadam" dodane do `ALLOWED_SOURCE_TAGS` (mark/unmark). `aggregateCycleRows` +
+  `HarvestVolume` zwracają `id` wiersza. Hook `useCyclesHarvest` dostał `toggleSource(id, tag, active)`.
+  Cache Notion inwalidowany przy zapisie → refetch pokazuje świeży status. Testy: „Posiadam" akceptowany,
+  „Nagroda" odrzucany. Teraz oznaczasz tomy w apce, nie tylko w Notion. (CV-PR3b domknięty; zostaje
+  ewentualne sprzątanie kolumny CycleCache.)
 - **1.40.3** — **Rytuał Żniw: spójny opis + summary (audyt spięcia).** Opis przycisku był NIEAKTUALNY
   („cache, bez dopisywania do bazy") — po CV-PR2 rytuał tworzy wiersze; poprawiono na „Materializacja
   tomów cykli jako wiersze… oznaczalne i skanowane na Vinted". Summary: dodano listę `updated`

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -188,7 +188,7 @@ export const stopSchemaSync = makeStopHandler("Zatrzymano inicjalizację schemat
 // Znaczniki „Źródło", które wolno dopisać z tego endpointu. Ograniczone do
 // znanego zbioru — endpoint jedynie oznacza pozycję (przeczytana / dostępna w
 // danej filii), nie może wstrzykiwać dowolnych tagów do bazy Notion.
-const ALLOWED_SOURCE_TAGS = new Set(["Przeczytane", "Biblioteka", "Biblioteka 9"]);
+const ALLOWED_SOURCE_TAGS = new Set(["Przeczytane", "Posiadam", "Biblioteka", "Biblioteka 9"]);
 
 export const markAsRead = async (req: Request, res: Response) => {
   try {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.40.3",
+  "version": "1.41.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.40.3",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.40.3",
+      "version": "1.41.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.40.3",
+  "version": "1.41.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/cycleRows.ts
+++ b/services/cycleRows.ts
@@ -11,6 +11,8 @@ import { CYCLE_VOLUME_CATEGORY, isCycleVolume } from "./bookCategory";
 
 /** Widok jednego tomu w Archiwum Cykli (agregacja z wierszy). */
 export interface HarvestVolume {
+  /** ID wiersza Notion — do oznaczania (przeczytane/posiadane) z karty. */
+  id: string;
   title: string;
   /** Zawsze true — tom jest wierszem bazy (zachowane dla zgodności z kartą). */
   inBase: boolean;
@@ -91,6 +93,7 @@ export function aggregateCycleRows(books: NotionBook[]): CyclesHarvest {
     const volumes: HarvestVolume[] = rows.map((r) => {
       const zr = r.zrodlo || [];
       return {
+        id: r.id,
         title: r.plTitle || r.origTitle || "",
         inBase: true,
         read: zr.includes("Przeczytane"),

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -15,11 +15,11 @@ const volStatus = (v: HarvestVolume) => {
 };
 
 /**
- * Archiwum Cykli — zbiorczy widok tomów cykli zebranych Rytuałem Żniw (bloby
- * `CycleCache`). Pokazuje ile tomów masz / brakuje, bez dodawania ich do bazy.
+ * Archiwum Cykli — zbiorczy widok tomów cykli (wiersze bazy z pola `Cykl`). Pokazuje
+ * ile tomów masz / do zdobycia i pozwala oznaczać tomy przeczytane/posiadane w miejscu.
  */
 export const CyclesHarvestCard: React.FC = () => {
-  const { view, loading, error } = useCyclesHarvest();
+  const { view, loading, error, busyId, toggleSource } = useCyclesHarvest();
   const [open, setOpen] = useState<string | null>(null);
 
   return (
@@ -85,11 +85,37 @@ export const CyclesHarvestCard: React.FC = () => {
                       const s = volStatus(v);
                       const Icon = s.icon;
                       return (
-                        <li key={i} className="flex items-center gap-2.5 p-2 rounded-lg bg-slate-950/40">
+                        <li key={v.id || i} className="flex items-center gap-2.5 p-2 rounded-lg bg-slate-950/40">
                           <span className="text-[10px] font-bold tabular-nums text-slate-500 w-4 text-right shrink-0">{i + 1}.</span>
                           <Icon className={`w-3.5 h-3.5 shrink-0 ${s.cls}`} />
-                          <span className={`flex-1 min-w-0 text-sm truncate ${v.inBase ? "text-slate-200" : "text-slate-400"}`}>{v.title}</span>
+                          <span className={`flex-1 min-w-0 text-sm truncate ${v.read || v.owned ? "text-slate-200" : "text-slate-400"}`}>{v.title}</span>
                           {v.awarded && <Award className="w-3.5 h-3.5 text-amber-400 shrink-0" aria-label="nagrodzona" />}
+
+                          {busyId === v.id ? (
+                            <Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin text-slate-400" />
+                          ) : (
+                            <>
+                              <button
+                                onClick={() => toggleSource(v.id, "Posiadam", !v.owned)}
+                                disabled={!!busyId}
+                                className={`shrink-0 p-1 rounded-md transition-colors disabled:opacity-40 ${v.owned ? "text-emerald-400 bg-emerald-500/10" : "text-slate-500 hover:text-emerald-300 hover:bg-emerald-500/10"}`}
+                                title={v.owned ? "Oznacz jako nieposiadaną" : "Oznacz jako posiadaną"}
+                                aria-label={`Przełącz posiadanie: ${v.title}`}
+                              >
+                                <Package className="w-3.5 h-3.5" />
+                              </button>
+                              <button
+                                onClick={() => toggleSource(v.id, "Przeczytane", !v.read)}
+                                disabled={!!busyId}
+                                className={`shrink-0 p-1 rounded-md transition-colors disabled:opacity-40 ${v.read ? "text-cyan-400 bg-cyan-500/10" : "text-slate-500 hover:text-cyan-300 hover:bg-cyan-500/10"}`}
+                                title={v.read ? "Oznacz jako nieprzeczytaną" : "Oznacz jako przeczytaną"}
+                                aria-label={`Przełącz przeczytanie: ${v.title}`}
+                              >
+                                <Check className="w-3.5 h-3.5" />
+                              </button>
+                            </>
+                          )}
+
                           <a
                             href={encyclopediaUrl(v.title)}
                             target="_blank"

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 
 export interface HarvestVolume {
+  id: string;
   title: string;
   inBase: boolean;
   read: boolean;
@@ -30,9 +31,11 @@ export function useCyclesHarvest() {
   const [view, setView] = useState<CyclesHarvest | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
 
-  const fetchHarvest = useCallback(async () => {
-    setLoading(true);
+  // `silent` = odświeżenie w tle (po oznaczeniu tomu) bez migania całą kartą.
+  const fetchHarvest = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
     setError(null);
     try {
       const res = await fetch("/api/cycles-harvest");
@@ -41,11 +44,34 @@ export function useCyclesHarvest() {
     } catch (e: any) {
       setError(e?.message || "Nie udało się pobrać zebranych cykli.");
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }, []);
 
+  /**
+   * Przełącza znacznik „Źródło" (Przeczytane/Posiadam) na wierszu tomu i odświeża
+   * widok. `active=true` dopisuje, `false` usuwa (endpoint mark/unmark-as-read).
+   */
+  const toggleSource = useCallback(async (id: string, tag: "Przeczytane" | "Posiadam", active: boolean) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const url = active ? "/api/mark-as-read" : "/api/unmark-as-read";
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pageId: id, tag }),
+      });
+      if (!res.ok) { const j = await res.json().catch(() => null); throw new Error(j?.error || `Błąd serwera: ${res.status}`); }
+      await fetchHarvest(true);
+    } catch (e: any) {
+      setError(e?.message || "Nie udało się zmienić statusu tomu.");
+    } finally {
+      setBusyId(null);
+    }
+  }, [fetchHarvest]);
+
   useEffect(() => { fetchHarvest(); }, [fetchHarvest]);
 
-  return { view, loading, error, fetchHarvest };
+  return { view, loading, error, busyId, fetchHarvest, toggleSource };
 }


### PR DESCRIPTION
Domknięcie głównego celu opcji A: oznaczanie tomów cykli **w aplikacji** (dotąd tylko w Notion).

## Co robi

Karta „Archiwum Cykli" ma teraz przy każdym tomie dwa przełączniki:
- **posiadane** (Package, emerald gdy aktywne) → toggle znacznika `Posiadam`,
- **przeczytane** (Check, cyan gdy aktywne) → toggle znacznika `Przeczytane`.

Klik dopisuje/usuwa znacznik `Źródło` na wierszu (endpoint mark/unmark-as-read) i **odświeża widok w tle** — bez migania całą kartą, z per-wierszowym spinnerem (`busyId`). Liczniki („N do zdobycia", „ukończony") aktualizują się od razu.

## Zmiany

- Backend: **„Posiadam" dodane do `ALLOWED_SOURCE_TAGS`** (mark i unmark); `aggregateCycleRows`/`HarvestVolume` zwracają **`id`** wiersza.
- Hook `useCyclesHarvest`: `toggleSource(id, tag, active)` (POST) + `busyId` + silent refetch. Zapis multi-select już inwaliduje cache książek → refetch pokazuje świeży status.
- Testy: „Posiadam" akceptowany, „Nagroda" nadal odrzucany.

## Weryfikacja

Zrzut karty: przełączniki odbijają stan (posiadana/przeczytana podświetlone), toggle mutuje i odświeża liczniki. `npm run lint` czysty, `npm test` zielony (372), `npm run build` OK. Wersja `1.41.0`.

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_