### PR TITLE
Archiwum Cykli: sortowanie „Blisko końca" (najmniej do przeczytania) + przełącznik

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.45.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.46.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.46.0** — **Archiwum Cykli: sortowanie „Blisko końca" (najmniej do przeczytania) + przełącznik.**
+  Domyślnie cykle sortowane po `total − read` rosnąco („szybkie zwycięstwa"), ukończone (przeczytane w
+  całości) na dół. Przełącznik trybu w karcie (jak w paczkach Vinted): „Blisko końca" (easywins) vs
+  „Najwięcej braków" (`missing` malejąco — dawne zachowanie). Czysty helper `src/utils/cycleSort.ts`
+  (`sortCycles`, +4 testy); sort client-side (`useMemo`), backend `aggregateCycleRows` bez zmian.
 - **1.45.2** — **„Odśwież Dane" pokrywa też Archiwum Cykli (audyt + fix).** Audyt: wszystkie karty
   statystyk czytają z `stats` (fetchStats), OPRÓCZ `CyclesHarvestCard` — miała własny `useCyclesHarvest`
   i przycisk „Odśwież Dane" jej NIE przeładowywał (jedyna luka; reszta modułów OK). Fix: `StatsSection`
@@ -765,14 +770,6 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 
 ## Otwarte pozycje
 
-- **Sortowanie „Archiwum Cykli" po najmniejszej liczbie książek do przeczytania (easy wins)** — NOWE, do zrobienia.
-  Cel: domyślnie na górze cykle, którym najmniej brakuje do ukończenia CZYTANIA („szybkie zwycięstwa") —
-  motywacja + naturalna kolejność „domknij prawie skończone". Dziś `aggregateCycleRows` sortuje po
-  `missing` (ani posiadane, ani przeczytane) malejąco → najwięcej-do-zdobycia na górze (odwrotnie). Plan:
-  metryka „do przeczytania" = `total − read` (już liczone jako `toRead` w UI); sort rosnąco po `toRead`,
-  ukończone (`toRead===0`) na dół. Rozważyć przełącznik trybu sortu w karcie (jak w paczkach Vinted:
-  „najbliżej ukończenia" vs „najwięcej do zdobycia") zamiast twardej zmiany. Czysto UI/`cycleRows` +
-  testy `aggregateCycleRows`. Tani PR.
 - **Vinted znowu zablokował skaner — alternatywy w zanadrzu** — NOTATKA (Vinted ubił skan z IP Render/datacenter).
   Co JUŻ mamy (obrona pasywna): throttle 3–5 s + jitter na każdej ścieżce, pula User-Agent (rotacja,
   konfigurowalna), keep-alive `https.Agent`, skan oldest-first + wznawialny (rozłożenie w czasie),

--- a/docs/cycles-rows.md
+++ b/docs/cycles-rows.md
@@ -33,6 +33,6 @@ Rozdział egzekwuje `services/bookCategory.ts` (`isAwardBook`/`isCycleVolume`). 
 
 ## 3. Archiwum + dostępność Vinted (`aggregateCycleRows`)
 
-`GET /api/cycles-harvest` → `aggregateCycleRows(books)` (czysty): grupuje wiersze z niepustym `Cykl`, sortuje po `CyklNr`, liczy `owned`/`read`/`missing` („do zdobycia" = ani posiadane, ani przeczytane) i `acquireCost` (suma najtańszych ofert Vinted dla tomów do zdobycia; z blobu `VintedData` przez `parseVintedData`). Karta „Archiwum Cykli" pokazuje tomy + status + pill „🛒 X zł" (link do oferty) + oznaczanie przeczytane/posiadane w miejscu (`toggleSource` → `/api/mark-as-read` / `/api/unmark-as-read`).
+`GET /api/cycles-harvest` → `aggregateCycleRows(books)` (czysty): grupuje wiersze z niepustym `Cykl`, sortuje po `CyklNr`, liczy `owned`/`read`/`missing` („do zdobycia" = ani posiadane, ani przeczytane) i `acquireCost` (suma najtańszych ofert Vinted dla tomów do zdobycia; z blobu `VintedData` przez `parseVintedData`). Karta „Archiwum Cykli" pokazuje tomy + status + pill „🛒 X zł" (link do oferty) + oznaczanie przeczytane/posiadane w miejscu (`toggleSource` → `/api/mark-as-read` / `/api/unmark-as-read`). Kolejność cykli w karcie ustala client-side `sortCycles` (`src/utils/cycleSort.ts`) z przełącznikiem: domyślnie **„Blisko końca"** (`total − read` rosnąco, ukończone na dół — „szybkie zwycięstwa"), alternatywnie **„Najwięcej braków"** (`missing` malejąco).
 
 Ponieważ tomy to wiersze, **skaner Vinted zbiera ich oferty za darmo** (wiersze z pustym `Źródło`); UC1 to tylko wyświetlenie zebranych danych.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.45.2",
+  "version": "1.46.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.45.2",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.45.2",
+      "version": "1.46.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.45.2",
+  "version": "1.46.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/cycleSort.test.ts
+++ b/src/__tests__/cycleSort.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { sortCycles } from "../utils/cycleSort";
+import { HarvestCycle } from "../hooks/useCyclesHarvest";
+
+const cyc = (over: Partial<HarvestCycle> & { cycle: string }): HarvestCycle => ({
+  volumes: [], total: 0, inBase: 0, owned: 0, read: 0, missing: 0, acquirable: 0, ...over,
+});
+
+describe("sortCycles", () => {
+  it("easywins: fewest still-to-read first, completed cycles sink to the bottom", () => {
+    const cycles = [
+      cyc({ cycle: "Trzy", total: 5, read: 2 }),   // toRead 3
+      cyc({ cycle: "Zero", total: 4, read: 4 }),   // done → bottom
+      cyc({ cycle: "Jeden", total: 3, read: 2 }),  // toRead 1
+      cyc({ cycle: "Dwa", total: 6, read: 4 }),    // toRead 2
+    ];
+    const order = sortCycles(cycles, "easywins").map((c) => c.cycle);
+    expect(order).toEqual(["Jeden", "Dwa", "Trzy", "Zero"]);
+  });
+
+  it("easywins: ties on to-read break by fewer to-acquire", () => {
+    const cycles = [
+      cyc({ cycle: "MaWiecej", total: 5, read: 3, owned: 1 }), // toRead 2, toAcquire 4
+      cyc({ cycle: "MaMniej", total: 4, read: 2, owned: 3 }),  // toRead 2, toAcquire 1
+    ];
+    const order = sortCycles(cycles, "easywins").map((c) => c.cycle);
+    expect(order).toEqual(["MaMniej", "MaWiecej"]);
+  });
+
+  it("acquire: most missing first (legacy behavior)", () => {
+    const cycles = [
+      cyc({ cycle: "Malo", missing: 1, total: 3 }),
+      cyc({ cycle: "Duzo", missing: 5, total: 8 }),
+      cyc({ cycle: "Srednio", missing: 3, total: 5 }),
+    ];
+    const order = sortCycles(cycles, "acquire").map((c) => c.cycle);
+    expect(order).toEqual(["Duzo", "Srednio", "Malo"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const cycles = [cyc({ cycle: "B", total: 2, read: 1 }), cyc({ cycle: "A", total: 2, read: 0 })];
+    const snapshot = cycles.map((c) => c.cycle);
+    sortCycles(cycles, "easywins");
+    expect(cycles.map((c) => c.cycle)).toEqual(snapshot);
+  });
+});

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -1,8 +1,14 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { motion } from "motion/react";
 import { Layers, ChevronDown, Check, CheckCheck, Package, PackageOpen, Book, CircleDashed, AlertTriangle, Award, ExternalLink, Loader2, ShoppingCart } from "lucide-react";
 import { useCyclesHarvest, HarvestVolume } from "../../hooks/useCyclesHarvest";
 import { encyclopediaUrl } from "../../utils/encyclopedia";
+import { sortCycles, CycleSortMode } from "../../utils/cycleSort";
+
+const SORTS: { mode: CycleSortMode; label: string }[] = [
+  { mode: "easywins", label: "Blisko końca" },
+  { mode: "acquire", label: "Najwięcej braków" },
+];
 
 const volStatus = (v: HarvestVolume) => {
   if (v.read) return { icon: Check, cls: "text-cyan-400", label: "przeczytana" };
@@ -20,6 +26,8 @@ const volStatus = (v: HarvestVolume) => {
 export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refreshSignal }) => {
   const { view, loading, error, busyId, fetchHarvest, toggleSource } = useCyclesHarvest();
   const [open, setOpen] = useState<string | null>(null);
+  const [sortMode, setSortMode] = useState<CycleSortMode>("easywins");
+  const sortedCycles = useMemo(() => (view ? sortCycles(view.cycles, sortMode) : []), [view, sortMode]);
 
   // „Odśwież Dane" (StatsSection) inkrementuje refreshSignal → dociągnij świeże cykle
   // (silent = bez migania kartą, fresh = pomiń cache). Pomiń pierwszy przebieg (mount
@@ -67,9 +75,24 @@ export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refres
         </p>
       )}
 
+      {view && !loading && view.totalCycles > 1 && (
+        <div className="flex items-center gap-1 p-0.5 rounded-xl bg-slate-900/60 border border-amber-500/15 w-fit">
+          {SORTS.map(({ mode, label }) => (
+            <button
+              key={mode}
+              onClick={() => setSortMode(mode)}
+              className={`px-2.5 py-1 rounded-lg text-[9px] font-bold uppercase tracking-wider transition-colors ${sortMode === mode ? "bg-amber-500/20 text-amber-200 border border-amber-500/30" : "text-slate-500 hover:text-slate-300 border border-transparent"}`}
+              title={mode === "easywins" ? "Najmniej tomów do przeczytania na górze (szybkie zwycięstwa)" : "Najwięcej tomów do zdobycia na górze"}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
       {view && !loading && view.totalCycles > 0 && (
         <div className="space-y-2 max-h-[460px] overflow-y-auto pr-2 custom-scrollbar">
-          {view.cycles.map((c) => {
+          {sortedCycles.map((c) => {
             const isOpen = open === c.cycle;
             // Cykl przeczytany w całości → wygaszony (nic nie zostało do nadrobienia).
             const done = c.total > 0 && c.read === c.total;

--- a/src/utils/cycleSort.ts
+++ b/src/utils/cycleSort.ts
@@ -1,0 +1,28 @@
+import { HarvestCycle } from "../hooks/useCyclesHarvest";
+
+/**
+ * Sortowanie kart „Archiwum Cykli":
+ * - `easywins` — najmniej DO PRZECZYTANIA na górze (`total − read` rosnąco) → „szybkie
+ *   zwycięstwa"; ukończone (przeczytane w całości) spadają na sam dół. Remis: mniej do
+ *   zdobycia, potem nazwa.
+ * - `acquire` — najwięcej BRAKÓW na górze (`missing` = ani posiadane, ani przeczytane) —
+ *   dawne zachowanie (co jeszcze skompletować).
+ * Czysta funkcja (zwraca kopię).
+ */
+export type CycleSortMode = "easywins" | "acquire";
+
+const toRead = (c: HarvestCycle) => c.total - c.read;
+const toAcquire = (c: HarvestCycle) => c.total - c.owned;
+const isDone = (c: HarvestCycle) => c.total > 0 && c.read === c.total;
+
+export function sortCycles(cycles: HarvestCycle[], mode: CycleSortMode): HarvestCycle[] {
+  const copy = [...cycles];
+  if (mode === "easywins") {
+    return copy.sort((a, b) => {
+      // Ukończone zawsze na dół (nic nie zostało do nadrobienia).
+      if (isDone(a) !== isDone(b)) return isDone(a) ? 1 : -1;
+      return toRead(a) - toRead(b) || toAcquire(a) - toAcquire(b) || a.cycle.localeCompare(b.cycle, "pl");
+    });
+  }
+  return copy.sort((a, b) => b.missing - a.missing || b.total - a.total || a.cycle.localeCompare(b.cycle, "pl"));
+}


### PR DESCRIPTION
Karta „Archiwum Cykli" dostaje przełącznik sortowania, domyślnie **„Blisko końca"** — cykle z najmniejszą liczbą tomów do przeczytania (`total − read`) na górze („szybkie zwycięstwa"), ukończone (przeczytane w całości) na dół. Alternatywa **„Najwięcej braków"** zachowuje dawną kolejność (`missing` = ani posiadane, ani przeczytane, malejąco).

- Czysty, testowany helper `src/utils/cycleSort.ts` (`sortCycles`), sort client-side (`useMemo`); backend `aggregateCycleRows` bez zmian.
- Przełącznik jak w paczkach Vinted; pokazuje się tylko przy >1 cyklu.

Weryfikacja wizualna (preview + screenshot obu trybów): „Blisko końca" → Wiedźmin (1 do czytania) … Diuna (4), ukończony na dole; „Najwięcej braków" → re-sort po brakach malejąco.

+4 testy `sortCycles`. Doc `cycles-rows.md` zaktualizowany. Suite: 399 zielonych, `tsc` czysty. Bump 1.45.2 → 1.46.0.

Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_