### PR TITLE
docs: usunięcie martwego odwołania do CycleCache w komentarzu

### DIFF
--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -24,8 +24,8 @@ export interface CyclesHarvest {
 }
 
 /**
- * Zebrane cykle (GET /api/cycles-harvest) — z blobów `CycleCache` uzupełnionych
- * Rytuałem Żniw. Odczyt jest lekki (agregacja po stronie serwera z cache książek).
+ * Zebrane cykle (GET /api/cycles-harvest) — agregacja WIERSZY cykli (pole `Cykl`)
+ * materializowanych Rytuałem Żniw. Odczyt lekki (agregacja serwera z cache książek).
  */
 export function useCyclesHarvest() {
   const [view, setView] = useState<CyclesHarvest | null>(null);


### PR DESCRIPTION
Odpowiedź na „które kolumny są niepotrzebne": jedyną martwą kolumną jest **`CycleCache`** (stary blob z Etapu 1). Po przejściu na wiersze (CV-PR2) nic jej nie czyta ani nie zapisuje — jedyny ślad w kodzie to nieaktualny komentarz w `useCyclesHarvest`, tu poprawiony.

Bez zmian funkcjonalnych (komentarz). Kolumnę `CycleCache` w Notion można usunąć ręcznie — żaden kod jej nie dotyka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_