### PR TITLE
Rytuały Oficyny/Serie/Cykle pomijają poboczne tomy cykli

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.44.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.3** — **Rytuały Oficyny/Serie/Cykle pomijają poboczne tomy cykli.** `WikiFieldSyncService`
+  (wydawca+seria) i `CyclesSyncService` iterowały `queryAllBooks()` bez filtra `isAwardBook` →
+  wzbogacały/taggowały też wiersze `Kategoria="Tom cyklu"` (zbędne pobrania stron + zapisy na
+  wierszach, których żaden konsument nagrodowy nie czyta). Filtr `rawBooks.filter(isAwardBook)` na
+  wejściu obu rytuałów — spójne z modelem kategorii wierszy. +2 testy (pomijanie tomów).
 - **1.44.2** — **Audyt integralności — remediacja kodu (front B).** Werdykt: kod jednolity (architektura
   wytrzymała), dryf głównie w DOKUMENTACJI (→ osobny PR). Fixy jednolitości: wspólny `encyclopediaUrl`
   (`src/utils/encyclopedia.ts`) zamiast 3 identycznych kopii (CyclePanel/CyclesHarvestCard/cycleRows;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.44.2",
+      "version": "1.44.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.44.2",
+  "version": "1.44.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/cyclesSyncService.test.ts
+++ b/services/__tests__/cyclesSyncService.test.ts
@@ -101,6 +101,26 @@ describe('CyclesSyncService', () => {
     expect(mockNotion.updatePage).toHaveBeenCalledWith('p2', { 'Część cyklu': { checkbox: true } });
   });
 
+  it('skips cycle-volume rows (Kategoria="Tom cyklu") — they are not re-evaluated', async () => {
+    const raw = `{{Książka\n | autor = Anna Nowak\n | cykl = Saga\n}}`;
+    mockNotion.queryAllBooks.mockResolvedValue([
+      bookOf({ id: 'award', plTitle: 'Nagroda', author: 'Anna Nowak' }),
+      bookOf({ id: 'vol', plTitle: 'Poboczny Tom', author: 'Anna Nowak', kategoria: 'Tom cyklu' }),
+    ]);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({
+      contents: { 'nagroda': raw, 'poboczny tom': raw },
+      failedTitles: [],
+    });
+
+    await service.runCyclesSync(mockSendEvent, () => false);
+
+    // The cycle volume must never be re-tagged; only the award anchor is processed.
+    expect(mockNotion.updatePage).toHaveBeenCalledTimes(1);
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('award', { 'Część cyklu': { checkbox: true } });
+    const complete = mockSendEvent.mock.calls.map((c: any[]) => c[0]).find((e: any) => e.type === 'complete');
+    expect(complete.result.found).toBe(1);
+  });
+
   it('reports a book as skipped (not silently) when no wiki page is found', async () => {
     mockNotion.queryAllBooks.mockResolvedValue([bookOf({ id: 'p3', plTitle: 'Widmo', author: 'Zenon Test' })]);
     mockWiki.fetchPagesContentBulk.mockResolvedValue({ contents: {}, failedTitles: [] });

--- a/services/__tests__/publisherSyncService.test.ts
+++ b/services/__tests__/publisherSyncService.test.ts
@@ -61,6 +61,38 @@ describe('PublisherSyncService', () => {
     expect(mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete' }));
   });
 
+  it('skips cycle-volume rows (Kategoria="Tom cyklu")', async () => {
+    const mockBooks: NotionBook[] = [
+      {
+        id: 'award-1', plTitle: 'Solaris', origTitle: 'Solaris', author: 'Stanisław Lem',
+        year: '1961', currentWydawnictwo: 'Stare', awards: [], zrodlo: [], currentSeria: '',
+        currentCzesccyklu: false, lp: '1', plTitleRichText: [], origTitleRichText: [],
+      },
+      {
+        id: 'vol-1', plTitle: 'Poboczny Tom', origTitle: 'Poboczny Tom', author: 'Stanisław Lem',
+        year: '1970', currentWydawnictwo: 'Stare', awards: [], zrodlo: [], currentSeria: '',
+        currentCzesccyklu: false, lp: 'Cykl (2)', plTitleRichText: [], origTitleRichText: [],
+        kategoria: 'Tom cyklu',
+      },
+    ];
+
+    mockNotion.queryAllBooks.mockResolvedValue(mockBooks);
+    mockWiki.fetchPagesContentBulk.mockResolvedValue({
+      contents: {
+        'solaris': '{{Książka infobox\n|wydawca = Nowe Wydawnictwo\n}}',
+        'poboczny tom': '{{Książka infobox\n|wydawca = Nowe Wydawnictwo\n}}',
+      },
+      failedTitles: [],
+    });
+
+    await service.runPublisherSync(mockSendEvent, () => false);
+
+    // Only the cycle volume's page must never be fetched nor written.
+    expect(mockWiki.fetchPagesContentBulk).toHaveBeenCalledWith(['Solaris']);
+    expect(mockNotion.updatePage).toHaveBeenCalledTimes(1);
+    expect(mockNotion.updatePage).toHaveBeenCalledWith('award-1', expect.anything());
+  });
+
   it('handles cancellation', async () => {
     mockNotion.queryAllBooks.mockResolvedValue([]);
     

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -5,6 +5,7 @@ import { WikiParser } from "../wiki.parser";
 import { NotionBook, SyncEvent } from "../src/types";
 import { isWikiAuthorMatch } from "./dataNormalizer";
 import { ConfigService } from "./configService";
+import { isAwardBook } from "./bookCategory";
 
 export class CyclesSyncService {
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
@@ -16,8 +17,12 @@ export class CyclesSyncService {
       sendEvent({ type: "status", message: "Sprawdzanie struktury bazy Notion..." });
       await this.notion.createColumnIfNeeded("Część cyklu", "checkbox");
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-      const allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
-      
+      const rawBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
+      // Wykrywanie przynależności do cyklu dotyczy pozycji NAGRODOWYCH — poboczne
+      // tomy cykli (Kategoria="Tom cyklu") są z definicji częścią cyklu i mają
+      // własny rytuał żniw, więc pomijamy je zamiast redundantnie taggować.
+      const allBooks = rawBooks.filter(isAwardBook);
+
       if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano synchronizację cykli." }); return; }
 
       // Zbieranie unikalnych tytułów do pobrania (zarówno polskie jak i oryginalne)

--- a/services/wikiFieldSyncService.ts
+++ b/services/wikiFieldSyncService.ts
@@ -5,6 +5,7 @@ import { WikiParser } from "../wiki.parser";
 import { NotionBook, SyncEvent } from "../src/types";
 import { normalizeData, isWikiAuthorMatch, NormalizationContext } from "./dataNormalizer";
 import { DiffEngine } from "./diffEngine";
+import { isAwardBook } from "./bookCategory";
 
 /**
  * Konfiguracja jednego pola wzbogacanego ze strony książki w encyklopedii.
@@ -43,10 +44,15 @@ export class WikiFieldSyncService {
     const cfg = this.config;
     try {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-      const allBooks: NotionBook[] = await this.notion.queryAllBooks(
+      const rawBooks: NotionBook[] = await this.notion.queryAllBooks(
         (count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }),
         checkCancellation
       );
+      // Wzbogacanie wydawcy/serii to koncern NAGRODOWY — poboczne tomy cykli
+      // (Kategoria="Tom cyklu") mają własny rytuał żniw i widok „Archiwum Cykli",
+      // więc pomijamy je (bez zbędnych pobrań stron i zapisów na wierszach,
+      // których żaden konsument nagrodowy nie czyta).
+      const allBooks = rawBooks.filter(isAwardBook);
 
       if (checkCancellation()) { sendEvent({ type: "status", message: `Przerwano ${cfg.ritualName}.` }); return; }
 


### PR DESCRIPTION
Rytuały wzbogacania nagrodowego przetwarzały też poboczne tomy cykli.

`WikiFieldSyncService` (Oficyny/Wydawnictwa + Serie) i `CyclesSyncService` (Cykle) iterowały `queryAllBooks()` bez filtra `isAwardBook`, więc pobierały strony encyklopedii i zapisywały `Wydawnictwo`/`Seria`/`Część cyklu` również na wierszach `Kategoria="Tom cyklu"` — a to konsumenci nagrodowi, którzy z założenia mają te tomy pomijać (mają własny rytuał żniw, widok „Archiwum Cykli" i skan Vinted).

**Zmiana**: `rawBooks.filter(isAwardBook)` na wejściu obu rytuałów — spójne z modelem kategorii wierszy. Eliminuje zbędne pobrania bulk/search, zbędne zapisy do Notion i redundantne oznaczanie `Część cyklu` na wierszach, których żaden konsument nagrodowy nie czyta.

- `services/wikiFieldSyncService.ts`, `services/cyclesSyncService.ts` — filtr + komentarz uzasadniający.
- +2 testy (`publisherSyncService`, `cyclesSyncService`) potwierdzające pomijanie tomów.
- Suite: 385 zielonych, `tsc` czysty. Bump 1.44.2 → 1.44.3.

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_