### PR TITLE
UC1: dostępność Vinted dla tomów cykli w Archiwum

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.42.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.43.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.43.0** — **UC1: Vinted dla tomów cykli (dostępność w Archiwum).** Dzięki modelowi wierszy skaner
+  Vinted JUŻ skanuje tomy cykli (są wierszami z pustym Źródło) i zapisuje `VintedData` — UC1 sprowadził
+  się do WYŚWIETLENIA. `aggregateCycleRows` dokłada per-tom najtańszą ofertę (`vinted:{price,url,count}`,
+  z `parseVintedData`, ceny > 0) oraz per-cykl `acquireCost` (suma najtańszych dla tomów „do zdobycia" z
+  ofertą) + `acquirable`. Karta „Archiwum Cykli": pill „🛒 X zł" (link do najtańszej oferty) przy tomach
+  nieposiadanych + badge „~X zł" w nagłówku cyklu (koszt skompletowania). Test agregacji ofert. To ORYGINALNY
+  UC1 z backlogu, ale prostszy — brak „widm", bo tomy to realne wiersze (skaner bierze je za darmo).
 - **1.42.0** — **Tomy cykli: „Tytuł polski" z linkiem do encyklopedii (jak oryginalne rytuały).** Wiersze
   tomów tworzonych żniwami mają teraz polski tytuł jako link do strony tomu w Encyklopedii — ten sam wzorzec
   URL co parser/karta (`cycleVolumeEncyclopediaUrl`: spacje→„_", encode). `buildCycleTitleProperty` (Tytuł

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.42.0",
+      "version": "1.43.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.42.0",
+  "version": "1.43.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/cycleRows.test.ts
+++ b/services/__tests__/cycleRows.test.ts
@@ -70,4 +70,19 @@ describe("aggregateCycleRows", () => {
   it("brak wierszy z Cykl → pusto", () => {
     expect(aggregateCycleRows([mk("a", {})])).toEqual({ cycles: [], totalCycles: 0, harvestedAt: null });
   });
+
+  it("dołącza najtańszą ofertę Vinted i liczy koszt kompletacji (tylko do zdobycia)", () => {
+    const vd = (p: number) => JSON.stringify({ scannedAt: "2026-01-01", offers: [
+      { url: "https://vinted.pl/items/1", price: p + 5 }, { url: "https://vinted.pl/items/2", price: p },
+    ] });
+    const out = aggregateCycleRows([
+      mk("1", { cykl: "C", cyklNr: 1, kategoria: "Tom cyklu", vintedData: vd(12) }),                       // do zdobycia + oferta 12
+      mk("2", { cykl: "C", cyklNr: 2, kategoria: "Tom cyklu", zrodlo: ["Posiadam"], vintedData: vd(20) }), // posiadana → poza kosztem
+      mk("3", { cykl: "C", cyklNr: 3, kategoria: "Tom cyklu" }),                                           // do zdobycia, brak oferty
+    ]);
+    const c = out.cycles[0];
+    expect(c.volumes[0].vinted).toEqual({ price: 12, url: "https://vinted.pl/items/2", count: 2 });
+    expect(c.acquireCost).toBe(12); // tylko tom 1
+    expect(c.acquirable).toBe(1);
+  });
 });

--- a/services/cycleRows.ts
+++ b/services/cycleRows.ts
@@ -2,6 +2,7 @@ import { NotionBook } from "../src/types";
 import { sanitizeNotionString, isValidUrl } from "../utils";
 import { buildAuthorTags } from "./bookDiff";
 import { CYCLE_VOLUME_CATEGORY, isCycleVolume } from "./bookCategory";
+import { parseVintedData } from "./vintedStore";
 
 /**
  * Link do strony tomu w Archiwum Encyklopedii Fantastyki — tytuł tomu to nazwa strony
@@ -24,6 +25,14 @@ export function buildCycleTitleProperty(title: string): Record<string, any> {
  * skanować na Vinted. Grupowanie po polu `Cykl`, kolejność po `CyklNr`.
  */
 
+/** Najtańsza oferta Vinted dla tomu (z blobu VintedData, zbieranego skanerem). */
+export interface VolumeOffer {
+  price: number;
+  url: string;
+  /** Liczba ofert łącznie dla tego tomu. */
+  count: number;
+}
+
 /** Widok jednego tomu w Archiwum Cykli (agregacja z wierszy). */
 export interface HarvestVolume {
   /** ID wiersza Notion — do oznaczania (przeczytane/posiadane) z karty. */
@@ -36,6 +45,18 @@ export interface HarvestVolume {
   awarded: boolean;
   /** Czy to pozycja nagrodowa (kotwica), czy poboczny tom cyklu. */
   isAward: boolean;
+  /** Najtańsza oferta Vinted (jeśli skaner coś znalazł). */
+  vinted?: VolumeOffer;
+}
+
+/** Najtańsza oferta z blobu VintedData wiersza (tylko ceny > 0). */
+function cheapestVinted(raw?: string): VolumeOffer | undefined {
+  const data = parseVintedData(raw);
+  if (!data) return undefined;
+  const priced = data.offers.filter((o) => typeof o.price === "number" && (o.price as number) > 0);
+  if (priced.length === 0) return undefined;
+  const best = priced.reduce((a, b) => ((b.price as number) < (a.price as number) ? b : a));
+  return { price: best.price as number, url: best.url, count: data.offers.length };
 }
 export interface HarvestCycle {
   cycle: string;
@@ -47,6 +68,10 @@ export interface HarvestCycle {
   missing: number;
   /** Zachowane dla zgodności kształtu (= liczba tomów, bo wszystkie są wierszami). */
   inBase: number;
+  /** Koszt skompletowania: suma najtańszych ofert Vinted dla tomów „do zdobycia". */
+  acquireCost?: number;
+  /** Ile tomów „do zdobycia" ma ofertę Vinted. */
+  acquirable: number;
 }
 export interface CyclesHarvest {
   cycles: HarvestCycle[];
@@ -116,12 +141,20 @@ export function aggregateCycleRows(books: NotionBook[]): CyclesHarvest {
         owned: zr.includes("Posiadam"),
         awarded: (r.awards || []).length > 0,
         isAward: !isCycleVolume(r),
+        vinted: cheapestVinted(r.vintedData),
       };
     });
     const owned = volumes.filter((v) => v.owned).length;
     const read = volumes.filter((v) => v.read).length;
-    const missing = volumes.filter((v) => !v.owned && !v.read).length;
-    return { cycle: g.name, volumes, total: volumes.length, owned, read, missing, inBase: volumes.length };
+    const toGet = volumes.filter((v) => !v.owned && !v.read);
+    // Koszt kompletacji = suma najtańszych ofert dla tomów „do zdobycia", które są na Vinted.
+    const withOffer = toGet.filter((v) => v.vinted);
+    const acquireCost = withOffer.length > 0 ? Math.round(withOffer.reduce((s, v) => s + v.vinted!.price, 0)) : undefined;
+    return {
+      cycle: g.name, volumes, total: volumes.length, owned, read,
+      missing: toGet.length, inBase: volumes.length,
+      acquireCost, acquirable: withOffer.length,
+    };
   });
   // Najwięcej „do zdobycia" na górze; ukończone (missing 0) spadają na dół.
   cycles.sort((a, b) => b.missing - a.missing || b.total - a.total || a.cycle.localeCompare(b.cycle));

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { motion } from "motion/react";
-import { Layers, ChevronDown, Check, CheckCheck, Package, AlertTriangle, Award, ExternalLink, Loader2 } from "lucide-react";
+import { Layers, ChevronDown, Check, CheckCheck, Package, AlertTriangle, Award, ExternalLink, Loader2, ShoppingCart } from "lucide-react";
 import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
 
 /** Link do tomu w Archiwum Encyklopedii Fantastyki (ten sam wzorzec co parser/panel). */
@@ -76,6 +76,11 @@ export const CyclesHarvestCard: React.FC = () => {
                       {c.missing} do zdobycia
                     </span>
                   )}
+                  {c.acquireCost != null && (
+                    <span className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full border border-rose-500/25 bg-rose-500/10 text-rose-300 text-[9px] font-bold uppercase tracking-wider" title={`Skompletuj ${c.acquirable} tomów z Vinted`}>
+                      <ShoppingCart className="w-2.5 h-2.5" /> ~{c.acquireCost} zł
+                    </span>
+                  )}
                   <span className="shrink-0 text-[10px] tabular-nums text-slate-500 font-bold">{c.inBase}/{c.total}</span>
                 </button>
 
@@ -90,6 +95,19 @@ export const CyclesHarvestCard: React.FC = () => {
                           <Icon className={`w-3.5 h-3.5 shrink-0 ${s.cls}`} />
                           <span className={`flex-1 min-w-0 text-sm truncate ${v.read || v.owned ? "text-slate-200" : "text-slate-400"}`}>{v.title}</span>
                           {v.awarded && <Award className="w-3.5 h-3.5 text-amber-400 shrink-0" aria-label="nagrodzona" />}
+
+                          {v.vinted && !v.owned && (
+                            <a
+                              href={v.vinted.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                              className="shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-rose-500/10 border border-rose-500/25 text-rose-300 text-[10px] font-bold tabular-nums hover:bg-rose-500/20 transition-colors"
+                              title={`${v.vinted.count} ${v.vinted.count === 1 ? "oferta" : "ofert"} na Vinted — najtańsza`}
+                            >
+                              <ShoppingCart className="w-3 h-3" /> {v.vinted.price} zł
+                            </a>
+                          )}
 
                           {busyId === v.id ? (
                             <Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin text-slate-400" />

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 
+export interface VolumeOffer {
+  price: number;
+  url: string;
+  count: number;
+}
 export interface HarvestVolume {
   id: string;
   title: string;
@@ -7,6 +12,7 @@ export interface HarvestVolume {
   read: boolean;
   owned: boolean;
   awarded: boolean;
+  vinted?: VolumeOffer;
 }
 export interface HarvestCycle {
   cycle: string;
@@ -16,6 +22,8 @@ export interface HarvestCycle {
   owned: number;
   read: number;
   missing: number;
+  acquireCost?: number;
+  acquirable: number;
 }
 export interface CyclesHarvest {
   cycles: HarvestCycle[];


### PR DESCRIPTION
UC1 — kupowanie brakujących tomów cykli. Dzięki modelowi wierszy skaner Vinted **już** skanuje tomy cykli (wiersze z pustym Źródło) i zapisuje `VintedData`, więc UC1 to głównie **wyświetlenie** zebranych ofert.

## Backend

- `aggregateCycleRows`: per-tom najtańsza oferta `vinted:{price,url,count}` (z `parseVintedData`, ceny > 0) + per-cykl `acquireCost` (suma najtańszych ofert dla tomów „do zdobycia", które są na Vinted) + `acquirable`.

## Frontend

Karta „Archiwum Cykli":
- pill **„🛒 X zł"** (link do najtańszej oferty, nowa karta) przy tomach **nieposiadanych**,
- badge **„~X zł"** w nagłówku cyklu = koszt skompletowania brakujących tomów z Vinted.

## Dlaczego prościej niż plan z backlogu

Oryginalny UC1 zakładał „widmowe" tomy bez wierszy. Po wyborze opcji A tomy są realnymi wierszami, więc skaner bierze je za darmo — nie trzeba osobnego przeszukiwania ani zapisu dostępności.

## Weryfikacja

Zrzut: nagłówek „~41 zł", pills „18 zł"/„23 zł" przy tomach do zdobycia, brak ceny przy posiadanych/bez oferty. Test agregacji ofert + kosztu. `npm run lint` czysty, `npm test` zielony (373), `npm run build` OK. Wersja `1.43.0`.

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_