### PR TITLE
Bughunt: naprawy poprawności żniw cykli + guard nadpisania configu

### DIFF
--- a/__tests__/cycleLookup.test.ts
+++ b/__tests__/cycleLookup.test.ts
@@ -82,6 +82,18 @@ describe("CycleLookupService.lookup", () => {
     expect(view!.unreadBefore).toBe(2); // T1 i T2 nieprzeczytane
   });
 
+  it("names a nameless (chain-only) cycle by its first volume, not the generic 'Cykl'", async () => {
+    // Łańcuch prev/next BEZ pola |cykl= — dawniej cycleName spadał do „Cykl", przez co
+    // wszystkie bezimienne cykle zlewały się w jedną grupę i były pomijane w żniwach.
+    const wiki = makeWiki({
+      "Alfa": page({ następna: "Beta" }),
+      "Beta": page({ poprzednia: "Alfa" }),
+    });
+    const svc = new CycleLookupService(makeNotion([]), wiki);
+    const view = await svc.lookup("Beta", "");
+    expect(view!.cycleName).toBe("Alfa"); // tytuł pierwszego tomu, stabilny między kotwicami
+  });
+
   it("returns null when the book is not part of any cycle", async () => {
     const wiki = makeWiki({ "X": page({ tytuł: "X" }) });
     const svc = new CycleLookupService(makeNotion([]), wiki);

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.44.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.1** — **Bughunt cykli (2 subagentów + weryfikacja) — naprawy.** Backend: (HIGH) bezimienne cykle
+  (łańcuch prev/next bez `|cykl=`) zlewały się w jedną grupę „Cykl" i większość była pomijana w żniwach →
+  `cycleName = |cykl= || tytuł pierwszego tomu` (stabilny między kotwicami); (DATA) żniwa używały `normKey`,
+  a lookup `normTitle` → wiersz uznany za `inBase` mógł nie trafić w indeks żniw → duplikat; teraz wspólny
+  `normTitle` (eksport z `cycleLookupService`); (DATA) wyścig get→await→set na `byTitle` → synchroniczna
+  REZERWACJA slotu przed `addRow` (równoległe zadanie pomija); (MINOR) pomijanie pustych tytułów (brak
+  junk-wiersza); (MINOR) sanityzacja nazwy cyklu RAZ (`cyc`) i użycie wszędzie → koniec thrash-write pola
+  Cykl co przebieg. Frontend: (DATA) `persistStatsOrder` mógł nadpisać config DEFAULTAMI, gdy GET configu
+  padł → guard `if (!cachedConfig) return`; `toggleSource` no-op na pustym id; błąd oznaczania → zwięzły
+  baner nad listą (nie duży komunikat sugerujący brak danych). Test: bezimienny cykl nazwany 1. tomem.
+  ZNANE OGRANICZENIE (nie-bug, chain-walk): `CyklNr` to pozycja W ODKRYTYM łańcuchu (MAX_HOPS/urwany
+  neighbor/`{{Cykl}}` extras na końcu) — kolejność względna OK, numer bezwzględny może być przesunięty.
 - **1.44.0** — **Rytuał Inicjacji Schematu: pełny provisioning (kolumny cykli + domknięcie długu).** Do
   `requiredProps` doszły: `Kategoria`(select), `Cykl`(rich_text), `CyklNr`(number) — dotąd tworzone leniwie
   przez Żniwa — oraz stary dług `Źródło`(multi_select), `VintedData`(rich_text), `ShelfOrder`(number) —

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.44.0",
+      "version": "1.44.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.44.0",
+  "version": "1.44.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/cycleHarvestService.ts
+++ b/services/cycleHarvestService.ts
@@ -2,14 +2,13 @@ import pLimit from "p-limit";
 import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent, NotionBook } from "../src/types";
 import { ConfigService } from "./configService";
-import { CycleLookupService } from "./cycleLookupService";
+import { CycleLookupService, normTitle } from "./cycleLookupService";
 import { buildCycleVolumeProperties, cycleLpLabel, cycleVolumeEncyclopediaUrl, buildCycleTitleProperty } from "./cycleRows";
 import { isCycleVolume } from "./bookCategory";
+import { sanitizeNotionString } from "../utils";
 import { createLogger } from "../logger";
 
 const log = createLogger("CycleHarvest");
-
-const normKey = (s: string): string => (s || "").toLowerCase().replace(/\s+/g, " ").trim();
 
 /**
  * Rytuał „Żniwa Cykli": dla każdej książki oznaczonej jako część cyklu zbiera
@@ -42,9 +41,11 @@ export class CycleHarvestService {
 
       // Indeks istniejących wierszy po znorm. tytule (polski + oryginalny) — żeby nie
       // tworzyć duplikatów i móc dotagować istniejące pozycje polem Cykl.
+      // Indeks po TEJ SAMEJ normalizacji co cross-ref w lookup (normTitle) — inaczej
+      // „inBase" z lookup i dopasowanie tutaj się rozjeżdżają i tworzymy duplikat.
       const byTitle = new Map<string, NotionBook>();
       for (const b of books) {
-        for (const t of [b.plTitle, b.origTitle]) if (t && t.trim()) byTitle.set(normKey(t), b);
+        for (const t of [b.plTitle, b.origTitle]) if (t && t.trim()) byTitle.set(normTitle(t), b);
       }
 
       const cycleAnchors = books.filter((b) => b.currentCzesccyklu && !isCycleVolume(b));
@@ -69,48 +70,57 @@ export class CycleHarvestService {
           const view = await this.cycleLookup.lookup(anchorTitle, anchor.author || "");
           if (!view || view.volumes.length <= 1) { noSiblingTitles.push(anchorTitle); return; }
 
-          const cycleKey = normKey(view.cycleName);
+          // Nazwa cyklu ustalona RAZ i sanityzowana — tak jak przy tworzeniu wiersza,
+          // inaczej guard `existing.cykl !== …` porównywałby surowe vs zsanityzowane i
+          // przepisywał Cykl co przebieg.
+          const cyc = sanitizeNotionString(view.cycleName);
+          const cycleKey = normTitle(cyc);
           // Cykl rozwijamy raz — kolejna kotwica tego samego cyklu tylko się dotaguje.
           if (cycleKey && processedCycles.has(cycleKey)) return;
           if (cycleKey) processedCycles.add(cycleKey);
 
-          for (let i = 0; i < view.volumes.length; i++) {
+          let nr = 0;
+          for (const vol of view.volumes) {
             if (checkCancellation()) return;
-            const vol = view.volumes[i];
-            const nr = i + 1;
-            const existing = byTitle.get(normKey(vol.title));
-            if (existing) {
-              // Istnieje jako wiersz — dotaguj Cykl/CyklNr (nie duplikuj). Dla wierszy
-              // tomów cykli ujednolić też etykietę Lp; kotwic nagrodowych (numer w Lp)
-              // NIE dotykamy.
+            const title = (vol.title || "").trim();
+            if (!title) continue;              // pomiń puste tytuły (brak junk-wiersza)
+            nr++;
+            const key = normTitle(title);
+            const existing = byTitle.get(key);
+            if (existing && !existing.id) {
+              // Rezerwacja innego zadania (wiersz w trakcie tworzenia) — nie duplikuj.
+              continue;
+            } else if (existing) {
+              // Istnieje realny wiersz — dotaguj Cykl/CyklNr (nie duplikuj). Dla wierszy
+              // tomów cykli ujednolić też Lp i link; kotwic nagrodowych (numer w Lp) NIE.
               const props: Record<string, any> = {};
-              if (existing.cykl !== view.cycleName || existing.cyklNr !== nr) {
-                props["Cykl"] = { rich_text: [{ text: { content: view.cycleName } }] };
+              if (existing.cykl !== cyc || existing.cyklNr !== nr) {
+                props["Cykl"] = { rich_text: [{ text: { content: cyc } }] };
                 props["CyklNr"] = { number: nr };
               }
               if (isCycleVolume(existing)) {
-                const label = cycleLpLabel(view.cycleName, nr);
+                const label = cycleLpLabel(cyc, nr);
                 if (existing.lp !== label) props["Lp"] = { title: [{ text: { content: label } }] };
-                // Domiguj link do encyklopedii przy polskim tytule, jeśli go brak/inny.
-                const wantLink = cycleVolumeEncyclopediaUrl(existing.plTitle || vol.title);
+                const wantLink = cycleVolumeEncyclopediaUrl(existing.plTitle || title);
                 const curLink = existing.plTitleRichText?.[0]?.text?.link?.url;
-                if (curLink !== wantLink) props["Tytuł polski"] = buildCycleTitleProperty(existing.plTitle || vol.title);
+                if (curLink !== wantLink) props["Tytuł polski"] = buildCycleTitleProperty(existing.plTitle || title);
               }
               if (Object.keys(props).length > 0) {
                 await this.notion.updatePage(existing.id, props);
-                taggedTitles.push(`${existing.plTitle || existing.origTitle} (${view.cycleName} ${nr})`);
-                existing.cykl = view.cycleName; existing.cyklNr = nr;
-                if (isCycleVolume(existing)) existing.lp = cycleLpLabel(view.cycleName, nr);
+                taggedTitles.push(`${existing.plTitle || existing.origTitle} (${cyc} ${nr})`);
+                existing.cykl = cyc; existing.cyklNr = nr;
+                if (isCycleVolume(existing)) existing.lp = cycleLpLabel(cyc, nr);
               }
             } else {
-              // Brak wiersza — utwórz poboczny tom cyklu (autor z kotwicy).
+              // Brak wiersza — REZERWUJ slot SYNCHRONICZNIE (przed await), potem utwórz.
+              // Równoległe zadanie zobaczy rezerwację (id="") i pominie ten tytuł.
+              const reserved = { id: "", plTitle: title, origTitle: "", cykl: cyc, cyklNr: nr } as NotionBook;
+              byTitle.set(key, reserved);
               const created = await this.notion.addRow(buildCycleVolumeProperties({
-                title: vol.title, author: anchor.author, cycleName: view.cycleName, nr,
+                title, author: anchor.author, cycleName: cyc, nr,
               }));
-              createdTitles.push(`${vol.title} (${view.cycleName})`);
-              // Dopisz do indeksu, by kolejna kotwica nie utworzyła duplikatu.
-              const stub = { id: created?.id, plTitle: vol.title, origTitle: "", cykl: view.cycleName, cyklNr: nr } as NotionBook;
-              byTitle.set(normKey(vol.title), stub);
+              reserved.id = created?.id ?? "";
+              createdTitles.push(`${title} (${cyc})`);
             }
           }
         } catch (err: any) {

--- a/services/cycleLookupService.ts
+++ b/services/cycleLookupService.ts
@@ -30,8 +30,10 @@ export interface CycleView {
   source: "chain" | "template" | "mixed" | "single";
 }
 
-/** Normalizacja tytułu do krzyżowania: bez formatowania wiki, lowercase, bez interpunkcji brzegowej. */
-function normTitle(t: string): string {
+/** Normalizacja tytułu do krzyżowania: bez formatowania wiki, lowercase, bez interpunkcji brzegowej.
+ *  Eksportowana, by rytuał żniw indeksował wiersze DOKŁADNIE tak samo (inaczej „inBase" z
+ *  lookup i dopasowanie w żniwach się rozjeżdżają → duplikat wiersza). */
+export function normTitle(t: string): string {
   return (t || "")
     .replace(/''+/g, "")
     .replace(/\[\[([^\]|]+\|)?([^\]]+)\]\]/g, "$2")
@@ -147,7 +149,11 @@ export class CycleLookupService {
     const currentIdx = volumes.findIndex((v) => v.isCurrent);
     const unreadBefore = currentIdx > 0 ? volumes.slice(0, currentIdx).filter((v) => !v.read).length : 0;
 
-    log.info("Cykl", { title: rawTitle, cycle: info.cycleName, volumes: volumes.length, source });
-    return { cycleName: info.cycleName || "Cykl", volumes, unreadBefore, source };
+    // Nazwa cyklu: pole |cykl= jeśli jest; inaczej NIE „Cykl" (wszystkie bezimienne
+    // cykle zlałyby się w jedną grupę i większość zostałaby pominięta w żniwach) —
+    // bierzemy tytuł PIERWSZEGO tomu, stabilny niezależnie od kotwicy startowej.
+    const cycleName = info.cycleName || volumes[0]?.title || "Cykl";
+    log.info("Cykl", { title: rawTitle, cycle: cycleName, volumes: volumes.length, source });
+    return { cycleName, volumes, unreadBefore, source };
   }
 }

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -45,7 +45,13 @@ export const CyclesHarvestCard: React.FC = () => {
         </div>
       )}
 
-      {error && !loading && <p className="text-sm text-slate-400 italic text-center py-8">{error}</p>}
+      {/* Błąd wczytywania (brak danych) → duży komunikat; błąd oznaczania (dane są) → zwięzły baner nad listą. */}
+      {error && !loading && !view && <p className="text-sm text-slate-400 italic text-center py-8">{error}</p>}
+      {error && !loading && view && (
+        <div className="flex items-center gap-2 p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-xs">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0" /> {error}
+        </div>
+      )}
 
       {view && !loading && view.totalCycles === 0 && (
         <p className="text-slate-400 text-sm italic text-center py-8">

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -50,8 +50,12 @@ export function publishEffectiveConfig(cfg: AppConfig): void {
  * knobów: bierze bieżącą efektywną konfigurację i podmienia tylko to pole.
  */
 export async function persistStatsOrder(order: string[]): Promise<void> {
-  const current = await loadShared();
-  const next: AppConfig = { ...current, ui: { ...current.ui, statsOrder: order } };
+  await loadShared();
+  // Jeśli wczytanie configu się nie powiodło (`cachedConfig` puste, `loadShared` zwrócił
+  // DEFAULT_CONFIG), NIE zapisujemy — inaczej PUT defaultów skasowałby realne knoby
+  // (filie, ustawienia) na serwerze. Reorder poczeka na sprawną sesję.
+  if (!cachedConfig) return;
+  const next: AppConfig = { ...cachedConfig, ui: { ...cachedConfig.ui, statsOrder: order } };
   publishEffectiveConfig(next);
   try {
     const res = await fetch("/api/app-config", {

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -61,6 +61,7 @@ export function useCyclesHarvest() {
    * widok. `active=true` dopisuje, `false` usuwa (endpoint mark/unmark-as-read).
    */
   const toggleSource = useCallback(async (id: string, tag: "Przeczytane" | "Posiadam", active: boolean) => {
+    if (!id) return; // bez ID nie ma czego oznaczać (i pusty busyId rozbrajałby blokadę)
     setBusyId(id);
     setError(null);
     try {


### PR DESCRIPTION
Wynik bughuntu (2 subagentów: backend cykli + frontend), każde znalezisko zweryfikowane w kodzie. Naprawy uszeregowane wg wagi.

## Backend (żniwa)

- **HIGH — bezimienne cykle się zlewały.** Łańcuch prev/next bez `|cykl=` dawał `cycleName="Cykl"`, więc wszystkie bezimienne cykle trafiały do jednej grupy, a dedup „rozwiń raz" pomijał każdy kolejny → większość cykli nie powstawała. Fix: `cycleName = |cykl= || tytuł pierwszego tomu` (stabilny niezależnie od kotwicy startowej).
- **DATA — duplikat wiersza przez rozjazd normalizacji.** Żniwa indeksowały `normKey` (z interpunkcją), lookup krzyżował bazę `normTitle` (bez) → tom uznany za `inBase` mógł nie trafić w indeks żniw → drugi wiersz. Fix: wspólny `normTitle` (eksport).
- **DATA — wyścig współbieżnego tworzenia.** get→await(addRow)→set na `byTitle` pozwalał dwóm równoległym cyklom utworzyć duplikat współdzielonego tytułu. Fix: **synchroniczna rezerwacja** slotu przed `addRow` (równoległe zadanie widzi rezerwację i pomija).
- **MINOR:** pomijanie pustych tytułów (brak junk-wiersza); sanityzacja nazwy cyklu **raz** i użycie wszędzie → koniec przepisywania `Cykl` co przebieg.

## Frontend

- **DATA — `persistStatsOrder` mógł nadpisać config DEFAULTAMI**, gdy GET configu padł przy wczytaniu (kasując realne knoby: filie, ustawienia). Fix: `if (!cachedConfig) return`.
- `toggleSource` no-op na pustym id (chroni blokadę `busyId`); błąd oznaczania → **zwięzły baner** nad listą zamiast dużego komunikatu „brak danych".

## Znane ograniczenie (nie-bug, natura chain-walku)

`CyklNr` to pozycja w **odkrytym** łańcuchu (urwanie przez MAX_HOPS / nieudany neighbor / `{{Cykl}}` extras doklejane na końcu) — kolejność **względna** poprawna, numer **bezwzględny** może być przesunięty. Udokumentowane w backlogu.

## Testy

Nowy: bezimienny cykl nazwany 1. tomem. `npm run lint` czysty, `npm test` zielony (374, +1), `npm run build` OK. Wersja `1.44.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_