### PR TITLE
Archiwum Cykli: rozdzielone luki (do zdobycia / do przeczytania) + łagodniejszy znacznik tomu

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.44.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.5** — **Archiwum Cykli: rozdzielone luki + łagodniejszy znacznik tomu.** Nagłówek cyklu
+  zamiast jednego chipa „X do zdobycia" (missing = ani posiadane, ani przeczytane) pokazuje dwie
+  NIEZALEŻNE luki: zielony chip `<PackageOpen> X` (do zdobycia = nieposiadane, `total−owned`) i
+  niebieski `<Book> X` (do przeczytania = nieprzeczytane, `total−read`). Per-tom znacznik „do
+  zdobycia" zmieniony z ostrzegawczego `AlertTriangle` (amber) na łagodny `CircleDashed`
+  (amber/70). Tylko UI (`CyclesHarvestCard`), backend bez zmian.
 - **1.44.4** — **Fix: paski „Top Oficyny" pokazywały rozmiar zamiast read-rate.** `PublishingCard`
   rysował pasek oficyny jako `count/maxPub` (rozmiar względem największej), a etykieta mówiła
   `read/count` → największa oficyna (Mag) miała pełny pasek przy „26/82 przecz.". Pasek liczy teraz

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.44.4",
+      "version": "1.44.5",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.44.4",
+  "version": "1.44.5",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { motion } from "motion/react";
-import { Layers, ChevronDown, Check, CheckCheck, Package, AlertTriangle, Award, ExternalLink, Loader2, ShoppingCart } from "lucide-react";
+import { Layers, ChevronDown, Check, CheckCheck, Package, PackageOpen, Book, CircleDashed, AlertTriangle, Award, ExternalLink, Loader2, ShoppingCart } from "lucide-react";
 import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
 import { encyclopediaUrl } from "../../utils/encyclopedia";
 
@@ -8,7 +8,9 @@ const volStatus = (v: HarvestVolume) => {
   if (v.read) return { icon: Check, cls: "text-cyan-400", label: "przeczytana" };
   if (v.owned) return { icon: Package, cls: "text-emerald-400", label: "posiadana" };
   // Tomy są teraz wierszami bazy — brak posiadania/przeczytania = „do zdobycia".
-  return { icon: AlertTriangle, cls: "text-amber-400", label: "do zdobycia" };
+  // Łagodny znacznik (dashed circle) zamiast trójkąta ostrzegawczego — poboczne
+  // tomy to zaproszenie do skompletowania, nie błąd.
+  return { icon: CircleDashed, cls: "text-amber-400/70", label: "do zdobycia" };
 };
 
 /**
@@ -62,6 +64,10 @@ export const CyclesHarvestCard: React.FC = () => {
             const isOpen = open === c.cycle;
             // Cykl przeczytany w całości → wygaszony (nic nie zostało do nadrobienia).
             const done = c.total > 0 && c.read === c.total;
+            // Dwie NIEZALEŻNE luki (dotąd zlane w jeden licznik „missing"):
+            // do zdobycia = nieposiadane; do przeczytania = nieprzeczytane.
+            const toAcquire = c.total - c.owned;
+            const toRead = c.total - c.read;
             return (
               <div key={c.cycle} className={`rounded-2xl border border-white/5 bg-slate-950/40 overflow-hidden transition-opacity ${done && !isOpen ? "opacity-45" : ""}`}>
                 <button
@@ -74,10 +80,25 @@ export const CyclesHarvestCard: React.FC = () => {
                     <span className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full border border-cyan-500/25 bg-cyan-500/10 text-cyan-300/90 text-[9px] font-bold uppercase tracking-wider">
                       <CheckCheck className="w-2.5 h-2.5" /> ukończony
                     </span>
-                  ) : c.missing > 0 && (
-                    <span className="shrink-0 px-2 py-0.5 rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-300 text-[9px] font-bold uppercase tracking-wider">
-                      {c.missing} do zdobycia
-                    </span>
+                  ) : (
+                    <>
+                      {toAcquire > 0 && (
+                        <span
+                          className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full border border-emerald-500/25 bg-emerald-500/10 text-emerald-300 text-[9px] font-bold tabular-nums uppercase tracking-wider"
+                          title={`${toAcquire} do zdobycia (nieposiadane)`}
+                        >
+                          <PackageOpen className="w-2.5 h-2.5" /> {toAcquire}
+                        </span>
+                      )}
+                      {toRead > 0 && (
+                        <span
+                          className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full border border-cyan-500/25 bg-cyan-500/10 text-cyan-300 text-[9px] font-bold tabular-nums uppercase tracking-wider"
+                          title={`${toRead} do przeczytania`}
+                        >
+                          <Book className="w-2.5 h-2.5" /> {toRead}
+                        </span>
+                      )}
+                    </>
                   )}
                   {c.acquireCost != null && (
                     <span className="shrink-0 flex items-center gap-1 px-2 py-0.5 rounded-full border border-rose-500/25 bg-rose-500/10 text-rose-300 text-[9px] font-bold uppercase tracking-wider" title={`Skompletuj ${c.acquirable} tomów z Vinted`}>


### PR DESCRIPTION
Dwie zmiany w karcie „Archiwum Cykli":

**1. Rozdzielony licznik luk.** Nagłówek cyklu pokazywał jeden chip „X do zdobycia", gdzie `missing` = tomy *ani posiadane, ani przeczytane* — zlewając dwie niezależne osie w jeden numer. Teraz dwa niezależne chipy:
- 🟢 `<PackageOpen> X` — **do zdobycia** (nieposiadane, `total − owned`), zielony jak toggle „Posiadam".
- 🔵 `<Book> X` — **do przeczytania** (nieprzeczytane, `total − read`), niebieski jak toggle „Przeczytane".

Każdy pokazuje się tylko gdy jego luka > 0. Ukończone cykle (przeczytane w całości) nadal dostają badge „ukończony".

**2. Łagodniejszy znacznik tomu.** Per-tom „do zdobycia" miał ostrzegawczy `AlertTriangle` (amber) — czytało się jak błąd. Zmienione na spokojne `CircleDashed` (amber/70) — poboczne tomy to zaproszenie do skompletowania, nie alarm.

Tylko UI (`src/components/stats/CyclesHarvestCard.tsx`) — backend/agregacja bez zmian. Suite: 385 zielonych, `tsc` czysty. Bump 1.44.4 → 1.44.5.

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_