### PR TITLE
Tomy cykli: „Tytuł polski" z linkiem do encyklopedii

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.41.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.42.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.42.0** — **Tomy cykli: „Tytuł polski" z linkiem do encyklopedii (jak oryginalne rytuały).** Wiersze
+  tomów tworzonych żniwami mają teraz polski tytuł jako link do strony tomu w Encyklopedii — ten sam wzorzec
+  URL co parser/karta (`cycleVolumeEncyclopediaUrl`: spacje→„_", encode). `buildCycleTitleProperty` (Tytuł
+  polski + link z `isValidUrl`) używane przy tworzeniu; rytuał DOMIGRUJE istniejące wiersze (dokłada link
+  gdy brak/inny — porównuje po `plTitleRichText[0].text.link.url`, bez zbędnych zapisów). Test kodowania URL.
 - **1.41.0** — **Cykle jako wiersze — CV-PR3b (oznaczanie tomów w Archiwum).** Karta „Archiwum Cykli"
   ma teraz per-tom przełączniki **posiadane** (Posiadam) i **przeczytane** (Przeczytane) — klik dopisuje/
   usuwa znacznik Źródło na wierszu i odświeża widok (silent refetch, bez migania kartą; per-wiersz spinner

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.41.0",
+  "version": "1.42.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/cycleRows.test.ts
+++ b/services/__tests__/cycleRows.test.ts
@@ -13,6 +13,10 @@ describe("buildCycleVolumeProperties", () => {
     // Lp (kolumna tytułowa) = etykieta cyklu, tytuł żyje w „Tytuł polski".
     expect(p["Lp"].title[0].text.content).toBe("Mistborn (3)");
     expect(p["Tytuł polski"].rich_text[0].text.content).toBe("Bohater Wieków");
+    // Tytuł polski linkuje do strony tomu w encyklopedii (jak oryginalne rytuały).
+    expect(p["Tytuł polski"].rich_text[0].text.link).toEqual({
+      url: "https://encyklopediafantastyki.pl/index.php?title=Bohater_Wiek%C3%B3w",
+    });
     expect(p["Autor"].multi_select).toEqual([{ name: "Brandon Sanderson" }]);
   });
 

--- a/services/cycleHarvestService.ts
+++ b/services/cycleHarvestService.ts
@@ -3,7 +3,7 @@ import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent, NotionBook } from "../src/types";
 import { ConfigService } from "./configService";
 import { CycleLookupService } from "./cycleLookupService";
-import { buildCycleVolumeProperties, cycleLpLabel } from "./cycleRows";
+import { buildCycleVolumeProperties, cycleLpLabel, cycleVolumeEncyclopediaUrl, buildCycleTitleProperty } from "./cycleRows";
 import { isCycleVolume } from "./bookCategory";
 import { createLogger } from "../logger";
 
@@ -91,6 +91,10 @@ export class CycleHarvestService {
               if (isCycleVolume(existing)) {
                 const label = cycleLpLabel(view.cycleName, nr);
                 if (existing.lp !== label) props["Lp"] = { title: [{ text: { content: label } }] };
+                // Domiguj link do encyklopedii przy polskim tytule, jeśli go brak/inny.
+                const wantLink = cycleVolumeEncyclopediaUrl(existing.plTitle || vol.title);
+                const curLink = existing.plTitleRichText?.[0]?.text?.link?.url;
+                if (curLink !== wantLink) props["Tytuł polski"] = buildCycleTitleProperty(existing.plTitle || vol.title);
               }
               if (Object.keys(props).length > 0) {
                 await this.notion.updatePage(existing.id, props);

--- a/services/cycleRows.ts
+++ b/services/cycleRows.ts
@@ -1,7 +1,22 @@
 import { NotionBook } from "../src/types";
-import { sanitizeNotionString } from "../utils";
+import { sanitizeNotionString, isValidUrl } from "../utils";
 import { buildAuthorTags } from "./bookDiff";
 import { CYCLE_VOLUME_CATEGORY, isCycleVolume } from "./bookCategory";
+
+/**
+ * Link do strony tomu w Archiwum Encyklopedii Fantastyki — tytuł tomu to nazwa strony
+ * wiki (z łańcucha poprzednia/następna). Ten sam wzorzec co w parserze i w karcie
+ * (spacje → „_"), więc link w Notion i w UI są identyczne.
+ */
+export function cycleVolumeEncyclopediaUrl(title: string): string {
+  return `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent((title || "").replace(/ /g, "_"))}`;
+}
+
+/** Właściwość „Tytuł polski" z linkiem do encyklopedii (jak w oryginalnych rytuałach). */
+export function buildCycleTitleProperty(title: string): Record<string, any> {
+  const link = cycleVolumeEncyclopediaUrl(title);
+  return { rich_text: [{ text: { content: sanitizeNotionString(title || ""), ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
+}
 
 /**
  * Wiersze tomów cykli w bazie (opcja A). Poboczne tomy cyklu są REALNYMI wierszami
@@ -52,7 +67,8 @@ export function buildCycleVolumeProperties(input: { title: string; author?: stri
   const title = sanitizeNotionString(input.title || "");
   const properties: Record<string, any> = {
     "Lp": { title: [{ text: { content: sanitizeNotionString(cycleLpLabel(input.cycleName, input.nr)) } }] },
-    "Tytuł polski": { rich_text: [{ text: { content: title } }] },
+    // Tytuł polski z linkiem do encyklopedii — jak w oryginalnych rytuałach.
+    "Tytuł polski": buildCycleTitleProperty(input.title),
     "Kategoria": { select: { name: CYCLE_VOLUME_CATEGORY } },
     "Cykl": { rich_text: [{ text: { content: sanitizeNotionString(input.cycleName || "") } }] },
     "CyklNr": { number: input.nr },


### PR DESCRIPTION
Jak w oryginalnych rytuałach: pozycje nagrodowe mają polski tytuł jako link do strony w Encyklopedii — teraz tak samo wiersze tomów tworzone żniwami.

## Co robi

- Tytuł tomu = nazwa strony wiki (z łańcucha poprzednia/następna), więc link buduje się tym samym wzorcem co parser i karta (`cycleVolumeEncyclopediaUrl`: spacje → „_", `encodeURIComponent`).
- `buildCycleTitleProperty` (Tytuł polski + link, zabezpieczony `isValidUrl`) używane przy tworzeniu wiersza.
- Rytuał **DOMIGRUJE istniejące wiersze**: dokłada link, gdy bieżący link przy polskim tytule jest inny/brak (porównanie po `plTitleRichText[0].text.link.url`) — więc ponowne odpalenie żniw uzupełni pozycje z Twojego testu, bez zbędnych zapisów.

## Testy

Test kodowania URL (`Bohater_Wiek%C3%B3w`). `npm run lint` czysty, `npm test` zielony (372), `npm run build` OK. Wersja `1.42.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_