### PR TITLE
Paski „Top Oficyny" liczą read-rate zamiast rozmiaru oficyny

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.44.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.4** — **Fix: paski „Top Oficyny" pokazywały rozmiar zamiast read-rate.** `PublishingCard`
+  rysował pasek oficyny jako `count/maxPub` (rozmiar względem największej), a etykieta mówiła
+  `read/count` → największa oficyna (Mag) miała pełny pasek przy „26/82 przecz.". Pasek liczy teraz
+  `read/count` (emerald przy komplecie), spójnie z sekcją Serie i własną etykietą. Usunięty martwy
+  `maxPub`/`maxSer`. County zbierane poprawnie — błąd był tylko w proporcji paska (UI).
 - **1.44.3** — **Rytuały Oficyny/Serie/Cykle pomijają poboczne tomy cykli.** `WikiFieldSyncService`
   (wydawca+seria) i `CyclesSyncService` iterowały `queryAllBooks()` bez filtra `isAwardBook` →
   wzbogacały/taggowały też wiersze `Kategoria="Tom cyklu"` (zbędne pobrania stron + zapisy na

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.44.3",
+  "version": "1.44.4",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.44.3",
+  "version": "1.44.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.44.3",
+      "version": "1.44.4",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.44.3",
+  "version": "1.44.4",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/stats/PublishingCard.tsx
+++ b/src/components/stats/PublishingCard.tsx
@@ -5,8 +5,9 @@ import { PublisherStat, SeriesStat, CycleStats } from "../../hooks/useStats";
 
 /**
  * Wydawnictwa / Serie / Cykle — dane z rytuałów publisher/series/cycles, dotąd
- * niepokazywane. Wydawnictwa: liczba tytułów + read-rate. Serie: posiadane/total
- * (luki). Cykle: udział „części cyklu" w kolekcji (donut-bar).
+ * niepokazywane. Każdy pasek pokazuje POSTĘP wg swojej etykiety, nie rozmiar:
+ * Wydawnictwa = przeczytane/tytuły, Serie = posiadane/total (luki), Cykle =
+ * udział „części cyklu" w kolekcji. Lista i tak posortowana malejąco po liczbie.
  */
 
 const barRow = (label: string, value: number, max: number, sub: string, color: string) => (
@@ -22,8 +23,6 @@ const barRow = (label: string, value: number, max: number, sub: string, color: s
 );
 
 export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: SeriesStat[]; cycles: CycleStats }> = ({ publishers, series, cycles }) => {
-  const maxPub = Math.max(1, ...publishers.map((p) => p.count));
-  const maxSer = Math.max(1, ...series.map((s) => s.count));
   const cyclePct = cycles.total > 0 ? Math.round((cycles.partOfCycle / cycles.total) * 100) : 0;
 
   return (
@@ -59,7 +58,7 @@ export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: Ser
           <p className="text-slate-500 text-xs italic">Brak danych — uruchom Rytuał Wydania.</p>
         ) : (
           <div className="space-y-2.5 max-h-[200px] overflow-y-auto pr-1 custom-scrollbar">
-            {publishers.slice(0, 8).map((p) => barRow(p.name, p.count, maxPub, `${p.read}/${p.count} przecz.`, "bg-indigo-500"))}
+            {publishers.slice(0, 8).map((p) => barRow(p.name, p.read, p.count, `${p.read}/${p.count} przecz.`, p.read >= p.count ? "bg-emerald-500" : "bg-indigo-500"))}
           </div>
         )}
       </div>


### PR DESCRIPTION
Pasek w sekcji **Top Oficyny** nie zgadzał się z własną etykietą: rysował `count / maxPub` (rozmiar oficyny względem największej), a podpis pokazywał `read/count`. Największa oficyna (Mag, 82 tytuły) dostawała pełny pasek przy „26/82 przecz.".

Sekcja **Serie** była poprawna (`owned/count`) — dlatego jej paski wyglądały sensownie, a Oficyny nie.

**Zmiana** (`src/components/stats/PublishingCard.tsx`): pasek oficyny = `read/count` (postęp czytania), spójnie z etykietą i sekcją Serie; emerald przy komplecie, indigo w toku. County są zbierane poprawnie — błąd był wyłącznie w proporcji paska. Usunięty martwy `maxPub`/`maxSer`.

Suite: 385 zielonych, `tsc` czysty. Bump 1.44.3 → 1.44.4.

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_