### PR TITLE
„Odśwież Dane" odświeża też Archiwum Cykli (audyt + fix)

### DIFF
--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -111,6 +111,28 @@ describe("SyncManager lifecycle", () => {
   afterAll(() => closeServer());
 });
 
+describe("GET /api/cycles-harvest", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NOTION_API_KEY = "test-key";
+    process.env.NOTION_DATABASE_ID = "test-db";
+  });
+
+  it("passes fresh=false by default (may reuse the books cache)", async () => {
+    const spy = vi.spyOn(syncManager, "getCyclesHarvest").mockResolvedValue({ cycles: [], totalCycles: 0, harvestedAt: null } as any);
+    const res = await request(app).get("/api/cycles-harvest");
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it("threads fresh=1 (manual refresh) through to bypass the cache", async () => {
+    const spy = vi.spyOn(syncManager, "getCyclesHarvest").mockResolvedValue({ cycles: [], totalCycles: 0, harvestedAt: null } as any);
+    const res = await request(app).get("/api/cycles-harvest?fresh=1");
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+});
+
 describe("POST /api/mark-as-read", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.45.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.45.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.45.2** — **„Odśwież Dane" pokrywa też Archiwum Cykli (audyt + fix).** Audyt: wszystkie karty
+  statystyk czytają z `stats` (fetchStats), OPRÓCZ `CyclesHarvestCard` — miała własny `useCyclesHarvest`
+  i przycisk „Odśwież Dane" jej NIE przeładowywał (jedyna luka; reszta modułów OK). Fix: `StatsSection`
+  trzyma `refreshTick` — klik odświeża `fetchStats()` I inkrementuje sygnał; karta refetchuje na sygnał
+  (guard pomija mount, silent = bez migania). Dodatkowo świeżość: `/api/cycles-harvest?fresh=1` omija
+  5-min `booksCache` (`getCyclesHarvest(fresh)` → `{cache:!fresh}`), więc ręczny refresh jest tak świeży
+  jak `/api/stats`. +2 testy (routing fresh flag). Uwaga: `useEffectiveConfig` (filie) świadomie poza
+  refreshem — to konfiguracja, nie dane statystyk.
 - **1.45.1** — **Podgląd cyklu: popover w miejscu kliknięcia (fix pozycjonowania) + etykieta „Cykl · N".**
   ROOT CAUSE: `CyclePanel` (`position: fixed`) renderowany WEWNĄTRZ transformowanych przodków
   (framer-motion `motion.div`) → fixed liczył się względem karty, nie viewportu (na długiej liście
@@ -757,14 +765,6 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 
 ## Otwarte pozycje
 
-- **Weryfikacja: „Odśwież dane" pokrywa WSZYSTKIE nowe moduły statystyk archiwum** — DO SPRAWDZENIA.
-  Po dołożeniu kafelków (Oficyny/Serie/Cykle, Oś czasu/dekady, Rynek Vinted, Archiwum Cykli, kafelki
-  Vinted z cyklem) upewnić się, że przycisk „Odśwież dane" faktycznie przeładowuje KAŻDY z nich, a nie
-  tylko część. Sprawdzić w `useSyncManager`/hookach statystyk (`useStats`, `useCyclesHarvest`,
-  `useVintedStored`, market/`useAppConfig`), które źródła są invalidowane/refetchowane po kliknięciu, a
-  które trzymają własny cache (np. modułowy cache `useEffectiveConfig`, ref-cache `useCycle`,
-  `booksCache` w adapterze) i mogą serwować nieświeże dane. Wynik: albo potwierdzić pełne pokrycie, albo
-  domknąć luki (jeden refetch orchestrujący wszystkie moduły). Tani audyt + ewentualny fix.
 - **Sortowanie „Archiwum Cykli" po najmniejszej liczbie książek do przeczytania (easy wins)** — NOWE, do zrobienia.
   Cel: domyślnie na górze cykle, którym najmniej brakuje do ukończenia CZYTANIA („szybkie zwycięstwa") —
   motywacja + naturalna kolejność „domknij prawie skończone". Dziś `aggregateCycleRows` sortuje po

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -318,9 +318,10 @@ export const getCycle = async (req: Request, res: Response) => {
   }
 };
 
-export const getCyclesHarvest = async (_req: Request, res: Response) => {
+export const getCyclesHarvest = async (req: Request, res: Response) => {
   try {
-    res.json(await syncManager.getCyclesHarvest());
+    const fresh = req.query.fresh === "1" || req.query.fresh === "true";
+    res.json(await syncManager.getCyclesHarvest(fresh));
   } catch (error: any) {
     log.error("Cycles harvest read error", { message: error?.message });
     res.status(500).json({ error: error.message || "Błąd odczytu zebranych cykli." });

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.45.1",
+      "version": "1.45.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.45.1",
+  "version": "1.45.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -34,6 +34,11 @@ export const StatsSection: React.FC = () => {
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
   const { markingId, markedIds, markAsRead } = useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats });
 
+  // „Odśwież Dane" odświeża `stats` (fetchStats) ORAZ karty z własnym fetchem
+  // (Archiwum Cykli) — inkrement sygnału zmusza je do świeżego pobrania.
+  const [refreshTick, setRefreshTick] = useState(0);
+  const refreshAll = () => { fetchStats(); setRefreshTick((t) => t + 1); };
+
   // Tryb układania kart (drag&drop) + stan bieżącego przeciągania.
   const [arranging, setArranging] = useState(false);
   const [dragId, setDragId] = useState<string | null>(null);
@@ -119,7 +124,7 @@ export const StatsSection: React.FC = () => {
     { id: "availability", node: <AvailabilityCard stats={stats.availabilityStats} /> },
     { id: "market", node: <MarketCard market={stats.marketStats} /> },
     { id: "publishing", node: <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} /> },
-    { id: "cyclesHarvest", node: <CyclesHarvestCard /> },
+    { id: "cyclesHarvest", node: <CyclesHarvestCard refreshSignal={refreshTick} /> },
     { id: "decades", span2: true, node: <DecadeHistogram decades={stats.decadeStats} /> },
     {
       id: "yearly",
@@ -315,7 +320,7 @@ export const StatsSection: React.FC = () => {
         </button>
 
         <button
-          onClick={fetchStats}
+          onClick={refreshAll}
           disabled={loading}
           className="p-2 hover:bg-slate-900 rounded-lg text-slate-500 hover:text-cyan-400 transition-colors disabled:opacity-50"
           title="Odśwież Dane"

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { motion } from "motion/react";
 import { Layers, ChevronDown, Check, CheckCheck, Package, PackageOpen, Book, CircleDashed, AlertTriangle, Award, ExternalLink, Loader2, ShoppingCart } from "lucide-react";
 import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
@@ -17,9 +17,18 @@ const volStatus = (v: HarvestVolume) => {
  * Archiwum Cykli — zbiorczy widok tomów cykli (wiersze bazy z pola `Cykl`). Pokazuje
  * ile tomów masz / do zdobycia i pozwala oznaczać tomy przeczytane/posiadane w miejscu.
  */
-export const CyclesHarvestCard: React.FC = () => {
-  const { view, loading, error, busyId, toggleSource } = useCyclesHarvest();
+export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refreshSignal }) => {
+  const { view, loading, error, busyId, fetchHarvest, toggleSource } = useCyclesHarvest();
   const [open, setOpen] = useState<string | null>(null);
+
+  // „Odśwież Dane" (StatsSection) inkrementuje refreshSignal → dociągnij świeże cykle
+  // (silent = bez migania kartą, fresh = pomiń cache). Pomiń pierwszy przebieg (mount
+  // już pobiera w hooku), by nie dublować żądania.
+  const firstRun = useRef(true);
+  useEffect(() => {
+    if (firstRun.current) { firstRun.current = false; return; }
+    fetchHarvest(true, true);
+  }, [refreshSignal, fetchHarvest]);
 
   return (
     <motion.div

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -42,11 +42,12 @@ export function useCyclesHarvest() {
   const [busyId, setBusyId] = useState<string | null>(null);
 
   // `silent` = odświeżenie w tle (po oznaczeniu tomu) bez migania całą kartą.
-  const fetchHarvest = useCallback(async (silent = false) => {
+  // `fresh` = pomiń 5-min cache książek na serwerze (ręczne „Odśwież Dane").
+  const fetchHarvest = useCallback(async (silent = false, fresh = false) => {
     if (!silent) setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/cycles-harvest");
+      const res = await fetch(`/api/cycles-harvest${fresh ? "?fresh=1" : ""}`);
       if (!res.ok) throw new Error(`Błąd serwera: ${res.status}`);
       setView(await res.json());
     } catch (e: any) {

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -180,8 +180,9 @@ class SyncManager {
 
   /** Podgląd cyklu dla książki (na żądanie, bez zapisu do bazy). */
   /** Zagregowany widok cykli (z wierszy oznaczonych polem `Cykl`) dla Archiwum. */
-  async getCyclesHarvest() {
-    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
+  /** `fresh` (ręczne „Odśwież Dane") pomija 5-min cache książek → dane jak w /api/stats. */
+  async getCyclesHarvest(fresh = false) {
+    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: !fresh });
     return aggregateCycleRows(books);
   }
 


### PR DESCRIPTION
Audyt: przycisk „Odśwież Dane" w statystykach archiwum przeładowywał wszystkie karty (czytają z `stats` przez `fetchStats`) OPRÓCZ jednej — **`CyclesHarvestCard`** („Archiwum Cykli"), która ma własny hook `useCyclesHarvest`. Klik wołał tylko `fetchStats`, więc karta cykli nigdy się nie odświeżała. To jedyna luka — reszta modułów (Autorzy, Nagrody, Dostępność, Rynek, Oficyny/Serie/Cykle, Dekady, Chronologia, Posiadane, Biblioteki) była pokryta.

**Fix:**
- `StatsSection` trzyma `refreshTick`; przycisk woła `fetchStats()` **i** inkrementuje sygnał. `CyclesHarvestCard` refetchuje na zmianę sygnału (guard pomija mount, silent → bez migania kartą).
- Świeżość: `GET /api/cycles-harvest?fresh=1` omija 5-min `booksCache` (`getCyclesHarvest(fresh)` → `{ cache: !fresh }`), więc ręczny refresh jest tak świeży jak `/api/stats` (czyta bez cache). Ładowanie na mount dalej korzysta z cache.

Poza zakresem (świadomie): `useEffectiveConfig` (filie biblioteczne) — to konfiguracja, nie dane statystyk; „Zidentyfikowane w bibliotekach" ma własny skan on-demand.

+2 testy (routing flagi `fresh`). Suite: 395 zielonych, `tsc` czysty. Bump 1.45.1 → 1.45.2.

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_