### PR TITLE
Vinted cykl 1/2 (backend): propagacja nazwy cyklu + numeru tomu przez pipeline

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.44.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.44.6** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.44.6** — **Vinted: propagacja cyklu przez pipeline (backend, część 1/2 feature).** `StoredBookView`
+  + `toStoredBookView` niosą teraz `cykl`/`cyklNr` (obok `partOfCycle`/`year`); wynik `match` z żywego
+  skanu też (`partOfCycle`/`cykl`/`cyklNr`) — więc `/api/vinted-stored` i skan na żywo mają nazwę cyklu
+  i numer tomu prosto z wiersza Notion. +2 testy (`toStoredBookView`). Frontend (interaktywny kafelek
+  + wyświetlenie tomu) w kolejnym PR.
 - **1.44.5** — **Archiwum Cykli: rozdzielone luki + łagodniejszy znacznik tomu.** Nagłówek cyklu
   zamiast jednego chipa „X do zdobycia" (missing = ani posiadane, ani przeczytane) pokazuje dwie
   NIEZALEŻNE luki: zielony chip `<PackageOpen> X` (do zdobycia = nieposiadane, `total−owned`) i

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.44.5",
+  "version": "1.44.6",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.44.5",
+  "version": "1.44.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.44.5",
+      "version": "1.44.6",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.44.5",
+  "version": "1.44.6",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/vintedStore.test.ts
+++ b/services/__tests__/vintedStore.test.ts
@@ -1,8 +1,34 @@
 import { describe, it, expect } from "vitest";
-import { offerFromItem, serializeVintedData, parseVintedData, mergeAndDiff, hasChanges, StoredOffer } from "../vintedStore";
+import { offerFromItem, serializeVintedData, parseVintedData, mergeAndDiff, hasChanges, toStoredBookView, StoredOffer, StoredVintedData } from "../vintedStore";
 import { VintedItem } from "../vintedParser";
+import { NotionBook } from "../../src/types";
 
 describe("vintedStore", () => {
+  it("toStoredBookView carries cycle metadata (cykl/cyklNr/partOfCycle) from the book", () => {
+    const book = {
+      id: "b1", plTitle: "Tom II", origTitle: "Vol II", author: "Autor", year: "2000",
+      currentCzesccyklu: true, cykl: "Wielka Saga", cyklNr: 2,
+      awards: [], zrodlo: [], plTitleRichText: [], origTitleRichText: [],
+    } as unknown as NotionBook;
+    const data: StoredVintedData = { scannedAt: "2020-01-01T00:00:00Z", offers: [] };
+
+    const view = toStoredBookView(book, data);
+    expect(view.partOfCycle).toBe(true);
+    expect(view.cykl).toBe("Wielka Saga");
+    expect(view.cyklNr).toBe(2);
+    expect(view.title).toBe("Tom II");
+  });
+
+  it("toStoredBookView leaves cycle fields undefined when the book has none", () => {
+    const book = {
+      id: "b2", plTitle: "Samotnik", origTitle: "Loner", author: "Autor",
+      awards: [], zrodlo: [], plTitleRichText: [], origTitleRichText: [],
+    } as unknown as NotionBook;
+    const view = toStoredBookView(book, { scannedAt: "2020-01-01T00:00:00Z", offers: [] });
+    expect(view.cykl).toBeUndefined();
+    expect(view.cyklNr).toBeUndefined();
+  });
+
   it("offerFromItem maps VintedItem fields (priceValue → price)", () => {
     const item: VintedItem = {
       title: "T", price: "10", priceValue: 10, currency: "zł", url: "u", photo: "p",

--- a/services/vintedStore.ts
+++ b/services/vintedStore.ts
@@ -41,6 +41,10 @@ export interface StoredBookView {
   year?: string;
   /** Czy książka jest częścią cyklu (kolumna „Część cyklu", checkbox) — ryzyko „kolejny tom". */
   partOfCycle?: boolean;
+  /** Nazwa cyklu (kolumna „Cykl") — jeśli ustalona żniwami. Do etykiety kafelka. */
+  cykl?: string;
+  /** Numer tomu w cyklu (kolumna „CyklNr") — jeśli ustalony żniwami. */
+  cyklNr?: number;
   scannedAt: string;
   changedAt?: string;
   offers: StoredOffer[];
@@ -77,6 +81,8 @@ export function toStoredBookView(book: NotionBook, data: StoredVintedData): Stor
     author: book.author || "",
     year: book.year,
     partOfCycle: book.currentCzesccyklu,
+    cykl: book.cykl,
+    cyklNr: book.cyklNr,
     scannedAt: data.scannedAt,
     changedAt: data.changedAt,
     offers: data.offers,

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -160,7 +160,7 @@ export class VintedSyncService {
           if (items.length > 0) {
             // Utrwal (scala ze składowanymi — zachowuje sprzedawców przy niezmienionym URL) + policz diff.
             const diff = persistEnabled ? await this.persistBookOffers(book, items, scannedAt) : EMPTY_DIFF;
-            const matchResult = { id: book.id, title: book.plTitle, author: book.author, searchUrl: url, vintedItems: items };
+            const matchResult = { id: book.id, title: book.plTitle, author: book.author, searchUrl: url, vintedItems: items, partOfCycle: book.currentCzesccyklu, cykl: book.cykl, cyklNr: book.cyklNr };
             results.push(matchResult);
             sendEvent({ type: "match", result: matchResult });
             sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length, debug: { ...debug, changes: diff } } });


### PR DESCRIPTION
Backendowa połowa (1/2) feature'u „cykl w skanerze Vinted" (#237). Pipeline Vinted trzymał pełny `NotionBook` w trakcie skanu, ale gubił metadane cyklu przed UI.

- `StoredBookView` + `toStoredBookView` niosą teraz `cykl` / `cyklNr` (obok istniejących `partOfCycle` / `year`) → `GET /api/vinted-stored` podaje nazwę cyklu i numer tomu prosto z wiersza Notion.
- Wynik `match` z żywego skanu też niesie `partOfCycle` / `cykl` / `cyklNr`, więc świeży skan pokazuje te same dane cyklu co widok ze składu.

Bez zmiany zachowania — to opcjonalne pola konsumowane przez frontendową połowę. +2 testy `toStoredBookView` (z polami cyklu i bez).

Suite: 387 zielonych, `tsc` czysty. Bump 1.44.5 → 1.44.6 (patch — plumbing, jeszcze niewidoczne dla użytkownika).

Część #237 (domknie frontendowy PR 2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_