### PR TITLE
Rytuał Inicjacji Schematu: kolumny cykli + domknięcie długu leniwych kolumn

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.43.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.0** — **Rytuał Inicjacji Schematu: pełny provisioning (kolumny cykli + domknięcie długu).** Do
+  `requiredProps` doszły: `Kategoria`(select), `Cykl`(rich_text), `CyklNr`(number) — dotąd tworzone leniwie
+  przez Żniwa — oraz stary dług `Źródło`(multi_select), `VintedData`(rich_text), `ShelfOrder`(number) —
+  dotąd tworzone leniwie przez skan/regał. Krok 1 „Wielkiego Rytuału" w pełni przygotowuje świeżą bazę,
+  bez czekania na pierwsze użycie funkcji. Idempotentnie (tylko brakujące), `updateDatabaseProperty`
+  obsługuje select/number/rich_text. Test rozszerzony o nowe kolumny. (AppConfig pominięty — zarządza nim
+  config store przez opis kolumny.)
 - **1.43.0** — **UC1: Vinted dla tomów cykli (dostępność w Archiwum).** Dzięki modelowi wierszy skaner
   Vinted JUŻ skanuje tomy cykli (są wierszami z pustym Źródło) i zapisuje `VintedData` — UC1 sprowadził
   się do WYŚWIETLENIA. `aggregateCycleRows` dokłada per-tom najtańszą ofertę (`vinted:{price,url,count}`,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.43.0",
+      "version": "1.44.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.43.0",
+  "version": "1.44.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/schemaValidationService.test.ts
+++ b/services/__tests__/schemaValidationService.test.ts
@@ -50,5 +50,12 @@ describe('SchemaValidationService', () => {
 
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Autor', 'multi_select');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Tytuł polski', 'rich_text');
+    // Kolumny cykli + domknięcie starego długu też są provisionowane.
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Kategoria', 'select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Cykl', 'rich_text');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'CyklNr', 'number');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Źródło', 'multi_select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'VintedData', 'rich_text');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'ShelfOrder', 'number');
   });
 });

--- a/services/schemaValidationService.ts
+++ b/services/schemaValidationService.ts
@@ -31,7 +31,15 @@ export class SchemaValidationService {
         { name: "Wydawnictwo", type: "multi_select" },
         { name: "Seria", type: "multi_select" },
         { name: "Nagroda", type: "multi_select" },
-        { name: "Część cyklu", type: "checkbox" }
+        { name: "Źródło", type: "multi_select" },
+        { name: "Część cyklu", type: "checkbox" },
+        // Kolumny cykli (tomy jako wiersze) — dotąd tworzone leniwie przez Rytuał Żniw.
+        { name: "Kategoria", type: "select" },
+        { name: "Cykl", type: "rich_text" },
+        { name: "CyklNr", type: "number" },
+        // Domknięcie starego długu — dotąd tworzone leniwie przez skaner/regał.
+        { name: "VintedData", type: "rich_text" },
+        { name: "ShelfOrder", type: "number" }
       ];
 
       // 1. Handle primary (title) column renaming if necessary


### PR DESCRIPTION
Rytuał schematu pilnował tylko rdzenia importu nagród; kolumny feature'owe tworzyły się leniwie. Wariant **B**: dodać je do `requiredProps`, żeby krok 1 „Wielkiego Rytuału" w pełni przygotował świeżą bazę.

## Dodane do `requiredProps`

- **Kolumny cykli** (dotąd leniwie przez Żniwa): `Kategoria` (select), `Cykl` (rich_text), `CyklNr` (number).
- **Stary dług** (dotąd leniwie przez skan/regał): `Źródło` (multi_select), `VintedData` (rich_text), `ShelfOrder` (number).

## Bezpieczeństwo

Idempotentne — tworzy tylko brakujące kolumny (a przy zgodnym typie nic nie rusza). `updateDatabaseProperty` obsługuje `select`/`number`/`rich_text`. `AppConfig` pominięty celowo — zarządza nim config store przez **opis** kolumny, nie przez schema-ritual.

## Testy

Test schematu rozszerzony o 6 nowych kolumn. `npm run lint` czysty, `npm test` zielony (373), `npm run build` OK. Wersja `1.44.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_