### PR TITLE
Audyt: remediacja kodu (wspólny URL + hook shelf-order + testy serwisów)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.44.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.2** — **Audyt integralności — remediacja kodu (front B).** Werdykt: kod jednolity (architektura
+  wytrzymała), dryf głównie w DOKUMENTACJI (→ osobny PR). Fixy jednolitości: wspólny `encyclopediaUrl`
+  (`src/utils/encyclopedia.ts`) zamiast 3 identycznych kopii (CyclePanel/CyclesHarvestCard/cycleRows;
+  StatusSection = statyczne stałe, wiki.parser = inny wariant — zostają); `useShelfOrder` — `BookshelfSection`
+  nie robi już surowego `fetch` (§2 Logic Isolation), transport w hooku, optymistyczny override zostaje w
+  komponencie; testy `configService` (merge diff/defaulty/corrupt/cache/save-tylko-diff) + `cycleHarvestService`
+  (create-missing/tag-existing/idempotencja/no-siblings). AKCEPTOWANE (nie-fix): `useMarkRead` (Regał) vs
+  `useMarkAsRead` (Statystyki) — różne konteksty/efekty uboczne; duplikacja typów cross-boundary spójna z
+  precedensem `statsService↔useStats`. NASTĘPNE: sync dokumentacji (guidelines v1.6 + CLAUDE.md + README + docs/).
 - **1.44.1** — **Bughunt cykli (2 subagentów + weryfikacja) — naprawy.** Backend: (HIGH) bezimienne cykle
   (łańcuch prev/next bez `|cykl=`) zlewały się w jedną grupę „Cykl" i większość była pomijana w żniwach →
   `cycleName = |cykl= || tytuł pierwszego tomu` (stabilny między kotwicami); (DATA) żniwa używały `normKey`,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.44.1",
+      "version": "1.44.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.44.1",
+  "version": "1.44.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/configService.test.ts
+++ b/services/__tests__/configService.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ConfigService } from "../configService";
+import { NotionAdapter } from "../../notion.adapter";
+import { mergeConfig } from "../../src/configSchema";
+
+describe("ConfigService", () => {
+  let notion: any;
+  let svc: ConfigService;
+
+  beforeEach(() => {
+    notion = { getAppConfigRaw: vi.fn(), saveAppConfigRaw: vi.fn() };
+    svc = new ConfigService(notion as unknown as NotionAdapter);
+  });
+
+  it("merges the stored diff over defaults", async () => {
+    notion.getAppConfigRaw.mockResolvedValue(JSON.stringify({ ui: { shelfRowsPerPage: 9 } }));
+    const cfg = await svc.getConfig(true);
+    expect(cfg.ui.shelfRowsPerPage).toBe(9);              // override applied
+    expect(cfg.library.branches.length).toBeGreaterThan(0); // defaults still present
+  });
+
+  it("falls back to defaults on a corrupt blob (never throws)", async () => {
+    notion.getAppConfigRaw.mockResolvedValue("{not json");
+    expect(await svc.getConfig(true)).toEqual(mergeConfig(undefined));
+  });
+
+  it("falls back to defaults when Notion read throws", async () => {
+    notion.getAppConfigRaw.mockRejectedValue(new Error("network"));
+    expect(await svc.getConfig(true)).toEqual(mergeConfig(undefined));
+  });
+
+  it("saves ONLY the diff from defaults, not whole config", async () => {
+    await svc.saveConfig({ ui: { shelfRowsPerPage: 8 } });
+    const stored = JSON.parse(notion.saveAppConfigRaw.mock.calls[0][0]);
+    expect(stored.ui.shelfRowsPerPage).toBe(8);
+    expect(stored.library).toBeUndefined(); // niezmienione sekcje nie są składowane
+  });
+
+  it("stores empty string when nothing differs from defaults", async () => {
+    await svc.saveConfig(mergeConfig(undefined));
+    expect(notion.saveAppConfigRaw).toHaveBeenCalledWith("");
+  });
+
+  it("caches within TTL (single Notion read for repeated getConfig)", async () => {
+    notion.getAppConfigRaw.mockResolvedValue("");
+    await svc.getConfig();
+    await svc.getConfig();
+    expect(notion.getAppConfigRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/__tests__/cycleHarvestService.test.ts
+++ b/services/__tests__/cycleHarvestService.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CycleHarvestService } from "../cycleHarvestService";
+import { NotionAdapter } from "../../notion.adapter";
+import { CycleLookupService, CycleView } from "../cycleLookupService";
+import { fakeConfig } from "./testConfig";
+
+const view = (over: Partial<CycleView> = {}): CycleView => ({
+  cycleName: "Saga",
+  source: "chain",
+  unreadBefore: 0,
+  volumes: [
+    { title: "Tom 1", isCurrent: true, inBase: true, read: false, owned: false, awarded: true, awards: ["Hugo"] },
+    { title: "Tom 2", isCurrent: false, inBase: false, read: false, owned: false, awarded: false, awards: [] },
+  ],
+  ...over,
+});
+
+describe("CycleHarvestService.runCycleHarvest", () => {
+  let notion: any;
+  let lookup: any;
+  let svc: CycleHarvestService;
+  const collect = async () => {
+    const events: any[] = [];
+    await svc.runCycleHarvest((e) => events.push(e), () => false);
+    return events;
+  };
+
+  beforeEach(() => {
+    notion = {
+      createColumnIfNeeded: vi.fn(),
+      getBooksForStats: vi.fn(),
+      addRow: vi.fn(async () => ({ id: "new-id" })),
+      updatePage: vi.fn(),
+    };
+    lookup = { lookup: vi.fn() };
+    svc = new CycleHarvestService(notion as unknown as NotionAdapter, lookup as unknown as CycleLookupService, fakeConfig);
+  });
+
+  it("creates missing volumes as rows and tags the existing anchor", async () => {
+    notion.getBooksForStats.mockResolvedValue([
+      { id: "anchor", plTitle: "Tom 1", origTitle: "", currentCzesccyklu: true, awards: ["Hugo"], zrodlo: [] },
+    ]);
+    lookup.lookup.mockResolvedValue(view());
+
+    const events = await collect();
+
+    // Tom 1 istnieje jako wiersz nagrodowy → dotagowany Cykl/CyklNr (nie duplikowany).
+    expect(notion.updatePage).toHaveBeenCalledWith("anchor", expect.objectContaining({ CyklNr: { number: 1 } }));
+    // Tom 2 spoza bazy → utworzony jako nowy wiersz.
+    expect(notion.addRow).toHaveBeenCalledTimes(1);
+    const done = events.find((e) => e.type === "complete");
+    expect(done.result).toMatchObject({ added: 1, updated: 1 });
+  });
+
+  it("is idempotent — an already-tagged base makes no writes", async () => {
+    notion.getBooksForStats.mockResolvedValue([
+      { id: "anchor", plTitle: "Tom 1", origTitle: "", currentCzesccyklu: true, awards: ["Hugo"], zrodlo: [], cykl: "Saga", cyklNr: 1 },
+      { id: "vol2", plTitle: "Tom 2", origTitle: "", currentCzesccyklu: false, kategoria: "Tom cyklu", awards: [], zrodlo: [], cykl: "Saga", cyklNr: 2, lp: "Saga (2)",
+        plTitleRichText: [{ text: { content: "Tom 2", link: { url: "https://encyklopediafantastyki.pl/index.php?title=Tom_2" } } }] },
+    ]);
+    lookup.lookup.mockResolvedValue(view());
+
+    const events = await collect();
+
+    expect(notion.addRow).not.toHaveBeenCalled();   // brak duplikatu
+    expect(notion.updatePage).not.toHaveBeenCalled(); // brak zbędnych zapisów
+    const done = events.find((e) => e.type === "complete");
+    expect(done.result).toMatchObject({ added: 0, updated: 0 });
+  });
+
+  it("reports anchors with no siblings as skipped, writes nothing", async () => {
+    notion.getBooksForStats.mockResolvedValue([
+      { id: "a", plTitle: "Solo", origTitle: "", currentCzesccyklu: true, awards: [], zrodlo: [] },
+    ]);
+    lookup.lookup.mockResolvedValue(view({ volumes: [view().volumes[0]] })); // tylko 1 tom
+
+    const events = await collect();
+    expect(notion.addRow).not.toHaveBeenCalled();
+    const done = events.find((e) => e.type === "complete");
+    expect(done.result.summary.skipped).toContain("Solo");
+  });
+});

--- a/services/cycleHarvestService.ts
+++ b/services/cycleHarvestService.ts
@@ -3,8 +3,9 @@ import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent, NotionBook } from "../src/types";
 import { ConfigService } from "./configService";
 import { CycleLookupService, normTitle } from "./cycleLookupService";
-import { buildCycleVolumeProperties, cycleLpLabel, cycleVolumeEncyclopediaUrl, buildCycleTitleProperty } from "./cycleRows";
+import { buildCycleVolumeProperties, cycleLpLabel, buildCycleTitleProperty } from "./cycleRows";
 import { isCycleVolume } from "./bookCategory";
+import { encyclopediaUrl } from "../src/utils/encyclopedia";
 import { sanitizeNotionString } from "../utils";
 import { createLogger } from "../logger";
 
@@ -101,7 +102,7 @@ export class CycleHarvestService {
               if (isCycleVolume(existing)) {
                 const label = cycleLpLabel(cyc, nr);
                 if (existing.lp !== label) props["Lp"] = { title: [{ text: { content: label } }] };
-                const wantLink = cycleVolumeEncyclopediaUrl(existing.plTitle || title);
+                const wantLink = encyclopediaUrl(existing.plTitle || title);
                 const curLink = existing.plTitleRichText?.[0]?.text?.link?.url;
                 if (curLink !== wantLink) props["Tytuł polski"] = buildCycleTitleProperty(existing.plTitle || title);
               }

--- a/services/cycleRows.ts
+++ b/services/cycleRows.ts
@@ -3,19 +3,11 @@ import { sanitizeNotionString, isValidUrl } from "../utils";
 import { buildAuthorTags } from "./bookDiff";
 import { CYCLE_VOLUME_CATEGORY, isCycleVolume } from "./bookCategory";
 import { parseVintedData } from "./vintedStore";
-
-/**
- * Link do strony tomu w Archiwum Encyklopedii Fantastyki — tytuł tomu to nazwa strony
- * wiki (z łańcucha poprzednia/następna). Ten sam wzorzec co w parserze i w karcie
- * (spacje → „_"), więc link w Notion i w UI są identyczne.
- */
-export function cycleVolumeEncyclopediaUrl(title: string): string {
-  return `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent((title || "").replace(/ /g, "_"))}`;
-}
+import { encyclopediaUrl } from "../src/utils/encyclopedia";
 
 /** Właściwość „Tytuł polski" z linkiem do encyklopedii (jak w oryginalnych rytuałach). */
 export function buildCycleTitleProperty(title: string): Record<string, any> {
-  const link = cycleVolumeEncyclopediaUrl(title);
+  const link = encyclopediaUrl(title);
   return { rich_text: [{ text: { content: sanitizeNotionString(title || ""), ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
 }
 

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -3,6 +3,7 @@ import { Library, BookOpen, CheckCircle2, Sparkles, Loader2, AlertCircle, X } fr
 import { BookIndexEntry } from "../types";
 import { useBooks } from "../hooks/useBooks";
 import { useMarkRead } from "../hooks/useMarkRead";
+import { useShelfOrder } from "../hooks/useShelfOrder";
 import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
 import { planInsertion } from "../utils/shelfInsertion";
 import { ShelfSkin, SHELF_SKINS, skinClass, loadSkin, saveSkin } from "../utils/shelfSkin";
@@ -15,6 +16,7 @@ import { RoomDecor } from "./shelf/RoomDecor";
 export const BookshelfSection: React.FC = () => {
   const { books, loading, error, fetchBooks } = useBooks();
   const { setRead } = useMarkRead();
+  const { saveOrders } = useShelfOrder();
 
   const [overrides, setOverrides] = useState<ReadOverrides>({});
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
@@ -103,15 +105,7 @@ export const BookshelfSection: React.FC = () => {
       });
       void (async () => {
         try {
-          const res = await fetch("/api/shelf-order", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ orders: plan.orders }),
-          });
-          if (!res.ok) {
-            const j = await res.json().catch(() => null);
-            throw new Error(j?.error || `Błąd serwera: ${res.status}`);
-          }
+          await saveOrders(plan.orders);
         } catch (e: any) {
           setOrderOverrides((prev) => {
             const next = { ...prev };

--- a/src/components/search/CyclePanel.tsx
+++ b/src/components/search/CyclePanel.tsx
@@ -2,10 +2,7 @@ import React, { useEffect } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Layers, X, Loader2, Check, Package, Award, CircleDashed, MapPin, AlertTriangle, ExternalLink } from "lucide-react";
 import { useCycle } from "../../hooks/useCycle";
-
-/** Link do strony tomu w Archiwum Encyklopedii Fantastyki (ten sam wzorzec co parser). */
-const encyclopediaUrl = (title: string) =>
-  `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent(title.replace(/ /g, "_"))}`;
+import { encyclopediaUrl } from "../../utils/encyclopedia";
 
 /**
  * Modal podglądu cyklu (Skryptorium). Pobiera na żądanie uporządkowaną listę tomów

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -2,10 +2,7 @@ import React, { useState } from "react";
 import { motion } from "motion/react";
 import { Layers, ChevronDown, Check, CheckCheck, Package, AlertTriangle, Award, ExternalLink, Loader2, ShoppingCart } from "lucide-react";
 import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
-
-/** Link do tomu w Archiwum Encyklopedii Fantastyki (ten sam wzorzec co parser/panel). */
-const encyclopediaUrl = (title: string) =>
-  `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent(title.replace(/ /g, "_"))}`;
+import { encyclopediaUrl } from "../../utils/encyclopedia";
 
 const volStatus = (v: HarvestVolume) => {
   if (v.read) return { icon: Check, cls: "text-cyan-400", label: "przeczytana" };

--- a/src/hooks/useShelfOrder.ts
+++ b/src/hooks/useShelfOrder.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+
+/**
+ * Zapis ręcznych kluczy porządku regału (precyzyjny drag&drop → POST /api/shelf-order).
+ * Sam transport sieciowy — optymistyczny override i rollback zostają w komponencie
+ * (to stan UI). Wydzielone z `BookshelfSection`, by komponent nie robił własnego I/O (§2).
+ */
+export function useShelfOrder() {
+  const saveOrders = useCallback(async (orders: { pageId: string; order: number }[]): Promise<void> => {
+    const res = await fetch("/api/shelf-order", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orders }),
+    });
+    if (!res.ok) {
+      const j = await res.json().catch(() => null);
+      throw new Error(j?.error || `Błąd serwera: ${res.status}`);
+    }
+  }, []);
+
+  return { saveOrders };
+}

--- a/src/utils/encyclopedia.ts
+++ b/src/utils/encyclopedia.ts
@@ -1,0 +1,9 @@
+/**
+ * Jedno źródło prawdy dla linku do strony w Archiwum Encyklopedii Fantastyki.
+ * Tytuł tomu/książki = nazwa strony wiki; spacje → „_", potem `encodeURIComponent`.
+ * Współdzielone przez front (panele cyklu) i backend (żniwa — link przy tytule).
+ * Moduł czysty, bez zależności Node/DOM (wzorzec jak `configSchema.ts`).
+ */
+export function encyclopediaUrl(title: string): string {
+  return `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent((title || "").replace(/ /g, "_"))}`;
+}


### PR DESCRIPTION
Front **B** remediacji po audycie integralności. (Werdykt audytu: kod jednolity, główny dryf w dokumentacji — osobny PR.)

## Fixy jednolitości

- **Wspólny `encyclopediaUrl`** (`src/utils/encyclopedia.ts`) — zamiast **3 identycznych kopii** (`CyclePanel`, `CyclesHarvestCard`, `cycleRows`). `StatusSection` (statyczne URL-e nagród) i `wiki.parser` (inny wariant) zostają — to osobne przypadki.
- **`useShelfOrder`** — `BookshelfSection` nie robi już surowego `fetch("/api/shelf-order")` (§2 „Logic Isolation"); transport w hooku, optymistyczny override + rollback zostają w komponencie jako stan UI.
- **Brakujące testy warstwy serwisów**: `configService` (merge diff nad defaultami, fallback na corrupt/throw, zapis TYLKO diffu, cache TTL) + `cycleHarvestService` (tworzenie brakujących / tagowanie istniejących / idempotentny re-run / raport braku sąsiadów).

## Zaakceptowane (nie-defekt)

`useMarkRead` (Regał) vs `useMarkAsRead` (Statystyki) — różne konteksty i efekty uboczne; duplikacja typów cross-boundary spójna z istniejącym precedensem `statsService↔useStats`.

## Testy

`npm run lint` czysty, `npm test` zielony (383, +9), `npm run build` OK. Wersja `1.44.2`.

Następny PR: **sync dokumentacji** (guidelines v1.6 + CLAUDE.md + README + docs/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_