### PR TITLE
Wszystkie komentarze w kodzie po angielsku

### DIFF
--- a/__tests__/cycleLookup.test.ts
+++ b/__tests__/cycleLookup.test.ts
@@ -56,7 +56,7 @@ describe("CycleLookupService.lookup", () => {
     const notion = makeNotion([
       { id: "a", plTitle: "Tom 1", origTitle: "", zrodlo: ["Posiadam"], awards: [] },
       { id: "b", plTitle: "Tom 2", origTitle: "", zrodlo: ["Przeczytane", "Posiadam"], awards: ["Nagroda Hugo"] },
-      // Tom 3 poza bazą
+      // Tom 3 not in the base
     ]);
     const svc = new CycleLookupService(notion, wiki);
     const view = await svc.lookup("Tom 2", "");
@@ -79,19 +79,19 @@ describe("CycleLookupService.lookup", () => {
     const notion = makeNotion([{ id: "1", plTitle: "T1", origTitle: "", zrodlo: [], awards: [] }]);
     const svc = new CycleLookupService(notion, wiki);
     const view = await svc.lookup("T3", "");
-    expect(view!.unreadBefore).toBe(2); // T1 i T2 nieprzeczytane
+    expect(view!.unreadBefore).toBe(2); // T1 and T2 unread
   });
 
   it("names a nameless (chain-only) cycle by its first volume, not the generic 'Cykl'", async () => {
-    // Łańcuch prev/next BEZ pola |cykl= — dawniej cycleName spadał do „Cykl", przez co
-    // wszystkie bezimienne cykle zlewały się w jedną grupę i były pomijane w żniwach.
+    // A prev/next chain WITHOUT a |cykl= field — cycleName used to fall back to „Cykl", which made
+    // all nameless cycles merge into one group and get skipped in the harvest.
     const wiki = makeWiki({
       "Alfa": page({ następna: "Beta" }),
       "Beta": page({ poprzednia: "Alfa" }),
     });
     const svc = new CycleLookupService(makeNotion([]), wiki);
     const view = await svc.lookup("Beta", "");
-    expect(view!.cycleName).toBe("Alfa"); // tytuł pierwszego tomu, stabilny między kotwicami
+    expect(view!.cycleName).toBe("Alfa"); // the first volume's title, stable between anchors
   });
 
   it("returns null when the book is not part of any cycle", async () => {
@@ -106,6 +106,6 @@ describe("CycleLookupService.lookup", () => {
     await svc.lookup("T1", "");
     const calls = (wiki.fetchPageContent as any).mock.calls.length;
     await svc.lookup("T1", "");
-    expect((wiki.fetchPageContent as any).mock.calls.length).toBe(calls); // brak nowych fetchy
+    expect((wiki.fetchPageContent as any).mock.calls.length).toBe(calls); // no new fetches
   });
 });

--- a/__tests__/notion.adapter.test.ts
+++ b/__tests__/notion.adapter.test.ts
@@ -127,9 +127,9 @@ describe('NotionAdapter', () => {
       mockClient.dataSources.retrieve.mockResolvedValue({ id: 'test-db-id' }); // init
       mockClient.dataSources.query.mockResolvedValue({ results: [page('1')], has_more: false });
 
-      // Pierwszy skan pobiera z Notion...
+      // The first scan fetches from Notion...
       const first = await adapter.getBooksForStats(undefined, undefined, { cache: true });
-      // ...drugi (np. kolejna filia) korzysta z cache — bez nowego query.
+      // ...the second (e.g. another branch) uses the cache — no new query.
       const second = await adapter.getBooksForStats(undefined, undefined, { cache: true });
 
       expect(first).toHaveLength(1);
@@ -142,7 +142,7 @@ describe('NotionAdapter', () => {
       mockClient.dataSources.query.mockResolvedValue({ results: [page('1')], has_more: false });
 
       await adapter.getBooksForStats(undefined, undefined, { cache: true }); // primes cache
-      await adapter.getBooksForStats(); // stats path — musi pobrać świeżo
+      await adapter.getBooksForStats(); // stats path — must fetch fresh
 
       expect(mockClient.dataSources.query).toHaveBeenCalledTimes(2);
     });

--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -6,7 +6,7 @@ import request from "supertest";
 
 process.env.NODE_ENV = "test";
 
-// Sterowalna implementacja runBookSync — każdy test podstawia własną przez holder.
+// A controllable runBookSync implementation — each test injects its own via a holder.
 const h = vi.hoisted(() => ({
   runBook: null as null | ((params: any, send: (e: any) => void, checkCancel: () => boolean) => Promise<void>),
 }));
@@ -38,7 +38,7 @@ describe("SyncManager lifecycle", () => {
     h.runBook = null;
     process.env.NOTION_API_KEY = "test-key";
     process.env.NOTION_DATABASE_ID = "test-db";
-    // Upewnij się, że nie zostało nic z poprzedniego testu
+    // Make sure nothing is left from the previous test
     syncManager.resetSyncState();
   });
 
@@ -56,13 +56,13 @@ describe("SyncManager lifecycle", () => {
     };
 
     const running = syncManager.run("book", vi.fn(), {});
-    // executeTask ustawia currentTask synchronicznie, zanim odda sterowanie
+    // executeTask sets currentTask synchronously, before yielding control
     expect(syncManager.isSyncing).toBe(true);
     expect(syncManager.activeTask).toBe("book");
 
     await expect(syncManager.run("purify", vi.fn())).rejects.toThrow(/już w toku/);
 
-    // stopActiveSync ustawia flagę anulowania widoczną przez token zadania
+    // stopActiveSync sets a cancellation flag visible through the task token
     expect(captured()).toBe(false);
     expect(syncManager.stopActiveSync()).toBe(true);
     expect(captured()).toBe(true);
@@ -70,7 +70,7 @@ describe("SyncManager lifecycle", () => {
     release();
     await running;
 
-    // Blokada zwolniona po zakończeniu zadania
+    // Lock released after the task finishes
     expect(syncManager.isSyncing).toBe(false);
     expect(syncManager.activeTask).toBe(null);
   });
@@ -87,13 +87,13 @@ describe("SyncManager lifecycle", () => {
     expect(syncManager.isSyncing).toBe(true);
 
     syncManager.resetSyncState();
-    // Anulowanie zasygnalizowane, ale blokada TRZYMANA — brak okna równoległych
-    // zapisów: osierocone zadanie wciąż jest właścicielem locka aż do wyjścia.
+    // Cancellation signaled, but the lock is HELD — no window for concurrent
+    // writes: the orphaned task still owns the lock until it exits.
     expect(captured()).toBe(true);
     expect(syncManager.isSyncing).toBe(true);
     await expect(syncManager.run("purify", vi.fn())).rejects.toThrow(/już w toku/);
 
-    release(); // zadanie zauważa anulowanie i wychodzi → finally zwalnia lock
+    release(); // the task notices the cancellation and exits → finally releases the lock
     await running;
     expect(syncManager.isSyncing).toBe(false);
     expect(syncManager.activeTask).toBe(null);
@@ -214,14 +214,14 @@ describe("SSE event stream (POST /api/sync)", () => {
 
     const frames = parseFrames(res.text);
     const types = frames.map((f) => f.type);
-    // Pierwsze zdarzenie to handshake serwera, ostatnie to complete
+    // The first event is the server handshake, the last is complete
     expect(frames[0]).toMatchObject({ type: "status" });
     expect(frames[0].message).toMatch(/Połączono/);
     expect(types).toContain("progress");
     expect(types[types.length - 1]).toBe("complete");
     expect(frames[frames.length - 1].result).toEqual({ success: true });
 
-    // Lock zwolniony po zamknięciu strumienia
+    // Lock released after the stream closes
     expect(syncManager.isSyncing).toBe(false);
   });
 
@@ -229,13 +229,13 @@ describe("SSE event stream (POST /api/sync)", () => {
     let release!: () => void;
     h.runBook = () => new Promise<void>((r) => { release = r; });
 
-    // .then() faktycznie wysyła żądanie supertest (jest leniwe) — trzymamy je w locie
+    // .then() actually sends the supertest request (it's lazy) — we keep it in flight
     const firstDone = request(app)
       .post("/api/sync")
       .send({ awardName: "A", pageTitle: "B" })
       .then((r) => r);
 
-    // Poczekaj aż pierwszy sync przejmie blokadę
+    // Wait until the first sync takes the lock
     await vi.waitFor(() => expect(syncManager.isSyncing).toBe(true));
 
     const second = await request(app).post("/api/sync").send({ awardName: "C", pageTitle: "D" });

--- a/__tests__/wiki.parser.test.ts
+++ b/__tests__/wiki.parser.test.ts
@@ -75,8 +75,8 @@ describe('WikiParser', () => {
     });
 
     it('takes both fields from the latest edition and does not backfill series from an older one', () => {
-      // Decyzja projektowa: najnowsze wydanie jest miarodajne. Wydanie 2022 (Rebis)
-      // ma wydawcę, ale pustą serię — seria z wydania 1989 NIE ma się cofać.
+      // Design decision: the latest edition is authoritative. The 2022 edition (Rebis)
+      // has a publisher but an empty series — the series from the 1989 edition must NOT be backfilled.
       const wikitext = `
         {{tabela wydania
         |informacja1={{infowydanie|wydawca= klubówka |seria= Wielkie Serie SF|isbn= }}

--- a/app.ts
+++ b/app.ts
@@ -3,14 +3,14 @@ import syncRoutes from "./routes/syncRoutes";
 import { basicAuth } from "./middleware/basicAuth";
 
 /**
- * Wiring aplikacji Express (bez nasłuchu). Statyka/Vite i `listen` żyją w
- * `server.ts` (entrypoint), bo są zależne od środowiska; tutaj jest tylko
- * czysty łańcuch middleware + trasy API, łatwy do zamontowania w testach.
+ * Express app wiring (no listening). Static/Vite and `listen` live in
+ * `server.ts` (entrypoint), because they're environment-dependent; here there's
+ * only the pure middleware chain + API routes, easy to mount in tests.
  */
 export const app = express();
 
-// Opt-in Basic Auth (aktywne tylko gdy ustawiono BASIC_AUTH_USER + _PASSWORD).
-// Musi być pierwszy, by chronić także SPA i pliki statyczne.
+// Opt-in Basic Auth (active only when BASIC_AUTH_USER + _PASSWORD are set).
+// Must come first, to protect the SPA and static files too.
 app.use(basicAuth());
 app.use(express.json());
 app.use("/api", syncRoutes);

--- a/controllers/sseStream.ts
+++ b/controllers/sseStream.ts
@@ -6,37 +6,37 @@ import { createLogger } from "../logger";
 const log = createLogger("SSE");
 
 /**
- * Plumbing strumienia SSE dla długich rytuałów — nagłówki, hardening pod proxy,
- * keepalive, anulowanie przy rozłączeniu klienta. Wydzielone z kontrolera, który
- * powinien trzymać tylko parsowanie żądań i delegację; tu żyje transport.
+ * SSE stream plumbing for long rituals — headers, proxy hardening,
+ * keepalive, cancellation on client disconnect. Split out of the controller, which
+ * should hold only request parsing and delegation; the transport lives here.
  */
 
-/** Ustaw nagłówki SSE + hardening pod buforujące proxy; zwróć funkcję `sendEvent`. */
+/** Set SSE headers + hardening for buffering proxies; return a `sendEvent` function. */
 export const setupSSE = (res: Response) => {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache, no-transform");
   res.setHeader("Connection", "keep-alive");
-  // Wyłącz buforowanie po stronie proxy (nginx/Render) — bez tego zdarzenia SSE
-  // nie docierają do klienta na bieżąco i UI "nie reaguje" na hostingu.
+  // Disable proxy-side buffering (nginx/Render) — without it SSE events
+  // don't reach the client in real time and the UI "doesn't react" on hosting.
   res.setHeader("X-Accel-Buffering", "no");
-  // Wyślij nagłówki natychmiast, żeby połączenie było otwarte zanim ruszy zadanie.
+  // Send headers immediately so the connection is open before the task starts.
   res.flushHeaders?.();
-  // Padding ~2KB komentarza: niektóre proxy (Render) buforują odpowiedź do progu
-  // kilku KB zanim zaczną strumieniować — to wypycha bufor i wymusza flush,
-  // dzięki czemu klient dostaje zdarzenia na bieżąco (a nie dopiero na końcu).
+  // ~2KB comment padding: some proxies (Render) buffer the response up to a
+  // few-KB threshold before they start streaming — this fills the buffer and forces a flush,
+  // so the client gets events in real time (not only at the end).
   res.write(`:${" ".repeat(2048)}\n\n`);
   return (data: SyncEvent) => {
-    // Po abort klienta socket bywa `destroyed` przy wciąż `writableEnded === false`
-    // — sam guard writableEnded przepuszczał zapis do martwego socketu, co rzucało
-    // nieobsłużony 'error' na strumieniu. Sprawdzaj też destroyed.
+    // After a client abort the socket can be `destroyed` while still `writableEnded === false`
+    // — a writableEnded-only guard let a write through to a dead socket, which threw
+    // an unhandled 'error' on the stream. Check destroyed too.
     if (!res.writableEnded && !res.destroyed) res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
 };
 
 /**
- * Uruchom zadanie sync jako strumień SSE: guard pojedynczego rytuału, keepalive
- * co 5 s, anulowanie przy rozłączeniu klienta (na `res`, nie `req`) i mapowanie
- * błędu na zdarzenie `error`.
+ * Run a sync task as an SSE stream: single-ritual guard, keepalive
+ * every 5 s, cancellation on client disconnect (on `res`, not `req`) and mapping
+ * an error to an `error` event.
  */
 export const executeSyncTask = async (
   req: Request,
@@ -47,24 +47,24 @@ export const executeSyncTask = async (
   if (syncManager.isSyncing) return res.status(400).json({ error: "Inna synchronizacja jest już w toku." });
 
   const sendEvent = setupSSE(res);
-  // Natychmiastowy sygnał, że połączenie żyje — użytkownik widzi reakcję od razu,
-  // nawet jeśli pierwszy krok zadania (pobranie z wiki) trwa kilka sekund.
+  // Immediate signal that the connection is alive — the user sees a reaction right away,
+  // even if the task's first step (fetching from the wiki) takes a few seconds.
   sendEvent({ type: "status", message: "Połączono z serwerem. Inicjacja rytuału..." });
   log.info("Sync task started", { endpoint: req.path });
 
-  // Częstszy keepalive (5s) utrzymuje strumień "gorący" u proxy, które inaczej
-  // zbierają dane w bufor między rzadkimi zapisami długiego zadania.
+  // A more frequent keepalive (5s) keeps the stream "hot" at proxies that otherwise
+  // collect data into a buffer between the long task's infrequent writes.
   const keepAlive = setInterval(() => {
     if (!res.writableEnded && !res.destroyed) res.write(": keepalive\n\n");
   }, 5000);
 
-  // Rozłączenie klienta (zamknięta karta, utrata sieci) — anuluj zadanie,
-  // żeby osierocony sync nie blokował kolejnych rytuałów godzinami.
-  // UWAGA: nasłuchujemy na res, nie req. Dla POST z ciałem req emituje "close"
-  // po skonsumowaniu ciała przez express.json() — nie przy rozłączeniu klienta —
-  // co anulowało aktywny sync tuż po starcie. res "close" odpala się dopiero gdy
-  // odpowiedź faktycznie się zamyka; przy normalnym końcu writableEnded==true,
-  // więc guard poniżej nie anuluje niczego przez pomyłkę.
+  // Client disconnect (closed tab, network loss) — cancel the task,
+  // so an orphaned sync doesn't block subsequent rituals for hours.
+  // NOTE: we listen on res, not req. For a POST with a body, req emits "close"
+  // after express.json() consumes the body — not on client disconnect —
+  // which cancelled the active sync right after start. res "close" fires only when
+  // the response actually closes; on a normal end writableEnded==true,
+  // so the guard below doesn't cancel anything by mistake.
   res.on("close", () => {
     if (!res.writableEnded) {
       clearInterval(keepAlive);
@@ -73,9 +73,9 @@ export const executeSyncTask = async (
     }
   });
 
-  // Zapis do strumienia (sendEvent/keepalive) ma wyścig check-then-write: reset TCP między
-  // guardem `!writableEnded` a `res.write` emituje 'error'. Bez listenera stałby się to
-  // nieobsłużony uncaughtException. Połknij i zaloguj — `res.on('close')` i tak sprząta.
+  // Writing to the stream (sendEvent/keepalive) has a check-then-write race: a TCP reset between
+  // the `!writableEnded` guard and `res.write` emits 'error'. Without a listener this would become
+  // an unhandled uncaughtException. Swallow and log — `res.on('close')` cleans up anyway.
   res.on("error", (err: any) => {
     log.warn("Błąd strumienia SSE (klient prawdopodobnie się rozłączył).", { endpoint: req.path, error: err?.message });
   });
@@ -94,7 +94,7 @@ export const executeSyncTask = async (
       status: error?.status,
       stack: error?.stack?.split("\n").slice(0, 4).join(" | "),
     });
-    // WikiFetchError niesie userHint z konkretną wskazówką — pokaż ją użytkownikowi.
+    // WikiFetchError carries userHint with a concrete tip — show it to the user.
     const userMessage = error?.userHint
       ? `${error.message}`
       : error?.message || errorMessage;

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -41,7 +41,7 @@ export const getWikiLastUpdate = async (req: Request, res: Response) => {
 export const getDiagnostics = async (req: Request, res: Response) => {
   try {
     const report = await syncManager.runDiagnostics();
-    // Zwróć 200 zawsze — raport sam opisuje status; ułatwia odczyt w przeglądarce.
+    // Always return 200 — the report itself describes the status; makes it easier to read in the browser.
     res.json(report);
   } catch (error: any) {
     log.error("Diagnostics endpoint failed", { message: error?.message });
@@ -63,7 +63,7 @@ export const getConfig = (req: Request, res: Response) => {
   });
 };
 
-/** Efektywna konfiguracja aplikacji (defaulty + nadpisania z Notion) — zakładka „Konfiguracja". */
+/** Effective app configuration (defaults + overrides from Notion) — the „Konfiguracja" tab. */
 export const getAppConfig = async (req: Request, res: Response) => {
   try {
     res.json(await configService.getConfig(req.query.force === "1"));
@@ -72,7 +72,7 @@ export const getAppConfig = async (req: Request, res: Response) => {
   }
 };
 
-/** Zapis konfiguracji: wejście przechodzi clampy w configSchema; składowany jest diff od defaultów. */
+/** Config save: input passes through the clamps in configSchema; the diff from defaults is stored. */
 export const updateAppConfig = async (req: Request, res: Response) => {
   try {
     res.json(await configService.saveConfig(req.body));
@@ -94,8 +94,8 @@ export const getNotionSchema = async (req: Request, res: Response) => {
   }
 };
 
-// Ten endpoint edytuje wyłącznie opcje kolumn select/multi_select — waliduj
-// wejście zanim trafi do Notion (mutacja schematu jest operacją uprzywilejowaną).
+// This endpoint edits only select/multi_select column options — validate
+// the input before it reaches Notion (a schema mutation is a privileged operation).
 const ALLOWED_SCHEMA_TYPES = new Set(["select", "multi_select"]);
 
 export const updateNotionSchema = async (req: Request, res: Response) => {
@@ -134,8 +134,8 @@ const stopSyncTask = (res: Response, message: string) => {
   }
 };
 
-// Zatrzymanie jest globalne (anuluje aktywne zadanie, jakiekolwiek by nie było) —
-// handlery różnią się wyłącznie komunikatem. Generujemy je z fabryki.
+// Stopping is global (cancels the active task, whatever it is) —
+// the handlers differ only by message. We generate them from a factory.
 const makeStopHandler = (message: string) =>
   (_req: Request, res: Response) => stopSyncTask(res, message);
 
@@ -164,8 +164,8 @@ export const runSync = async (req: Request, res: Response) => {
   );
 };
 
-// Rytuały bez parametrów żądania mają identyczny handler — różnią się tylko
-// nazwą zadania i etykietą błędu. Generujemy je z tabeli zamiast powielać.
+// Rituals without request parameters have an identical handler — they differ only in
+// the task name and error label. We generate them from a table instead of duplicating.
 const makeSyncHandler = (task: SyncTaskName, errorLabel: string) =>
   async (req: Request, res: Response) => {
     await executeSyncTask(req, res, (sendEvent) => syncManager.run(task, sendEvent), errorLabel);
@@ -185,9 +185,9 @@ export const stopPurifySync = makeStopHandler("Zatrzymano rytuał puryfikacji.")
 
 export const stopSchemaSync = makeStopHandler("Zatrzymano inicjalizację schematu.");
 
-// Znaczniki „Źródło", które wolno dopisać z tego endpointu. Ograniczone do
-// znanego zbioru — endpoint jedynie oznacza pozycję (przeczytana / dostępna w
-// danej filii), nie może wstrzykiwać dowolnych tagów do bazy Notion.
+// „Źródło" tags that may be added from this endpoint. Limited to
+// a known set — the endpoint only marks an entry (read / available at
+// a given branch), it cannot inject arbitrary tags into the Notion base.
 const ALLOWED_SOURCE_TAGS = new Set(["Przeczytane", "Posiadam", "Biblioteka", "Biblioteka 9"]);
 
 export const markAsRead = async (req: Request, res: Response) => {
@@ -209,8 +209,8 @@ export const markAsRead = async (req: Request, res: Response) => {
 };
 
 /**
- * Zapis ręcznych kluczy porządku regału (precyzyjny drag&drop). Partia mała
- * (1 wpis + ewentualna renumeracja remisów roku) — twardy limit 40 chroni Notion.
+ * Saving manual shelf-order keys (precise drag&drop). Small batch
+ * (1 entry + optional renumbering of year ties) — a hard limit of 40 protects Notion.
  */
 export const updateShelfOrders = async (req: Request, res: Response) => {
   try {
@@ -255,7 +255,7 @@ export const checkVintedAvailability = async (req: Request, res: Response) => {
     return res.status(400).json({ error: "Brak kluczy API Notion." });
   }
 
-  // Wznawianie: front może poprosić o pominięcie książek skanowanych w ostatnich N godzin.
+  // Resume: the frontend can ask to skip books scanned within the last N hours.
   const skipRaw = req.body?.skipScannedWithinHours;
   const skipScannedWithinHours = typeof skipRaw === "number" && skipRaw > 0 ? Math.min(skipRaw, 24 * 365) : undefined;
 
@@ -273,8 +273,8 @@ export const resolveVintedSellers = async (req: Request, res: Response) => {
   if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
     return res.status(400).json({ error: "Brak kluczy API Notion." });
   }
-  // Bez capu domyślnie — resolucja jest przyrostowa i wznawialna, więc jeden przebieg
-  // ustala wszystkie brakujące, ile zdąży. Opcjonalny `cap` z body ogranicza przebieg.
+  // No cap by default — resolution is incremental and resumable, so one pass
+  // resolves all the missing ones it can. An optional `cap` from the body limits the pass.
   const capRaw = req.body?.cap;
   const cap = typeof capRaw === "number" && capRaw > 0 ? capRaw : undefined;
 
@@ -300,9 +300,9 @@ export const getVintedStored = async (_req: Request, res: Response) => {
 };
 
 /**
- * Podgląd cyklu dla książki (Skryptorium) — pobiera stronę wiki na żądanie, buduje
- * listę tomów i krzyżuje z bazą. NIE zapisuje niczego do Notion. 404 = książka nie
- * jest w cyklu / brak danych na wiki.
+ * Cycle preview for a book (Skryptorium) — fetches the wiki page on demand, builds
+ * the volume list and cross-refs the base. Does NOT write anything to Notion. 404 = the book
+ * is not in a cycle / no data on the wiki.
  */
 export const getCycle = async (req: Request, res: Response) => {
   const title = typeof req.query.title === "string" ? req.query.title.trim() : "";

--- a/logger.ts
+++ b/logger.ts
@@ -1,5 +1,5 @@
-// Prosty strukturalny logger. Jedna linia na wpis, czytelna w logach Rendera,
-// z komponentem, poziomem i opcjonalnym kontekstem (bez sekretów).
+// Simple structured logger. One line per entry, readable in Render's logs,
+// with component, level and optional context (no secrets).
 
 type Level = "info" | "warn" | "error";
 
@@ -10,7 +10,7 @@ const LEVEL_TAG: Record<Level, string> = {
 };
 
 function emit(level: Level, component: string, message: string, context?: Record<string, unknown>) {
-  // Nie logujemy sekretów — kontekst powinien zawierać tylko metadane.
+  // We don't log secrets — context should contain only metadata.
   const parts = [`[${LEVEL_TAG[level]}]`, `[${component}]`, message];
   let line = parts.join(" ");
   if (context && Object.keys(context).length > 0) {
@@ -39,17 +39,17 @@ export function createLogger(component: string): Logger {
 }
 
 /**
- * Klasyfikuje błąd żądania HTTP (axios/network) do zrozumiałej kategorii.
- * Używane, by odróżnić blokadę IP/Cloudflare od zwykłego timeoutu czy
- * błędu aplikacyjnego — kluczowe przy diagnozie "sync nie działa".
+ * Classifies an HTTP request error (axios/network) into an understandable category.
+ * Used to tell an IP/Cloudflare block apart from a plain timeout or an
+ * application error — crucial when diagnosing "sync doesn't work".
  */
 export type ErrorClass =
-  | "ip_blocked"        // 403 / Cloudflare challenge — najczęstsza przyczyna na hostingu
+  | "ip_blocked"        // 403 / Cloudflare challenge — most common cause on hosting
   | "rate_limited"      // 429
-  | "server_error"      // 5xx po stronie wiki
-  | "timeout"           // przekroczony czas / zerwane połączenie
-  | "dns"               // nie rozwiązano hosta
-  | "http_error"        // inny status HTTP
+  | "server_error"      // 5xx on the wiki side
+  | "timeout"           // timed out / dropped connection
+  | "dns"               // host not resolved
+  | "http_error"        // other HTTP status
   | "unknown";
 
 export function classifyHttpError(error: any): { class: ErrorClass; status?: number; code?: string; hint: string; snippet?: string } {

--- a/middleware/basicAuth.ts
+++ b/middleware/basicAuth.ts
@@ -11,13 +11,13 @@ function safeEqual(a: string, b: string): boolean {
 /**
  * Opt-in HTTP Basic Auth.
  *
- * Aktywne tylko gdy ustawiono OBIE zmienne BASIC_AUTH_USER i
- * BASIC_AUTH_PASSWORD — w przeciwnym razie middleware przepuszcza wszystko
- * (zachowanie domyślne, brak lockoutu istniejącego wdrożenia).
- * `/api/health` jest zawsze otwarte (health check hostingu).
+ * Active only when BOTH BASIC_AUTH_USER and BASIC_AUTH_PASSWORD are set —
+ * otherwise the middleware lets everything through
+ * (default behavior, no lockout of an existing deployment).
+ * `/api/health` is always open (hosting health check).
  *
- * Chroni cały serwis (SPA + API): przeglądarka pokazuje natywny prompt, a
- * same-origin `fetch` z SPA automatycznie dołącza poświadczenia po zalogowaniu.
+ * Protects the whole service (SPA + API): the browser shows the native prompt, and
+ * same-origin `fetch` from the SPA automatically attaches credentials after login.
  */
 export function basicAuth(getEnv: () => NodeJS.ProcessEnv = () => process.env) {
   return (req: Request, res: Response, next: NextFunction) => {
@@ -25,10 +25,10 @@ export function basicAuth(getEnv: () => NodeJS.ProcessEnv = () => process.env) {
     const user = env.BASIC_AUTH_USER;
     const pass = env.BASIC_AUTH_PASSWORD;
 
-    // Opt-in: bez skonfigurowanych poświadczeń nie wymuszamy autoryzacji.
+    // Opt-in: without configured credentials we don't enforce authorization.
     if (!user || !pass) return next();
 
-    // Health check musi być osiągalny bez logowania (monitoring hostingu).
+    // The health check must be reachable without logging in (hosting monitoring).
     if (req.path === "/api/health") return next();
 
     const header = req.headers.authorization || "";

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -4,11 +4,11 @@ import { sanitizeNotionString, sanitizeNotionTag } from "./utils";
 import { NotionPage, NotionBook } from "./src/types";
 import { mapPageToBook } from "./notionMapper";
 
-// Krótki cache pełnej listy książek dla ścieżek TYLKO-DO-ODCZYTU skanerów
-// (biblioteka „Skanuj wszystkie" odpytywałaby Notion raz na filię). Cache jest
-// opt-in (`{ cache: true }`), więc statystyki (`/api/stats`) zawsze czytają
-// świeże dane, a każdy zapis książki go unieważnia. TTL to tylko bezpiecznik na
-// edycje spoza aplikacji.
+// Short cache of the full book list for the scanners' READ-ONLY paths
+// (the library „Skanuj wszystkie" would query Notion once per branch). The cache is
+// opt-in (`{ cache: true }`), so stats (`/api/stats`) always read fresh data, and
+// every book write invalidates it. The TTL is only a safeguard against edits made
+// outside the app.
 const BOOKS_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export class NotionAdapter {
@@ -22,17 +22,17 @@ export class NotionAdapter {
     this.notion = new Client({ auth: apiKey });
   }
 
-  /** Unieważnia cache listy książek — wołane po każdym zapisie zmieniającym książki. */
+  /** Invalidates the book-list cache — called after every write that changes books. */
   private invalidateBooksCache(): void {
     this.booksCache = null;
   }
 
   async init(): Promise<void> {
     if (this.actualDataSourceId) return; // Already initialized
-    // Deduplikuj równoległe wywołania init() — jedna inicjalizacja w locie
+    // Deduplicate concurrent init() calls — a single in-flight initialization
     if (!this.initPromise) {
       this.initPromise = this.doInit().catch((err) => {
-        this.initPromise = null; // pozwól spróbować ponownie po błędzie
+        this.initPromise = null; // allow retrying after an error
         throw err;
       });
     }
@@ -41,7 +41,7 @@ export class NotionAdapter {
 
   private async doInit(): Promise<void> {
     try {
-      // Try as data_source first (withRetry nie ponawia 404 — tylko 429/5xx/sieć)
+      // Try as data_source first (withRetry doesn't retry 404 — only 429/5xx/network)
       await withRetry(() => (this.notion as any).dataSources.retrieve({ data_source_id: this.databaseId }));
       this.actualDataSourceId = this.databaseId;
       this.isDataSource = true;
@@ -58,7 +58,7 @@ export class NotionAdapter {
           this.isDataSource = false;
         }
       } catch (dbError: any) {
-        // "Brak dostępu" tylko przy prawdziwym 404 — timeout to nie problem uprawnień
+        // "No access" only on a genuine 404 — a timeout isn't a permissions problem
         if (dbError?.code === "object_not_found" || dbError?.status === 404) {
           throw new Error(`Nie można znaleźć bazy danych ani źródła danych o ID: ${this.databaseId}. Upewnij się, że integracja ma dostęp.`);
         }
@@ -68,9 +68,9 @@ export class NotionAdapter {
   }
 
   // --- Dual-mode helpers ---
-  // Notion udostępnia bazę jako "data source" (nowe API) lub klasyczną "database".
-  // Te trzy helpery kapsułkują rozgałęzienie isDataSource, które wcześniej było
-  // powielone w ~7 metodach.
+  // Notion exposes the base as a "data source" (new API) or a classic "database".
+  // These three helpers encapsulate the isDataSource branching, which was previously
+  // duplicated across ~7 methods.
 
   private async retrieveSource(id: string): Promise<any> {
     return this.isDataSource
@@ -114,10 +114,10 @@ export class NotionAdapter {
   }
 
   /**
-   * Zapis ręcznych kluczy porządku regału (kolumna „ShelfOrder", number) dla partii
-   * książek — precyzyjny drag&drop wysyła 1 wpis (wstawiona), a przy renumeracji
-   * remisów kilka. Kolumna tworzona przy pierwszym zapisie. Sekwencyjnie (nie
-   * równolegle) — partie są małe, a rate-limit Notion wrażliwy na bursty.
+   * Writes manual shelf ordering keys (column „ShelfOrder", number) for a batch of
+   * books — precise drag&drop sends 1 entry (the inserted one), and several when
+   * renumbering ties. The column is created on first write. Sequential (not parallel)
+   * — batches are small, and Notion's rate limit is sensitive to bursts.
    */
   async setShelfOrders(entries: { pageId: string; order: number }[]): Promise<void> {
     await this.init();
@@ -131,14 +131,14 @@ export class NotionAdapter {
     this.invalidateBooksCache();
   }
 
-  /** Nazwa kolumny-nośnika konfiguracji aplikacji (blob JSON żyje w jej OPISIE, nie w wierszach). */
+  /** Name of the column that carries the app config (the JSON blob lives in its DESCRIPTION, not in rows). */
   private static readonly APP_CONFIG_COLUMN = "AppConfig";
 
   /**
-   * Odczyt blobu konfiguracji z opisu kolumny `AppConfig`. Brak kolumny/opisu → null
-   * (aplikacja działa na defaultach z `configSchema`). Opis kolumny wybrano zamiast
-   * wiersza-sentinela, bo rytuały (puryfikacja/integralność/LP) iterują po wszystkich
-   * wierszach i sentinel by w nie wyciekał.
+   * Reads the config blob from the `AppConfig` column's description. Missing column/description → null
+   * (the app runs on defaults from `configSchema`). The column description was chosen over a
+   * sentinel row, because the rituals (purification/integrity/LP) iterate over all rows
+   * and a sentinel would leak into them.
    */
   async getAppConfigRaw(): Promise<string | null> {
     const schema = await this.getSchema();
@@ -146,7 +146,7 @@ export class NotionAdapter {
     return typeof desc === "string" && desc.trim() ? desc : null;
   }
 
-  /** Zapis blobu konfiguracji do opisu kolumny `AppConfig` (tworzy kolumnę przy pierwszym zapisie). */
+  /** Writes the config blob to the `AppConfig` column's description (creates the column on first write). */
   async saveAppConfigRaw(json: string): Promise<void> {
     await this.init();
     await this.updateSource(this.actualDataSourceId!, {
@@ -171,8 +171,8 @@ export class NotionAdapter {
 
       hasMore = response.has_more;
       nextCursor = response.next_cursor ?? undefined;
-      // Zabezpieczenie: has_more === true bez kursora oznaczałoby ponowne pobranie
-      // strony 1 od początku w kółko (i podwójne liczenie). Przerwij zamiast zawisnąć.
+      // Safeguard: has_more === true without a cursor would mean re-fetching
+      // page 1 from the start over and over (and double counting). Break instead of hanging.
       if (hasMore && !nextCursor) break;
       if (onProgress) onProgress(allBooks.length);
     }
@@ -185,17 +185,17 @@ export class NotionAdapter {
     checkCancellation?: () => boolean,
     opts?: { cache?: boolean },
   ): Promise<NotionBook[]> {
-    // Ta sama pętla co queryAllBooks — jedna implementacja, żeby skany
-    // biblioteki/Vinted też dało się anulować w fazie pobierania z Notion.
-    // `cache: true` współdzieli jedno pobranie między kolejnymi skanami
-    // (np. obie filie w „Skanuj wszystkie") — statystyki wołają bez cache.
+    // Same loop as queryAllBooks — one implementation, so library/Vinted scans
+    // can also be cancelled during the Notion fetch phase.
+    // `cache: true` shares a single fetch across successive scans
+    // (e.g. both branches in „Skanuj wszystkie") — stats call without cache.
     if (opts?.cache && this.booksCache && this.booksCache.expiresAt > Date.now()) {
       return this.booksCache.data;
     }
 
     const books = await this.queryAllBooks(onProgress, checkCancellation);
 
-    // Nie zapisuj listy urwanej przez anulowanie — byłaby niepełna.
+    // Don't cache a list cut short by cancellation — it would be incomplete.
     const cancelled = checkCancellation ? checkCancellation() : false;
     if (opts?.cache && !cancelled) {
       this.booksCache = { data: books, expiresAt: Date.now() + BOOKS_CACHE_TTL_MS };
@@ -244,10 +244,10 @@ export class NotionAdapter {
   }
 
   /**
-   * Wspólny rdzeń mutacji pola multi_select: pobiera aktualne tagi, przepuszcza je
-   * przez `transform` i zapisuje wynik. `transform` zwraca nową listę tagów albo
-   * `null` = brak zmiany (pomiń zapis i inwalidację cache). Add/remove to cienkie
-   * przypadki na tym rdzeniu — jedno miejsce na retrieve→mutate→update.
+   * Shared core for mutating a multi_select field: fetches the current tags, passes them
+   * through `transform` and writes the result. `transform` returns a new tag list or
+   * `null` = no change (skip the write and cache invalidation). Add/remove are thin
+   * cases on top of this core — one place for retrieve→mutate→update.
    */
   private async mutateMultiSelect(
     pageId: string,
@@ -264,7 +264,7 @@ export class NotionAdapter {
 
     const currentTags = prop.multi_select.map((t: any) => ({ name: t.name }));
     const nextTags = transform(currentTags);
-    if (nextTags === null) return; // no-op: tag już jest / nie było
+    if (nextTags === null) return; // no-op: tag already present / was absent
 
     await withRetry(() => this.notion.pages.update({
       page_id: pageId,
@@ -273,13 +273,13 @@ export class NotionAdapter {
     this.invalidateBooksCache();
   }
 
-  /** Dopisuje znacznik do pola multi_select (pomija, jeśli już jest). */
+  /** Appends a tag to a multi_select field (skips if already present). */
   async addTagToMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
     return this.mutateMultiSelect(pageId, propertyName, (tags) =>
       tags.some((t) => t.name === tag) ? null : [...tags, { name: tag }]);
   }
 
-  /** Usuwa znacznik z pola multi_select (odwrotność `addTagToMultiSelect`). */
+  /** Removes a tag from a multi_select field (inverse of `addTagToMultiSelect`). */
   async removeTagFromMultiSelect(pageId: string, propertyName: string, tag: string): Promise<void> {
     return this.mutateMultiSelect(pageId, propertyName, (tags) => {
       const next = tags.filter((t) => t.name !== tag);
@@ -316,9 +316,9 @@ export class NotionAdapter {
   }
 
   /**
-   * Zapis blobu składowanych wyników Vinted do pola „VintedData" (rich_text). Tekst
-   * dzielony na segmenty ≤2000 znaków (limit Notion) — mapper skleja je z powrotem
-   * przez `join("")`. NIE używa `buildPropertyValue` (obcina do 2000 i psułoby JSON).
+   * Writes the stored Vinted results blob to the „VintedData" field (rich_text). The text
+   * is split into segments ≤2000 chars (Notion's limit) — the mapper joins them back
+   * with `join("")`. Does NOT use `buildPropertyValue` (it truncates to 2000 and would corrupt the JSON).
    */
   async saveVintedData(pageId: string, text: string): Promise<void> {
     const chunks: { text: { content: string } }[] = [];
@@ -339,9 +339,9 @@ export class NotionAdapter {
       ? { type: "data_source_id", data_source_id: this.actualDataSourceId! }
       : { type: "database_id", database_id: this.actualDataSourceId! };
 
-    // idempotent=false: pages.create tworzy nowy wiersz — po błędzie sieci/5xx
-    // ponowienie mogłoby zdublować książkę (błąd resetu socketu po zapisie).
-    // 429 nadal jest ponawiane (żądanie odrzucone przed przetworzeniem).
+    // idempotent=false: pages.create creates a new row — after a network/5xx error
+    // a retry could duplicate the book (socket reset error after the write).
+    // 429 is still retried (request rejected before processing).
     const response = await withRetry(() => this.notion.pages.create({
       parent: parent,
       properties

--- a/notionMapper.ts
+++ b/notionMapper.ts
@@ -1,12 +1,12 @@
 import { NotionPage, NotionProperty, NotionPageProperties, NotionBook } from "./src/types";
 
 /**
- * Mapowanie strony Notion → domenowy `NotionBook`. To logika domenowa (nie czyste
- * opakowanie API), więc mieszka poza `NotionAdapter` — czysta funkcja, testowalna
- * bez klienta Notion. Adapter tylko pobiera strony i woła `mapPageToBook`.
+ * Maps a Notion page → domain `NotionBook`. This is domain logic (not a pure
+ * API wrapper), so it lives outside `NotionAdapter` — a pure function, testable
+ * without a Notion client. The adapter only fetches pages and calls `mapPageToBook`.
  */
 
-/** Pobierz właściwość po nazwie, case-insensitive (Notion bywa niespójny w wielkości liter). */
+/** Get a property by name, case-insensitive (Notion is sometimes inconsistent about casing). */
 function getProp(props: NotionPageProperties, name: string): NotionProperty | undefined {
   if (props[name]) return props[name];
   const lowerName = name.toLowerCase();
@@ -16,7 +16,7 @@ function getProp(props: NotionPageProperties, name: string): NotionProperty | un
   return undefined;
 }
 
-/** Wyciągnij tekst z dowolnego typu właściwości Notion. */
+/** Extract text from any Notion property type. */
 function getPlainText(prop?: NotionProperty): string {
   if (!prop) return "";
   const type = prop.type;
@@ -30,7 +30,7 @@ function getPlainText(prop?: NotionProperty): string {
   return "";
 }
 
-/** Wartości multi_select (lub pojedynczy select) jako lista nazw. */
+/** multi_select values (or a single select) as a list of names. */
 function multiSelectNames(prop?: NotionProperty): string[] {
   if (prop?.type === "multi_select") return prop.multi_select?.map((x) => x.name) || [];
   if (prop?.type === "select" && prop.select?.name) return [prop.select.name];
@@ -64,24 +64,24 @@ export function mapPageToBook(page: NotionPage): NotionBook {
   const currentWydawnictwo = getPlainText(getProp(props, "Wydawnictwo"));
   const currentSeria = getPlainText(getProp(props, "Seria"));
   const currentCzesccyklu = getProp(props, "Część cyklu")?.checkbox || false;
-  // Kategoria wiersza: „Nagroda" (domyślnie, gdy pusto) vs „Tom cyklu" (poboczny tom
-  // cyklu dodany rytuałem żniw). Rozdziela pozycje nagrodowe od reszty.
+  // Row category: „Nagroda" (default, when empty) vs „Tom cyklu" (sibling cycle
+  // volume added by the harvest ritual). Separates award entries from the rest.
   const kategoria = getProp(props, "Kategoria")?.select?.name || undefined;
   const lp = getPlainText(getProp(props, "Lp"));
 
   const awards = multiSelectNames(getProp(props, "Nagroda"));
   const zrodlo = multiSelectNames(getProp(props, "Źródło"));
 
-  // Blob składowanych wyników Vinted (rich_text; wiele segmentów jest sklejanych w getPlainText).
+  // Stored Vinted results blob (rich_text; multiple segments are joined in getPlainText).
   const vintedData = getPlainText(getProp(props, "VintedData")) || undefined;
 
-  // Grupowanie cyklu: nazwa cyklu (rich_text) + pozycja w cyklu (number). Ustawiane
-  // rytuałem żniw na kotwicy nagrodowej ORAZ na wierszach pobocznych tomów.
+  // Cycle grouping: cycle name (rich_text) + position within the cycle (number). Set
+  // by the harvest ritual on the award anchor AND on the sibling volume rows.
   const cykl = getPlainText(getProp(props, "Cykl")) || undefined;
   const cyklNrProp = getProp(props, "CyklNr");
   const cyklNr = cyklNrProp?.type === "number" && typeof cyklNrProp.number === "number" ? cyklNrProp.number : undefined;
 
-  // Ręczny klucz porządku na regale (number; brak/null → undefined = sort po roku).
+  // Manual shelf ordering key (number; missing/null → undefined = sort by year).
   const shelfOrderProp = getProp(props, "ShelfOrder");
   const shelfOrder = shelfOrderProp?.type === "number" && typeof shelfOrderProp.number === "number" ? shelfOrderProp.number : undefined;
 

--- a/retry.ts
+++ b/retry.ts
@@ -15,13 +15,13 @@ export async function withRetry<T>(
         throw error;
       }
 
-      // 429 (rate limit) oznacza, że żądanie zostało ODRZUCONE przed przetworzeniem
-      // — ponowienie jest zawsze bezpieczne, nawet dla operacji nieidempotentnych.
+      // 429 (rate limit) means the request was REJECTED before processing
+      // — retrying is always safe, even for non-idempotent operations.
       const isRateLimit = error?.status === 429 || error?.response?.status === 429;
 
-      // 5xx i błędy sieci (socket hang up itd.) mogą zostawić żądanie CZĘŚCIOWO
-      // przetworzone: dla operacji nieidempotentnych (np. pages.create) ponowienie
-      // tworzy duplikat. Ponawiaj je tylko, gdy wołający deklaruje idempotent=true.
+      // 5xx and network errors (socket hang up etc.) may leave a request PARTIALLY
+      // processed: for non-idempotent operations (e.g. pages.create) a retry
+      // creates a duplicate. Retry them only when the caller declares idempotent=true.
       const isServerError = idempotent && (error?.status >= 500 || error?.response?.status >= 500);
 
       const transientCodes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED', 'EPIPE', 'ENOTFOUND', 'EAI_AGAIN', 'ERR_HTTP2_GOAWAY_SESSION', 'ERR_STREAM_WRITE_AFTER_END'];
@@ -33,14 +33,14 @@ export async function withRetry<T>(
                                      )));
 
       if (!isRateLimit && !isServerError && !isTransientNetworkError) {
-        // Nie ponawiaj błędów klienta (4xx poza 429) ani — dla operacji
-        // nieidempotentnych — błędów 5xx/sieci, które mogły już zapisać dane.
+        // Don't retry client errors (4xx other than 429) nor — for non-idempotent
+        // operations — 5xx/network errors that may have already written data.
         throw error;
       }
 
       let waitTime = delayMs * Math.pow(backoffFactor, attempt - 1);
 
-      // Notion (i inne API) przy 429 podaje Retry-After — uszanuj go zamiast zgadywać
+      // Notion (and other APIs) send Retry-After on 429 — respect it instead of guessing
       if (isRateLimit) {
         const retryAfter = error?.headers?.['retry-after'] ?? error?.response?.headers?.['retry-after'];
         const retryAfterSec = parseFloat(retryAfter);

--- a/scrapingClient.ts
+++ b/scrapingClient.ts
@@ -1,17 +1,17 @@
 import https from "https";
 
 /**
- * Wspólna infrastruktura dla skanerów scrapujących HTML (Biblioteka OPAC, Vinted).
- * Adaptery i serwisy sync korzystają z Notion/Wiki API; skanery uderzają w publiczne
- * strony HTML, więc potrzebują rotacji User-Agent i keep-alive agenta HTTPS.
+ * Shared infrastructure for the HTML-scraping scanners (library OPAC, Vinted).
+ * Adapters and sync services use the Notion/Wiki API; the scanners hit public
+ * HTML pages, so they need User-Agent rotation and a keep-alive HTTPS agent.
  */
 
-// Pula bieżących wersji przeglądarek (stan: sierpień 2026 — Chrome 151/152,
-// Firefox 154, Edge 151, Safari 26). Anty-boty punktują przestarzałe UA (rozjazd
-// z resztą fingerprintu), więc odświeżaj pulę co kilka miesięcy. Format ma znaczenie:
-// Chrome/Edge raportują zredukowane wersje x.0.0.0, Safari 26 zamrożone Version/26.0,
-// a tokeny platform (Windows NT 10.0, Mac OS X 10_15_7 / 10.15) są celowo zamrożone
-// przez przeglądarki — nie „unowocześniać" ich.
+// Pool of current browser versions (as of: August 2026 — Chrome 151/152,
+// Firefox 154, Edge 151, Safari 26). Anti-bots penalize outdated UAs (mismatch
+// with the rest of the fingerprint), so refresh the pool every few months. The format matters:
+// Chrome/Edge report reduced versions x.0.0.0, Safari 26 a frozen Version/26.0,
+// and the platform tokens (Windows NT 10.0, Mac OS X 10_15_7 / 10.15) are intentionally frozen
+// by the browsers — don't „modernize" them.
 const USER_AGENTS = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
@@ -22,26 +22,26 @@ const USER_AGENTS = [
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15'
 ];
 
-/** Losowy UA z przekazanej puli (konfig `scraping.userAgents`); bez argumentu — z wbudowanej. */
+/** Random UA from the passed pool (config `scraping.userAgents`); without an argument — from the built-in one. */
 export const getRandomUserAgent = (pool?: string[]) => {
   const list = pool && pool.length > 0 ? pool : USER_AGENTS;
   return list[Math.floor(Math.random() * list.length)];
 };
 
 export interface ScrapingAgentOptions {
-  /** Maks. równoległych połączeń do jednego hosta (domyślnie 5). */
+  /** Max concurrent connections to a single host (default 5). */
   maxSockets?: number;
   /**
-   * Domyślnie `true` (pełna weryfikacja TLS). Ustaw `false` TYLKO dla hostów,
-   * które błędnie konfigurują łańcuch certyfikatów (np. nie wysyłają certyfikatu
-   * pośredniego → Node zgłasza „unable to verify the first certificate"). Skanery
-   * czytają WYŁĄCZNIE publiczne dane (katalog biblioteki) i nie wysyłają żadnych
-   * sekretów, więc ryzyko jest znikome; mimo to trzymaj to per-host, nie globalnie.
+   * Defaults to `true` (full TLS verification). Set `false` ONLY for hosts
+   * that misconfigure their certificate chain (e.g. don't send the intermediate
+   * certificate → Node reports „unable to verify the first certificate"). The scanners
+   * read EXCLUSIVELY public data (the library catalog) and don't send any
+   * secrets, so the risk is negligible; still, keep it per-host, not global.
    */
   rejectUnauthorized?: boolean;
 }
 
-/** Keep-alive agent współdzielony przez skanery HTML. */
+/** Keep-alive agent shared by the HTML scanners. */
 export const createScrapingAgent = (opts: ScrapingAgentOptions = {}) => new https.Agent({
   keepAlive: true,
   keepAliveMsecs: 1000,

--- a/server.ts
+++ b/server.ts
@@ -8,9 +8,9 @@ dotenv.config();
 
 const serverLog = createLogger("Server");
 
-// Re-eksport dla zgodności wstecznej — kontrolery importują `syncManager` z
-// ./syncManager, ale testy i inne moduły nadal mogą sięgać po { app, syncManager }
-// przez ./server.
+// Re-export for backward compatibility — controllers import `syncManager` from
+// ./syncManager, but tests and other modules can still reach for { app, syncManager }
+// via ./server.
 export { app } from "./app";
 export { syncManager } from "./syncManager";
 

--- a/services/__tests__/configService.test.ts
+++ b/services/__tests__/configService.test.ts
@@ -34,7 +34,7 @@ describe("ConfigService", () => {
     await svc.saveConfig({ ui: { shelfRowsPerPage: 8 } });
     const stored = JSON.parse(notion.saveAppConfigRaw.mock.calls[0][0]);
     expect(stored.ui.shelfRowsPerPage).toBe(8);
-    expect(stored.library).toBeUndefined(); // niezmienione sekcje nie są składowane
+    expect(stored.library).toBeUndefined(); // unchanged sections are not stored
   });
 
   it("stores empty string when nothing differs from defaults", async () => {

--- a/services/__tests__/cycleHarvestService.test.ts
+++ b/services/__tests__/cycleHarvestService.test.ts
@@ -45,9 +45,9 @@ describe("CycleHarvestService.runCycleHarvest", () => {
 
     const events = await collect();
 
-    // Tom 1 istnieje jako wiersz nagrodowy → dotagowany Cykl/CyklNr (nie duplikowany).
+    // Tom 1 exists as an award row → tagged with Cykl/CyklNr (not duplicated).
     expect(notion.updatePage).toHaveBeenCalledWith("anchor", expect.objectContaining({ CyklNr: { number: 1 } }));
-    // Tom 2 spoza bazy → utworzony jako nowy wiersz.
+    // Tom 2 not in the base → created as a new row.
     expect(notion.addRow).toHaveBeenCalledTimes(1);
     const done = events.find((e) => e.type === "complete");
     expect(done.result).toMatchObject({ added: 1, updated: 1 });
@@ -63,8 +63,8 @@ describe("CycleHarvestService.runCycleHarvest", () => {
 
     const events = await collect();
 
-    expect(notion.addRow).not.toHaveBeenCalled();   // brak duplikatu
-    expect(notion.updatePage).not.toHaveBeenCalled(); // brak zbędnych zapisów
+    expect(notion.addRow).not.toHaveBeenCalled();   // no duplicate
+    expect(notion.updatePage).not.toHaveBeenCalled(); // no unnecessary writes
     const done = events.find((e) => e.type === "complete");
     expect(done.result).toMatchObject({ added: 0, updated: 0 });
   });
@@ -73,7 +73,7 @@ describe("CycleHarvestService.runCycleHarvest", () => {
     notion.getBooksForStats.mockResolvedValue([
       { id: "a", plTitle: "Solo", origTitle: "", currentCzesccyklu: true, awards: [], zrodlo: [] },
     ]);
-    lookup.lookup.mockResolvedValue(view({ volumes: [view().volumes[0]] })); // tylko 1 tom
+    lookup.lookup.mockResolvedValue(view({ volumes: [view().volumes[0]] })); // only 1 volume
 
     const events = await collect();
     expect(notion.addRow).not.toHaveBeenCalled();

--- a/services/__tests__/cycleRows.test.ts
+++ b/services/__tests__/cycleRows.test.ts
@@ -10,10 +10,10 @@ describe("buildCycleVolumeProperties", () => {
     expect(p["Cykl"].rich_text[0].text.content).toBe("Mistborn");
     expect(p["CyklNr"]).toEqual({ number: 3 });
     expect(p["Część cyklu"]).toEqual({ checkbox: true });
-    // Lp (kolumna tytułowa) = etykieta cyklu, tytuł żyje w „Tytuł polski".
+    // Lp (title column) = cycle label, the title lives in „Tytuł polski".
     expect(p["Lp"].title[0].text.content).toBe("Mistborn (3)");
     expect(p["Tytuł polski"].rich_text[0].text.content).toBe("Bohater Wieków");
-    // Tytuł polski linkuje do strony tomu w encyklopedii (jak oryginalne rytuały).
+    // Tytuł polski links to the volume's encyclopedia page (like the original rituals).
     expect(p["Tytuł polski"].rich_text[0].text.link).toEqual({
       url: "https://encyklopediafantastyki.pl/index.php?title=Bohater_Wiek%C3%B3w",
     });
@@ -41,19 +41,19 @@ describe("aggregateCycleRows", () => {
       mk("1", { plTitle: "Tom 1", cykl: "Mistborn", cyklNr: 1, zrodlo: ["Przeczytane", "Posiadam"], awards: ["Hugo"] }),
       mk("3", { plTitle: "Tom 3", cykl: "Mistborn", cyklNr: 3, kategoria: "Tom cyklu" }),
       mk("2", { plTitle: "Tom 2", cykl: "Mistborn", cyklNr: 2, kategoria: "Tom cyklu", zrodlo: ["Posiadam"] }),
-      mk("x", { plTitle: "Bez cyklu" }), // brak pola Cykl → pomijane
+      mk("x", { plTitle: "Bez cyklu" }), // no Cykl field → skipped
     ];
     const out = aggregateCycleRows(books);
     expect(out.totalCycles).toBe(1);
     const c = out.cycles[0];
     expect(c.cycle).toBe("Mistborn");
-    expect(c.volumes.map((v) => v.title)).toEqual(["Tom 1", "Tom 2", "Tom 3"]); // po CyklNr
+    expect(c.volumes.map((v) => v.title)).toEqual(["Tom 1", "Tom 2", "Tom 3"]); // by CyklNr
     expect(c.volumes[0].isAward).toBe(true);
     expect(c.volumes[1].isAward).toBe(false);
     expect(c.total).toBe(3);
     expect(c.owned).toBe(2);
     expect(c.read).toBe(1);
-    expect(c.missing).toBe(1); // Tom 3: ani owned ani read
+    expect(c.missing).toBe(1); // Tom 3: neither owned nor read
   });
 
   it("sortuje cykle malejąco po 'do zdobycia'", () => {
@@ -76,13 +76,13 @@ describe("aggregateCycleRows", () => {
       { url: "https://vinted.pl/items/1", price: p + 5 }, { url: "https://vinted.pl/items/2", price: p },
     ] });
     const out = aggregateCycleRows([
-      mk("1", { cykl: "C", cyklNr: 1, kategoria: "Tom cyklu", vintedData: vd(12) }),                       // do zdobycia + oferta 12
-      mk("2", { cykl: "C", cyklNr: 2, kategoria: "Tom cyklu", zrodlo: ["Posiadam"], vintedData: vd(20) }), // posiadana → poza kosztem
-      mk("3", { cykl: "C", cyklNr: 3, kategoria: "Tom cyklu" }),                                           // do zdobycia, brak oferty
+      mk("1", { cykl: "C", cyklNr: 1, kategoria: "Tom cyklu", vintedData: vd(12) }),                       // to acquire + offer 12
+      mk("2", { cykl: "C", cyklNr: 2, kategoria: "Tom cyklu", zrodlo: ["Posiadam"], vintedData: vd(20) }), // owned → excluded from cost
+      mk("3", { cykl: "C", cyklNr: 3, kategoria: "Tom cyklu" }),                                           // to acquire, no offer
     ]);
     const c = out.cycles[0];
     expect(c.volumes[0].vinted).toEqual({ price: 12, url: "https://vinted.pl/items/2", count: 2 });
-    expect(c.acquireCost).toBe(12); // tylko tom 1
+    expect(c.acquireCost).toBe(12); // only volume 1
     expect(c.acquirable).toBe(1);
   });
 });

--- a/services/__tests__/diffEngine.test.ts
+++ b/services/__tests__/diffEngine.test.ts
@@ -7,7 +7,7 @@ describe('DiffEngine', () => {
     expect(DiffEngine.isMultiSelectEqual('Zysk, MAG', 'MAG, Zysk, Rebis')).toBe(false);
     expect(DiffEngine.isMultiSelectEqual('  Zysk  ', 'Zysk')).toBe(true);
     expect(DiffEngine.isMultiSelectEqual('', null as any)).toBe(true);
-    // Różnica samej wielkości liter to nie zmiana (Notion i tak scala opcje case-insensitive)
+    // A case-only difference is not a change (Notion merges options case-insensitively anyway)
     expect(DiffEngine.isMultiSelectEqual('Zysk i S-ka', 'Zysk i s-ka')).toBe(true);
   });
 

--- a/services/__tests__/libraryCheckService.test.ts
+++ b/services/__tests__/libraryCheckService.test.ts
@@ -12,7 +12,7 @@ import { NotionAdapter } from '../../notion.adapter';
 
 const mockedGet = axios.get as unknown as ReturnType<typeof vi.fn>;
 
-// Odwzorowanie realnej struktury OPAC (Prolib Integro): <article> + <dl> + ikona typu.
+// Mirrors the real OPAC structure (Prolib Integro): <article> + <dl> + type icon.
 const ICON = { book: 'pdt-p-book', movie: 'pdt-p-movie', audiobook: 'pdt-p-audiobook' } as const;
 const article = (id: string, title: string, author: string, icon: keyof typeof ICON) => `
 <article data-item-id="${id}" data-type="cataloged" class="fixed-height-article">
@@ -59,9 +59,9 @@ describe('LibraryCheckService', () => {
     const notion = makeNotion([{ id: '1', plTitle: 'Solaris', author: 'Stanisław Lem', zrodlo: [] }]);
     mockedGet.mockResolvedValue({
       data: opacPage(
-        article('a', 'Solaris', '', 'movie'),                     // film — ignorowany
-        article('b', 'Solaris', 'Lem, Stanisław', 'audiobook'),   // audiobook — ignorowany
-        article('c', 'Solaris', 'Lem, Stanisław (1921-2006)', 'book'), // książka — TO trafienie
+        article('a', 'Solaris', '', 'movie'),                     // film — ignored
+        article('b', 'Solaris', 'Lem, Stanisław', 'audiobook'),   // audiobook — ignored
+        article('c', 'Solaris', 'Lem, Stanisław (1921-2006)', 'book'), // book — THIS is the match
       ),
     });
 
@@ -78,9 +78,9 @@ describe('LibraryCheckService', () => {
     const notion = makeNotion([{ id: '1', plTitle: 'Gra o tron', author: 'George R. R. Martin', zrodlo: [] }]);
     mockedGet.mockResolvedValue({
       data: opacPage(
-        article('a', 'Gra o tron', 'Martin, George R. R. (1948- )', 'audiobook'), // audiobook — nie liczy się
+        article('a', 'Gra o tron', 'Martin, George R. R. (1948- )', 'audiobook'), // audiobook — does not count
         article('b', 'Game of thrones. Sezon 1 = Gra o tron', '', 'movie'),        // film
-        article('c', 'Rycerz Siedmiu Królestw', 'Martin, George R. R. (1948- )', 'book'), // inna książka Martina
+        article('c', 'Rycerz Siedmiu Królestw', 'Martin, George R. R. (1948- )', 'book'), // another Martin book
       ),
     });
 

--- a/services/__tests__/lpSyncService.test.ts
+++ b/services/__tests__/lpSyncService.test.ts
@@ -72,7 +72,7 @@ describe('LpSyncService', () => {
 
     await service.runLpSync(mockSendEvent, () => false);
 
-    // Tylko pozycja nagrodowa dostaje numer; tom cyklu pominięty w numeracji.
+    // Only the award entry gets a number; the cycle volume is skipped in numbering.
     expect(mockNotion.updateLp).toHaveBeenCalledWith('award', '1');
     expect(mockNotion.updateLp).not.toHaveBeenCalledWith('vol', expect.anything());
   });

--- a/services/__tests__/marketStats.test.ts
+++ b/services/__tests__/marketStats.test.ts
@@ -38,7 +38,7 @@ describe("marketStats.computeMarketStats", () => {
     const books = [
       mk("1", { vintedData: blob([{ url: "u", price: 18, prevPrice: 25, currency: "PLN" }]) }),
       mk("2", { vintedData: blob([{ url: "u", price: 40, prevPrice: 100, currency: "PLN" }]) }),
-      mk("3", { vintedData: blob([{ url: "u", price: 10, prevPrice: 8, currency: "PLN" }]) }), // wzrost — pomijany
+      mk("3", { vintedData: blob([{ url: "u", price: 10, prevPrice: 8, currency: "PLN" }]) }), // price rise — skipped
     ];
     const m = computeMarketStats(books);
     expect(m.priceDrops.map((d) => d.bookId)).toEqual(["2", "1"]);
@@ -50,7 +50,7 @@ describe("marketStats.computeMarketStats", () => {
     const books = [
       mk("1", { vintedData: blob([{ url: "u", price: 20, currency: "PLN", seller: seller("s1", "ala") }]) }),
       mk("2", { vintedData: blob([{ url: "u", price: 30, currency: "PLN", seller: seller("s1", "ala") }]) }),
-      mk("3", { vintedData: blob([{ url: "u", price: 15, currency: "PLN", seller: seller("s2", "bob") }]) }), // tylko 1 książka
+      mk("3", { vintedData: blob([{ url: "u", price: 15, currency: "PLN", seller: seller("s2", "bob") }]) }), // only 1 book
     ];
     const m = computeMarketStats(books);
     expect(m.topSellers).toHaveLength(1);
@@ -59,9 +59,9 @@ describe("marketStats.computeMarketStats", () => {
 
   it("ignores books without offers / without prices / without blob", () => {
     const books = [
-      mk("1", {}),                                                   // brak blobu
-      mk("2", { vintedData: blob([]) }),                             // pusto
-      mk("3", { vintedData: blob([{ url: "u", price: null, currency: "PLN" }]) }), // bez ceny
+      mk("1", {}),                                                   // no blob
+      mk("2", { vintedData: blob([]) }),                             // empty
+      mk("3", { vintedData: blob([{ url: "u", price: null, currency: "PLN" }]) }), // no price
     ];
     const m = computeMarketStats(books);
     expect(m).toMatchObject({ completionCost: 0, booksWithOffers: 0, totalOffers: 0 });

--- a/services/__tests__/schemaValidationService.test.ts
+++ b/services/__tests__/schemaValidationService.test.ts
@@ -50,7 +50,7 @@ describe('SchemaValidationService', () => {
 
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Autor', 'multi_select');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Tytuł polski', 'rich_text');
-    // Kolumny cykli + domknięcie starego długu też są provisionowane.
+    // Cycle columns + closing the old debt are provisioned too.
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Kategoria', 'select');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Cykl', 'rich_text');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'CyklNr', 'number');

--- a/services/__tests__/statsService.test.ts
+++ b/services/__tests__/statsService.test.ts
@@ -72,7 +72,7 @@ describe('StatsService', () => {
     ] as NotionBook[]);
 
     const stats = await service.getStats();
-    // Tylko pozycja nagrodowa liczona; tom cyklu pominięty w awardBooks i autorach.
+    // Only the award entry is counted; the cycle volume is skipped in awardBooks and authors.
     expect(stats.awardBooksStats).toEqual({ read: 1, total: 1 });
     expect(stats.authorStats).toEqual([expect.objectContaining({ name: 'Autor X', total: 1 })]);
   });
@@ -85,12 +85,12 @@ describe('StatsService', () => {
       plTitleRichText: [], origTitleRichText: [], vintedData,
     });
     mockNotion.getBooksForStats.mockResolvedValue([
-      mk("1", ["Przeczytane"]),                    // przeczytana — poza licznikiem
+      mk("1", ["Przeczytane"]),                    // read — excluded from the counter
       mk("2", ["Posiadam"]),                       // owned
       mk("3", ["Biblioteka"]),                     // library (default sourceTag)
       mk("4", [], vintedBlob),                     // vinted
       mk("5", []),                                 // none
-      mk("6", ["Posiadam", "Biblioteka"], vintedBlob), // owned wygrywa priorytet
+      mk("6", ["Posiadam", "Biblioteka"], vintedBlob), // owned wins priority
     ]);
 
     const { availabilityStats: a } = await service.getStats();
@@ -124,8 +124,8 @@ describe('StatsService', () => {
     mockNotion.getBooksForStats.mockResolvedValue([
       mk("1", "1954", ["Przeczytane"]),
       mk("2", "1959", ["Posiadam"]),
-      mk("3", "1965/1966"),        // wielodatowe → 1960
-      mk("4", "brak"),             // bez roku → pominięta
+      mk("3", "1965/1966"),        // multi-dated → 1960
+      mk("4", "brak"),             // no year → skipped
     ]);
     const { decadeStats } = await service.getStats();
     expect(decadeStats).toEqual([

--- a/services/__tests__/testConfig.ts
+++ b/services/__tests__/testConfig.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from "../configService";
 import { mergeConfig } from "../../src/configSchema";
 
-/** Fake ConfigService dla testów serwisów — zawsze zwraca defaulty (bez Notion). */
+/** Fake ConfigService for service tests — always returns defaults (without Notion). */
 export const fakeConfig = { getConfig: async () => mergeConfig(undefined) } as unknown as ConfigService;

--- a/services/__tests__/vintedParser.test.ts
+++ b/services/__tests__/vintedParser.test.ts
@@ -49,7 +49,7 @@ describe("parseVintedItems", () => {
   });
 
   it("parses the current Vinted grid (hashed CSS-module class) with structural price and photo", () => {
-    // Realny DOM Vinted: klasa feed-grid jest hashowana, cena i miniatura są w kafelku.
+    // Real Vinted DOM: the feed-grid class is hashed, the price and thumbnail are in the tile.
     const html =
       `<div class="Grid-module-scss-module__HmDNda__feed-grid__item">` +
       `<img src="https://images1.vinted.net/t/abc/310x430/x.webp?s=deadbeef" alt="Cień nocy, Andrea Cremer"/>` +
@@ -66,8 +66,8 @@ describe("parseVintedItems", () => {
   });
 
   it("returns standalone (detached) strings so a huge parent HTML is not pinned", () => {
-    // Rodzic ~1 MB otaczający jeden kafelek. Pola oferty muszą być krótkimi kopiami,
-    // nie podstringami rodzica (SlicedString) — inaczej `results` pinuje cały HTML → OOM.
+    // Parent ~1 MB wrapping a single tile. The offer fields must be short copies,
+    // not substrings of the parent (SlicedString) — otherwise `results` pins the whole HTML → OOM.
     const filler = "x".repeat(1_000_000);
     const tile =
       `<div class="Grid-module-scss-module__HmDNda__feed-grid__item">` +
@@ -77,9 +77,9 @@ describe("parseVintedItems", () => {
     const html = `<html><body>${filler}${tile}${filler}</body></html>`;
     const items = parseVintedItems(html, "Solaris", "Lem");
     expect(items).toHaveLength(1);
-    // Wartości nietknięte...
+    // Values untouched...
     expect(items[0]).toMatchObject({ url: "https://www.vinted.pl/items/77-solaris", currency: "zł" });
-    // ...ale każdy string krótki (kopia), nie ~1 MB rodzic.
+    // ...but every string short (a copy), not the ~1 MB parent.
     for (const v of [items[0].title, items[0].url, String(items[0].price), items[0].currency, items[0].photo]) {
       if (typeof v === "string") expect(v.length).toBeLessThan(1000);
     }
@@ -99,11 +99,11 @@ describe("parseVintedItems", () => {
   });
 
   it("recovers the item price from the offer title attribute when structural price is missing", () => {
-    // Realny przypadek: fallback HTML łapie title aukcji z ceną w opisie.
+    // Real case: the HTML fallback catches the listing title with the price in the description.
     const html = `<a href="/items/5" title="Pokrzywa i kość, T. Kingfisher, Stan: Bardzo dobry, 12,00 zł, 18,65 zł"></a>`;
     const items = parseVintedItems(html, "Pokrzywa i kość", "Kingfisher");
     expect(items).toHaveLength(1);
-    expect(items[0].priceValue).toBe(12); // niższa z pary = cena przedmiotu
+    expect(items[0].priceValue).toBe(12); // the lower of the pair = the item price
     expect(items[0].currency).toBe("zł");
   });
 
@@ -137,9 +137,9 @@ describe("vintedDiagnostics", () => {
   });
 
   it("flags a block only for a small challenge page, not a huge normal page", () => {
-    // Mała strona challenge → blokada.
+    // Small challenge page → block.
     expect(vintedDiagnostics(`<html>Just a moment... checking your browser</html>`, 0).blockedMarker).toBe(true);
-    // Wielka normalna strona zawierająca słowo „cloudflare" (analytics) → NIE blokada.
+    // Large normal page containing the word „cloudflare" (analytics) → NOT a block.
     const huge = `<html>${"x".repeat(200000)} cloudflare robot captcha</html>`;
     expect(vintedDiagnostics(huge, 5).blockedMarker).toBe(false);
   });

--- a/services/bookCategory.ts
+++ b/services/bookCategory.ts
@@ -1,10 +1,10 @@
 /**
- * Kategoria wiersza w bazie — rozdziela pozycje nagrodowe od pobocznych tomów cykli
- * dodanych rytuałem żniw. Wiersze bez ustawionej „Kategorii" traktujemy jako nagrodowe
- * (zgodność wstecz — istniejące pozycje nie mają tego pola).
+ * Row category in the database — separates award entries from side cycle volumes
+ * added by the Rytuał Żniw. Rows without „Kategoria" set are treated as award ones
+ * (backward compatibility — existing entries lack this field).
  *
- * Konsumenci nagrodowi (statystyki, integralność, indeks Skryptorium/Regału) filtrują
- * `isAwardBook`; skaner Vinted celowo bierze WSZYSTKO (tomy cykli też chcemy skanować).
+ * Award consumers (stats, integrity, Skryptorium/Regał index) filter on
+ * `isAwardBook`; the Vinted scanner deliberately takes EVERYTHING (we want to scan cycle volumes too).
  */
 export const CYCLE_VOLUME_CATEGORY = "Tom cyklu";
 export const AWARD_CATEGORY = "Nagroda";

--- a/services/bookDiff.ts
+++ b/services/bookDiff.ts
@@ -3,21 +3,21 @@ import { sanitizeNotionString, sanitizeNotionTag, isValidUrl } from "../utils";
 import { normalizeData } from "./dataNormalizer";
 
 /**
- * Warstwa diffu książek: czyste funkcje budujące payloady dla Notion z pary
- * (rekord w Notion, książka z wiki). Bez I/O — BookSyncService tylko woła te
- * buildery i wysyła wynik do adaptera, dzięki czemu logika idempotencji jest
- * testowalna w izolacji i nie zaśmieca orkiestratora.
+ * Book diff layer: pure functions building Notion payloads from a pair
+ * (Notion record, wiki book). No I/O — BookSyncService only calls these
+ * builders and sends the result to the adapter, so the idempotency logic is
+ * testable in isolation and doesn't clutter the orchestrator.
  */
 
 /**
- * Buduje listę tagów autora dla pola multi_select. KOLEJNOŚĆ MA ZNACZENIE:
- * najpierw normalizacja (mapowania potrafią rozwinąć jedno nazwisko w kilka
- * rozdzielonych przecinkiem, np. "Liu Cixin" → "Liu Cixin, Ken Liu"), potem
- * podział po przecinku, a sanitizacja NA KOŃCU. `sanitizeNotionTag` usuwa
- * przecinki (Notion nie dopuszcza ich w opcjach select/multi_select) — gdy
- * sanitizacja biegła PRZED normalizacją, wstrzyknięty przez mapowanie przecinek
- * trafiał do nazwy opcji i Notion odrzucał cały wiersz (laureat gubiony w ciszy).
- * Deduplikacja jest case-insensitive, z zachowaniem pierwszej napotkanej pisowni.
+ * Builds the author tag list for a multi_select field. ORDER MATTERS:
+ * normalization first (mappings can expand one name into several
+ * comma-separated ones, e.g. "Liu Cixin" → "Liu Cixin, Ken Liu"), then
+ * split on comma, and sanitization LAST. `sanitizeNotionTag` strips
+ * commas (Notion doesn't allow them in select/multi_select options) — when
+ * sanitization ran BEFORE normalization, a comma injected by a mapping
+ * ended up in the option name and Notion rejected the whole row (laureate silently lost).
+ * Deduplication is case-insensitive, keeping the first encountered spelling.
  */
 export function buildAuthorTags(raw: string): string[] {
   if (!raw) return [];
@@ -36,7 +36,7 @@ export function buildAuthorTags(raw: string): string[] {
   return tags;
 }
 
-/** Case-insensitive union nagród + reguła "Wszystkie" (Hugo+Nebula+Locus). */
+/** Case-insensitive union of awards + the "Wszystkie" rule (Hugo+Nebula+Locus). */
 function mergeAwards(existing: string[], incoming: string[]): { awards: string[]; changed: boolean } {
   const lower = new Set(existing.map(a => a.toLowerCase()));
   const combined = [...existing];
@@ -57,9 +57,9 @@ function mergeAwards(existing: string[], incoming: string[]): { awards: string[]
 }
 
 /**
- * Diff istniejącego rekordu Notion względem książki z wiki → payload aktualizacji
- * (tylko zmienione pola). Puste = brak zmian. Autorzy/nagrody scalane (union),
- * porównania case-insensitive po obu stronach (Notion zachowuje własną pisownię).
+ * Diff of an existing Notion record against a wiki book → update payload
+ * (only changed fields). Empty = no changes. Authors/awards merged (union),
+ * comparisons case-insensitive on both sides (Notion keeps its own spelling).
  */
 export function buildBookUpdates(existingBook: NotionBook, book: Book): Record<string, any> {
   const updates: Record<string, any> = {};
@@ -84,7 +84,7 @@ export function buildBookUpdates(existingBook: NotionBook, book: Book): Record<s
     updates["Tytuł oryginalny"] = { rich_text: [{ text: { content: cleanExistingOrig } }] };
   }
 
-  // Autorzy — union (nigdy nie gub ręcznie dodanych w Notion), case-insensitive
+  // Authors — union (never lose ones manually added in Notion), case-insensitive
   const newAuthors = buildAuthorTags(book.author || "");
   const existingAuthors = buildAuthorTags(existingBook.author || "");
   const existingLower = new Set(existingAuthors.map(a => a.toLowerCase()));
@@ -99,7 +99,7 @@ export function buildBookUpdates(existingBook: NotionBook, book: Book): Record<s
     updates["Autor"] = { multi_select: combinedAuthors.slice(0, 100).map(name => ({ name })) };
   }
 
-  // Nagrody — union case-insensitive (zob. GUIDELINES §3)
+  // Awards — case-insensitive union (see GUIDELINES §3)
   const newAwards = (book.awards || []).map(sanitizeNotionTag).filter(Boolean);
   const existingAwards = (existingBook.awards || []).map(sanitizeNotionTag).filter(Boolean);
   const { awards: combinedAwards, changed: awardsUpdated } = mergeAwards(existingAwards, newAwards);
@@ -107,7 +107,7 @@ export function buildBookUpdates(existingBook: NotionBook, book: Book): Record<s
     updates["Nagroda"] = { multi_select: combinedAwards.slice(0, 100).map(name => ({ name })) };
   }
 
-  // Rok — dołóż nowy rok do zbioru (multi_select), posortowany
+  // Rok — add the new year to the set (multi_select), sorted
   const newYear = (book.year || "").trim();
   const existingYears = (existingBook.year || "").split(',').map((y: string) => y.trim()).filter(Boolean);
   if (newYear && !existingYears.includes(newYear)) {
@@ -118,7 +118,7 @@ export function buildBookUpdates(existingBook: NotionBook, book: Book): Record<s
   return updates;
 }
 
-/** Payload dla nowego wiersza Notion z książki z wiki. */
+/** Payload for a new Notion row from a wiki book. */
 export function buildNewBookProperties(book: Book): Record<string, any> {
   const properties: Record<string, any> = {
     "Lp": { title: [{ text: { content: sanitizeNotionString(book.polishTitle || book.originalTitle || "Nowy") } }] },

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -2,16 +2,16 @@ import { NotionBook, BookIndexEntry } from "../src/types";
 import { isAwardBook } from "./bookCategory";
 
 /**
- * Czysta projekcja pełnych rekordów Notion → odchudzony indeks wyszukiwarki.
- * Odcina ciężkie pola (`vintedData` blob, `*RichText`), zostawia tylko to, po
- * czym filtruje/renderuje „Skryptorium". Zostawia rekord mający JAKIKOLWIEK
- * tytuł — polski LUB oryginalny; nieprzetłumaczone książki (tylko tytuł oryg.)
- * też mają być wyszukiwalne. Odpada dopiero rekord bez żadnego tytułu (szkielet).
+ * Pure projection of full Notion records → a slimmed-down search index.
+ * Cuts heavy fields (`vintedData` blob, `*RichText`), keeps only what
+ * „Skryptorium" filters/renders on. Keeps a record having ANY
+ * title — Polish OR original; untranslated books (original title only)
+ * should be searchable too. Only a record with no title at all is dropped (a skeleton).
  */
 export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
   return books
-    // Regał i Skryptorium pozostają nagrodowe — poboczne tomy cykli wykluczamy
-    // (mają własny widok „Archiwum Cykli"); włączenie opcjonalne dojdzie później.
+    // Regał and Skryptorium stay award-only — side cycle volumes are excluded
+    // (they have their own „Archiwum Cykli" view); optional inclusion will come later.
     .filter((b) => isAwardBook(b))
     .filter((b) => (b.plTitle && b.plTitle.trim().length > 0) || (b.origTitle && b.origTitle.trim().length > 0))
     .map((b) => ({

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -20,7 +20,7 @@ export class BookSyncService {
     const wikitext = await this.wiki.fetchPageContent(pageTitle);
 
     if (!wikitext) {
-      // Strona istnieje w kodzie, ale wiki zwróciła pustą treść (brak strony / zmieniony tytuł)
+      // Page exists in code, but wiki returned empty content (missing page / changed title)
       log.warn(`Pusta treść strony "${pageTitle}" — 0 książek dla ${awardName}`, { pageTitle, awardName });
     }
 
@@ -36,7 +36,7 @@ export class BookSyncService {
       await this.notion.init();
       let allBooksToSync: Book[] = [];
       if (params.syncAll) {
-        // Lista stron nagród z konfiguracji (knob `sync.awards`) — bez kopii w kodzie.
+        // List of award pages from config (knob `sync.awards`) — no copy in code.
         const awards = (await this.config.getConfig()).sync.awards;
         for (const aw of awards) {
           if (checkCancellation()) break;
@@ -135,9 +135,9 @@ export class BookSyncService {
 
           if (existingBook) {
             const updates = buildBookUpdates(existingBook, book);
-            // Promocja: rytuał nagród przetwarza laureatów, więc jeśli trafił na wiersz
-            // oznaczony jako „Tom cyklu", ten tom JEDNAK jest nagrodzony — przenosimy go
-            // do Kategoria=Nagroda (inaczej zostałby ukryty w statystykach nagród).
+            // Promotion: the award ritual processes laureates, so if it hit a row
+            // tagged as „Tom cyklu", that volume IS in fact awarded — we move it
+            // to Kategoria=Nagroda (otherwise it would stay hidden in award stats).
             if (isCycleVolume(existingBook)) {
               updates["Kategoria"] = { select: { name: AWARD_CATEGORY } };
             }

--- a/services/configService.ts
+++ b/services/configService.ts
@@ -4,23 +4,23 @@ import { createLogger } from "../logger";
 
 const log = createLogger("Config");
 
-/** Krótki cache efektywnej konfiguracji — rytuały czytają ją na starcie przebiegu. */
+/** Short cache of the effective config — rituals read it at the start of a run. */
 const CONFIG_CACHE_TTL_MS = 30 * 1000;
 
-/** Twardy limit rozmiaru blobu w opisie kolumny (diff od defaultów jest zwykle < 1 KB). */
+/** Hard cap on the blob size in the column description (the diff from defaults is usually < 1 KB). */
 const MAX_BLOB_CHARS = 1900;
 
 /**
- * Serwis konfiguracji: efektywna konfiguracja = defaulty z `configSchema` + diff
- * składowany w Notion (opis kolumny `AppConfig`). Odczyt jest odporny: uszkodzony
- * blob / brak kolumny / błąd Notion → defaulty (aplikacja nigdy nie pada od configu).
+ * Config service: effective config = defaults from `configSchema` + diff
+ * stored in Notion (description of the `AppConfig` column). Reads are resilient: a corrupt
+ * blob / missing column / Notion error → defaults (the app never crashes on config).
  */
 export class ConfigService {
   private cached: { cfg: AppConfig; expiresAt: number } | null = null;
 
   constructor(private notion: NotionAdapter) {}
 
-  /** Efektywna konfiguracja (defaulty + nadpisania). `force` pomija cache. */
+  /** Effective config (defaults + overrides). `force` bypasses the cache. */
   async getConfig(force = false): Promise<AppConfig> {
     if (!force && this.cached && this.cached.expiresAt > Date.now()) return this.cached.cfg;
     let cfg: AppConfig;
@@ -36,8 +36,8 @@ export class ConfigService {
   }
 
   /**
-   * Zapis: wejście przechodzi przez mergeConfig (clampy/typy), składujemy TYLKO diff
-   * od defaultów. Zwraca efektywną konfigurację po zapisie.
+   * Save: input goes through mergeConfig (clamps/types), we store ONLY the diff
+   * from defaults. Returns the effective config after the save.
    */
   async saveConfig(input: unknown): Promise<AppConfig> {
     const cfg = mergeConfig(input);

--- a/services/cycleHarvestService.ts
+++ b/services/cycleHarvestService.ts
@@ -12,15 +12,15 @@ import { createLogger } from "../logger";
 const log = createLogger("CycleHarvest");
 
 /**
- * Rytuał „Żniwa Cykli": dla każdej książki oznaczonej jako część cyklu zbiera
- * sąsiednie tomy (reużywa `CycleLookupService`) i materializuje je jako REALNE
- * wiersze bazy (`Kategoria=Tom cyklu`, pole `Cykl`/`CyklNr`). Dzięki temu tomy można
- * oznaczać (przeczytane/posiadane) i skanować na Vinted — poprzednio siedziały w
- * blobie i nie dało się ich oznaczyć (opcja A wybrana przez użytkownika).
+ * The „Żniwa Cykli" ritual: for each book tagged as part of a cycle it collects
+ * neighboring volumes (reuses `CycleLookupService`) and materializes them as REAL
+ * database rows (`Kategoria=Tom cyklu`, `Cykl`/`CyklNr` fields). This lets volumes be
+ * tagged (read/owned) and scanned on Vinted — previously they sat in a
+ * blob and couldn't be tagged (option A chosen by the user).
  *
- * Idempotentny: istniejący wiersz (po znorm. tytule) nie jest duplikowany, a tylko
- * dotagowany polem `Cykl`/`CyklNr`, jeśli go nie miał. Cykl przetwarzany raz, nawet
- * gdy ma kilka kotwic nagrodowych.
+ * Idempotent: an existing row (by normalized title) is not duplicated, only
+ * tagged with `Cykl`/`CyklNr` if it lacked them. A cycle is processed once, even
+ * when it has several award anchors.
  */
 export class CycleHarvestService {
   constructor(
@@ -40,10 +40,10 @@ export class CycleHarvestService {
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       const books: NotionBook[] = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
-      // Indeks istniejących wierszy po znorm. tytule (polski + oryginalny) — żeby nie
-      // tworzyć duplikatów i móc dotagować istniejące pozycje polem Cykl.
-      // Indeks po TEJ SAMEJ normalizacji co cross-ref w lookup (normTitle) — inaczej
-      // „inBase" z lookup i dopasowanie tutaj się rozjeżdżają i tworzymy duplikat.
+      // Index of existing rows by normalized title (Polish + original) — so we don't
+      // create duplicates and can tag existing entries with the Cykl field.
+      // Index by the SAME normalization as the cross-ref in lookup (normTitle) — otherwise
+      // „inBase" from lookup and the match here diverge and we create a duplicate.
       const byTitle = new Map<string, NotionBook>();
       for (const b of books) {
         for (const t of [b.plTitle, b.origTitle]) if (t && t.trim()) byTitle.set(normTitle(t), b);
@@ -57,7 +57,7 @@ export class CycleHarvestService {
       }
 
       const limit = pLimit(Math.min(3, Math.max(1, (await this.config.getConfig()).sync.writeConcurrency)));
-      const processedCycles = new Set<string>(); // nazwy cykli już rozwinięte (dedup po kotwicach)
+      const processedCycles = new Set<string>(); // cycle names already expanded (dedup across anchors)
       const createdTitles: string[] = [];
       const taggedTitles: string[] = [];
       const noSiblingTitles: string[] = [];
@@ -71,12 +71,12 @@ export class CycleHarvestService {
           const view = await this.cycleLookup.lookup(anchorTitle, anchor.author || "");
           if (!view || view.volumes.length <= 1) { noSiblingTitles.push(anchorTitle); return; }
 
-          // Nazwa cyklu ustalona RAZ i sanityzowana — tak jak przy tworzeniu wiersza,
-          // inaczej guard `existing.cykl !== …` porównywałby surowe vs zsanityzowane i
-          // przepisywał Cykl co przebieg.
+          // Cycle name determined ONCE and sanitized — same as when creating the row,
+          // otherwise the `existing.cykl !== …` guard would compare raw vs sanitized and
+          // rewrite Cykl every run.
           const cyc = sanitizeNotionString(view.cycleName);
           const cycleKey = normTitle(cyc);
-          // Cykl rozwijamy raz — kolejna kotwica tego samego cyklu tylko się dotaguje.
+          // A cycle is expanded once — another anchor of the same cycle only gets tagged.
           if (cycleKey && processedCycles.has(cycleKey)) return;
           if (cycleKey) processedCycles.add(cycleKey);
 
@@ -84,16 +84,16 @@ export class CycleHarvestService {
           for (const vol of view.volumes) {
             if (checkCancellation()) return;
             const title = (vol.title || "").trim();
-            if (!title) continue;              // pomiń puste tytuły (brak junk-wiersza)
+            if (!title) continue;              // skip empty titles (no junk row)
             nr++;
             const key = normTitle(title);
             const existing = byTitle.get(key);
             if (existing && !existing.id) {
-              // Rezerwacja innego zadania (wiersz w trakcie tworzenia) — nie duplikuj.
+              // Reservation by another task (row being created) — don't duplicate.
               continue;
             } else if (existing) {
-              // Istnieje realny wiersz — dotaguj Cykl/CyklNr (nie duplikuj). Dla wierszy
-              // tomów cykli ujednolić też Lp i link; kotwic nagrodowych (numer w Lp) NIE.
+              // A real row exists — tag Cykl/CyklNr (don't duplicate). For cycle-volume
+              // rows also normalize Lp and the link; award anchors (number in Lp) are NOT touched.
               const props: Record<string, any> = {};
               if (existing.cykl !== cyc || existing.cyklNr !== nr) {
                 props["Cykl"] = { rich_text: [{ text: { content: cyc } }] };
@@ -113,8 +113,8 @@ export class CycleHarvestService {
                 if (isCycleVolume(existing)) existing.lp = cycleLpLabel(cyc, nr);
               }
             } else {
-              // Brak wiersza — REZERWUJ slot SYNCHRONICZNIE (przed await), potem utwórz.
-              // Równoległe zadanie zobaczy rezerwację (id="") i pominie ten tytuł.
+              // No row — RESERVE the slot SYNCHRONOUSLY (before await), then create it.
+              // A parallel task will see the reservation (id="") and skip this title.
               const reserved = { id: "", plTitle: title, origTitle: "", cykl: cyc, cyklNr: nr } as NotionBook;
               byTitle.set(key, reserved);
               const created = await this.notion.addRow(buildCycleVolumeProperties({
@@ -142,12 +142,12 @@ export class CycleHarvestService {
         result: {
           success: !checkCancellation(),
           found: cycleAnchors.length,
-          added: createdTitles.length,          // nowe wiersze tomów cykli
-          updated: taggedTitles.length,         // istniejące pozycje dopięte do cyklu / migracja Lp
+          added: createdTitles.length,          // new cycle-volume rows
+          updated: taggedTitles.length,         // existing entries attached to a cycle / Lp migration
           summary: {
-            added: createdTitles,               // panel „Nowe Zapisy"
-            updated: taggedTitles,              // panel „Zaktualizowane"
-            skipped: noSiblingTitles,           // panel „Pominięte" — kotwice bez sąsiednich tomów
+            added: createdTitles,               // „Nowe Zapisy" panel
+            updated: taggedTitles,              // „Zaktualizowane" panel
+            skipped: noSiblingTitles,           // „Pominięte" panel — anchors with no neighboring volumes
           },
           errors: errors.length > 0 ? errors : undefined,
         },

--- a/services/cycleLookupService.ts
+++ b/services/cycleLookupService.ts
@@ -7,16 +7,16 @@ import { createLogger } from "../logger";
 
 const log = createLogger("CycleLookup");
 
-/** Status jednego tomu względem TWOJEJ bazy (krzyżowanie po znormalizowanym tytule). */
+/** Status of a single volume relative to YOUR database (cross-ref by normalized title). */
 export interface CycleVolume {
   title: string;
-  /** Czy to książka, z której wyszedł podgląd. */
+  /** Whether this is the book the preview started from. */
   isCurrent: boolean;
-  /** Czy tom jest w bazie Notion. */
+  /** Whether the volume is in the Notion database. */
   inBase: boolean;
   read: boolean;
   owned: boolean;
-  /** Czy tom jest nagrodzony (ma jakąkolwiek nagrodę w bazie). */
+  /** Whether the volume is awarded (has any award in the database). */
   awarded: boolean;
   awards: string[];
 }
@@ -24,15 +24,15 @@ export interface CycleVolume {
 export interface CycleView {
   cycleName: string;
   volumes: CycleVolume[];
-  /** Ile tomów PRZED bieżącym nie jest przeczytanych (książki do nadrobienia przed fabułą). */
+  /** How many volumes BEFORE the current one are unread (books to catch up on before the plot). */
   unreadBefore: number;
-  /** Źródło listy: „chain" (prev/next), „template" ({{Cykl}}), „mixed". */
+  /** List source: „chain" (prev/next), „template" ({{Cykl}}), „mixed". */
   source: "chain" | "template" | "mixed" | "single";
 }
 
-/** Normalizacja tytułu do krzyżowania: bez formatowania wiki, lowercase, bez interpunkcji brzegowej.
- *  Eksportowana, by rytuał żniw indeksował wiersze DOKŁADNIE tak samo (inaczej „inBase" z
- *  lookup i dopasowanie w żniwach się rozjeżdżają → duplikat wiersza). */
+/** Title normalization for cross-referencing: no wiki formatting, lowercase, no edge punctuation.
+ *  Exported so the harvest ritual indexes rows EXACTLY the same way (otherwise „inBase" from
+ *  lookup and the match in harvest diverge → duplicate row). */
 export function normTitle(t: string): string {
   return (t || "")
     .replace(/''+/g, "")
@@ -43,25 +43,25 @@ export function normTitle(t: string): string {
     .trim();
 }
 
-const MAX_HOPS = 15; // bezpiecznik chodzenia po łańcuchu w każdą stronę
+const MAX_HOPS = 15; // safety cap on walking the chain in each direction
 
 /**
- * Podgląd cyklu dla pojedynczej książki — NA ŻĄDANIE, bez zapisu do Notion.
- * Buduje uporządkowaną listę tomów z łańcucha `|poprzednia=`/`|następna=` (pewny,
- * potwierdzony format), wzbogaca o linki z `{{Cykl}}`, i krzyżuje każdy tom z bazą.
- * Cache w pamięci procesu (klucz: tytuł+autor) — powtórne kliknięcie jest natychmiastowe.
+ * Cycle preview for a single book — ON DEMAND, without writing to Notion.
+ * Builds an ordered list of volumes from the `|poprzednia=`/`|następna=` chain (a solid,
+ * confirmed format), enriches it with links from `{{Cykl}}`, and cross-refs each volume with the database.
+ * In-process memory cache (key: title+author) — a repeat click is instant.
  */
 export class CycleLookupService {
   private cache = new Map<string, CycleView | null>();
 
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
 
-  /** Rozwiązuje stronę wiki dla (tytuł, autor): direct fetch + search, z bramką autora. */
+  /** Resolves the wiki page for (title, author): direct fetch + search, with an author gate. */
   private async resolvePage(title: string, author: string): Promise<string> {
-    // 1. Bezpośrednie pobranie po dokładnym tytule.
+    // 1. Direct fetch by exact title.
     const direct = await this.wiki.fetchPageContent(title);
     if (direct && (!author || isWikiAuthorMatch(WikiParser.extractAuthor(direct), author))) return direct;
-    // 2. Wyszukiwanie po „tytuł autor".
+    // 2. Search by „tytuł autor".
     if (author) {
       const hits = await this.wiki.searchPage(`${title} ${author}`, 3);
       for (const h of hits) {
@@ -72,7 +72,7 @@ export class CycleLookupService {
     return direct || "";
   }
 
-  /** Fetch po dokładnym tytule sąsiada z łańcucha (bez bramki autora — tytuł z zaufanego pola). */
+  /** Fetch by the exact title of a chain neighbor (no author gate — title from a trusted field). */
   private async fetchNeighbor(title: string): Promise<string> {
     try { return await this.wiki.fetchPageContent(title); } catch { return ""; }
   }
@@ -91,7 +91,7 @@ export class CycleLookupService {
     const info = WikiParser.extractCycleInfo(wikitext);
     if (!info.cycleName && !info.prev && !info.next && info.templateVolumes.length === 0) return null;
 
-    // Uporządkowany łańcuch: ...prev(prev), prev, [current], next, next(next)...
+    // Ordered chain: ...prev(prev), prev, [current], next, next(next)...
     const before: string[] = [];
     const after: string[] = [];
     const visited = new Set<string>([normTitle(rawTitle)]);
@@ -116,7 +116,7 @@ export class CycleLookupService {
     }
 
     const chain = [...before, rawTitle, ...after];
-    // Linki z {{Cykl}} — dołóż nieobecne w łańcuchu (dla cykli bez prev/next).
+    // Links from {{Cykl}} — add ones absent from the chain (for cycles without prev/next).
     const extras = info.templateVolumes.filter((t) => !chain.some((c) => normTitle(c) === normTitle(t)));
     const ordered = chain.length > 1 ? [...chain, ...extras] : (extras.length > 0 ? [rawTitle, ...extras] : chain);
 
@@ -125,7 +125,7 @@ export class CycleLookupService {
       chain.length > 1 ? "chain" :
       extras.length > 0 ? "template" : "single";
 
-    // Krzyżowanie z bazą (cache: współdzielone pobranie).
+    // Cross-referencing with the database (cache: shared fetch).
     const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
     const byTitle = new Map<string, NotionBook>();
     for (const b of books) {
@@ -149,9 +149,9 @@ export class CycleLookupService {
     const currentIdx = volumes.findIndex((v) => v.isCurrent);
     const unreadBefore = currentIdx > 0 ? volumes.slice(0, currentIdx).filter((v) => !v.read).length : 0;
 
-    // Nazwa cyklu: pole |cykl= jeśli jest; inaczej NIE „Cykl" (wszystkie bezimienne
-    // cykle zlałyby się w jedną grupę i większość zostałaby pominięta w żniwach) —
-    // bierzemy tytuł PIERWSZEGO tomu, stabilny niezależnie od kotwicy startowej.
+    // Cycle name: the |cykl= field if present; otherwise NOT „Cykl" (all nameless
+    // cycles would collapse into one group and most would be skipped in the harvest) —
+    // we take the title of the FIRST volume, stable regardless of the starting anchor.
     const cycleName = info.cycleName || volumes[0]?.title || "Cykl";
     log.info("Cykl", { title: rawTitle, cycle: cycleName, volumes: volumes.length, source });
     return { cycleName, volumes, unreadBefore, source };

--- a/services/cycleRows.ts
+++ b/services/cycleRows.ts
@@ -5,43 +5,43 @@ import { CYCLE_VOLUME_CATEGORY, isCycleVolume } from "./bookCategory";
 import { parseVintedData } from "./vintedStore";
 import { encyclopediaUrl } from "../src/utils/encyclopedia";
 
-/** Właściwość „Tytuł polski" z linkiem do encyklopedii (jak w oryginalnych rytuałach). */
+/** „Tytuł polski" property with a link to the encyclopedia (as in the original rituals). */
 export function buildCycleTitleProperty(title: string): Record<string, any> {
   const link = encyclopediaUrl(title);
   return { rich_text: [{ text: { content: sanitizeNotionString(title || ""), ...(isValidUrl(link) ? { link: { url: link } } : {}) } }] };
 }
 
 /**
- * Wiersze tomów cykli w bazie (opcja A). Poboczne tomy cyklu są REALNYMI wierszami
- * z `Kategoria=Tom cyklu`, dzięki czemu można je oznaczać (przeczytane/posiadane) i
- * skanować na Vinted. Grupowanie po polu `Cykl`, kolejność po `CyklNr`.
+ * Cycle-volume rows in the database (option A). Side cycle volumes are REAL rows
+ * with `Kategoria=Tom cyklu`, so they can be tagged (read/owned) and
+ * scanned on Vinted. Grouped by the `Cykl` field, ordered by `CyklNr`.
  */
 
-/** Najtańsza oferta Vinted dla tomu (z blobu VintedData, zbieranego skanerem). */
+/** Cheapest Vinted offer for a volume (from the VintedData blob collected by the scanner). */
 export interface VolumeOffer {
   price: number;
   url: string;
-  /** Liczba ofert łącznie dla tego tomu. */
+  /** Total number of offers for this volume. */
   count: number;
 }
 
-/** Widok jednego tomu w Archiwum Cykli (agregacja z wierszy). */
+/** View of a single volume in Archiwum Cykli (aggregated from rows). */
 export interface HarvestVolume {
-  /** ID wiersza Notion — do oznaczania (przeczytane/posiadane) z karty. */
+  /** Notion row ID — for tagging (read/owned) from the card. */
   id: string;
   title: string;
-  /** Zawsze true — tom jest wierszem bazy (zachowane dla zgodności z kartą). */
+  /** Always true — the volume is a database row (kept for card compatibility). */
   inBase: boolean;
   read: boolean;
   owned: boolean;
   awarded: boolean;
-  /** Czy to pozycja nagrodowa (kotwica), czy poboczny tom cyklu. */
+  /** Whether this is an award entry (anchor) or a side cycle volume. */
   isAward: boolean;
-  /** Najtańsza oferta Vinted (jeśli skaner coś znalazł). */
+  /** Cheapest Vinted offer (if the scanner found something). */
   vinted?: VolumeOffer;
 }
 
-/** Najtańsza oferta z blobu VintedData wiersza (tylko ceny > 0). */
+/** Cheapest offer from a row's VintedData blob (only prices > 0). */
 function cheapestVinted(raw?: string): VolumeOffer | undefined {
   const data = parseVintedData(raw);
   if (!data) return undefined;
@@ -56,13 +56,13 @@ export interface HarvestCycle {
   total: number;
   owned: number;
   read: number;
-  /** „Do zdobycia" = ani posiadane, ani przeczytane. */
+  /** „Do zdobycia" = neither owned nor read. */
   missing: number;
-  /** Zachowane dla zgodności kształtu (= liczba tomów, bo wszystkie są wierszami). */
+  /** Kept for shape compatibility (= number of volumes, since all are rows). */
   inBase: number;
-  /** Koszt skompletowania: suma najtańszych ofert Vinted dla tomów „do zdobycia". */
+  /** Cost to complete: sum of the cheapest Vinted offers for „do zdobycia" volumes. */
   acquireCost?: number;
-  /** Ile tomów „do zdobycia" ma ofertę Vinted. */
+  /** How many „do zdobycia" volumes have a Vinted offer. */
   acquirable: number;
 }
 export interface CyclesHarvest {
@@ -72,19 +72,19 @@ export interface CyclesHarvest {
 }
 
 /**
- * Etykieta kolumny „Lp" (tytułowej) dla tomu cyklu: „Nazwa cyklu (nr)", np. „Mistborn (3)".
- * Stabilna (nie zależy od przenumerowań Lp), czytelna, jasno odróżnia tom od numeru nagrody.
+ * Label of the „Lp" (title) column for a cycle volume: „Nazwa cyklu (nr)", e.g. „Mistborn (3)".
+ * Stable (independent of Lp renumbering), readable, clearly distinguishes a volume from an award number.
  */
 export function cycleLpLabel(cycleName: string, nr: number): string {
   return `${(cycleName || "Cykl").trim()} (${nr})`;
 }
 
-/** Payload nowego wiersza pobocznego tomu cyklu. */
+/** Payload for a new side cycle-volume row. */
 export function buildCycleVolumeProperties(input: { title: string; author?: string; cycleName: string; nr: number }): Record<string, any> {
   const title = sanitizeNotionString(input.title || "");
   const properties: Record<string, any> = {
     "Lp": { title: [{ text: { content: sanitizeNotionString(cycleLpLabel(input.cycleName, input.nr)) } }] },
-    // Tytuł polski z linkiem do encyklopedii — jak w oryginalnych rytuałach.
+    // „Tytuł polski" with a link to the encyclopedia — as in the original rituals.
     "Tytuł polski": buildCycleTitleProperty(input.title),
     "Kategoria": { select: { name: CYCLE_VOLUME_CATEGORY } },
     "Cykl": { rich_text: [{ text: { content: sanitizeNotionString(input.cycleName || "") } }] },
@@ -100,9 +100,9 @@ export function buildCycleVolumeProperties(input: { title: string; author?: stri
 const normKey = (s: string): string => (s || "").toLowerCase().replace(/\s+/g, " ").trim();
 
 /**
- * Agreguje wiersze należące do cykli (pole `Cykl` niepuste) w listę cykli do Archiwum.
- * Grupuje po nazwie cyklu, sortuje po `CyklNr` (potem po tytule), liczy statusy z pól
- * Źródło/Nagroda. Zawiera zarówno kotwice nagrodowe, jak i poboczne tomy cyklu.
+ * Aggregates rows belonging to cycles (non-empty `Cykl` field) into a cycle list for Archiwum.
+ * Groups by cycle name, sorts by `CyklNr` (then by title), computes statuses from the
+ * „Źródło"/„Nagroda" fields. Includes both award anchors and side cycle volumes.
  */
 export function aggregateCycleRows(books: NotionBook[]): CyclesHarvest {
   const groups = new Map<string, { name: string; rows: NotionBook[] }>();
@@ -139,7 +139,7 @@ export function aggregateCycleRows(books: NotionBook[]): CyclesHarvest {
     const owned = volumes.filter((v) => v.owned).length;
     const read = volumes.filter((v) => v.read).length;
     const toGet = volumes.filter((v) => !v.owned && !v.read);
-    // Koszt kompletacji = suma najtańszych ofert dla tomów „do zdobycia", które są na Vinted.
+    // Completion cost = sum of the cheapest offers for „do zdobycia" volumes that are on Vinted.
     const withOffer = toGet.filter((v) => v.vinted);
     const acquireCost = withOffer.length > 0 ? Math.round(withOffer.reduce((s, v) => s + v.vinted!.price, 0)) : undefined;
     return {
@@ -148,7 +148,7 @@ export function aggregateCycleRows(books: NotionBook[]): CyclesHarvest {
       acquireCost, acquirable: withOffer.length,
     };
   });
-  // Najwięcej „do zdobycia" na górze; ukończone (missing 0) spadają na dół.
+  // Most „do zdobycia" on top; completed ones (missing 0) fall to the bottom.
   cycles.sort((a, b) => b.missing - a.missing || b.total - a.total || a.cycle.localeCompare(b.cycle));
 
   return { cycles, totalCycles: cycles.length, harvestedAt: null };

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -18,14 +18,14 @@ export class CyclesSyncService {
       await this.notion.createColumnIfNeeded("Część cyklu", "checkbox");
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       const rawBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
-      // Wykrywanie przynależności do cyklu dotyczy pozycji NAGRODOWYCH — poboczne
-      // tomy cykli (Kategoria="Tom cyklu") są z definicji częścią cyklu i mają
-      // własny rytuał żniw, więc pomijamy je zamiast redundantnie taggować.
+      // Cycle-membership detection concerns AWARD entries — side
+      // cycle volumes (Kategoria="Tom cyklu") are by definition part of a cycle and have
+      // their own harvest ritual, so we skip them instead of redundantly tagging.
       const allBooks = rawBooks.filter(isAwardBook);
 
       if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano synchronizację cykli." }); return; }
 
-      // Zbieranie unikalnych tytułów do pobrania (zarówno polskie jak i oryginalne)
+      // Collect unique titles to fetch (both Polish and original)
       const titlesToFetch = Array.from(new Set([
         ...allBooks.map(b => b.plTitle).filter(Boolean),
         ...allBooks.map(b => b.origTitle).filter(Boolean)
@@ -46,14 +46,14 @@ export class CyclesSyncService {
 
       const checkCycleInWikitext = (wikitext: string): boolean => {
         if (!wikitext) return false;
-        // Wykrywanie cyklu: NIEPUSTE pole |cykl= / |cykle= w infoboksie {{Książka}}
-        // (potwierdzone na realnym rawie: „| cykl = Childe"). Świadomie WYKLUCZAMY
-        // |seria= — na Encyklopedii to imprint wydawcy (np. „Kanon science fiction"),
-        // nie cykl fabularny → inaczej byłyby false-positive.
+        // Cycle detection: NON-EMPTY |cykl= / |cykle= field in the {{Książka}} infobox
+        // (confirmed on real raw: „| cykl = Childe"). We deliberately EXCLUDE
+        // |seria= — on the Encyclopedia it's a publisher imprint (e.g. „Kanon science fiction"),
+        // not a story cycle → otherwise it would be a false positive.
         const hasCycleParam = /\|\s*cykl(e)?\s*=\s*[^\s|}]/i.test(wikitext);
-        // Szablon nawigacyjny cyklu. Poszerzone vs stare `\{\{Cykl\s*\|` — łapie też
-        // `{{Cykl}}` (bez parametrów) i `{{Cykl nawigacja|…}}`, a wciąż odrzuca np.
-        // `{{Cyklista}}` (po „cykl" musi iść spacja / pipe / zamknięcie).
+        // Cycle navigation template. Widened vs the old `\{\{Cykl\s*\|` — also catches
+        // `{{Cykl}}` (no parameters) and `{{Cykl nawigacja|…}}`, while still rejecting e.g.
+        // `{{Cyklista}}` (after „cykl" there must be a space / pipe / closing).
         const hasCycleTemplate = /\{\{\s*cykl[\s|}]/i.test(wikitext);
         return hasCycleParam || hasCycleTemplate;
       };
@@ -75,10 +75,10 @@ export class CyclesSyncService {
         try {
           let wikitext = "";
           let foundSource = "";
-          // Czy w OGÓLE natrafiliśmy na treść strony (choćby odrzuconą przez bramkę
-          // autora). Rozróżnia dwie przyczyny pominięcia: „strony nie ma" vs „strona
-          // jest, ale autor się nie zgadza" — inaczej pominięcie było niewidoczne i
-          // wyglądało jak „książka nie należy do cyklu".
+          // Whether we hit page content AT ALL (even if rejected by the author
+          // gate). Distinguishes two skip causes: „page missing" vs „page
+          // exists, but author doesn't match" — otherwise the skip was invisible and
+          // looked like „book doesn't belong to a cycle".
           let sawPage = false;
 
           // 1. Try Bulk Fetch results (Polish title first, then Original)
@@ -126,11 +126,11 @@ export class CyclesSyncService {
           }
 
           // 4. Direct Fetch Fallback (Exact title from Notion)
-          // Bez wewnętrznego catch — fetchPageContent zwraca "" dla brakującej
-          // strony, ale RZUCA przy awarii infrastruktury (blokada IP/timeout).
-          // Połykanie tego rzutu zamieniało "sieć padła" w "brak danych → pomiń",
-          // przez co awaria widoczna tylko w tej ścieżce znikała po cichu. Teraz
-          // propaguje do per-book catch niżej i trafia do errors[].
+          // No inner catch — fetchPageContent returns "" for a missing
+          // page, but THROWS on infrastructure failure (IP block/timeout).
+          // Swallowing that throw turned "network down" into "no data → skip",
+          // so a failure visible only on this path vanished silently. Now it
+          // propagates to the per-book catch below and lands in errors[].
           if (!wikitext && plTitle) {
             const content = await this.wiki.fetchPageContent(plTitle);
             if (content) sawPage = true;
@@ -142,9 +142,9 @@ export class CyclesSyncService {
           }
 
           if (!wikitext) {
-            // Honest reporting: książka pominięta, cykl NIE oceniony. Bez tego
-            // „complete" raportował sam sukces i user nie wiedział, że część
-            // pozycji w ogóle nie sprawdzono (root cause „czasem nie łapie cykli").
+            // Honest reporting: book skipped, cycle NOT evaluated. Without this
+            // „complete" reported only success and the user didn't know that some
+            // entries weren't checked at all (root cause of "sometimes misses cycles").
             syncSummary.skipped.push(
               `${plTitle || origTitle}${sawPage ? " (autor się nie zgadza — strona pominięta)" : " (nie znaleziono strony w encyklopedii)"}`
             );

--- a/services/dataNormalizer.ts
+++ b/services/dataNormalizer.ts
@@ -47,8 +47,8 @@ const MAPPINGS: Record<NormalizationContext, Record<string, string>> = {
 };
 
 /**
- * Normalizuje dane na podstawie zdefiniowanych mapowań wyjątków.
- * Jeśli wartość nie znajduje się w mapowaniu, zwraca wartość oryginalną.
+ * Normalizes data based on the defined exception mappings.
+ * If the value isn't in the mapping, returns the original value.
  */
 export function normalizeData(value: string, context: NormalizationContext): string {
     if (!value) return value;
@@ -72,11 +72,11 @@ export function normalizeData(value: string, context: NormalizationContext): str
 }
 
 /**
- * Sprawdza, czy autor ze strony wiki pasuje do autora z Notion.
- * Chroni przed pobraniem danych z niewłaściwej strony o tym samym tytule
- * (inna książka, film, strona ujednoznaczniająca).
- * Brak autora po którejkolwiek stronie jest akceptowany (strony wiki nie
- * zawsze mają infobox z autorem).
+ * Checks whether the author from the wiki page matches the author from Notion.
+ * Guards against pulling data from the wrong page with the same title
+ * (a different book, a film, a disambiguation page).
+ * A missing author on either side is accepted (wiki pages don't
+ * always have an author infobox).
  */
 export function isWikiAuthorMatch(wikiAuthor: string, notionAuthor: string): boolean {
     if (!wikiAuthor || !notionAuthor) return true;
@@ -85,11 +85,11 @@ export function isWikiAuthorMatch(wikiAuthor: string, notionAuthor: string): boo
     if (!normWiki || !normNotion) return true;
     if (normWiki === normNotion) return true;
 
-    // Dopasowanie na poziomie CAŁYCH SŁÓW, nie surowego substringa. Wcześniej
-    // `normNotion.includes(normWiki)` akceptowało kolizje prefiksowe — "lem"
-    // pasowało do "lemański", "ann" do "anna" — przepuszczając stronę o innym
-    // dziele. Wymagamy, by krótsze nazwisko było PEŁNYM imieniem (≥2 słowa)
-    // w całości zawartym w drugim.
+    // Matching at the level of WHOLE WORDS, not a raw substring. Previously
+    // `normNotion.includes(normWiki)` accepted prefix collisions — "lem"
+    // matched "lemański", "ann" matched "anna" — letting through a page about a different
+    // work. We require the shorter name to be a FULL name (≥2 words)
+    // fully contained in the other.
     const words = (s: string) => new Set(s.split(/[\s,]+/).filter(Boolean));
     const a = words(normWiki);
     const b = words(normNotion);

--- a/services/diffEngine.ts
+++ b/services/diffEngine.ts
@@ -1,11 +1,11 @@
 export class DiffEngine {
   /**
-   * Porównuje dwie wartości typu multi_select (np. "Zysk, MAG" i "MAG, Zysk").
-   * Rozdziela po przecinku, usuwa białe znaki, sortuje i porównuje.
-   * Porównanie jest case-insensitive: Notion dopasowuje opcje multi_select bez
-   * względu na wielkość liter i zachowuje własną pisownię, więc różnica samej
-   * wielkości liter (np. "Zysk i S-ka" vs "Zysk i s-ka") nie jest realną zmianą
-   * i nie może wywoływać aktualizacji przy każdym sync.
+   * Compares two multi_select values (e.g. "Zysk, MAG" and "MAG, Zysk").
+   * Splits on comma, strips whitespace, sorts and compares.
+   * The comparison is case-insensitive: Notion matches multi_select options
+   * regardless of case and keeps its own spelling, so a difference in case
+   * alone (e.g. "Zysk i S-ka" vs "Zysk i s-ka") is not a real change
+   * and must not trigger an update on every sync.
    */
   static isMultiSelectEqual(val1: string, val2: string): boolean {
     const normalize = (s: string) =>
@@ -20,7 +20,7 @@ export class DiffEngine {
   }
 
   /**
-   * Standardowe porównanie stringów z pominięciem spacji brzegowych.
+   * Standard string comparison ignoring leading/trailing whitespace.
    */
   static isStringEqual(val1: string, val2: string): boolean {
     return (val1 || "").trim() === (val2 || "").trim();

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -11,15 +11,15 @@ export class DuplicateSyncService {
   async runDuplicateCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
     console.log("DuplicateSyncService runDuplicateCheck started");
     try {
-      // Progi podobieństwa z konfiguracji (knoby `sync.dup*Threshold`).
+      // Similarity thresholds from config (knobs `sync.dup*Threshold`).
       const { dupAuthorThreshold, dupTitleThreshold } = (await this.config.getConfig()).sync;
       sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
       await this.notion.init();
       console.log("Notion initialized");
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       const fetched: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
-      // Wykrywanie duplikatów dotyczy pozycji nagrodowych — poboczne tomy cykli to
-      // legalne odrębne książki, nie duplikaty (wykluczamy z porównań).
+      // Duplicate detection concerns award entries — side cycle volumes are
+      // legitimately distinct books, not duplicates (excluded from comparisons).
       const allBooks: NotionBook[] = fetched.filter(isAwardBook);
       console.log(`Fetched ${fetched.length} books (${allBooks.length} award after category filter)`);
       

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -16,9 +16,9 @@ const PREDEFINED_AWARDS = [
 
 const IGNORED_LOCUS_TAGS = ["Powieść dla młodzieży", "Locus - Powieść dla młodzieży", "Locus YA"];
 
-/** Książka zredukowana do kluczy tożsamości + lat wydania, po scaleniu duplikatów. */
+/** A book reduced to identity keys + publication years, after merging duplicates. */
 interface MergedBook { years: Set<string>; display: string; keys: string[] }
-/** Wejście do scalania: pre-wyekstrahowane klucze/lata/etykieta pojedynczego rekordu. */
+/** Merge input: pre-extracted keys/years/label of a single record. */
 interface BookEntry { keys: string[]; years: string[]; display: string }
 
 export class IntegrityService {
@@ -38,8 +38,8 @@ export class IntegrityService {
         (count) => sendEvent({ type: "status", message: `Pobrano ${count} rekordów z Notion...` }),
         checkCancellation
       );
-      // Integralność dotyczy pozycji NAGRODOWYCH — poboczne tomy cykli (Kategoria=Tom
-      // cyklu) nie są na listach nagród wiki, więc wykluczamy je z porównań (rok/Lp).
+      // Integrity concerns AWARD entries — side cycle volumes (Kategoria=Tom
+      // cyklu) aren't on the wiki award lists, so we exclude them from comparisons (year/Lp).
       const notionBooks = allNotionRows.filter(isAwardBook);
       if (checkCancellation()) return;
 
@@ -49,8 +49,8 @@ export class IntegrityService {
 
       sendEvent({ type: "status", message: "Analiza integralności danych (Rytuał Weryfikacji)..." });
 
-      // Scal duplikaty po kluczach tożsamości (tytuł|autor) — te same mapy zasilają
-      // porównanie liczby książek per rok.
+      // Merge duplicates by identity keys (title|author) — the same maps feed
+      // the per-year book count comparison.
       const mergedNotion = this.mergeBooksByKey(this.notionEntries(notionBooks));
       const mergedWiki = this.mergeBooksByKey(this.wikiEntries(allWikiBooks));
 
@@ -61,7 +61,7 @@ export class IntegrityService {
         yearCountMatch: { status: false, diffs: this.computeYearDiffs(mergedNotion, mergedWiki) },
         awardCountMatch: { status: false, diffs: this.computeAwardDiffs(notionBooks, allWikiBooks) },
       };
-      // status = brak rozbieżności
+      // status = no discrepancies
       result.lpUniqueness.status = result.lpUniqueness.duplicates.length === 0;
       result.originalTitleUniqueness.status = result.originalTitleUniqueness.duplicates.length === 0;
       result.polishTitleUniqueness.status = result.polishTitleUniqueness.duplicates.length === 0;
@@ -85,9 +85,9 @@ export class IntegrityService {
   }
 
   /**
-   * Klucz tożsamości książki odporny na wariacje: normalizuje autora (mapowania),
-   * sortuje i czyści nazwiska, normalizuje tytuł. Pusty tytuł → pusty klucz
-   * (odrzucany), by "|autor" nie scalał różnych książek tego samego autora.
+   * A variation-resistant book identity key: normalizes the author (mappings),
+   * sorts and cleans names, normalizes the title. Empty title → empty key
+   * (rejected), so "|author" doesn't merge different books by the same author.
    */
   private robustKey(author: string, title: string): string {
     const normalizedAuthor = normalizeData(author || "", 'author');
@@ -156,7 +156,7 @@ export class IntegrityService {
     }));
   }
 
-  /** Scala rekordy dzielące dowolny klucz tożsamości w jedną książkę (union lat). */
+  /** Merges records sharing any identity key into one book (union of years). */
   private mergeBooksByKey(entries: BookEntry[]): Map<string, MergedBook> {
     const merged = new Map<string, MergedBook>();
     const keyToPrimary = new Map<string, string>();

--- a/services/libraryCheckService.ts
+++ b/services/libraryCheckService.ts
@@ -13,10 +13,10 @@ const log = createLogger("LibraryCheck");
 const REQUEST_TIMEOUT = 20000;
 
 /**
- * Skaner dostępności w bibliotece (OPAC MBP Lublin, Prolib Integro). Dla każdej
- * nieprzeczytanej/nieposiadanej książki odpytuje OPAC zawężony do wybranej filii
- * (param f2), parsuje rekordy i szuka dopasowania KSIĄŻKI (filmy/audiobooki są
- * pomijane). Zob. docs/library-check.md i services/opacParser.ts.
+ * Library availability scanner (OPAC MBP Lublin, Prolib Integro). For each
+ * unread/unowned book it queries the OPAC narrowed to the chosen branch
+ * (param f2), parses the records and looks for a BOOK match (films/audiobooks are
+ * skipped). See docs/library-check.md and services/opacParser.ts.
  */
 export class LibraryCheckService {
   constructor(private notion: NotionAdapter, private config: ConfigService) {}
@@ -26,14 +26,14 @@ export class LibraryCheckService {
     sendEvent: (data: SyncEvent) => void,
     checkCancellation: () => boolean,
   ) {
-    // Knoby skanera (równoległość / wykluczenia / pula UA) czytane raz na przebieg.
+    // Scanner knobs (concurrency / exclusions / UA pool) read once per run.
     const cfg = await this.config.getConfig();
     const concurrency = cfg.library.concurrency;
     sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-    // cache: kolejne filie w „Skanuj wszystkie" współdzielą jedno pobranie z Notion.
+    // cache: successive branches in „Skanuj wszystkie" share one fetch from Notion.
     const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
-    // Kandydaci: mają polski tytuł i NIE są już przeczytane/posiadane/w bibliotece.
+    // Candidates: have a Polish title and are NOT already read/owned/in the library.
     const candidates = allBooks.filter((b) => {
       const zrodlo = b.zrodlo || [];
       return !zrodlo.some((z) => cfg.library.excludedSources.includes(z)) && b.plTitle && b.plTitle.trim() !== "";
@@ -42,9 +42,9 @@ export class LibraryCheckService {
     sendEvent({ type: "status", message: `Znaleziono ${candidates.length} kandydatów do sprawdzenia...` });
 
     const results: any[] = [];
-    // OPAC MBP Lublin nie wysyła certyfikatu pośredniego → Node zgłasza „unable to
-    // verify the first certificate" i każde żądanie leci wyjątkiem. Wyłączamy
-    // weryfikację TLS tylko dla tego agenta (czytamy publiczny katalog, bez sekretów).
+    // OPAC MBP Lublin doesn't send the intermediate certificate → Node reports „unable to
+    // verify the first certificate" and every request throws. We disable
+    // TLS verification only for this agent (reading a public catalog, no secrets).
     const httpsAgent = createScrapingAgent({ rejectUnauthorized: false, maxSockets: concurrency });
     const limit = pLimit(concurrency);
     let processed = 0;

--- a/services/lpSyncService.ts
+++ b/services/lpSyncService.ts
@@ -12,9 +12,9 @@ export class LpSyncService {
       let allBooks: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
       
       // Filter out empty books (ghost rows) to avoid assigning Lp to them.
-      // Numeracja Lp dotyczy TYLKO pozycji nagrodowych — poboczne tomy cykli nie
-      // uczestniczą w globalnym numerze porządkowym (nie przesuwają numerów nagród;
-      // ich kolejność wewnątrz cyklu daje pole CyklNr).
+      // Lp numbering applies ONLY to award entries — side cycle volumes don't
+      // participate in the global ordinal number (they don't shift award numbers;
+      // their order within a cycle comes from the CyklNr field).
       allBooks = allBooks.filter(b => isAwardBook(b) && (b.plTitle || b.origTitle || b.author));
 
       if (checkCancellation()) { sendEvent({ type: "error", error: "Przerwano aktualizację Lp." }); return; }

--- a/services/marketStats.ts
+++ b/services/marketStats.ts
@@ -2,9 +2,9 @@ import { NotionBook } from "../src/types";
 import { parseVintedData } from "./vintedStore";
 
 /**
- * „Rynek" — statystyki z blobu `VintedData` (składowane oferty). Czysta funkcja
- * (bez I/O): liczy z pól, które skaner już zebrał. „Chciane" = nieprzeczytane
- * i nieposiadane (te faktycznie warto kupić). Zob. docs/stats-service.md.
+ * „Rynek" — stats from the `VintedData` blob (stored offers). Pure function
+ * (no I/O): computes from fields the scanner already gathered. „Chciane" = unread
+ * and unowned (the ones actually worth buying). See docs/stats-service.md.
  */
 
 export interface CheapOffer { bookId: string; bookTitle: string; price: number; currency: string; url: string }
@@ -13,17 +13,17 @@ export interface TopSeller { id: string; login: string; url: string; books: numb
 
 export interface MarketStats {
   currency: string;
-  /** Suma najtańszych ofert po jednej na chcianą książkę z ofertami — koszt skompletowania. */
+  /** Sum of the cheapest offers, one per wanted book with offers — the completion cost. */
   completionCost: number;
-  /** Ile chcianych książek ma ≥1 ofertę z ceną. */
+  /** How many wanted books have ≥1 priced offer. */
   booksWithOffers: number;
-  /** Łączna liczba ofert z ceną wśród chcianych książek. */
+  /** Total number of priced offers among wanted books. */
   totalOffers: number;
-  /** Najtańsze pojedyncze oferty (top). */
+  /** Cheapest individual offers (top). */
   cheapest: CheapOffer[];
-  /** Świeże spadki cen (cena < poprzednia). */
+  /** Fresh price drops (price < previous). */
   priceDrops: PriceDrop[];
-  /** Sprzedawcy z największą liczbą chcianych książek (naturalne paczki). */
+  /** Sellers with the most wanted books (natural bundles). */
   topSellers: TopSeller[];
 }
 
@@ -62,7 +62,7 @@ export function computeMarketStats(books: NotionBook[]): MarketStats {
       if (typeof o.prevPrice === "number" && o.prevPrice > price) {
         drops.push({ bookId: book.id, bookTitle: title, price, prevPrice: o.prevPrice, currency: o.currency, url: o.url });
       }
-      // Sprzedawca (dociągnięty w etapie 2) — grupowanie chcianych książek.
+      // Seller (fetched in stage 2) — grouping of wanted books.
       if (o.seller?.id) {
         const s = (sellers[o.seller.id] ||= { login: o.seller.login, url: o.seller.url, books: new Set(), perBookMin: {} });
         s.books.add(book.id);
@@ -76,7 +76,7 @@ export function computeMarketStats(books: NotionBook[]): MarketStats {
 
   const topSellers: TopSeller[] = Object.entries(sellers)
     .map(([id, s]) => ({ id, login: s.login, url: s.url, books: s.books.size, total: Object.values(s.perBookMin).reduce((a, b) => a + b, 0) }))
-    .filter((s) => s.books >= 2) // paczka ma sens od 2 książek
+    .filter((s) => s.books >= 2) // a bundle makes sense from 2 books up
     .sort((a, b) => b.books - a.books || a.total - b.total)
     .slice(0, 6);
 

--- a/services/opacParser.ts
+++ b/services/opacParser.ts
@@ -1,15 +1,15 @@
 import { cleanTitle, calculateSimilarity, normalizeAuthor } from "../utils";
 
 /**
- * Parser wyników OPAC (Prolib Integro, MBP Lublin). Czysty (bez I/O) — skaner
- * podaje HTML, dostaje listę rekordów. Struktura strony wyników:
+ * OPAC results parser (Prolib Integro, MBP Lublin). Pure (no I/O) — the scanner
+ * supplies HTML, gets a list of records. Results page structure:
  *   <article data-item-id="…"> … <dl class="dl-horizontal">
  *       <dt>Tytuł:</dt><dd><span>…</span></dd>
  *       <dt>Autorzy:</dt><dd><span><a>Nazwisko, Imię (rok- )</a></span></dd> …
  *   </dl>
- *   <span class="pdt-p-book|pdt-p-movie|pdt-p-audiobook"></span>  ← typ nośnika
- * Zapytanie jest już zawężone do filii (param f2), więc obecność rekordu = filia
- * ma dany egzemplarz w zbiorach.
+ *   <span class="pdt-p-book|pdt-p-movie|pdt-p-audiobook"></span>  ← medium type
+ * The query is already narrowed to the branch (param f2), so a record's presence = the branch
+ * holds that copy in its collection.
  */
 
 export type OpacDocType = "ksiazka" | "audiobook" | "film" | "inne";
@@ -23,7 +23,7 @@ export interface OpacRecord {
 
 const stripTags = (s: string) => s.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
 
-/** Wyciąga wartość pola z listy <dl>: <dt>Label:</dt><dd>…</dd>. */
+/** Extracts a field value from the <dl> list: <dt>Label:</dt><dd>…</dd>. */
 function dlField(block: string, labelRe: string): string {
   const re = new RegExp(`<dt[^>]*>\\s*${labelRe}\\s*</dt>\\s*<dd[^>]*>([\\s\\S]*?)</dd>`, "i");
   const m = block.match(re);
@@ -53,11 +53,11 @@ export function parseOpacResults(html: string): OpacRecord[] {
 }
 
 /**
- * Znajduje najlepiej pasujący rekord KSIĄŻKI (domyślnie z wykluczeniem filmów i
- * audiobooków — wyszukiwanie „gra o tron" zwraca też seriale i inne dzieła autora,
- * a użytkownik szuka konkretnej książki). Dopasowanie = zgodność tytułu (z obsługą
- * tytułów równoległych „Oryginał = Polski") ORAZ autora (gdy znany po obu stronach).
- * Zwraca najlepszy rekord ponad progiem albo null.
+ * Finds the best-matching BOOK record (by default excluding films and
+ * audiobooks — a search for „gra o tron" also returns series and other works by the author,
+ * while the user is looking for a specific book). A match = title agreement (handling
+ * parallel titles „Oryginał = Polski") AND author (when known on both sides).
+ * Returns the best record above the threshold or null.
  */
 export function findBookMatch(
   records: OpacRecord[],
@@ -76,7 +76,7 @@ export function findBookMatch(
   let bestSim = 0;
 
   for (const r of books) {
-    // Tytuły równoległe: „Game of thrones … = Gra o tron" — porównaj każdą stronę.
+    // Parallel titles: „Game of thrones … = Gra o tron" — compare each side.
     const parts = r.title.split("=").map((s) => cleanTitle(s).toLowerCase()).filter(Boolean);
     let titleSim = 0;
     for (const p of parts) {
@@ -87,8 +87,8 @@ export function findBookMatch(
     }
     if (titleSim <= 0.8) continue;
 
-    // Autor: gdy znamy autora z Notion, musi zgadzać się z rekordem (redukuje
-    // fałszywe trafienia na inne dzieła tego samego autora złapane po serii/temacie).
+    // Author: when we know the author from Notion, it must agree with the record (reduces
+    // false hits on other works by the same author caught by series/topic).
     let authorOk = true;
     if (normAuthor) {
       const recAuthor = normalizeAuthor(r.author || "");

--- a/services/publisherSyncService.ts
+++ b/services/publisherSyncService.ts
@@ -4,8 +4,8 @@ import { SyncEvent } from "../src/types";
 import { WikiFieldSyncService, PUBLISHER_FIELD } from "./wikiFieldSyncService";
 
 /**
- * Synchronizacja wydawcy ze stron książek. Cienkie opakowanie nad
- * WikiFieldSyncService (wspólny potok, konfiguracja pola "Wydawnictwo").
+ * Publisher sync from book pages. A thin wrapper over
+ * WikiFieldSyncService (shared pipeline, config for the "Wydawnictwo" field).
  */
 export class PublisherSyncService {
   private field: WikiFieldSyncService;

--- a/services/schemaValidationService.ts
+++ b/services/schemaValidationService.ts
@@ -33,11 +33,11 @@ export class SchemaValidationService {
         { name: "Nagroda", type: "multi_select" },
         { name: "Źródło", type: "multi_select" },
         { name: "Część cyklu", type: "checkbox" },
-        // Kolumny cykli (tomy jako wiersze) — dotąd tworzone leniwie przez Rytuał Żniw.
+        // Cycle columns (volumes as rows) — until now created lazily by the Rytuał Żniw.
         { name: "Kategoria", type: "select" },
         { name: "Cykl", type: "rich_text" },
         { name: "CyklNr", type: "number" },
-        // Domknięcie starego długu — dotąd tworzone leniwie przez skaner/regał.
+        // Closing old debt — until now created lazily by the scanner/shelf.
         { name: "VintedData", type: "rich_text" },
         { name: "ShelfOrder", type: "number" }
       ];

--- a/services/seriesSyncService.ts
+++ b/services/seriesSyncService.ts
@@ -4,8 +4,8 @@ import { SyncEvent } from "../src/types";
 import { WikiFieldSyncService, SERIES_FIELD } from "./wikiFieldSyncService";
 
 /**
- * Synchronizacja serii ze stron książek. Cienkie opakowanie nad
- * WikiFieldSyncService (wspólny potok, konfiguracja pola "Seria").
+ * Series sync from book pages. A thin wrapper over
+ * WikiFieldSyncService (shared pipeline, config for the "Seria" field).
  */
 export class SeriesSyncService {
   private field: WikiFieldSyncService;

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -11,8 +11,8 @@ export class StatsService {
     let books = await this.notion.getBooksForStats();
     const branches = (await this.config.getConfig()).library.branches;
 
-    // Global filter: tylko pozycje NAGRODOWE (poboczne tomy cykli mają własny widok
-    // w „Archiwum Cykli") oraz z niepustym tytułem polskim.
+    // Global filter: only AWARD entries (side cycle volumes have their own view
+    // in „Archiwum Cykli") and with a non-empty Polish title.
     books = books.filter(b => isAwardBook(b) && b.plTitle && b.plTitle.trim() !== "");
     
     // 1. Author progress
@@ -68,9 +68,9 @@ export class StatsService {
     const allAwardsRead = allAwardsBooks.filter(b => (b.zrodlo || []).includes("Przeczytane")).length;
     const allAwardsStats = { read: allAwardsRead, total: allAwardsBooks.length };
 
-    // 5b. Aggregate availability of UNREAD books — jeden „skąd zdobyć" licznik łączący
-    // posiadanie / biblioteki (tagi filii z konfiguracji) / Vinted (blob ofert). Partycja
-    // priorytetowa (posiadane > biblioteka > Vinted > brak śladu) — każda książka liczona raz.
+    // 5b. Aggregate availability of UNREAD books — one „skąd zdobyć" counter combining
+    // ownership / libraries (branch tags from config) / Vinted (offers blob). Priority
+    // partition (owned > library > Vinted > no trace) — each book counted once.
     const branchTags = new Set(branches.map(b => b.sourceTag));
     const hasVintedOffers = (raw?: string) => (parseVintedData(raw)?.offers.length ?? 0) > 0;
     const availability = { owned: 0, library: 0, vinted: 0, none: 0 };
@@ -86,12 +86,12 @@ export class StatsService {
     });
     const availabilityStats = { totalUnread, ...availability };
 
-    // 5c. Wydawnictwa / Serie / Cykle — dane z rytuałów publisher/series/cycles, dotąd
-    // nietknięte przez statystyki. Wszystkie liczą się per książka z niepustym polem.
+    // 5c. Wydawnictwa / Serie / Cykle — data from the publisher/series/cycles rituals, until now
+    // untouched by stats. All are counted per book with a non-empty field.
     const isReadBook = (b: typeof books[number]) => (b.zrodlo || []).includes("Przeczytane");
     const isOwnedBook = (b: typeof books[number]) => (b.zrodlo || []).includes("Posiadam");
 
-    // Top wydawnictwa: liczba tytułów + ile przeczytanych.
+    // Top publishers: number of titles + how many read.
     const publisherMap: Record<string, { count: number; read: number }> = {};
     books.forEach(book => {
       const pub = (book.currentWydawnictwo || "").trim();
@@ -105,7 +105,7 @@ export class StatsService {
       .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
       .slice(0, 15);
 
-    // Serie: ile tytułów w serii, ile posiadasz (luki = count − owned).
+    // Series: how many titles in the series, how many you own (gaps = count − owned).
     const seriesMap: Record<string, { count: number; owned: number; read: number }> = {};
     books.forEach(book => {
       const ser = (book.currentSeria || "").trim();
@@ -120,12 +120,12 @@ export class StatsService {
       .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
       .slice(0, 15);
 
-    // Cykle: udział książek będących częścią cyklu (currentCzesccyklu) w kolekcji.
+    // Cycles: share of books that are part of a cycle (currentCzesccyklu) in the collection.
     const cyclePart = books.filter(b => b.currentCzesccyklu === true).length;
     const cycleStats = { partOfCycle: cyclePart, standalone: books.length - cyclePart, total: books.length };
 
-    // 5d. Rozkład dekad — rollup roczników do dekad (aplikacja już myśli dekadami przez
-    // regał). Pierwszy 4-cyfrowy rok z pola; wielodatowe → pierwszy rok. Brak roku pomijany.
+    // 5d. Decade distribution — rollup of years into decades (the app already thinks in decades via
+    // the shelf). First 4-digit year from the field; multi-dated → first year. Missing year skipped.
     const decadeMap: Record<number, { total: number; read: number; owned: number }> = {};
     books.forEach(book => {
       const m = (book.year || "").toString().match(/\d{4}/);
@@ -140,7 +140,7 @@ export class StatsService {
       .map(([decade, s]) => ({ decade: parseInt(decade, 10), ...s }))
       .sort((a, b) => a.decade - b.decade);
 
-    // 5e. Rynek — statystyki z blobu VintedData (koszt skompletowania, okazje, spadki, sprzedawcy).
+    // 5e. Market — stats from the VintedData blob (completion cost, deals, drops, sellers).
     const marketStats = computeMarketStats(books);
 
     // 6. Yearly progress
@@ -189,8 +189,8 @@ export class StatsService {
       cycleStats,
       decadeStats,
       marketStats,
-      // Filie z konfiguracji (`library.branches`) — dopisanie 3. filii w Kalibracji od razu
-      // pojawia się w statystykach. `id` = tag „Źródło" filii (dopasowanie po znaczniku).
+      // Branches from config (`library.branches`) — adding a 3rd branch in Kalibracja immediately
+      // shows up in stats. `id` = the branch's „Źródło" tag (matched by the marker).
       libraryStats: branches.map(branch => ({
         id: branch.sourceTag,
         name: branch.name,

--- a/services/vintedHttp.ts
+++ b/services/vintedHttp.ts
@@ -1,17 +1,17 @@
 import { getRandomUserAgent } from "../scrapingClient";
 
-/** Rozgrzana sesja Vinted: ustalony User-Agent + ciasteczka (m.in. Cloudflare `cf_clearance`). */
+/** A warmed-up Vinted session: a fixed User-Agent + cookies (incl. Cloudflare `cf_clearance`). */
 export interface VintedSession {
-  /** UA użyty do primingu — MUSI być spójny z żądaniami niosącymi ciasteczko (cf_clearance wiąże się z UA). */
+  /** UA used for priming — MUST be consistent with requests carrying the cookie (cf_clearance is bound to the UA). */
   userAgent: string;
-  /** Nagłówek `Cookie` (np. „cf_clearance=…; anon_id=…"). Pusty = brak sesji. */
+  /** The `Cookie` header (e.g. „cf_clearance=…; anon_id=…"). Empty = no session. */
   cookie: string;
 }
 
 /**
- * Nagłówki żądania Vinted. Bez sesji: świeży losowy User-Agent na wywołanie (pula z
- * konfiguracji). Z rozgrzaną sesją: STAŁY UA + `Cookie` (spójność wymagana przez
- * Cloudflare — cf_clearance jest związany z UA, więc rotacja UA unieważniłaby ciasteczko).
+ * Vinted request headers. Without a session: a fresh random User-Agent per call (pool from
+ * config). With a warmed-up session: a FIXED UA + `Cookie` (consistency required by
+ * Cloudflare — cf_clearance is bound to the UA, so rotating the UA would invalidate the cookie).
  */
 export function vintedRequestHeaders(uaPool?: string[], session?: VintedSession) {
   const headers: Record<string, string> = {
@@ -33,10 +33,10 @@ export function vintedRequestHeaders(uaPool?: string[], session?: VintedSession)
 }
 
 /**
- * Odczyt pamięci procesu (MB). Strony Vinted to ~7 MB HTML każda — na hostingu z
- * limitem RAM (Render free = 512 MB) powtarzane piki przy parsowaniu mogą wywołać
- * OOM-kill procesu, co urywa SSE i „ubija" skan przy w miarę stałej liczbie prób.
- * Dołączamy `rssMb`/`heapMb` do debug każdej próby, żeby to zobaczyć w panelu logów.
+ * Reads process memory (MB). Vinted pages are ~7 MB of HTML each — on hosting with
+ * a RAM cap (Render free = 512 MB) repeated spikes during parsing can trigger an
+ * OOM-kill of the process, which cuts the SSE and „kills" the scan at a roughly constant number of tries.
+ * We attach `rssMb`/`heapMb` to each attempt's debug so this is visible in the logs panel.
  */
 export function memMb() {
   const m = process.memoryUsage();
@@ -44,16 +44,16 @@ export function memMb() {
 }
 
 /**
- * Odczekanie między żądaniami z jitterem (domyślnie 3–5 s). Stosowane na KAŻDEJ
- * ścieżce (też przy braku wyników) — burst żądań to prosta droga do bloku Cloudflare.
+ * Wait between requests with jitter (default 3–5 s). Applied on EVERY
+ * path (including no results) — a burst of requests is a straight road to a Cloudflare block.
  */
 export function throttle(minMs = 3000, jitterMs = 2000): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, minMs + Math.floor(Math.random() * jitterMs)));
 }
 
 /**
- * Mapuje błąd HTTP Vinted na komunikat dla UI + ewentualne dodatkowe odczekanie.
- * 429 = rate-limit (odczekaj 5 s), 403 = Cloudflare (leć dalej), reszta = timeout/inne.
+ * Maps a Vinted HTTP error to a UI message + an optional extra wait.
+ * 429 = rate-limit (wait 5 s), 403 = Cloudflare (carry on), the rest = timeout/other.
  */
 export function classifyVintedError(err: any, title: string): { message: string; waitMs: number } {
   const status = err?.response?.status;

--- a/services/vintedParser.ts
+++ b/services/vintedParser.ts
@@ -6,37 +6,37 @@ export interface VintedItem {
   id?: string | number;
   title: string;
   price: string | number;
-  /** Cena jako liczba (do sortowania). null, gdy nieznana (placeholder „Sprawdź"/„??"). */
+  /** Price as a number (for sorting). null when unknown (placeholder „Sprawdź"/„??"). */
   priceValue: number | null;
   currency: string;
   url: string;
-  /** Miniatura oferty z katalogu Vinted (tylko ścieżka JSON — fallbacki HTML jej nie mają). */
+  /** Offer thumbnail from the Vinted catalog (JSON path only — the HTML fallbacks don't have it). */
   photo?: string | null;
-  /** Sprzedawca — dociągany on-demand ze strony oferty (nie ma go w katalogu). */
+  /** Seller — fetched on-demand from the offer page (not present in the catalog). */
   seller?: VintedSeller | null;
 }
 
 export interface VintedSeller {
-  /** Numeryczne ID profilu (`/member/{id}`) — klucz grupowania. */
+  /** Numeric profile ID (`/member/{id}`) — the grouping key. */
   id: string;
-  /** Widoczny login sprzedawcy. */
+  /** Visible seller login. */
   login: string;
-  /** Link do profilu. */
+  /** Link to the profile. */
   url: string;
 }
 
 /**
- * Normalizuje surową cenę Vinted do liczby: „15" → 15, „25,00" → 25, „12.90" → 12.9,
- * liczba → liczba. Placeholdery („??", „Sprawdź", puste) i wartości nieliczbowe → null,
- * żeby oferty bez ceny dało się posortować na koniec zamiast psuć porównania.
+ * Normalizes a raw Vinted price to a number: „15" → 15, „25,00" → 25, „12.90" → 12.9,
+ * number → number. Placeholders („??", „Sprawdź", empty) and non-numeric values → null,
+ * so offers without a price can be sorted to the end instead of breaking comparisons.
  */
 /**
- * Odcina string od rodzica. V8 NIE kopiuje podstringów: `str.match()`/`.split()` na
- * wielkim HTML (~7 MB) zwraca SlicedString trzymający wskaźnik do CAŁEGO rodzica.
- * Gdy takie pole trafia do długo żyjącej tablicy (`results` skanera), pinuje cały
- * HTML — po ~26 stronach to OOM (potwierdzone logami Rendera). `Buffer.from(...)`
- * tworzy samodzielną kopię bajtów, odcinając referencję do 7 MB rodzica. Pola oferty
- * są krótkie, więc koszt kopii jest pomijalny.
+ * Detaches a string from its parent. V8 does NOT copy substrings: `str.match()`/`.split()` on
+ * huge HTML (~7 MB) returns a SlicedString holding a pointer to the WHOLE parent.
+ * When such a field lands in a long-lived array (the scanner's `results`), it pins the whole
+ * HTML — after ~26 pages that's OOM (confirmed by Render logs). `Buffer.from(...)`
+ * makes a standalone copy of the bytes, cutting the reference to the 7 MB parent. Offer fields
+ * are short, so the copy cost is negligible.
  */
 function detach(s: string): string {
   return Buffer.from(s, "utf8").toString("utf8");
@@ -52,34 +52,34 @@ export function parseVintedPrice(raw: string | number | null | undefined): numbe
 }
 
 /**
- * Czysty parser wyników katalogu Vinted (HTML → oferty). Bez I/O ani zdarzeń SSE —
- * skaner tylko podaje surowy HTML, tytuł i autora, a dostaje do 5 dopasowanych
- * ofert. Cztery kaskadowe ścieżki: (1) blob JSON `data-component-name="Catalog"`,
- * (2) fallback po regexie `"items":[…]` z domykaniem nawiasów, (3) bloki
- * `feed-grid__item`, (4) globalny regex `href=/items/…`. Wyodrębnione, by tę
- * kruchą logikę dało się testować jednostkowo na utrwalonym HTML.
+ * Pure parser of Vinted catalog results (HTML → offers). No I/O or SSE events —
+ * the scanner only supplies the raw HTML, title and author, and gets back up to 5 matched
+ * offers. Four cascading paths: (1) JSON blob `data-component-name="Catalog"`,
+ * (2) regex fallback `"items":[…]` with bracket closing, (3) `feed-grid__item`
+ * blocks, (4) global regex `href=/items/…`. Extracted so this
+ * fragile logic can be unit-tested on captured HTML.
  */
 export interface VintedDebug {
-  /** Długość odpowiedzi HTML (znaki). Bardzo mała = możliwy blok/challenge. */
+  /** HTML response length (chars). Very small = possible block/challenge. */
   chars: number;
-  /** Czy strona zawiera blob JSON katalogu (ścieżka „bogata"). */
+  /** Whether the page contains the catalog JSON blob (the „rich" path). */
   hasCatalogJson: boolean;
-  /** Czy są bloki feed-grid (ścieżka fallback). */
+  /** Whether there are feed-grid blocks (the fallback path). */
   hasFeedGrid: boolean;
-  /** Ile linków /items/ jest w HTML (są oferty, nawet jeśli parser ich nie złapał). */
+  /** How many /items/ links are in the HTML (offers exist, even if the parser didn't catch them). */
   itemLinks: number;
-  /** Markery blokady bota (cloudflare/captcha/robot). */
+  /** Bot-block markers (cloudflare/captcha/robot). */
   blockedMarker: boolean;
-  /** Markery „brak wyników" Vinted. */
+  /** Vinted „no results" markers. */
   noResultsMarker: boolean;
-  /** Ile ofert faktycznie wyłuskał parser. */
+  /** How many offers the parser actually extracted. */
   parsed: number;
 }
 
-// Realna strona wyników Vinted to megabajty HTML. Strona challenge/blokady
-// Cloudflare jest MAŁA i niesie konkretny marker. Samo słowo „cloudflare"/
-// „robot" występuje w normalnym HTML (analytics, meta), więc było fałszywym
-// alarmem na każdej stronie — dlatego bramkujemy rozmiarem i frazą challenge.
+// A real Vinted results page is megabytes of HTML. The Cloudflare challenge/block
+// page is SMALL and carries a specific marker. The word „cloudflare"/
+// „robot" alone appears in normal HTML (analytics, meta), so it was a false
+// alarm on every page — hence we gate by size and the challenge phrase.
 const CHALLENGE_RE = /just a moment|attention required|cf-mitigated|checking your browser|verify you are human|enable javascript and cookies|please complete the security check/i;
 
 export function looksBlocked(html: string): boolean {
@@ -88,32 +88,32 @@ export function looksBlocked(html: string): boolean {
 }
 
 /**
- * Marker „brak wyników" na stronie katalogu. UWAGA: to naiwny substring w ~7 MB
- * markupie i bywa fałszywy na stronie Z ofertami — wołający NIE kasuje wtedy
- * zapisanych danych (patrz vintedSyncService: persist tylko gdy nic nie było).
+ * „No results" marker on the catalog page. NOTE: this is a naive substring in ~7 MB
+ * of markup and is sometimes false on a page WITH offers — the caller then does NOT wipe
+ * stored data (see vintedSyncService: persist only when there was nothing).
  */
 export function looksEmpty(html: string): boolean {
   const h = html || "";
   return h.includes("Brak wyników") || h.includes("Nie znaleźliśmy żadnych przedmiotów");
 }
 
-// Kafelek oferty w siatce katalogu. Vinted hashuje nazwy klas CSS-modules
-// (`Grid-module-scss-module__HmDNda__feed-grid__item`), więc celujemy w stabilny
-// suffiks `feed-grid__item"`. Trailing `"` odcina wariant `feed-grid__item-content`.
+// Offer tile in the catalog grid. Vinted hashes CSS-modules class names
+// (`Grid-module-scss-module__HmDNda__feed-grid__item`), so we target the stable
+// suffix `feed-grid__item"`. The trailing `"` cuts off the `feed-grid__item-content` variant.
 const FEED_GRID_RE = /feed-grid__item"/;
 
 /**
- * Lekka diagnostyka odpowiedzi Vinted (bez I/O) — pomaga odróżnić realny brak
- * ofert od cichej blokady lub gubienia ofert przez parser. `itemLinks > 0` przy
- * `parsed === 0` i braku markerów = mocny sygnał, że parser coś przeoczył.
+ * Lightweight diagnostics of a Vinted response (no I/O) — helps tell a genuine lack
+ * of offers from a silent block or the parser dropping offers. `itemLinks > 0` with
+ * `parsed === 0` and no markers = a strong signal the parser missed something.
  */
 export function vintedDiagnostics(html: string, parsed: number): VintedDebug {
   const h = html || "";
   return {
     chars: h.length,
     hasCatalogJson: h.includes('data-component-name="Catalog"'),
-    // Vinted hashuje klasy CSS-modules (np. `Grid-module-scss-module__…__feed-grid__item`),
-    // więc dopasowujemy stabilny suffiks `feed-grid__item"`, nie całą klasę.
+    // Vinted hashes CSS-modules classes (e.g. `Grid-module-scss-module__…__feed-grid__item`),
+    // so we match the stable suffix `feed-grid__item"`, not the whole class.
     hasFeedGrid: FEED_GRID_RE.test(h),
     itemLinks: (h.match(/\/items\//g) || []).length,
     blockedMarker: looksBlocked(h),
@@ -126,13 +126,13 @@ export function parseVintedItems(html: string, title: string, author: string): V
   const items: VintedItem[] = [];
   let rawItems: any[] = [];
 
-  // 1. Blob JSON w atrybucie data-props / treści skryptu Catalog
+  // 1. JSON blob in the data-props attribute / Catalog script content
   const catalogMatch = html.match(/data-component-name="Catalog"[^>]*data-props="([^"]+)"/s) ||
                        html.match(/data-component-name="Catalog"[^>]*>\s*({.*?})\s*<\/script>/s);
 
   if (catalogMatch) {
     try {
-      // Atrybuty HTML używają &quot; zamiast "
+      // HTML attributes use &quot; instead of "
       let jsonStr = catalogMatch[1];
       if (jsonStr.includes('&quot;')) {
         jsonStr = jsonStr.replace(/&quot;/g, '"')
@@ -153,7 +153,7 @@ export function parseVintedItems(html: string, title: string, author: string): V
     }
   }
 
-  // 2. Fallback po starym regexie "items" (z domykaniem nawiasów tablicy)
+  // 2. Fallback via the old "items" regex (with array-bracket closing)
   if (rawItems.length === 0) {
     const jsonMatch = html.match(/"items":\s*(\[.*?\])/);
     if (jsonMatch) {
@@ -174,7 +174,7 @@ export function parseVintedItems(html: string, title: string, author: string): V
         const jsonStr = endIndex !== -1 ? str.substring(0, endIndex) : str;
         rawItems = JSON.parse(jsonStr);
       } catch (e) {
-        // Regex bywa zbyt prosty — trudno; przejdź do fallbacków HTML
+        // The regex is sometimes too simple — never mind; move on to the HTML fallbacks
       }
     }
   }
@@ -187,8 +187,8 @@ export function parseVintedItems(html: string, title: string, author: string): V
       const searchTitle = title.toLowerCase();
       const searchAuthor = (author || "").toLowerCase();
 
-      // Elastyczne dopasowanie: tytuł oferty zawiera tytuł książki (lub odwrotnie),
-      // albo tytuł oferty zawiera nazwisko autora.
+      // Flexible matching: the offer title contains the book title (or vice versa),
+      // or the offer title contains the author's name.
       const hasTitle = itemTitle.includes(searchTitle) || searchTitle.includes(itemTitle);
       const hasAuthor = searchAuthor && itemTitle.includes(searchAuthor);
 
@@ -208,10 +208,10 @@ export function parseVintedItems(html: string, title: string, author: string): V
     }
   }
 
-  // 3. Fallback po kafelkach siatki feed-grid (aktualny DOM Vinted, klasy hashowane).
-  // Dzielimy na `feed-grid__item"` — łapie stary `class="feed-grid__item"` i nowy
-  // `class="Grid-module-scss-module__…__feed-grid__item"`. Z każdego kafelka bierzemy
-  // URL, tytuł, cenę strukturalną i miniaturę (`images1.vinted.net`).
+  // 3. Fallback via feed-grid tiles (current Vinted DOM, hashed classes).
+  // We split on `feed-grid__item"` — catches the old `class="feed-grid__item"` and the new
+  // `class="Grid-module-scss-module__…__feed-grid__item"`. From each tile we take
+  // the URL, title, structured price and thumbnail (`images1.vinted.net`).
   if (items.length === 0) {
     const itemBlocks = html.split(FEED_GRID_RE);
     if (itemBlocks.length > 1) {
@@ -219,11 +219,11 @@ export function parseVintedItems(html: string, title: string, author: string): V
       const searchAuthor = (author || "").toLowerCase();
       for (let j = 1; j < itemBlocks.length && items.length < 5; j++) {
         const block = itemBlocks[j];
-        // URL bez query (`?referrer=catalog`) — spójny z kanonicznym linkiem oferty.
+        // URL without query (`?referrer=catalog`) — consistent with the canonical offer link.
         const urlMatch = block.match(/href="(\/items\/[^"?]+)/);
         const titleMatch = block.match(/title="([^"]+)"/);
-        // Oba warianty mają group1 = kwota, group2 = waluta. Pierwsze trafienie
-        // w kafelku to cena przedmiotu (drugie = cena z ochroną kupującego).
+        // Both variants have group1 = amount, group2 = currency. The first hit
+        // in a tile is the item price (the second = price with buyer protection).
         const priceMatch = block.match(/aria-label="[^"]*?(\d+[.,]\d+)\s*([A-Z]{3}|zł)"/i) ||
                            block.match(/>(\d+[.,]\d+)\s*([A-Z]{3}|zł)</i);
         const photoMatch = block.match(/<img[^>]+?src="(https?:\/\/[^"]*vinted\.net\/[^"]+)"/i);
@@ -235,7 +235,7 @@ export function parseVintedItems(html: string, title: string, author: string): V
           const hasAuthor = !!searchAuthor && lower.includes(searchAuthor);
           if (hasTitle || hasAuthor) {
             const rawPrice = priceMatch ? priceMatch[1] : "Sprawdź";
-            // detach: wszystkie te pola to podstringi 7 MB HTML — bez kopii pinują rodzica.
+            // detach: all these fields are substrings of the 7 MB HTML — without a copy they pin the parent.
             items.push({
               title: detach(itemTitle),
               url: detach(`https://www.vinted.pl${urlMatch[1]}`),
@@ -250,7 +250,7 @@ export function parseVintedItems(html: string, title: string, author: string): V
     }
   }
 
-  // 4. Ostateczność: prosty globalny regex
+  // 4. Last resort: a simple global regex
   if (items.length === 0) {
     const itemRegex = /href="(\/items\/[^"]+)"[^>]*title="([^"]+)"/g;
     let match;
@@ -258,16 +258,16 @@ export function parseVintedItems(html: string, title: string, author: string): V
       const itemUrl = `https://www.vinted.pl${match[1]}`;
       const itemTitle = match[2];
       if (itemTitle.toLowerCase().includes(title.toLowerCase())) {
-        // detach: itemTitle/itemUrl to podstringi HTML — bez kopii pinują 7 MB rodzica.
+        // detach: itemTitle/itemUrl are substrings of the HTML — without a copy they pin the 7 MB parent.
         items.push({ title: detach(itemTitle), url: detach(itemUrl), price: "Sprawdź", priceValue: null, currency: "PLN" });
       }
     }
   }
 
-  // Ostatnia deska ratunku dla ceny: ścieżki HTML łapią atrybut title aukcji,
-  // który Vinted buduje jako „Tytuł, Marka, Stan: …, {cena} zł, {cena z ochroną} zł".
-  // Gdy nie mamy ceny strukturalnej, wyłuskujemy ją z tego tekstu (niższa z dwóch
-  // = cena przedmiotu, wyższa = z ochroną kupującego).
+  // Last-ditch fallback for price: the HTML paths catch the listing's title attribute,
+  // which Vinted builds as „Tytuł, Marka, Stan: …, {cena} zł, {cena z ochroną} zł".
+  // When we lack a structured price, we extract it from that text (the lower of the two
+  // = item price, the higher = with buyer protection).
   for (const item of items) {
     if (item.priceValue === null) {
       const fromText = extractPriceFromText(item.title);
@@ -283,11 +283,11 @@ export function parseVintedItems(html: string, title: string, author: string): V
 }
 
 /**
- * Wyłuskuje sprzedawcę ze strony pojedynczej oferty Vinted (`/items/{id}`).
- * Sprzedawcy NIE ma w kafelkach katalogu — pojawia się dopiero na stronie oferty.
- * Dwa stabilne, unikalne uchwyty (zweryfikowane na realnym HTML): link profilu
- * `/member/{id}` (ID) oraz `data-testid="profile-username"` (login). `detach` na
- * loginie — strona oferty to ~2 MB, podstring bez kopii pinowałby ją (jak w skanie).
+ * Extracts the seller from a single Vinted offer page (`/items/{id}`).
+ * The seller is NOT in the catalog tiles — it appears only on the offer page.
+ * Two stable, unique handles (verified on real HTML): the profile link
+ * `/member/{id}` (ID) and `data-testid="profile-username"` (login). `detach` on
+ * the login — the offer page is ~2 MB, a substring without a copy would pin it (as in the scan).
  */
 export function extractVintedSeller(html: string): VintedSeller | null {
   const idMatch = html.match(/href="\/member\/(\d+)"/);
@@ -299,12 +299,12 @@ export function extractVintedSeller(html: string): VintedSeller | null {
 }
 
 /**
- * Wyłuskuje najniższą kwotę „NN[.,]NN zł/PLN" z tekstu (np. z atrybutu title
- * oferty). Zwraca cenę przedmiotu (niższą z pary cena/total) albo null.
+ * Extracts the lowest amount „NN[.,]NN zł/PLN" from text (e.g. from an offer's title
+ * attribute). Returns the item price (the lower of the price/total pair) or null.
  */
 export function extractPriceFromText(text: string): number | null {
   if (!text) return null;
-  // Uwaga: bez \b po „zł" — „ł" to nie-słowny znak, więc granica słowa nie zachodzi.
+  // Note: no \b after „zł" — „ł" is a non-word character, so the word boundary doesn't hold.
   const re = /(\d+(?:[.,]\d+)?)\s*(?:zł|PLN)/gi;
   const values: number[] = [];
   let m: RegExpExecArray | null;

--- a/services/vintedScanPlanner.ts
+++ b/services/vintedScanPlanner.ts
@@ -1,10 +1,10 @@
 import { NotionBook } from "../src/types";
 import { parseVintedData } from "./vintedStore";
 
-/** Znaczniki „Źródło" wykluczające książkę ze skanu (już mamy / czytamy). */
+/** „Źródło" markers that exclude a book from the scan (already have / reading). */
 export const EXCLUDED_SOURCES = ["Posiadam", "Przeczytane", "Audioteka", "Biblioteka", "Biblioteka 9"];
 
-/** Czas ostatniego skanu książki w ms; nigdy-skanowane = -Infinity (najstarsze → najwyższy priorytet). */
+/** Last scan time of a book in ms; never-scanned = -Infinity (oldest → highest priority). */
 export function scannedMs(book: NotionBook): number {
   const at = parseVintedData(book.vintedData)?.scannedAt;
   const t = at ? Date.parse(at) : NaN;
@@ -13,16 +13,16 @@ export function scannedMs(book: NotionBook): number {
 
 export interface ScanPlan {
   candidates: NotionBook[];
-  /** Ile pominięto przez okno „Kontynuuj" (skanowane < N h). */
+  /** How many were skipped by the „Kontynuuj" window (scanned < N h ago). */
   skipped: number;
 }
 
 /**
- * Czysty plan skanu: (1) odsiej niekandydatów (wykluczone źródła / brak tytułu PL),
- * (2) opcjonalnie pomiń skanowane w ostatnich `skipScannedWithinHours` (bieżąca partia),
- * (3) posortuj OD NAJSTARSZYCH (nigdy-skanowane pierwsze) — przerwany przebieg zawsze
- * posuwa najbardziej nieaktualne dane, a „Kontynuuj" domyka partię zamiast dublować świeże.
- * `now` wstrzykiwalny dla testów; `excludedSources` z konfiguracji (default = dotychczasowa lista).
+ * Pure scan plan: (1) filter out non-candidates (excluded sources / no PL title),
+ * (2) optionally skip ones scanned within the last `skipScannedWithinHours` (current batch),
+ * (3) sort OLDEST-FIRST (never-scanned first) — an interrupted run always
+ * advances the most stale data, and „Kontynuuj" closes out the batch instead of re-doing fresh ones.
+ * `now` injectable for tests; `excludedSources` from config (default = the existing list).
  */
 export function selectAndOrderCandidates(
   books: NotionBook[],
@@ -40,7 +40,7 @@ export function selectAndOrderCandidates(
   if (skipScannedWithinHours && skipScannedWithinHours > 0) {
     const cutoff = now - skipScannedWithinHours * 3_600_000;
     const before = withDates.length;
-    withDates = withDates.filter((x) => x.at < cutoff); // -Infinity (nigdy) też przechodzi
+    withDates = withDates.filter((x) => x.at < cutoff); // -Infinity (never) passes too
     skipped = before - withDates.length;
   }
 

--- a/services/vintedSession.ts
+++ b/services/vintedSession.ts
@@ -6,9 +6,9 @@ import { vintedRequestHeaders, VintedSession } from "./vintedHttp";
 const VINTED_HOME = "https://www.vinted.pl/";
 
 /**
- * Sk­leja nagłówek `Cookie` z tablicy `Set-Cookie` odpowiedzi (axios `res.headers["set-cookie"]`).
- * Bierze tylko parę `nazwa=wartość` (część przed pierwszym `;`), pomija atrybuty (Path/Expires/…)
- * i puste/wadliwe wpisy. Czysta funkcja — łatwa do testów.
+ * Assembles the `Cookie` header from a response's `Set-Cookie` array (axios `res.headers["set-cookie"]`).
+ * Takes only the `name=value` pair (the part before the first `;`), skips attributes (Path/Expires/…)
+ * and empty/malformed entries. Pure function — easy to test.
  */
 export function parseSetCookie(setCookie: string[] | undefined | null): string {
   if (!Array.isArray(setCookie)) return "";
@@ -27,12 +27,12 @@ export function parseSetCookie(setCookie: string[] | undefined | null): string {
 }
 
 /**
- * „Rozgrzanie" sesji Vinted: jedno GET strony głównej realną przeglądarkową sygnaturą,
- * by przejąć ciasteczka (m.in. Cloudflare `cf_clearance` + anonimowa sesja Vinted).
- * Zwrócony UA jest STAŁY dla całego skanu — cf_clearance jest związany z UA, więc kolejne
- * żądania katalogu MUSZĄ nieść ten sam UA + Cookie. Odporne: przy błędzie / braku ciasteczek
- * zwraca pustą sesję (skan leci dalej bez primingu — jak dotąd). `validateStatus: () => true`,
- * bo Cloudflare bywa serwuje ciasteczko nawet na stronie-wyzwaniu (403).
+ * „Warming up" a Vinted session: one GET of the home page with a real browser signature,
+ * to pick up cookies (incl. Cloudflare `cf_clearance` + an anonymous Vinted session).
+ * The returned UA is FIXED for the whole scan — cf_clearance is bound to the UA, so subsequent
+ * catalog requests MUST carry the same UA + Cookie. Resilient: on error / missing cookies it
+ * returns an empty session (the scan carries on without priming — as before). `validateStatus: () => true`,
+ * because Cloudflare sometimes serves a cookie even on the challenge page (403).
  */
 export async function primeVintedSession(
   httpsAgent: https.Agent,
@@ -48,14 +48,14 @@ export async function primeVintedSession(
       validateStatus: () => true,
     });
     const cookie = parseSetCookie(res.headers?.["set-cookie"] as string[] | undefined);
-    // Bez ciasteczka priming nic nie daje → pusta sesja (UA wróci do rotacji per-żądanie).
+    // Without a cookie, priming does nothing → empty session (UA falls back to per-request rotation).
     return cookie ? { userAgent, cookie } : { userAgent: "", cookie: "" };
   } catch {
     return { userAgent: "", cookie: "" };
   }
 }
 
-/** Liczba ciasteczek w nagłówku Cookie (do komunikatu statusu). */
+/** Number of cookies in the Cookie header (for the status message). */
 export function cookieCount(cookie: string): number {
   return cookie ? cookie.split(";").filter((c) => c.trim()).length : 0;
 }

--- a/services/vintedStore.ts
+++ b/services/vintedStore.ts
@@ -2,55 +2,55 @@ import { VintedItem, VintedSeller } from "./vintedParser";
 import { NotionBook } from "../src/types";
 
 /**
- * Trwałe składowanie wyników Vinted w Notion (blob JSON w polu tekstowym książki).
- * Rozdziela drogie/limitowane zdobywanie danych (scrape pod Cloudflare) od taniej,
- * powtarzalnej analizy (grupowanie per sprzedawca) — raz zescrapowane oferty żyją w
- * bazie, więc skan jest wznawialny, a analiza nie wymaga ponownego pobierania.
- * Zob. docs/vinted-scanner.md §5.
+ * Persistent storage of Vinted results in Notion (a JSON blob in a book's text field).
+ * Separates the expensive/rate-limited data acquisition (scraping behind Cloudflare) from cheap,
+ * repeatable analysis (grouping per seller) — once scraped, offers live in the
+ * database, so the scan is resumable and analysis needs no re-fetching.
+ * See docs/vinted-scanner.md §5.
  */
 
 export interface StoredOffer {
   url: string;
   title?: string;
-  /** Cena jako liczba (priceValue). null = nieznana. */
+  /** Price as a number (priceValue). null = unknown. */
   price: number | null;
   currency: string;
   photo?: string | null;
-  /** Sprzedawca — null, dopóki nie dociągnięty osobnym krokiem (etap 2). */
+  /** Seller — null until fetched in a separate step (stage 2). */
   seller?: VintedSeller | null;
-  /** Cena z POPRZEDNIEGO skanu (do wykrycia spadku). Ustawiana dla ofert, które przetrwały. */
+  /** Price from the PREVIOUS scan (to detect a drop). Set for offers that survived. */
   prevPrice?: number | null;
-  /** ISO — kiedy ten URL oferty pojawił się po raz pierwszy (do znacznika „nowa"). */
+  /** ISO — when this offer URL first appeared (for the „nowa" marker). */
   firstSeenAt?: string;
 }
 
 export interface StoredVintedData {
-  /** ISO timestamp ostatniego skanu tej książki (świeżość danych). */
+  /** ISO timestamp of this book's last scan (data freshness). */
   scannedAt: string;
-  /** ISO — kiedy zestaw ofert OSTATNIO się zmienił (nowa/zniknięta/inna cena). */
+  /** ISO — when the set of offers LAST changed (new/gone/different price). */
   changedAt?: string;
   offers: StoredOffer[];
 }
 
-/** Widok składowanych danych książki (do renderu kafelków/paczek z bazy — etap 3). */
+/** View of a book's stored data (for rendering tiles/bundles from the database — stage 3). */
 export interface StoredBookView {
   id: string;
   title: string;
   author: string;
-  /** Rok wydania (kolumna „Rok" w Notion) — metadana, prosto z bazy. */
+  /** Publication year (the „Rok" column in Notion) — metadata, straight from the database. */
   year?: string;
-  /** Czy książka jest częścią cyklu (kolumna „Część cyklu", checkbox) — ryzyko „kolejny tom". */
+  /** Whether the book is part of a cycle (the „Część cyklu" column, checkbox) — „next volume" risk. */
   partOfCycle?: boolean;
-  /** Nazwa cyklu (kolumna „Cykl") — jeśli ustalona żniwami. Do etykiety kafelka. */
+  /** Cycle name (the „Cykl" column) — if determined by the harvest. For the tile label. */
   cykl?: string;
-  /** Numer tomu w cyklu (kolumna „CyklNr") — jeśli ustalony żniwami. */
+  /** Volume number in the cycle (the „CyklNr" column) — if determined by the harvest. */
   cyklNr?: number;
   scannedAt: string;
   changedAt?: string;
   offers: StoredOffer[];
 }
 
-/** Podsumowanie zmian jednej książki między poprzednim a świeżym skanem. */
+/** Summary of one book's changes between the previous and the fresh scan. */
 export interface OfferDiff {
   added: number;
   removed: number;
@@ -65,15 +65,15 @@ export function hasChanges(d: OfferDiff): boolean {
 }
 
 /**
- * Polityka znacznika `changedAt`: bump do `scannedAt` TYLKO gdy istnieje poprzedni
- * stan (baseline) I faktycznie coś się zmieniło — inaczej pierwszy skan fałszywie
- * oznaczałby całą książkę jako „zmiana". Bez baseline / bez zmian: zachowaj stary.
+ * `changedAt` marker policy: bump to `scannedAt` ONLY when a previous
+ * state (baseline) exists AND something actually changed — otherwise the first scan would falsely
+ * mark the whole book as „zmiana". Without a baseline / without changes: keep the old one.
  */
 export function computeChangedAt(prevData: StoredVintedData | null, diff: OfferDiff, scannedAt: string): string | undefined {
   return prevData && hasChanges(diff) ? scannedAt : prevData?.changedAt;
 }
 
-/** Projekcja wiersza Notion + składowanych danych → widok kafelka/paczki (etap 3). */
+/** Projection of a Notion row + stored data → a tile/bundle view (stage 3). */
 export function toStoredBookView(book: NotionBook, data: StoredVintedData): StoredBookView {
   return {
     id: book.id,
@@ -89,7 +89,7 @@ export function toStoredBookView(book: NotionBook, data: StoredVintedData): Stor
   };
 }
 
-/** VintedItem (ze skanu) → StoredOffer (do zapisu). */
+/** VintedItem (from the scan) → StoredOffer (for storage). */
 export function offerFromItem(item: VintedItem): StoredOffer {
   return {
     url: item.url,
@@ -105,7 +105,7 @@ export function serializeVintedData(data: StoredVintedData): string {
   return JSON.stringify(data);
 }
 
-/** Parsuje blob z Notion; zwraca null dla pustego/uszkodzonego (nie wywala skanu). */
+/** Parses the blob from Notion; returns null for empty/corrupt (doesn't crash the scan). */
 export function parseVintedData(raw: string | null | undefined): StoredVintedData | null {
   if (!raw) return null;
   try {
@@ -124,10 +124,10 @@ export function parseVintedData(raw: string | null | undefined): StoredVintedDat
 }
 
 /**
- * Scala świeżo zeskanowane oferty ze składowanymi ORAZ liczy diff (nowe / zniknięte /
- * zmiana ceny). ZACHOWUJE rozpoznanego sprzedawcę i `firstSeenAt` dla ofert o niezmienionym
- * URL (re-scan nie kasuje danych sprzedawcy z etapu 2), ustawia `prevPrice` = cena z
- * poprzedniego skanu (do wykrycia spadku), a nowym ofertom stempluje `firstSeenAt = scannedAt`.
+ * Merges freshly scanned offers with the stored ones AND computes a diff (new / gone /
+ * price change). PRESERVES the recognized seller and `firstSeenAt` for offers with an unchanged
+ * URL (a re-scan doesn't wipe stage-2 seller data), sets `prevPrice` = price from the
+ * previous scan (to detect a drop), and stamps new offers with `firstSeenAt = scannedAt`.
  */
 export function mergeAndDiff(
   fresh: StoredOffer[],
@@ -136,8 +136,8 @@ export function mergeAndDiff(
 ): { offers: StoredOffer[]; diff: OfferDiff } {
   const prevByUrl = new Map((prev ?? []).map(o => [o.url, o]));
 
-  // Dedupe świeżych po URL — parser potrafi zwrócić tę samą ofertę dwa razy; bez tego
-  // `added` i lista ofert puchną (duplikat renderowany 2× i liczony jako 2 „nowe").
+  // Dedupe fresh ones by URL — the parser can return the same offer twice; without this
+  // `added` and the offer list balloon (a duplicate rendered 2× and counted as 2 „nowe").
   const uniqueFresh: StoredOffer[] = [];
   const freshUrls = new Set<string>();
   for (const o of fresh) {
@@ -153,9 +153,9 @@ export function mergeAndDiff(
       added++;
       return { ...o, seller: o.seller ?? null, firstSeenAt: scannedAt };
     }
-    // Oferta przetrwała: zachowaj sprzedawcę i ORYGINALNY firstSeenAt (może być undefined
-    // dla starych blobów sprzed tej funkcji — wtedy NIE oznaczamy jej jako „nowa"), zapisz
-    // poprzednią cenę do wykrycia spadku.
+    // Offer survived: keep the seller and the ORIGINAL firstSeenAt (may be undefined
+    // for old blobs from before this function — then we do NOT mark it as „nowa"), record
+    // the previous price to detect a drop.
     const seller = o.seller ?? old.seller ?? null;
     const firstSeenAt = old.firstSeenAt;
     const prevPrice = typeof old.price === "number" ? old.price : null;

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -15,24 +15,24 @@ import { AppConfig } from "../src/configSchema";
 
 const log = createLogger("VintedScan");
 
-/** URL katalogu Vinted zbudowany z knobów konfiguracji (kategoria/język/cena/waluta/sortowanie). */
+/** Vinted catalog URL built from config knobs (category/language/price/currency/sorting). */
 function buildCatalogUrl(v: AppConfig["vinted"], searchText: string): string {
   return `https://www.vinted.pl/catalog?catalog[]=${v.catalogId}&language_book_ids[]=${v.languageId}&page=1&order=${encodeURIComponent(v.order)}&price_from=${v.priceFrom}&currency=${v.currency}&search_text=${encodeURIComponent(searchText)}`;
 }
 
 /**
- * Skaner ofert na Vinted (bezpośredni scraper HTML — NIE AI). Dla każdej książki,
- * której jeszcze nie posiadamy, wyszukuje oferty w katalogu Vinted i emituje
- * trafienia przez SSE. Cienki orkiestrator — plan skanu (`vintedScanPlanner`),
- * HTTP/throttling (`vintedHttp`), parsowanie (`vintedParser`) i merge/diff
- * (`vintedStore`) żyją w czystych helperach. Zob. docs/vinted-scanner.md.
+ * Vinted offer scanner (a direct HTML scraper — NOT AI). For each book
+ * we don't yet own, it searches the Vinted catalog for offers and emits
+ * hits over SSE. A thin orchestrator — the scan plan (`vintedScanPlanner`),
+ * HTTP/throttling (`vintedHttp`), parsing (`vintedParser`) and merge/diff
+ * (`vintedStore`) live in pure helpers. See docs/vinted-scanner.md.
  */
 export class VintedSyncService {
   constructor(private notion: NotionAdapter, private config: ConfigService) {}
 
   /**
-   * Etap 3: czyta składowane wyniki Vinted ze wszystkich książek (blob VintedData) do
-   * renderu kafelków/paczek z bazy — bez re-scrape. Zwraca tylko książki z ofertami.
+   * Stage 3: reads stored Vinted results from all books (VintedData blob) for
+   * rendering tiles/bundles from the database — no re-scrape. Returns only books with offers.
    */
   async getStoredData(): Promise<{ books: StoredBookView[]; generatedAt: string }> {
     const allBooks = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
@@ -46,9 +46,9 @@ export class VintedSyncService {
   }
 
   /**
-   * Zapisuje świeżo zeskanowane oferty książki do Notion (blob VintedData), scalając ze
-   * składowanymi — zachowuje rozpoznanego sprzedawcę dla ofert, których URL nadal istnieje.
-   * Best-effort: błąd zapisu nie przerywa skanu (dane w bazie to bonus, nie warunek).
+   * Saves a book's freshly scanned offers to Notion (VintedData blob), merging with the
+   * stored ones — preserves the recognized seller for offers whose URL still exists.
+   * Best-effort: a write error doesn't stop the scan (data in the database is a bonus, not a condition).
    */
   private async persistBookOffers(book: NotionBook, items: VintedItem[], scannedAt: string): Promise<OfferDiff> {
     try {
@@ -65,9 +65,9 @@ export class VintedSyncService {
   }
 
   /**
-   * Utrwala PUSTY rekord tylko dla pierwszego skanu tej książki. Gdy coś już było
-   * zapisane, NIE kasuje ofert/sprzedawców (marker „brak wyników"/0 ofert bywa fałszywy
-   * na stronie z ofertami — zachowanie jak przy cichym missie).
+   * Persists an EMPTY record only for this book's first scan. When something was already
+   * stored, it does NOT wipe offers/sellers (the „no results"/0-offers marker is sometimes false
+   * on a page with offers — same behavior as on a silent miss).
    */
   private async persistEmptyIfNew(book: NotionBook, scannedAt: string, persistEnabled: boolean, warnMsg: string): Promise<void> {
     const hadStored = (parseVintedData(book.vintedData)?.offers.length ?? 0) > 0;
@@ -84,11 +84,11 @@ export class VintedSyncService {
     params?: { skipScannedWithinHours?: number },
   ) {
     try {
-      // Knoby skanera (throttle/URL/retry/UA/wykluczenia) czytane raz na przebieg.
+      // Scanner knobs (throttle/URL/retry/UA/exclusions) read once per run.
       const cfg = await this.config.getConfig();
       const v = cfg.vinted;
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
-      // cache: współdziel pobranie z sąsiadującymi skanami (biblioteka/Vinted).
+      // cache: share the fetch with neighboring scans (library/Vinted).
       const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
       const skipHours = params?.skipScannedWithinHours;
@@ -101,8 +101,8 @@ export class VintedSyncService {
       const results: any[] = [];
       const httpsAgent = createScrapingAgent();
 
-      // Rozgrzej sesję (ciasteczko Cloudflare) RAZ na skan — realne żądania niosą wtedy
-      // stały UA + Cookie. Odporne: brak ciasteczek → skan leci bez primingu (jak dotąd).
+      // Warm up the session (Cloudflare cookie) ONCE per scan — real requests then carry
+      // a fixed UA + Cookie. Resilient: no cookies → the scan runs without priming (as before).
       let session: VintedSession = { userAgent: "", cookie: "" };
       if (v.primeSession && candidates.length > 0) {
         sendEvent({ type: "status", message: "Rozgrzewanie sesji Vinted (ciasteczko Cloudflare)..." });
@@ -111,11 +111,11 @@ export class VintedSyncService {
           ? `Sesja Vinted rozgrzana (${cookieCount(session.cookie)} ciasteczek, stały UA). Skanuję...`
           : "Nie udało się rozgrzać sesji (brak ciasteczek) — skanuję bez primingu." });
 
-        // SAMONAPRAWA: rozgrzana sesja (Cookie + stały UA) potrafi zmienić WARIANT strony,
-        // którą Vinted serwuje — jeśli to strona bez struktury katalogu, parser gubiłby
-        // WSZYSTKIE oferty (200 OK, ale 0 książek). Jedna próba walidacyjna: gdy strona nie
-        // jest zablokowana ANI nie ma żadnej struktury katalogu (JSON/feed-grid/`/items/`),
-        // porzucamy sesję i skanujemy bez primingu (priming może pomóc, nigdy nie szkodzić).
+        // SELF-HEAL: a warmed-up session (Cookie + fixed UA) can change the VARIANT of the page
+        // Vinted serves — if it's a page without catalog structure, the parser would drop
+        // ALL offers (200 OK, but 0 books). One validation probe: when the page is
+        // not blocked AND has no catalog structure at all (JSON/feed-grid/`/items/`),
+        // we drop the session and scan without priming (priming may help, never harm).
         if (session.cookie) {
           try {
             const probeUrl = buildCatalogUrl(v, `${candidates[0].plTitle} ${candidates[0].author || ""}`.trim());
@@ -129,12 +129,12 @@ export class VintedSyncService {
             }
             await throttle(v.throttleMinMs, v.throttleJitterMs);
           } catch {
-            // Błąd sondy nie przesądza — zostaw sesję, właściwy skan i tak ma retry/diagnostykę.
+            // A probe error isn't decisive — keep the session, the actual scan has retry/diagnostics anyway.
           }
         }
       }
 
-      // Zapewnij pole składowania raz na skan; gdy się nie uda — persystencja off (skan i tak leci).
+      // Ensure the storage field once per scan; if it fails — persistence off (the scan runs anyway).
       let persistEnabled = true;
       try {
         await this.notion.createColumnIfNeeded("VintedData");
@@ -170,12 +170,12 @@ export class VintedSyncService {
           const html = response.data;
           log.info(`Odpowiedź Vinted`, { title, chars: html.length, ...memMb() });
 
-          // Blokada = MAŁA strona challenge, nie samo słowo w wielkim HTML.
+          // Block = a SMALL challenge page, not just the word in huge HTML.
           if (looksBlocked(html)) {
             log.warn(`Vinted zablokował żądanie (wykrycie bota)`, { title });
             sendEvent({ type: "status", message: `⚠️ Vinted wykrył bota przy "${title}". Próbuję ominąć...` });
             sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "blocked", itemCount: 0, debug: { ...vintedDiagnostics(html, 0), ...memMb() } } });
-            // Blok to NIE „brak ofert": nie zapisujemy pustki ani scannedAt, by wznowienie ponowiło tę książkę.
+            // A block is NOT „no offers": we don't store emptiness or scannedAt, so a resume retries this book.
             await throttle(v.throttleMinMs, v.throttleJitterMs);
             continue;
           }
@@ -192,13 +192,13 @@ export class VintedSyncService {
           const debug = { ...vintedDiagnostics(html, items.length), ...memMb() };
 
           if (items.length > 0) {
-            // Utrwal (scala ze składowanymi — zachowuje sprzedawców przy niezmienionym URL) + policz diff.
+            // Persist (merges with the stored ones — keeps sellers on unchanged URLs) + compute the diff.
             const diff = persistEnabled ? await this.persistBookOffers(book, items, scannedAt) : EMPTY_DIFF;
             const matchResult = { id: book.id, title: book.plTitle, author: book.author, searchUrl: url, vintedItems: items, partOfCycle: book.currentCzesccyklu, cykl: book.cykl, cyklNr: book.cyklNr };
             results.push(matchResult);
             sendEvent({ type: "match", result: matchResult });
             sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "success", itemCount: items.length, debug: { ...debug, changes: diff } } });
-            // Książka istnieje na Vinted → oznacz źródło tagiem „Vinted" (best-effort, pomiń jeśli już jest).
+            // The book exists on Vinted → tag the source with „Vinted" (best-effort, skip if already present).
             if (!(book.zrodlo || []).includes("Vinted")) {
               try {
                 await this.notion.addTagToMultiSelect(book.id, "Źródło", "Vinted");
@@ -207,7 +207,7 @@ export class VintedSyncService {
               }
             }
           } else {
-            // 0 ofert BEZ markera i bez blokady: realnie pusto ALBO cichy miss parsera.
+            // 0 offers WITHOUT a marker and without a block: genuinely empty OR a silent parser miss.
             await this.persistEmptyIfNew(book, scannedAt, persistEnabled, "0 ofert mimo zapisanych wcześniej — pomijam zapis (możliwy miss/blok), zachowuję dane");
             sendEvent({ type: "search_attempt", result: { id: book.id, title, author: book.author, url, status: "no_results", itemCount: 0, debug } });
           }
@@ -219,7 +219,7 @@ export class VintedSyncService {
           if (waitMs) await new Promise((resolve) => setTimeout(resolve, waitMs));
         }
 
-        // Odstęp między żądaniami (z jitterem) — na KAŻDEJ ścieżce, by nie wywołać bloku.
+        // Gap between requests (with jitter) — on EVERY path, to avoid triggering a block.
         await throttle(v.throttleMinMs, v.throttleJitterMs);
       }
 
@@ -232,18 +232,18 @@ export class VintedSyncService {
   }
 
   /**
-   * Etap 2 (przyrostowo, wznawialnie): dociąga sprzedawcę do SKŁADOWANYCH ofert bez
-   * sprzedawcy i zapisuje z powrotem do Notion. Rozpoznani zostają w blobie, więc kolejny
-   * przebieg bierze tylko wciąż-`null`. Bez capu domyślnie: przebieg ustala WSZYSTKIE
-   * brakujące, ile zdąży zanim padnie (zapis raz na książkę utrwala postęp). Opcjonalny
-   * `cap` ogranicza przebieg (np. z UI).
+   * Stage 2 (incremental, resumable): fetches the seller for STORED offers without
+   * a seller and writes them back to Notion. Recognized ones stay in the blob, so the next
+   * run takes only still-`null` ones. No cap by default: a run resolves ALL
+   * missing ones, as many as it manages before dying (a write per book persists progress). An optional
+   * `cap` limits the run (e.g. from the UI).
    */
   async resolveSellersToStore(
     sendEvent: (data: SyncEvent) => void,
     checkCancellation: () => boolean,
     params?: { cap?: number },
   ) {
-    // Cap: parametr żądania > knob konfiguracji (`sellerResolveCap`; 0 = bez limitu).
+    // Cap: request parameter > config knob (`sellerResolveCap`; 0 = no limit).
     const cfg = await this.config.getConfig();
     const v = cfg.vinted;
     const capKnob = params?.cap && params.cap > 0 ? params.cap : v.sellerResolveCap;
@@ -252,7 +252,7 @@ export class VintedSyncService {
       sendEvent({ type: "status", message: "Wczytywanie składowanych ofert z Notion..." });
       const allBooks = await this.notion.getBooksForStats(undefined, checkCancellation, { cache: true });
 
-      // Książki z ofertami bez sprzedawcy (offer to referencja do data.offers — mutacja wraca do blobu).
+      // Books with offers lacking a seller (offer is a reference into data.offers — the mutation flows back to the blob).
       const pending: { book: NotionBook; data: StoredVintedData; offers: StoredOffer[] }[] = [];
       let totalPending = 0;
       for (const book of allBooks) {
@@ -277,7 +277,7 @@ export class VintedSyncService {
 
       const httpsAgent = createScrapingAgent();
 
-      // Priming sesji też tutaj — strony ofert (`/items/…`) są pod tym samym Cloudflare.
+      // Session priming here too — offer pages (`/items/…`) are behind the same Cloudflare.
       let session: VintedSession = { userAgent: "", cookie: "" };
       if (v.primeSession) {
         sendEvent({ type: "status", message: "Rozgrzewanie sesji Vinted (ciasteczko Cloudflare)..." });
@@ -312,7 +312,7 @@ export class VintedSyncService {
           }
           await throttle(v.throttleMinMs, v.throttleJitterMs);
         }
-        // Zapisz książkę raz, po ustaleniu jej ofert (mniej zapisów do Notion).
+        // Save the book once, after resolving its offers (fewer writes to Notion).
         if (dirty) {
           try {
             await this.notion.saveVintedData(p.book.id, serializeVintedData(p.data));

--- a/services/wikiFieldSyncService.ts
+++ b/services/wikiFieldSyncService.ts
@@ -8,30 +8,30 @@ import { DiffEngine } from "./diffEngine";
 import { isAwardBook } from "./bookCategory";
 
 /**
- * Konfiguracja jednego pola wzbogacanego ze strony książki w encyklopedii.
- * PublisherSyncService i SeriesSyncService to tylko dwie instancje tego samego
- * potoku (fetch → weryfikacja autora → diff → update), różniące się polem.
+ * Config for a single field enriched from a book's encyclopedia page.
+ * PublisherSyncService and SeriesSyncService are just two instances of the same
+ * pipeline (fetch → author verification → diff → update), differing only in the field.
  */
 export interface WikiFieldConfig {
-  /** Kolumna w Notion, np. "Wydawnictwo" / "Seria". */
+  /** Notion column, e.g. "Wydawnictwo" / "Seria". */
   notionColumn: string;
-  /** Wybiera pole z wyniku parsera. */
+  /** Picks the field from the parser result. */
   pick: (extracted: { wydawca: string; seria: string }) => string;
-  /** Kontekst normalizacji dla dataNormalizer. */
+  /** Normalization context for dataNormalizer. */
   normalizeContext: NormalizationContext;
-  /** Odczytuje obecną wartość z rekordu Notion. */
+  /** Reads the current value from the Notion record. */
   current: (book: NotionBook) => string;
-  /** Nazwa rytuału (do komunikatu o przerwaniu). */
+  /** Ritual name (for the cancellation message). */
   ritualName: string;
-  /** Etykieta do komunikatu progresu (dopełniacz, np. "wydawnictw"). */
+  /** Label for the progress message (genitive, e.g. "wydawnictw"). */
   progressLabel: string;
-  /** Etykieta do podsumowania (np. "Wydawnictwo"). */
+  /** Label for the summary (e.g. "Wydawnictwo"). */
   summaryLabel: string;
 }
 
 /**
- * Wspólny potok synchronizacji pojedynczego pola (wydawca/seria) ze stron
- * książek. Zastępuje zduplikowane Publisher/SeriesSyncService.
+ * Shared pipeline for syncing a single field (publisher/series) from book
+ * pages. Replaces the duplicated Publisher/SeriesSyncService.
  */
 export class WikiFieldSyncService {
   constructor(
@@ -48,10 +48,10 @@ export class WikiFieldSyncService {
         (count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }),
         checkCancellation
       );
-      // Wzbogacanie wydawcy/serii to koncern NAGRODOWY — poboczne tomy cykli
-      // (Kategoria="Tom cyklu") mają własny rytuał żniw i widok „Archiwum Cykli",
-      // więc pomijamy je (bez zbędnych pobrań stron i zapisów na wierszach,
-      // których żaden konsument nagrodowy nie czyta).
+      // Publisher/series enrichment is an AWARD concern — side cycle volumes
+      // (Kategoria="Tom cyklu") have their own harvest ritual and „Archiwum Cykli" view,
+      // so we skip them (no needless page fetches and writes on rows
+      // that no award consumer reads).
       const allBooks = rawBooks.filter(isAwardBook);
 
       if (checkCancellation()) { sendEvent({ type: "status", message: `Przerwano ${cfg.ritualName}.` }); return; }
@@ -85,7 +85,7 @@ export class WikiFieldSyncService {
           const wikitext = wikiContents[titleToSearch.toLowerCase()];
           if (!wikitext) return;
 
-          // Zweryfikuj autora — strona o tym samym tytule może dotyczyć innego dzieła
+          // Verify the author — a page with the same title may concern a different work
           const wikiAuthor = WikiParser.extractAuthor(wikitext);
           if (!isWikiAuthorMatch(wikiAuthor, book.author || "")) return;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,8 @@ export default function App() {
   const [activeTab, setActiveTab] = useState<TabId>('stats');
   const [showScrollTop, setShowScrollTop] = useState(false);
 
-  // Jedna instancja managera — jej `anyError` zasila globalną kartę błędu (widoczną
-  // na każdej zakładce), a ten sam egzemplarz idzie do LiturgySection propem `sm`.
+  // A single manager instance — its `anyError` feeds the global error card (visible
+  // on every tab), and the same instance goes to LiturgySection via the `sm` prop.
   const sm = useSyncManager();
   const { anyError, isAnySyncLoading, handleResetSync } = sm;
 
@@ -49,7 +49,7 @@ export default function App() {
           animate={{ opacity: 1, y: 0 }}
           className="flex flex-col md:flex-row items-center gap-8 text-center md:text-left"
         >
-          {/* Logo = wejście do Sanktuarium Kalibracji (zakładka admin, poza paskiem). */}
+          {/* Logo = entry to the Sanktuarium Kalibracji (admin tab, outside the nav bar). */}
           <motion.button
             whileHover={{ scale: 1.05, rotate: 5 }}
             whileTap={{ scale: 0.95 }}

--- a/src/__tests__/bookSearch.test.ts
+++ b/src/__tests__/bookSearch.test.ts
@@ -63,7 +63,7 @@ describe("bookSearch.matchBooks", () => {
     ];
     const r = matchBooks("childe", idx);
     expect(r.map((b) => b.id)).toEqual(["u"]);
-    // prefiks tytułu efektywnego (origTitle) rankuje jak prefiks tytułu
+    // a prefix of the effective title (origTitle) ranks like a title prefix
     expect(matchBooks("chi", idx)[0].id).toBe("u");
   });
 

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -30,7 +30,7 @@ describe("bookshelf.spineStyle", () => {
     for (const t of ["Diuna", "Hyperion", "Ubik", "Solaris", "Lód"]) {
       const s = spineStyle(mk({ plTitle: t }));
       expect(CLOTH_PALETTE).toContain(s.color);
-      // akcent Holo+ z tego samego indeksu (równoległa paleta)
+      // Holo+ accent from the same index (parallel palette)
       const idx = CLOTH_PALETTE.indexOf(s.color);
       expect(s.app).toBe(APP_PALETTE[idx][0]);
       expect(s.appRgb).toBe(APP_PALETTE[idx][1]);
@@ -50,8 +50,8 @@ describe("bookshelf.planShelf", () => {
     const b = planShelf(shelf);
     expect(a).toEqual(b);
     const ids = a.flatMap((s) => (s.kind === "stack" ? s.books.map((x) => x.id) : [s.book.id]));
-    expect(ids).toEqual(shelf.map((x) => x.id));           // każda książka raz, w kolejności
-    expect(new Set(ids).size).toBe(shelf.length);          // bez duplikatów
+    expect(ids).toEqual(shelf.map((x) => x.id));           // each book once, in order
+    expect(new Set(ids).size).toBe(shelf.length);          // no duplicates
   });
 
   it("keeps most books upright, with a minority leaning/stacked", () => {
@@ -59,7 +59,7 @@ describe("bookshelf.planShelf", () => {
     const straight = slots.filter((s) => s.kind === "spine" && s.lean === 0).length;
     const lean = slots.filter((s) => s.kind === "spine" && s.lean !== 0).length;
     const stacks = slots.filter((s) => s.kind === "stack").length;
-    expect(straight).toBeGreaterThan(lean + stacks);        // zdecydowana większość prosto
+    expect(straight).toBeGreaterThan(lean + stacks);        // the vast majority upright
     expect(lean).toBeGreaterThan(0);
     expect(stacks).toBeGreaterThan(0);
   });
@@ -88,7 +88,7 @@ describe("bookshelf.planShelf", () => {
     for (let k = 1; k < slots.length; k++) {
       expect(slots[k].kind === "stack" && slots[k - 1].kind === "stack").toBe(false);
     }
-    expect(slots.some((s) => s.kind === "stack")).toBe(true); // a jakieś kupki są
+    expect(slots.some((s) => s.kind === "stack")).toBe(true); // yet some stacks exist
   });
 
   it("leans a stack's neighbours toward the stack (left → +, right → −)", () => {
@@ -99,7 +99,7 @@ describe("bookshelf.planShelf", () => {
       const left = slots[k - 1], right = slots[k + 1];
       if (left && left.kind === "spine") {
         expect(Math.abs(left.lean)).toBe(LEAN_TOWARD); checked++;
-        // kierunek pewny tylko gdy grzbiet nie jest wciśnięty między dwie kupki
+        // direction is certain only when the spine isn't wedged between two stacks
         if (slots[k - 2]?.kind !== "stack") expect(left.lean).toBe(LEAN_TOWARD);
       }
       if (right && right.kind === "spine") {
@@ -128,9 +128,9 @@ describe("bookshelf.title sizing (pełne nazwy)", () => {
     expect(short.width).toBeLessThanOrEqual(FLAT_MAX_W);
 
     const long = flatBookLayout(mk({ plTitle: "Hyperion i jego długa, rozwlekła kontynuacja opowieści" }));
-    expect(long.lines).toBe(2);                 // zawija, nie poszerza
-    expect(long.width).toBe(FLAT_MAX_W);        // szerokość zaczepiona na limicie
-    expect(long.thickness).toBeGreaterThan(short.thickness); // 2 linie → trochę grubsza
+    expect(long.lines).toBe(2);                 // wraps, doesn't widen
+    expect(long.width).toBe(FLAT_MAX_W);        // width pinned at the cap
+    expect(long.thickness).toBeGreaterThan(short.thickness); // 2 lines → a bit thicker
 
     for (const l of [short, long]) {
       expect(l.width).toBeLessThanOrEqual(FLAT_MAX_W);
@@ -138,7 +138,7 @@ describe("bookshelf.title sizing (pełne nazwy)", () => {
       expect(l.fontSize).toBeLessThanOrEqual(10);
       expect(l.thickness).toBeGreaterThanOrEqual(15);
       expect(l.thickness).toBeLessThanOrEqual(24);
-      // 2 linie muszą wystarczyć na pełny tytuł: połowa tekstu mieści się w linii
+      // 2 lines must suffice for the full title: half the text fits in one line
       const availW = FLAT_MAX_W - 20;
       expect(Math.ceil((l === long ? "Hyperion i jego długa, rozwlekła kontynuacja opowieści".length : 4) * 0.6 * l.fontSize / l.lines)).toBeLessThanOrEqual(availW);
     }
@@ -169,7 +169,7 @@ describe("bookshelf.layoutStack (wyrównanie + chaos)", () => {
   it("aligns left / right often and symmetric (center) only rarely", () => {
     const counts = { left: 0, right: 0, center: 0 } as Record<string, number>;
     for (let s = 0; s < 600; s++) counts[stackAlign(mkBooks(`Z${s}_`, 4))]++;
-    expect(counts.center).toBeLessThan(counts.left);   // piramida rzadka
+    expect(counts.center).toBeLessThan(counts.left);   // pyramid is rare
     expect(counts.center).toBeLessThan(counts.right);
     expect(counts.left).toBeGreaterThan(0);
     expect(counts.right).toBeGreaterThan(0);
@@ -183,7 +183,7 @@ describe("bookshelf.layoutStack (wyrównanie + chaos)", () => {
       if (c > 0) chaotic++;
     }
     expect(chaotic).toBeGreaterThan(0);
-    expect(chaotic).toBeLessThan(600 / 2); // większość równa
+    expect(chaotic).toBeLessThan(600 / 2); // most are aligned
   });
 });
 
@@ -191,11 +191,11 @@ describe("bookshelf.shelfPlankBackground", () => {
   it("draws a plank starting at the row baseline and repeats per row advance", () => {
     const { backgroundImage } = shelfPlankBackground();
     expect(backgroundImage.startsWith("repeating-linear-gradient(180deg,")).toBe(true);
-    // Deska zaczyna się dokładnie pod spodem rzędu (SHELF_ROW_H) …
+    // The plank starts exactly below the row (SHELF_ROW_H) …
     expect(backgroundImage).toContain(`${SHELF_ROW_H}px`);
-    // … kończy po SHELF_PLANK_H …
+    // … ends after SHELF_PLANK_H …
     expect(backgroundImage).toContain(`${SHELF_ROW_H + SHELF_PLANK_H}px`);
-    // … a okres powtórzenia = skok jednego rzędu (ROW_H + GAP).
+    // … and the repeat period = one row's advance (ROW_H + GAP).
     expect(backgroundImage).toContain(`${SHELF_ROW_H + SHELF_ROW_GAP}px`);
   });
 
@@ -214,7 +214,7 @@ describe("bookshelf.awardWins (color-code, bez nominacji)", () => {
   it("ignores nominations entirely", () => {
     expect(awardWins(mk({ awards: ["Nominacja Hugo", "Nominacja Nebula"] }))).toEqual([]);
     expect(hasAward(mk({ awards: ["Nominacja Hugo"] }))).toBe(false);
-    // wygrana + nominacja → tylko wygrana
+    // win + nomination → only the win
     expect(awardWins(mk({ awards: ["Nominacja Hugo", "Nagroda Nebula"] })).map((x) => x.key)).toEqual(["nebula"]);
   });
   it("treats Wszystkie as all three wins, deduped", () => {
@@ -256,7 +256,7 @@ describe("bookshelf.splitShelves", () => {
   it("respects overrides when partitioning (drag&drop move)", () => {
     const { read, toRead } = splitShelves(books, { "1": false });
     expect(read.map((b) => b.id)).toEqual(["3"]);
-    // toRead posortowane po dacie: 1965 (id 2) przed 1970 (id 1)
+    // toRead sorted by date: 1965 (id 2) before 1970 (id 1)
     expect(toRead.map((b) => b.id)).toEqual(["2", "1"]);
   });
 });

--- a/src/__tests__/shelfInsertion.test.ts
+++ b/src/__tests__/shelfInsertion.test.ts
@@ -12,15 +12,15 @@ describe("bookshelf.effShelfKey / byShelfPosition", () => {
   it("uses shelfOrder within the book's decade, falls back to year otherwise", () => {
     expect(effShelfKey(mk("a", "1954"))).toBe(1954);
     expect(effShelfKey(mk("a", "1954", 1955.5))).toBe(1955.5);
-    // Klucz STALE (spoza dekady książki) — ignorowany.
+    // A STALE key (outside the book's decade) — ignored.
     expect(effShelfKey(mk("a", "1964", 1955.5))).toBe(1964);
   });
 
   it("sorts by decade, then manual key interleaved with years, then title", () => {
-    const a = mk("a", "1954");            // klucz 1954
-    const b = mk("b", "1957", 1954.5);    // ręcznie między 1954 a 1955
+    const a = mk("a", "1954");            // key 1954
+    const b = mk("b", "1957", 1954.5);    // manually between 1954 and 1955
     const c = mk("c", "1955");
-    const d = mk("d", "1949");            // inna dekada — zawsze przed
+    const d = mk("d", "1949");            // different decade — always before
     const sorted = [a, b, c, d].sort(byShelfPosition).map((x) => x.id);
     expect(sorted).toEqual(["d", "a", "b", "c"]);
   });
@@ -31,15 +31,15 @@ describe("shelfInsertion.canInsertAt", () => {
 
   it("allows gaps inside and at the edges of the book's decade section", () => {
     const dragged = mk("x", "1953");
-    expect(canInsertAt(seq, dragged, "b")).toBe(true);  // przed 1952 (start sekcji 1950s — lewy sąsiad 1948)
-    expect(canInsertAt(seq, dragged, "c")).toBe(true);  // między 1952 a 1955
-    expect(canInsertAt(seq, dragged, "d")).toBe(true);  // koniec sekcji 1950s (lewy sąsiad 1955)
+    expect(canInsertAt(seq, dragged, "b")).toBe(true);  // before 1952 (start of the 1950s section — left neighbor 1948)
+    expect(canInsertAt(seq, dragged, "c")).toBe(true);  // between 1952 and 1955
+    expect(canInsertAt(seq, dragged, "d")).toBe(true);  // end of the 1950s section (left neighbor 1955)
   });
 
   it("rejects gaps in a foreign decade and unknown targets", () => {
     const dragged = mk("x", "1953");
-    expect(canInsertAt(seq, dragged, "a")).toBe(false); // przed 1948 — sąsiedzi 1940s/undefined
-    expect(canInsertAt(seq, dragged, null)).toBe(false); // koniec półki — lewy sąsiad 1969 (1960s)
+    expect(canInsertAt(seq, dragged, "a")).toBe(false); // before 1948 — neighbors 1940s/undefined
+    expect(canInsertAt(seq, dragged, null)).toBe(false); // end of the shelf — left neighbor 1969 (1960s)
     expect(canInsertAt(seq, dragged, "zzz")).toBe(false);
   });
 
@@ -70,12 +70,12 @@ describe("shelfInsertion.planInsertion", () => {
   it("tie of same-year keys renumbers only the tied run, preserving final order", () => {
     const seq = [mk("a", "1954"), mk("b", "1954"), mk("c", "1957")];
     const plan = planInsertion(seq, mk("x", "1954"), "b")!;
-    // renumeracja: a, x, b (+x) — 3 wpisy; c nietknięte
+    // renumbering: a, x, b (+x) — 3 entries; c untouched
     expect(plan.orders.map((o) => o.pageId)).toEqual(["a", "x", "b"]);
     const byId = Object.fromEntries(plan.orders.map((o) => [o.pageId, o.order]));
     expect(byId.a).toBeLessThan(byId.x);
     expect(byId.x).toBeLessThan(byId.b);
-    expect(byId.b).toBeLessThan(1955); // poniżej następnego rocznika
+    expect(byId.b).toBeLessThan(1955); // below the next year
     for (const o of plan.orders) expect(o.order).toBeGreaterThanOrEqual(1954);
   });
 

--- a/src/__tests__/shelfLayout.test.ts
+++ b/src/__tests__/shelfLayout.test.ts
@@ -26,7 +26,7 @@ describe("shelfLayout.decade", () => {
 });
 
 describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {
-  // Posortowane po dacie (jak z splitShelves): 1948, 1952, 1955, 1969, brak.
+  // Sorted by date (as from splitShelves): 1948, 1952, 1955, 1969, none.
   const books = [
     mk({ id: "a", year: "1948" }),
     mk({ id: "b", year: "1952" }),
@@ -38,7 +38,7 @@ describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {
   it("inserts one divider per decade section, before its books", () => {
     const { items, slotByKey } = buildShelfItems(books);
     const dividers = items.filter((it) => it.kind === "divider");
-    // dekady: 1940, 1950, 1960, bez daty → 4 tabliczki
+    // decades: 1940, 1950, 1960, no date → 4 plates
     expect(dividers.length).toBe(4);
     const labels = dividers.map((d) => (slotByKey.get(d.key) as { label: string }).label);
     expect(labels).toEqual(["1940–1949", "1950–1959", "1960–1969", "bez daty"]);
@@ -47,7 +47,7 @@ describe("shelfLayout.buildShelfItems (tabliczki dekad)", () => {
   it("keeps every book exactly once and dividers precede their decade", () => {
     const { items } = buildShelfItems(books);
     const seq = items.map((it) => (it.kind === "divider" ? "|" : it.key));
-    // pierwszy item to tabliczka; każda książka pojawia się raz
+    // the first item is a plate; each book appears once
     expect(seq[0]).toBe("|");
     expect(seq.filter((s) => s !== "|")).toEqual(["a", "b", "c", "d", "e"]);
   });
@@ -60,7 +60,7 @@ describe("shelfLayout.plateWidth / assignDividerPlacement", () => {
     a: "1940–1949", b: "1950–1959", c: "1960–1969", d: "1970–1979",
   };
   const labelOf = (k: string) => labels[k];
-  const W = 2000; // szeroka półka — bez zawijania przy prawej krawędzi
+  const W = 2000; // wide shelf — no wrapping at the right edge
 
   it("estimates plate width from label length (mono 11px)", () => {
     expect(plateWidth("1950–1959")).toBe(103); // 37 + 9·7.3
@@ -75,7 +75,7 @@ describe("shelfLayout.plateWidth / assignDividerPlacement", () => {
   });
 
   it("drops a plate to the bottom when the previous decade is too narrow", () => {
-    // b sits only 40px past a → górna tabliczka a (szer. ~103) zderza się z b.
+    // b sits only 40px past a → the top plate a (width ~103) collides with b.
     const row = [div("a", 0), div("b", 40), div("c", 420)];
     const pl = assignDividerPlacement(row, labelOf, W);
     expect(pl.get("b")?.level).toBe("bottom");
@@ -84,7 +84,7 @@ describe("shelfLayout.plateWidth / assignDividerPlacement", () => {
   });
 
   it("alternates top/bottom greedily and only the middle plate flips in a tight chain", () => {
-    // a(0) top; b(40) collides top → bottom; c(80) collides both → góra (fallback).
+    // a(0) top; b(40) collides top → bottom; c(80) collides both → top (fallback).
     const row = [div("a", 0), div("b", 40), div("c", 80)];
     const pl = assignDividerPlacement(row, labelOf, W);
     expect(pl.get("a")?.level).toBe("top");
@@ -93,7 +93,7 @@ describe("shelfLayout.plateWidth / assignDividerPlacement", () => {
   });
 
   it("extends a plate leftward when it would overflow the right shelf edge", () => {
-    // rowWidth 300; b przy 240 → 240+103=343 > 300 → rozwija się w lewo (bez kolizji z a).
+    // rowWidth 300; b at 240 → 240+103=343 > 300 → extends leftward (no collision with a).
     const row = [div("a", 0), div("b", 240)];
     const pl = assignDividerPlacement(row, labelOf, 300);
     expect(pl.get("a")?.dir).toBe("right");

--- a/src/__tests__/shelfPacking.test.ts
+++ b/src/__tests__/shelfPacking.test.ts
@@ -12,7 +12,7 @@ describe("shelfPacking.packRows", () => {
       const base = r.reduce((s, it) => s + it.bw, 0) + 3 * (r.length - 1);
       expect(base).toBeLessThanOrEqual(200 + 1e-9);
     }
-    expect(rows.flat().map((x) => x.key)).toEqual(items.map((x) => x.key)); // nic nie zgubione
+    expect(rows.flat().map((x) => x.key)).toEqual(items.map((x) => x.key)); // nothing lost
   });
   it("always keeps at least one item per row even if too wide", () => {
     const rows = packRows([spine("wide", 400)], 200, 3);
@@ -38,31 +38,31 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
   });
 
   it("a leaning book rests at θ = atan(gap / supportHeight), capped at MAX_LEAN", () => {
-    // a leans right onto b (support height 100). Duży luz → kąt ograniczony do MAX_LEAN.
+    // a leans right onto b (support height 100). Large slack → angle capped at MAX_LEAN.
     const row = [spine("a", 20, 150, 1), spine("b", 30, 100)];
     const placed = layoutRow(row, 400);
     const leaner = placed[0];
-    expect(leaner.deg).toBeGreaterThan(0);              // pochyla się w prawo (w stronę podpory)
+    expect(leaner.deg).toBeGreaterThan(0);              // leans right (toward the support)
     expect(leaner.deg).toBeLessThanOrEqual(MAX_LEAN_DEG + 1e-9);
-    // gap między a i b odpowiada kątowi: gap = supportH * tan(deg)
+    // the gap between a and b matches the angle: gap = supportH * tan(deg)
     const gap = placed[1].x - (leaner.x + leaner.bw);
     const expectDeg = Math.min(MAX_LEAN_DEG, Math.atan(gap / 100) * 180 / Math.PI);
     expect(leaner.deg).toBeCloseTo(expectDeg, 4);
   });
 
   it("fills slack by THICKENING straight spines (no gaps) — real shelves have no air between books", () => {
-    // 12 stojących grzbietów z zapasem na pogrubienie → luz idzie w grubość, nie w szczeliny.
+    // 12 upright spines with room to thicken → slack goes into thickness, not gaps.
     const row = Array.from({ length: 12 }, (_, i) => spine(`s${i}`, 20, 150, 0, 20));
-    const placed = layoutRow(row, 340); // base 240, slack 100, łączny zapas 240
+    const placed = layoutRow(row, 340); // base 240, slack 100, total headroom 240
     for (let i = 1; i < placed.length; i++) {
       const gap = placed[i].x - (placed[i - 1].x + placed[i - 1].w);
-      expect(gap).toBeLessThan(1e-6);                         // książki się stykają — zero przerw
+      expect(gap).toBeLessThan(1e-6);                         // books touch — zero gaps
     }
-    for (const p of placed) expect(p.w).toBeGreaterThanOrEqual(p.bw); // grzbiety zgrubiały
+    for (const p of placed) expect(p.w).toBeGreaterThanOrEqual(p.bw); // spines thickened
     const widened = placed.reduce((s, p) => s + (p.w - p.bw), 0);
-    expect(widened).toBeCloseTo(100, 4);                      // cały luz wchłonięty przez grubość
+    expect(widened).toBeCloseTo(100, 4);                      // all slack absorbed by thickness
     const last = placed[placed.length - 1];
-    expect(last.x + last.w).toBeCloseTo(340, 6);              // wypełnione do prawej
+    expect(last.x + last.w).toBeCloseTo(340, 6);              // filled to the right
   });
 
   it("falls back to EVEN gaps only when spines can't thicken further (stretch = 0)", () => {
@@ -71,7 +71,7 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
     const gaps: number[] = [];
     for (let i = 1; i < placed.length; i++) gaps.push(placed[i].x - (placed[i - 1].x + placed[i - 1].w));
     const min = Math.min(...gaps), max = Math.max(...gaps);
-    expect(max - min).toBeLessThan(1e-6);                     // równe (żadnej pojedynczej dziury)
+    expect(max - min).toBeLessThan(1e-6);                     // even (no single hole)
     expect(placed[placed.length - 1].x + placed[placed.length - 1].w).toBeCloseTo(340, 6);
   });
 
@@ -85,8 +85,8 @@ describe("shelfPacking.layoutRow (wypełnienie + fizyka oparcia)", () => {
   it("never leans an edge book outward (no support beyond the row edge)", () => {
     const row = [spine("a", 20, 150, -1), spine("b", 20, 150), spine("c", 20, 150, 1)];
     const placed = layoutRow(row, 300);
-    expect(placed[0].deg).toBe(0);                       // pierwszy nie pochyli się w lewo (brak podpory)
-    expect(placed[placed.length - 1].deg).toBe(0);       // ostatni nie pochyli się w prawo
+    expect(placed[0].deg).toBe(0);                       // the first won't lean left (no support)
+    expect(placed[placed.length - 1].deg).toBe(0);       // the last won't lean right
   });
 });
 
@@ -96,9 +96,9 @@ describe("shelfPacking.packAndLayout", () => {
     expect(packAndLayout(items, { rowWidth: 0 })).toEqual([]);
     const rows = packAndLayout(items, { rowWidth: 240 });
     for (const row of rows) {
-      if (row.length === 1) continue;                    // pojedyncze centrowane
+      if (row.length === 1) continue;                    // single ones are centered
       const last = row[row.length - 1];
-      expect(last.x + last.bw).toBeCloseTo(240, 4);      // każdy rząd wypełniony do prawej
+      expect(last.x + last.bw).toBeCloseTo(240, 4);      // every row filled to the right
     }
   });
 });

--- a/src/__tests__/vintedSellers.test.ts
+++ b/src/__tests__/vintedSellers.test.ts
@@ -8,7 +8,7 @@ const result = (id: string, title: string, items: ReturnType<typeof item>[]): Vi
   ({ id, title, author: "Autor", vintedItems: items });
 
 describe("sortBundles", () => {
-  // s1: 3 książki, suma 60 (droższa paczka). s2: 2 książki, suma 20 (tańsza paczka).
+  // s1: 3 books, total 60 (pricier bundle). s2: 2 books, total 20 (cheaper bundle).
   const results = [
     result("1", "A", [item("https://www.vinted.pl/items/1", 20)]),
     result("2", "B", [item("https://www.vinted.pl/items/2", 20)]),
@@ -73,7 +73,7 @@ describe("groupBySeller", () => {
   });
 
   it("uses the seller's cheapest copy per book and reports premium vs the global cheapest", () => {
-    // Książka A: najtaniej 10 (s2), ale s1 ma A za 11 + B za 8 → paczka s1 z dopłatą 1.
+    // Book A: cheapest 10 (s2), but s1 has A for 11 + B for 8 → s1's bundle with a premium of 1.
     const results = [
       result("1", "A", [item("https://www.vinted.pl/items/a-s2", 10), item("https://www.vinted.pl/items/a-s1", 11)]),
       result("2", "B", [item("https://www.vinted.pl/items/b-s1", 8)]),
@@ -87,11 +87,11 @@ describe("groupBySeller", () => {
     expect(bundles).toHaveLength(1);
     const b = bundles[0];
     expect(b.seller.id).toBe("s1");
-    expect(b.totalValue).toBe(19); // 11 (A u s1) + 8 (B)
+    expect(b.totalValue).toBe(19); // 11 (A at s1) + 8 (B)
     expect(b.totalPremium).toBe(1); // A: 11 - 10(min) = 1; B: 0
     const entryA = b.entries.find(e => e.bookTitle === "A")!;
     expect(entryA.premium).toBe(1);
-    expect(entryA.item.priceValue).toBe(11); // najtańsza kopia A U s1, nie globalna
+    expect(entryA.item.priceValue).toBe(11); // cheapest copy of A at s1, not the global one
   });
 
   it("feeds groupBySeller from stored data (via storedToView)", () => {
@@ -125,7 +125,7 @@ describe("groupBySeller", () => {
       result("2", "B", [item("https://www.vinted.pl/items/2", 8)]),
       result("3", "C", [item("https://www.vinted.pl/items/3", 8)]),
     ];
-    // s1 ma A (dwie oferty tej samej książki) + B; s2 ma tylko C.
+    // s1 has A (two offers of the same book) + B; s2 has only C.
     const sellers = {
       "https://www.vinted.pl/items/1": seller("s1"),
       "https://www.vinted.pl/items/1b": seller("s1"),
@@ -135,6 +135,6 @@ describe("groupBySeller", () => {
     const bundles = groupBySeller(results, sellers);
     expect(bundles).toHaveLength(1);
     expect(bundles[0].seller.id).toBe("s1");
-    expect(bundles[0].entries).toHaveLength(2); // A liczone raz, nie dwa
+    expect(bundles[0].entries).toHaveLength(2); // A counted once, not twice
   });
 });

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -22,21 +22,21 @@ export const BookshelfSection: React.FC = () => {
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
   const [skin, setSkin] = useState<ShelfSkin>(loadSkin);
-  // Knoby UI: liczba rzędów regału na stronę + precyzyjny drop.
+  // UI knobs: number of „Regał" rows per page + precise drop.
   const uiCfg = useEffectiveConfig().ui;
   const rowsPerPage = uiCfg.shelfRowsPerPage;
-  // Optymistyczne nadpisania ręcznych kluczy porządku (precyzyjny drop) do czasu refetch.
+  // Optimistic overrides of manual order keys (precise drop) until refetch.
   const [orderOverrides, setOrderOverrides] = useState<Record<string, number>>({});
   useEffect(() => { saveSkin(skin); }, [skin]);
 
-  // Zapis stanu „przeczytane" jest SERIALIZOWANY per książka (latest-wins). Backend
-  // `mutateMultiSelect` to nieatomowy retrieve→modify→update, więc dwa nakładające się
-  // zapisy tej samej książki mogłyby przeczytać ten sam stan i rozjechać Notion z UI.
-  // `pendingRef` trzyma najświeższy żądany stan, `runningRef` — książki z aktywnym runnerem.
+  // Saving the „przeczytane" state is SERIALIZED per book (latest-wins). The backend
+  // `mutateMultiSelect` is a non-atomic retrieve→modify→update, so two overlapping
+  // writes of the same book could read the same state and drift Notion from the UI.
+  // `pendingRef` holds the freshest requested state, `runningRef` — books with an active runner.
   const pendingRef = useRef<Record<string, boolean>>({});
   const runningRef = useRef<Set<string>>(new Set());
 
-  // Księgozbiór z nadpisanymi kluczami porządku (optymistycznie, do czasu refetch).
+  // Book collection with overridden order keys (optimistically, until refetch).
   const all = useMemo(() => {
     const src = books ?? [];
     return src.map((b) => (orderOverrides[b.id] !== undefined ? { ...b, shelfOrder: orderOverrides[b.id] } : b));
@@ -44,12 +44,12 @@ export const BookshelfSection: React.FC = () => {
   const { read, toRead } = useMemo(() => splitShelves(all, overrides), [all, overrides]);
   const featured = useMemo(() => featuredReads(all, overrides), [all, overrides]);
 
-  /** Optymistyczna zmiana „przeczytane" + serializowany zapis (latest-wins per książka). */
+  /** Optimistic „przeczytane" change + serialized save (latest-wins per book). */
   const applyReadChange = useCallback((book: BookIndexEntry, targetRead: boolean) => {
     setOverrides((prev) => ({ ...prev, [book.id]: targetRead }));
     setMoveError(null);
 
-    // Zapisz najświeższy żądany stan; jeśli runner tej książki już działa, weźmie go sam.
+    // Store the freshest requested state; if this book's runner is already running, it will pick it up itself.
     pendingRef.current[book.id] = targetRead;
     if (runningRef.current.has(book.id)) return;
     runningRef.current.add(book.id);
@@ -61,7 +61,7 @@ export const BookshelfSection: React.FC = () => {
           await setRead(book.id, desired);
         }
       } catch (e: any) {
-        // Zapis nie doszedł — wróć do stanu z bazy i pokaż błąd.
+        // Save didn't go through — revert to the DB state and show the error.
         delete pendingRef.current[book.id];
         setOverrides((prev) => { const next = { ...prev }; delete next[book.id]; return next; });
         setMoveError(`Nie udało się zapisać „${book.plTitle || book.origTitle}": ${e.message}`);
@@ -77,15 +77,15 @@ export const BookshelfSection: React.FC = () => {
     if (!book) return;
 
     const targetRead = target === "read";
-    if (isRead(book, overrides) === targetRead) return; // upuszczono na tę samą półkę — nic
+    if (isRead(book, overrides) === targetRead) return; // dropped on the same shelf — nothing
     applyReadChange(book, targetRead);
   }, [dragging, overrides, applyReadChange]);
 
   /**
-   * Precyzyjny drop: wstaw książkę przed `insertBeforeId` (null = koniec półki).
-   * Klucze liczy czysty `planInsertion` (zwykle 1 wpis; remis roku → mała renumeracja);
-   * zapis optymistyczny + POST /api/shelf-order z rollbackiem. Przy zmianie półki
-   * dokłada się standardowa zmiana „przeczytane".
+   * Precise drop: insert the book before `insertBeforeId` (null = end of shelf).
+   * Keys are computed by the pure `planInsertion` (usually 1 entry; year tie → small renumbering);
+   * optimistic save + POST /api/shelf-order with rollback. On a shelf change
+   * the standard „przeczytane" change is added on top.
    */
   const handlePreciseDrop = useCallback((target: ShelfId, insertBeforeId: string | null) => {
     const book = dragging;
@@ -122,7 +122,7 @@ export const BookshelfSection: React.FC = () => {
 
   return (
     <div className="space-y-8">
-      {/* Nagłówek */}
+      {/* Header */}
       <div className="flex items-center gap-6">
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
         <div className="flex items-center gap-4">
@@ -135,7 +135,7 @@ export const BookshelfSection: React.FC = () => {
         Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał N"
       </p>
 
-      {/* Przełącznik skóry regału (Holo+ / Relikwiarz) — wybór trwa w localStorage */}
+      {/* „Regał" skin switch (Holo+ / Relikwiarz) — choice persists in localStorage */}
       <div className="flex items-center justify-center gap-2 -mt-3">
         <span className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">Skóra</span>
         <div className="inline-flex rounded-lg border border-white/10 overflow-hidden">
@@ -178,7 +178,7 @@ export const BookshelfSection: React.FC = () => {
       ) : (
         <div className={skinClass(skin)}>
         <RoomDecor>
-          {/* Półka „Wyróżnione" (okładki twarzą) */}
+          {/* „Wyróżnione" shelf (covers facing out) */}
           {featured.length > 0 && (
             <div className="mb-8">
               <ShelfFrame
@@ -197,8 +197,8 @@ export const BookshelfSection: React.FC = () => {
             </div>
           )}
 
-          {/* Dwa regały stałej wysokości: lewy „Do przeczytania", prawy zawsze
-              „Przeczytane" — drag&drop między nimi. Każdy paginowany (Regał N/M). */}
+          {/* Two fixed-height shelves: left „Do przeczytania", right always
+              „Przeczytane" — drag&drop between them. Each paginated (Regał N/M). */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <Shelf
               shelfId="toRead" title="Do przeczytania" accent="cyan" pageSize={rowsPerPage}

--- a/src/components/ConfigSection.tsx
+++ b/src/components/ConfigSection.tsx
@@ -5,9 +5,9 @@ import { AppConfig, DEFAULT_CONFIG, LibraryBranch, AwardPage } from "../configSc
 import { useAppConfig } from "../hooks/useAppConfig";
 
 /**
- * Zakładka „Kalibracja" (wejście: klik w logo) — knoby konfiguracji aplikacji.
- * Draft edytowany lokalnie; „Zapisz" wysyła PUT /api/app-config (backend clampuje
- * i składuje diff od defaultów w Notion). Sekcja „Zaawansowane" zwijana.
+ * „Kalibracja" tab (entry: click the logo) — app configuration knobs.
+ * Draft edited locally; „Zapisz" sends PUT /api/app-config (backend clamps
+ * and stores the diff from defaults in Notion). The „Zaawansowane" section is collapsible.
  */
 
 const inputCls = "w-full px-3 py-2 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-xl focus:outline-none focus:border-cyan-500/50 focus:ring-2 focus:ring-cyan-500/10 transition-all font-medium";
@@ -35,7 +35,7 @@ const TextField: React.FC<{ label: string; hint?: string; value: string; onChang
   </Field>
 );
 
-/** Lista tekstowa (jeden wpis na linię) — wykluczone źródła, pula UA. */
+/** Text list (one entry per line) — excluded sources, UA pool. */
 const ListField: React.FC<{ label: string; hint?: string; rows?: number; value: string[]; onChange: (v: string[]) => void }> = ({ label, hint, rows = 4, value, onChange }) => (
   <Field label={label} hint={hint}>
     <textarea
@@ -70,7 +70,7 @@ export const ConfigSection: React.FC = () => {
     );
   }
 
-  // Pojedyncze settery per sekcja — draft jest zawsze pełnym AppConfig.
+  // Single setters per section — draft is always a full AppConfig.
   const upd = <S extends keyof AppConfig>(section: S, patch: Partial<AppConfig[S]>) =>
     setDraft({ ...draft, [section]: { ...draft[section], ...patch } });
 
@@ -85,7 +85,7 @@ export const ConfigSection: React.FC = () => {
 
   return (
     <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-      {/* Nagłówek + akcje */}
+      {/* Header + actions */}
       <div className="glass-card rounded-3xl p-6 flex flex-col sm:flex-row sm:items-center gap-4">
         <div className="flex-1">
           <h2 className="text-xl font-bold font-display uppercase tracking-widest text-cyan-400 flex items-center gap-3">
@@ -153,14 +153,14 @@ export const ConfigSection: React.FC = () => {
         </Field>
       </SectionCard>
 
-      {/* Pula UA */}
+      {/* UA pool */}
       <SectionCard icon={<Globe className="w-4 h-4" />} title="Kamuflaż noosferyczny (User-Agent)" accent="text-cyan-400">
         <ListField label="Pula User-Agentów" rows={7}
           hint={'Rotacja per żądanie (Vinted + biblioteka). Odświeżaj co ~kwartał do bieżących wersji przeglądarek — przestarzałe UA ściągają wykrycie bota. Jeden wpis na linię.'}
           value={draft.scraping.userAgents} onChange={(v) => upd("scraping", { userAgents: v })} />
       </SectionCard>
 
-      {/* Filie biblioteczne */}
+      {/* Library branches */}
       <SectionCard icon={<LibraryBig className="w-4 h-4" />} title="Filie biblioteczne (OPAC)" accent="text-indigo-400">
         <div className="space-y-3">
           {draft.library.branches.map((b, i) => (
@@ -183,7 +183,7 @@ export const ConfigSection: React.FC = () => {
         </div>
       </SectionCard>
 
-      {/* Nagrody */}
+      {/* Awards */}
       <SectionCard icon={<Trophy className="w-4 h-4" />} title="Strony nagród (Archiwum Encyklopedii)" accent="text-amber-400">
         <div className="space-y-3">
           {draft.sync.awards.map((a, i) => (
@@ -204,7 +204,7 @@ export const ConfigSection: React.FC = () => {
         </div>
       </SectionCard>
 
-      {/* Zaawansowane */}
+      {/* Advanced */}
       <div className="glass-card rounded-3xl p-6 space-y-5">
         <button onClick={() => setShowAdvanced(!showAdvanced)}
           className="w-full flex items-center justify-between text-sm font-display font-bold uppercase tracking-[0.2em] text-purple-400">

--- a/src/components/CycleTile.tsx
+++ b/src/components/CycleTile.tsx
@@ -6,22 +6,22 @@ import { AnchorRect } from "../utils/popoverPosition";
 interface Props {
   title: string;
   author: string;
-  /** Renderuje kafelek tylko dla książek należących do cyklu. */
+  /** Renders the tile only for books belonging to a cycle. */
   partOfCycle?: boolean;
-  /** Nazwa cyklu (kolumna „Cykl", z żniw) — tylko w tooltipie (hover), nie na chipie. */
+  /** Cycle name (column „Cykl", from harvest) — only in the tooltip (hover), not on the chip. */
   cykl?: string;
-  /** Numer tomu w cyklu (kolumna „CyklNr", z żniw) — pokazywany jako „Cykl · N". */
+  /** Volume number in the cycle (column „CyklNr", from harvest) — shown as „Cykl · N". */
   cyklNr?: number;
-  /** Rozmiar: „sm" (kafelki), „xs" (ciasne wiersze paczek). */
+  /** Size: „sm" (tiles), „xs" (tight bundle rows). */
   size?: "sm" | "xs";
 }
 
 /**
- * Interaktywny kafelek cyklu: klik → `CyclePanel` z listą tomów (kolejność czytania +
- * status w bazie), zakotwiczony w miejscu kliknięcia. Reużywa istniejący podgląd cyklu
- * (`useCycle` + `GET /api/cycle`) ze Skryptorium — jedyny wymagany wkład to (title,
- * author). Renderuje się tylko dla `partOfCycle`. Etykieta: „Cykl · N", gdy numer tomu
- * ustalono żniwami; inaczej samo „cykl". Pełna nazwa cyklu żyje w tooltipie (hover).
+ * Interactive cycle tile: click → `CyclePanel` with the volume list (reading order +
+ * status in the DB), anchored at the click point. Reuses the existing cycle preview
+ * (`useCycle` + `GET /api/cycle`) from Skryptorium — the only required input is (title,
+ * author). Renders only for `partOfCycle`. Label: „Cykl · N" when the volume number
+ * was determined by harvest; otherwise just „cykl". The full cycle name lives in the tooltip (hover).
  */
 export const CycleTile: React.FC<Props> = ({ title, author, partOfCycle, cykl, cyklNr, size = "sm" }) => {
   const [anchor, setAnchor] = useState<AnchorRect | null>(null);

--- a/src/components/LiturgySection.tsx
+++ b/src/components/LiturgySection.tsx
@@ -14,10 +14,10 @@ import { formatETA } from "../utils/time";
 import { IntegrityCheckResult } from "../types";
 
 /**
- * Zawartość zakładki „Liturgie Synchronizacji" — rytuały + ich wyniki + schemat.
- * `useSyncManager` żyje w `App` (jego `anyError` zasila globalną kartę błędu), więc
- * ten sam jego egzemplarz przychodzi propem `sm`; własny stan konfiguracji (schemat)
- * pobieramy lokalnie przez `useConfig`.
+ * Contents of the „Liturgie Synchronizacji" tab — rituals + their results + schema.
+ * `useSyncManager` lives in `App` (its `anyError` feeds the global error card), so
+ * that same instance arrives via the `sm` prop; its own config state (schema)
+ * is fetched locally via `useConfig`.
  */
 export const LiturgySection: React.FC<{ sm: ReturnType<typeof useSyncManager> }> = ({ sm }) => {
   const { configStatus, schema, schemaLoading, schemaError, fetchSchema } = useConfig();

--- a/src/components/OtherToolsCard.tsx
+++ b/src/components/OtherToolsCard.tsx
@@ -46,7 +46,7 @@ export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
   handleResetSync,
   isAnySyncLoading
 }) => {
-  // Wszystkie rytuały jednym idiomem (`RitualButton` + centralny `ritualButtonTheme`).
+  // All rituals in one idiom (`RitualButton` + central `ritualButtonTheme`).
   const rituals: { color: RitualColor; icon: typeof Database; title: string; subtitle: string; onClick: () => void; animate?: "spin" | "pulse" }[] = [
     { color: "emerald", icon: Database, title: "Rytuał Inicjacji Schematu", subtitle: "Weryfikacja i kreacja brakujących kolumn w bazie Notion", onClick: handleSyncSchema, animate: schemaSync.state.loading ? "pulse" : undefined },
     { color: "amber", icon: Sparkles, title: "Rytuał Puryfikacji", subtitle: "Oczyszczanie tytułów z nadmiarowych znaków i formatowania", onClick: handleSyncPurify, animate: purifySync.state.loading ? "pulse" : undefined },

--- a/src/components/ProgressAndResults.tsx
+++ b/src/components/ProgressAndResults.tsx
@@ -21,8 +21,8 @@ export const ProgressAndResults: React.FC<ProgressAndResultsProps> = ({
   const progress = state.progress || { current: 0, total: 1 };
   const percent = progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
 
-  // Motyw rytuału (patrz src/theme/ritualColors.ts). bg = pełne wypełnienie paska,
-  // shadow = poświata paska.
+  // Ritual theme (see src/theme/ritualColors.ts). bg = full bar fill,
+  // shadow = bar glow.
   const t = getRitualTheme(color);
   const theme = { text: t.text, border: t.border, bg: t.bgSolid, shadow: t.glow };
 

--- a/src/components/SchemaColumnCard.tsx
+++ b/src/components/SchemaColumnCard.tsx
@@ -6,20 +6,20 @@ interface Props {
   name: string;
   value: any;
   isSelectType: boolean;
-  options: any[];        // posortowane opcje (dla select/multi_select)
+  options: any[];        // sorted options (for select/multi_select)
   isOverLimit: boolean;
   limit: number;
-  index: number;         // do animacji wejścia (delay)
-  updating: boolean;     // czy trwa mutacja tej kolumny
+  index: number;         // for the entry animation (delay)
+  updating: boolean;     // whether a mutation of this column is in progress
   newOptionValue: string;
   onNewOptionChange: (v: string) => void;
   onAdd: () => void;
   onDeleteRequest: (optionName: string) => void;
 }
 
-/** Karta jednej kolumny schematu: nazwa, licznik limitu, opcje + dodawanie/usuwanie. */
+/** Card for a single schema column: name, limit counter, options + add/remove. */
 export const SchemaColumnCard: React.FC<Props> = ({ name, value, isSelectType, options, isOverLimit, limit, index, updating, newOptionValue, onNewOptionChange, onAdd, onDeleteRequest }) => {
-  // „Autor" jest tylko do odczytu — nie pokazujemy licznika, przycisków usuwania ani warnu.
+  // „Autor" is read-only — we don't show the counter, delete buttons, or the warning.
   const isEditable = name !== "Autor";
 
   return (

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -5,7 +5,7 @@ import { useBooks } from "../hooks/useBooks";
 import { matchBooks, buildSearchVocab, didYouMean, replaceLastToken } from "../utils/bookSearch";
 import { BookResultCard } from "./search/BookResultCard";
 
-/** Ile kart maksymalnie rysujemy (ochrona DOM przy „pustym" zapytaniu = cały zbiór). */
+/** Max number of cards we render (DOM guard for an „empty" query = the whole set). */
 const RENDER_CAP = 150;
 
 export const SearchSection: React.FC = () => {
@@ -22,7 +22,7 @@ export const SearchSection: React.FC = () => {
   const shown = results.slice(0, RENDER_CAP);
   const total = books?.length ?? 0;
 
-  // „Czy chodziło Ci o…" — słownik liczony raz na zbiór; podpowiedzi tylko przy 0 trafień.
+  // „Czy chodziło Ci o…" — vocab computed once per set; suggestions only on 0 hits.
   const vocab = useMemo(() => buildSearchVocab(books ?? []), [books]);
   const suggestions = useMemo(
     () => (results.length === 0 && deferredQuery.trim() ? didYouMean(deferredQuery, vocab) : []),
@@ -31,7 +31,7 @@ export const SearchSection: React.FC = () => {
 
   return (
     <div className="space-y-8">
-      {/* Nagłówek sekcji */}
+      {/* Section header */}
       <div className="flex items-center gap-6">
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent" />
         <div className="flex items-center gap-4">
@@ -47,7 +47,7 @@ export const SearchSection: React.FC = () => {
         Przeszukiwanie zapisów archiwum — tytuł, tytuł oryginalny, autor
       </p>
 
-      {/* Pole wyszukiwania */}
+      {/* Search field */}
       <div className="relative max-w-2xl mx-auto">
         <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-cyan-400/50 pointer-events-none" />
         <input
@@ -71,7 +71,7 @@ export const SearchSection: React.FC = () => {
         )}
       </div>
 
-      {/* Licznik */}
+      {/* Counter */}
       {books && !loading && (
         <p className="text-center text-xs text-slate-500 font-bold tracking-widest uppercase">
           {query.trim()
@@ -81,7 +81,7 @@ export const SearchSection: React.FC = () => {
         </p>
       )}
 
-      {/* Stany: ładowanie / błąd / brak trafień / siatka */}
+      {/* States: loading / error / no hits / grid */}
       {loading ? (
         <div className="flex items-center justify-center gap-3 py-16 text-slate-500">
           <Loader2 className="w-5 h-5 animate-spin" />

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -21,31 +21,31 @@ import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
 
 interface StatCard {
   id: string;
-  /** Karta na pełną szerokość siatki (md:col-span-2). */
+  /** Full-width grid card (md:col-span-2). */
   span2?: boolean;
   node: React.ReactNode;
 }
 
 export const StatsSection: React.FC = () => {
-  // Filie biblioteczne z konfiguracji (fallback: defaulty do czasu pobrania).
+  // Library branches from config (fallback: defaults until fetched).
   const cfg = useEffectiveConfig();
   const branches = cfg.library.branches;
   const { stats, loading, error, fetchStats, addBookToLibrarySection } = useStats();
   const { identifiedBooks, checkingLibrary, checkProgress, libraryError, checkLibrary, checkAllLibraries, stopLibraryCheck } = useLibraryCheck();
   const { markingId, markedIds, markAsRead } = useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats });
 
-  // „Odśwież Dane" odświeża `stats` (fetchStats) ORAZ karty z własnym fetchem
-  // (Archiwum Cykli) — inkrement sygnału zmusza je do świeżego pobrania.
+  // „Odśwież Dane" refreshes `stats` (fetchStats) AND cards with their own fetch
+  // („Archiwum Cykli") — incrementing the signal forces them to refetch.
   const [refreshTick, setRefreshTick] = useState(0);
   const refreshAll = () => { fetchStats(); setRefreshTick((t) => t + 1); };
 
-  // Tryb układania kart (drag&drop) + stan bieżącego przeciągania.
+  // Card arranging mode (drag&drop) + current drag state.
   const [arranging, setArranging] = useState(false);
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
 
-  // Liczba kolumn masonry zależna od breakpointu md (768px) — round-robin trzyma
-  // czytanie „wiersz po wierszu", więc kolumny muszą odpowiadać temu, co widać.
+  // Masonry column count depends on the md breakpoint (768px) — round-robin keeps
+  // reading „row by row", so the columns must match what's visible.
   const [cols, setCols] = useState(2);
   useEffect(() => {
     const mq = window.matchMedia("(min-width: 768px)");
@@ -86,8 +86,8 @@ export const StatsSection: React.FC = () => {
 
   if (!stats) return null;
 
-  // Definicje kart w kolejności kodu (= domyślna). Każda ma stabilne `id`, po którym
-  // zapamiętujemy układ użytkownika (ui.statsOrder). Reorder nie zmienia treści kart.
+  // Card definitions in code order (= default). Each has a stable `id`, by which
+  // we remember the user's layout (ui.statsOrder). Reordering doesn't change card content.
   const cards: StatCard[] = [
     {
       id: "authors",
@@ -228,7 +228,7 @@ export const StatsSection: React.FC = () => {
     },
   ];
 
-  // Kolejność efektywna (zapis użytkownika + nowe karty na końcu) i wyszukiwanie po id.
+  // Effective order (user's save + new cards at the end) and lookup by id.
   const order = orderByIds(cards.map((c) => c.id), cfg.ui.statsOrder);
   const byId = new Map(cards.map((c) => [c.id, c]));
   const ordered = order.map((id) => byId.get(id)).filter((c): c is StatCard => Boolean(c));
@@ -239,8 +239,8 @@ export const StatsSection: React.FC = () => {
   };
   const exitArrange = () => { setArranging(false); setDragId(null); setOverId(null); };
 
-  // Jedna karta z opakowaniem DnD + nakładkami trybu układania (reużywalna w blokach
-  // round-robin i w kartach pełnej szerokości).
+  // A single card with the DnD wrapper + arranging-mode overlays (reusable in round-robin
+  // blocks and in full-width cards).
   const renderCard = (card: StatCard) => {
     const dragging = dragId === card.id;
     const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
@@ -273,8 +273,8 @@ export const StatsSection: React.FC = () => {
     );
   };
 
-  // Segmentacja: karty pełnej szerokości (span2) przerywają blok round-robin i renderują
-  // się na całą szerokość; pozostałe idą w kolumny (i % cols) z niezależnym pakowaniem.
+  // Segmentation: full-width cards (span2) break the round-robin block and render
+  // at full width; the rest go into columns (i % cols) with independent packing.
   type Segment = { kind: "full"; card: StatCard } | { kind: "block"; cards: StatCard[] };
   const segments: Segment[] = [];
   let run: StatCard[] = [];
@@ -343,10 +343,10 @@ export const StatsSection: React.FC = () => {
         </div>
       )}
 
-      {/* Masonry „wiersz po wierszu": karty rozłożone round-robin (i % cols) na osobne
-          kolumny, każda pakuje się niezależnie (brak sprzężenia wysokości = brak dziur),
-          a odczyt lewo→prawo/góra→dół pozostaje 0,1,2,3,... Karta pełnej szerokości
-          (histogram dekad) przerywa blok i zajmuje całą szerokość. */}
+      {/* Masonry „row by row": cards laid out round-robin (i % cols) across separate
+          columns, each packing independently (no height coupling = no gaps),
+          while reading left→right/top→bottom stays 0,1,2,3,... A full-width card
+          (the decade histogram) breaks the block and takes the whole width. */}
       <div className="space-y-8">
         {segments.map((seg, si) =>
           seg.kind === "full" ? (

--- a/src/components/SyncAwards.tsx
+++ b/src/components/SyncAwards.tsx
@@ -7,7 +7,7 @@ import { IntegrityCheckCard } from "./IntegrityCheckCard";
 
 interface SyncAwardsProps {
   sync: ReturnType<typeof useSync>;
-  /** Lista nagród z konfiguracji (+ „Wszystkie Nagrody") — dropdown. */
+  /** List of awards from config (+ „Wszystkie Nagrody") — dropdown. */
   awardOptions: AwardPage[];
   integritySync: ReturnType<typeof useSync>;
   handleAwardChange: (name: string) => void;

--- a/src/components/SyncSummaryResult.tsx
+++ b/src/components/SyncSummaryResult.tsx
@@ -9,7 +9,7 @@ interface SyncSummaryResultProps {
   onClearFullResults?: () => void;
 }
 
-/** Rozdziela widok podsumowania: agregat „Wielkiego Rytuału" vs pojedynczy rytuał. */
+/** Splits the summary view: „Wielki Rytuał" aggregate vs a single ritual. */
 export const SyncSummaryResult: React.FC<SyncSummaryResultProps> = ({ syncs, fullSyncResults, onClearFullResults }) => {
   const activeSync = syncs.find(s => s.state.result && s.endpoint !== "/api/sync-integrity");
   if (!activeSync && !fullSyncResults) return null;

--- a/src/components/TabNav.tsx
+++ b/src/components/TabNav.tsx
@@ -4,11 +4,11 @@ export interface TabDef {
   id: string;
   label: string;
   icon: React.ReactNode;
-  /** Klasy aktywnego stanu (kolor/obwódka/glow) danej zakładki. */
+  /** Active-state classes (color/border/glow) for the given tab. */
   activeClass: string;
 }
 
-/** Pasek zakładek — jeden wzorzec przycisku zamiast 5× copy-paste. */
+/** Tab bar — one button pattern instead of 5× copy-paste. */
 export const TabNav: React.FC<{ tabs: TabDef[]; active: string; onSelect: (id: string) => void }> = ({ tabs, active, onSelect }) => (
   <div className="flex flex-col sm:flex-row sm:items-stretch justify-center gap-4 mt-8">
     {tabs.map((tab) => (

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -5,7 +5,7 @@ import { BookIndexEntry } from "../../types";
 import { HighlightedText } from "./HighlightedText";
 import { CycleTile } from "../CycleTile";
 
-/** Kolor tagu źródła — spójny język wizualny z resztą aplikacji. */
+/** Source tag color — consistent visual language with the rest of the app. */
 function zrodloTheme(tag: string): string {
   const t = tag.toLowerCase();
   if (t.includes("posiadam")) return "bg-emerald-500/10 border-emerald-500/25 text-emerald-300";
@@ -15,7 +15,7 @@ function zrodloTheme(tag: string): string {
   return "bg-slate-500/10 border-slate-500/25 text-slate-400";
 }
 
-/** Nagroda vs Nominacja — złoto dla zwycięstwa, chłodniej dla nominacji. */
+/** „Nagroda" vs „Nominacja" — gold for a win, cooler for a nomination. */
 function awardTheme(award: string): string {
   return award.toLowerCase().startsWith("nagroda")
     ? "bg-amber-500/10 border-amber-500/25 text-amber-300"
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export const BookResultCard: React.FC<Props> = ({ book, query }) => {
-  // Tytuł główny = polski, a gdy go brak — oryginalny (książki nieprzetłumaczone).
+  // Primary title = Polish, and when missing — the original (untranslated books).
   const primaryTitle = book.plTitle?.trim() ? book.plTitle : book.origTitle;
   const showOrig = book.origTitle && book.origTitle.trim() && book.origTitle !== primaryTitle;
 

--- a/src/components/search/CyclePanel.tsx
+++ b/src/components/search/CyclePanel.tsx
@@ -7,11 +7,11 @@ import { encyclopediaUrl } from "../../utils/encyclopedia";
 import { computePopoverPosition, AnchorRect } from "../../utils/popoverPosition";
 
 /**
- * Popover podglądu cyklu, zakotwiczony „w miejscu kliknięcia" (kotwica = prostokąt
- * triggera). Renderowany PRZEZ PORTAL do `document.body`, żeby uciec transformom
- * przodków (framer-motion) — inaczej `position: fixed` liczyłby się względem karty,
- * a nie viewportu (popover lądował na środku długiej listy / był ucinany). Wysokość
- * dopasowuje się do liczby tomów aż do dostępnej przestrzeni; dłuższa lista scrolluje.
+ * Cycle preview popover, anchored „at the click point" (anchor = trigger
+ * rectangle). Rendered THROUGH A PORTAL into `document.body` to escape ancestor
+ * transforms (framer-motion) — otherwise `position: fixed` would be relative to the card,
+ * not the viewport (the popover landed in the middle of a long list / got clipped). Height
+ * adapts to the number of volumes up to the available space; a longer list scrolls.
  */
 
 const STATUS = (v: { read: boolean; owned: boolean; inBase: boolean }) => {
@@ -24,7 +24,7 @@ const STATUS = (v: { read: boolean; owned: boolean; inBase: boolean }) => {
 interface Props {
   title: string;
   author: string;
-  /** Prostokąt triggera (getBoundingClientRect) — kotwica popovera. */
+  /** Trigger rectangle (getBoundingClientRect) — popover anchor. */
   anchor: AnchorRect;
   onClose: () => void;
 }
@@ -35,7 +35,7 @@ export const CyclePanel: React.FC<Props> = ({ title, author, anchor, onClose }) 
   useEffect(() => { fetchCycle(title, author); }, [title, author, fetchCycle]);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    // Scroll/resize dezaktualizuje kotwicę — najprościej zamknąć popover.
+    // Scroll/resize invalidates the anchor — simplest to just close the popover.
     const onShift = () => onClose();
     window.addEventListener("keydown", onKey);
     window.addEventListener("resize", onShift);
@@ -54,7 +54,7 @@ export const CyclePanel: React.FC<Props> = ({ title, author, anchor, onClose }) 
 
   return createPortal(
     <>
-      {/* Przezroczysty łapacz kliknięć poza popoverem (feel tooltipa — bez przyciemnienia). */}
+      {/* Transparent catcher for clicks outside the popover (tooltip feel — no dimming). */}
       <div className="fixed inset-0 z-[99]" onClick={onClose} aria-hidden="true" />
       <motion.div
         role="dialog"
@@ -66,7 +66,7 @@ export const CyclePanel: React.FC<Props> = ({ title, author, anchor, onClose }) 
         className="z-[100] glass-card rounded-2xl border-amber-500/20 flex flex-col overflow-hidden shadow-2xl shadow-slate-950/60"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Nagłówek */}
+        {/* Header */}
         <div className="flex items-start gap-2.5 p-3.5 border-b border-white/5 shrink-0">
           <div className="shrink-0 p-1.5 rounded-lg bg-amber-500/15 border border-amber-500/25 text-amber-300">
             <Layers className="w-3.5 h-3.5" />
@@ -82,7 +82,7 @@ export const CyclePanel: React.FC<Props> = ({ title, author, anchor, onClose }) 
           </button>
         </div>
 
-        {/* Treść */}
+        {/* Content */}
         <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar p-3 space-y-2">
           {loading && (
             <div className="flex items-center justify-center gap-2.5 py-8 text-slate-400">

--- a/src/components/search/HighlightedText.tsx
+++ b/src/components/search/HighlightedText.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { highlight } from "../../utils/bookSearch";
 
-/** Renderuje tekst z podświetlonymi fragmentami trafionymi zapytaniem. */
+/** Renders text with fragments matched by the query highlighted. */
 export const HighlightedText: React.FC<{ text: string; query: string; className?: string }> = ({ text, query, className }) => {
   const segments = highlight(text, query);
   return (

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -9,14 +9,14 @@ interface Props {
   onDragEnd: () => void;
 }
 
-/** Sygnatura katalogowa holo (deterministyczna z id) — cyfrowy detal na grzbiecie. */
+/** Holo catalog signature (deterministic from id) — a digital detail on the spine. */
 function catalogSig(id: string): string {
   let h = 0;
   for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
   return "M" + (1000 + (h % 9000));
 }
 
-/** Grzbiet książki (koncept A) — przeciągalny element regału. */
+/** Book spine (concept A) — a draggable shelf element. */
 export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd }) => (
   <div
     draggable

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -3,17 +3,17 @@ import { BookIndexEntry } from "../../types";
 import { spineStyle, layoutStack, displayTitle, awardWins } from "../../utils/bookshelf";
 
 interface Props {
-  books: BookIndexEntry[];          // każda warstwa to OSOBNA prawdziwa książka
+  books: BookIndexEntry[];          // each layer is a SEPARATE real book
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
 }
 
 /**
- * Kupka leżących książek — każda warstwa to osobny wolumin z PEŁNĄ nazwą (max 2
- * linie). Ułożenie liczy `layoutStack`: sortowanie od największej (dół) do
- * najmniejszej (góra), wyrównanie do lewej / do prawej / (rzadko) symetryczne,
- * plus opcjonalny „chaos" (poziomy rozjazd warstw). Każda warstwa ma własny
- * kolor, znacznik nagrody i przeciąganie.
+ * A pile of lying books — each layer is a separate volume with its FULL title (max 2
+ * lines). The arrangement is computed by `layoutStack`: sorting from largest (bottom) to
+ * smallest (top), aligned left / right / (rarely) symmetric,
+ * plus optional „chaos" (horizontal layer offset). Each layer has its own
+ * color, award marker and dragging.
  */
 export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) => {
   const { cellW, layers } = layoutStack(books);
@@ -42,9 +42,9 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
               boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",
             } as React.CSSProperties}
           >
-            {/* Krawędź kartek (fore-edge) po prawej */}
+            {/* Page edge (fore-edge) on the right */}
             <span className="fore-edge absolute top-[2px] bottom-[2px] right-[2px] w-[3px] rounded-[1px]" aria-hidden />
-            {/* PEŁNY tytuł wzdłuż grzbietu — zawijany do max 2 linii zamiast poszerzania */}
+            {/* FULL title along the spine — wrapped to max 2 lines instead of widening */}
             <span
               className="spine-title absolute inset-y-0 right-3 flex items-center font-bold"
               style={{ left: wins.length ? 6 + wins.length * 7 : 8 }}

--- a/src/components/shelf/CoverCard.tsx
+++ b/src/components/shelf/CoverCard.tsx
@@ -8,8 +8,8 @@ function hash(s: string): number {
   return h;
 }
 
-/** Okładka „twarzą" (koncept B) — półka „Wyróżnione". Widok, bez drag&drop.
- *  Kolory zależne od skóry: matowe (Relikwiarz) lub akcenty aplikacji (Holo+). */
+/** Cover shown „face-out" (concept B) — the „Wyróżnione" shelf. View only, no drag&drop.
+ *  Colors depend on the skin: matte (Relikwiarz) or app accents (Holo+). */
 export const CoverCard: React.FC<{ book: BookIndexEntry }> = ({ book }) => {
   const h = hash(displayTitle(book));
   const i1 = h % CLOTH_PALETTE.length;

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { motion } from "motion/react";
 
-/** Sygil koła zębatego (Mechanicus) — ozdoba pokoju. Kolor przez `style`, by
- *  rozwiązywały się zmienne skóry (`var(--sk-room-cog*)`). */
+/** Cog-wheel sigil (Mechanicus) — room decoration. Color via `style`, so
+ *  the skin variables resolve (`var(--sk-room-cog*)`). */
 const CogMark: React.FC<{ size: number; color: string; className?: string; style?: React.CSSProperties }> = ({ size, color, className, style }) => (
   <svg viewBox="0 0 48 48" width={size} height={size} className={className} style={style} aria-hidden>
     <g style={{ fill: color }}>
@@ -16,7 +16,7 @@ const CogMark: React.FC<{ size: number; color: string; className?: string; style
   </svg>
 );
 
-/** Świeca z migoczącym płomieniem i ciepłą poświatą. */
+/** Candle with a flickering flame and warm glow. */
 const Sconce: React.FC<{ className?: string }> = ({ className }) => (
   <div className={`absolute pointer-events-none ${className ?? ""}`} aria-hidden>
     <svg viewBox="0 0 60 70" width="52" height="60">
@@ -38,7 +38,7 @@ const Sconce: React.FC<{ className?: string }> = ({ className }) => (
   </div>
 );
 
-/** Dryfująca drobinka kurzu w świetle. */
+/** A drifting speck of dust in the light. */
 const Mote: React.FC<{ i: number }> = ({ i }) => {
   const left = (i * 61) % 100;
   const top = 12 + ((i * 37) % 60);
@@ -54,9 +54,9 @@ const Mote: React.FC<{ i: number }> = ({ i }) => {
 };
 
 /**
- * „Sala Archiwum" — ciepły skryptorium wokół regałów: drewniana ściana z panelami,
- * podłoga, kinkiety z migoczącym światłem, proporzec, sygil koła zębatego, kurz
- * i winieta. Czysto dekoracyjne (aria-hidden). Fizyki książek nie dotyka.
+ * „Sala Archiwum" — a warm scriptorium around the shelves: paneled wooden wall,
+ * floor, sconces with flickering light, banner, cog-wheel sigil, dust
+ * and vignette. Purely decorative (aria-hidden). Does not touch the book physics.
  */
 export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div
@@ -66,24 +66,24 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
       boxShadow: "inset 0 2px 0 var(--sk-room-inset), inset 0 40px 80px -40px rgba(0,0,0,.7)",
     }}
   >
-    {/* Znak wodny koła zębatego */}
+    {/* Cog-wheel watermark */}
     <CogMark size={320} color="var(--sk-room-cog)" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
 
-    {/* Kinkiety */}
+    {/* Sconces */}
     <Sconce className="left-3 top-16 hidden md:block" />
     <Sconce className="right-3 top-16 hidden md:block" />
 
-    {/* Kurz w powietrzu */}
+    {/* Dust in the air */}
     {Array.from({ length: 16 }).map((_, i) => <Mote key={i} i={i} />)}
 
-    {/* Treść (regały) */}
+    {/* Content (shelves) */}
     <div className="relative z-10">{children}</div>
 
-    {/* Podłoga */}
+    {/* Floor */}
     <div className="absolute left-0 right-0 bottom-0 h-[120px] pointer-events-none"
       style={{ background: "var(--sk-room-floor)", boxShadow: "inset 0 16px 26px -12px rgba(0,0,0,.85)" }} aria-hidden />
 
-    {/* Winieta */}
+    {/* Vignette */}
     <div className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(120% 90% at 50% 40%, rgba(0,0,0,0) 45%, rgba(0,0,0,.5) 100%)" }} aria-hidden />
   </div>
 );

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -17,17 +17,17 @@ interface Props {
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
   onDropBook: (target: ShelfId) => void;
-  /** Precyzyjny drop: wstaw przeciąganą książkę przed `insertBeforeId` (null = koniec półki). */
+  /** Precise drop: insert the dragged book before `insertBeforeId` (null = end of shelf). */
   onPreciseDrop?: (target: ShelfId, insertBeforeId: string | null) => void;
-  /** Przeciągana książka (do walidacji dekady precyzyjnego dropu); null = brak przeciągania. */
+  /** The dragged book (for decade validation of the precise drop); null = not dragging. */
   draggingBook: BookIndexEntry | null;
-  /** Knob `ui.preciseShelfDrop` — wyłączony = tylko globalny drop na ramę. */
+  /** Knob `ui.preciseShelfDrop` — disabled = only a global drop onto the frame. */
   preciseEnabled?: boolean;
-  /** Gdy podane: regał ma STAŁĄ wysokość tylu rzędów i dzieli się na segmenty „Regał I/N". */
+  /** When provided: the shelf has a FIXED height of this many rows and splits into „Regał I/N" segments. */
   pageSize?: number;
 }
 
-/** Jeden regał: drewniany korpus + FIZYCZNE rozłożenie woluminów (wypełnione półki, oparte pochyły). */
+/** One shelf: wooden body + PHYSICAL layout of volumes (filled shelves, leaning tilted ones). */
 export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, onPreciseDrop, draggingBook, preciseEnabled = true, pageSize }) => {
   const dragging = draggingBook !== null;
   const [over, setOver] = useState(false);
@@ -35,15 +35,15 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
   const wellRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
-  // Kursor wstawienia + rozstrzygnięty cel (beforeId) — czyszczone z końcem przeciągania.
+  // Insertion caret + resolved target (beforeId) — cleared when dragging ends.
   const [caret, setCaret] = useState<(GapCaret & { beforeId: string | null }) | null>(null);
   useEffect(() => { if (!dragging) setCaret(null); }, [dragging]);
 
   const preciseActive = preciseEnabled && dragging && !!onPreciseDrop;
-  // Sekwencja półki bez przeciąganej książki (przy przeciąganiu w obrębie tej samej półki).
+  // The shelf sequence without the dragged book (when dragging within the same shelf).
   const seqSans = draggingBook ? books.filter((b) => b.id !== draggingBook.id) : books;
 
-  /** Granica szczeliny → cel wstawienia; undefined = no-op (szczelina przy samej przeciąganej). */
+  /** Gap boundary → insertion target; undefined = no-op (gap right next to the dragged one). */
   const resolveBoundary = (b: GapBoundary): string | null | undefined => {
     if (b.beforeId) return b.beforeId === draggingBook?.id ? undefined : b.beforeId;
     if (b.afterId) {
@@ -90,7 +90,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
   const { items, slotByKey } = buildShelfItems(books);
   const rows = width > 0 ? packAndLayout(items, { rowWidth: width }) : [];
 
-  // Segmenty „Regał I/N" przy stałej wysokości.
+  // „Regał I/N" segments at fixed height.
   const segments = pageSize ? chunk(rows, pageSize) : [rows];
   const pageCount = Math.max(1, segments.length);
   const cur = Math.min(page, pageCount - 1);
@@ -118,7 +118,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
 
   return (
     <div className="relative">
-      {/* Świeca na szczycie regału */}
+      {/* Candle on top of the shelf */}
       <div className="absolute -top-[26px] left-8 z-20 pointer-events-none" aria-hidden>
         <div className="w-[9px] h-[24px] mx-auto rounded-[2px] bg-gradient-to-b from-[#e8dcc0] via-[#d8c8a2] to-[#b9a271]" />
         <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 w-[8px] h-[13px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
@@ -150,7 +150,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
         )}
       </ShelfFrame>
 
-      {/* Cokół / nóżki — regał „stoi na podłodze" */}
+      {/* Plinth / feet — the shelf „stands on the floor" */}
       <div className="mx-2 h-[10px] rounded-b-[6px]" style={{ background: "var(--sk-plinth)", boxShadow: "0 10px 16px -6px rgba(0,0,0,.7)" }} aria-hidden />
       <div className="flex justify-between px-6" aria-hidden>
         {[0, 1].map((i) => <div key={i} className="w-8 h-[9px] rounded-b-[4px]" style={{ background: "var(--sk-foot)" }} />)}

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -4,32 +4,32 @@ import { DividerLevel, DividerDir } from "../../utils/shelfLayout";
 import { CogSigil } from "./ShelfOrnaments";
 
 interface Props {
-  label: string;      // np. „1950–1959" (w przyszłości litera alfabetu / nazwisko autora)
-  width?: number;     // szerokość deseczki (footprint na półce)
-  height?: number;    // wysokość toru rzędu (wyrównanie tabliczki u góry)
-  /** Poziom tabliczki: „top" (domyślnie) lub „bottom", gdy górna kolidowałaby z sąsiadem. */
+  label: string;      // e.g. „1950–1959" (in the future an alphabet letter / author's surname)
+  width?: number;     // divider board width (footprint on the shelf)
+  height?: number;    // row track height (aligns the plate at the top)
+  /** Plate level: „top" (default) or „bottom" when the top one would collide with a neighbor. */
   plate?: DividerLevel;
-  /** Kierunek rozwijania tabliczki: „right" (domyślnie) lub „left" przy prawej krawędzi półki. */
+  /** Plate expansion direction: „right" (default) or „left" at the right edge of the shelf. */
   dir?: DividerDir;
-  /** Warstwa renderu: „board" (deseczka+sygile+żyła) albo „plate" (sama tabliczka).
-   *  `ShelfRow` maluje wszystkie deseczki, a POTEM wszystkie tabliczki, wyżej — dzięki
-   *  temu tabliczka nigdy nie chowa się pod deseczką sąsiada. */
+  /** Render layer: „board" (board+sigils+vein) or „plate" (just the plate).
+   *  `ShelfRow` paints all boards, and THEN all plates, on top — so
+   *  the plate never hides under a neighbor's board. */
   part?: "board" | "plate";
 }
 
-/** Wysokość widocznej deseczki — spójna z `DIVIDER_H` w `shelfLayout` (podpora fizyki). */
+/** Height of the visible board — consistent with `DIVIDER_H` in `shelfLayout` (physics support). */
 export const BOARD_H = 168;
 
 /**
- * Generyczna **przekładka sekcji** w stylu noosferycznym: cienka **deseczka** z żyłą
- * danych i sygilami koła u góry i u dołu (`part="board"`) + pozioma **tabliczka-runa**
- * rocznika (`part="plate"`). Warstwy są rozdzielone, bo `ShelfRow` maluje najpierw
- * wszystkie deseczki, a potem wszystkie tabliczki wyżej (tabliczka zawsze na wierzchu).
- * Rozmieszczenie liczy `assignDividerPlacement`: tabliczka domyślnie u góry i w prawo,
- * przy wąskiej dekadzie → `plate="bottom"` (siada na krawędzi półki, by nie zasłaniać
- * tytułów), a przy prawej krawędzi półki → `dir="left"`. Klasa `shelf-divider` pozwala
- * skórze przemalować przekładkę (Holo+ = przytłumiony amber, w tonie oprawy Regału).
- * Nieprzeciągalna.
+ * A generic **section divider** in the noospheric style: a thin **board** with a data
+ * vein and cog sigils at the top and bottom (`part="board"`) + a horizontal **rune-plate**
+ * of the year (`part="plate"`). The layers are separated, because `ShelfRow` paints first
+ * all boards, and then all plates on top (the plate is always on top).
+ * The placement is computed by `assignDividerPlacement`: the plate defaults to top and right,
+ * for a narrow decade → `plate="bottom"` (sits on the shelf edge so it doesn't cover
+ * titles), and at the right edge of the shelf → `dir="left"`. The `shelf-divider` class lets
+ * the skin repaint the divider (Holo+ = muted amber, in the tone of the Regał frame).
+ * Not draggable.
  */
 export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHELF_ROW_H, plate = "top", dir = "right", part = "board" }) => {
   const atBottom = plate === "bottom";
@@ -38,7 +38,7 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
     <div className="shelf-divider relative select-none" style={{ width, height }} title={label} aria-hidden>
       {part === "board" ? (
         <>
-          {/* cienka deseczka rozgraniczająca (dół toru) */}
+          {/* thin separating board (bottom of the track) */}
           <div
             className="absolute bottom-0 left-0 rounded-[2px_2px_1px_1px]"
             style={{
@@ -47,18 +47,18 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
               boxShadow: "inset 1px 0 0 rgba(var(--noo-glow),.35), inset -1px 0 2px rgba(0,0,0,.6), 0 6px 10px -6px rgba(0,0,0,.6)",
             }}
           >
-            {/* cog-finial na szczycie deseczki */}
+            {/* cog-finial at the top of the board */}
             <CogSigil className="absolute -top-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
-            {/* cog-finial u dołu deseczki (na linii półki) */}
+            {/* cog-finial at the bottom of the board (on the shelf line) */}
             <CogSigil className="absolute -bottom-[7px] left-1/2 -translate-x-1/2 w-[13px] h-[13px] drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />
-            {/* świecąca żyła danych */}
+            {/* glowing data vein */}
             <div
               className="noo-data absolute left-1/2 -translate-x-1/2 rounded-[2px]"
               style={{ top: 14, bottom: 8, width: 2, background: "linear-gradient(180deg, rgba(var(--noo-glow),.9), rgba(var(--noo-glow),.15))", boxShadow: "0 0 6px rgba(var(--noo-glow),.8)" }}
             />
           </div>
 
-          {/* projekcyjna smużka światła łącząca tabliczkę z deseczką (kierunek zależny od poziomu) */}
+          {/* projected light streak connecting the plate to the board (direction depends on the level) */}
           <div
             className="noo-data absolute"
             style={{
@@ -71,9 +71,9 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
           />
         </>
       ) : (
-        /* tabliczka-runa rocznika, krawędzią przy deseczce; u góry domyślnie, u dołu
-           (na linii półki, nachodzi na deskę) gdy górna kolidowałaby z sąsiadem;
-           rozwija się w prawo, a przy prawej krawędzi półki w lewo */
+        /* year rune-plate, its edge next to the board; at the top by default, at the bottom
+           (on the shelf line, overlapping the board) when the top one would collide with a neighbor;
+           expands to the right, and to the left at the right edge of the shelf */
         <div
           className="absolute flex items-center gap-[6px] whitespace-nowrap font-mono rounded-[3px] px-[9px] pt-[3px] pb-[4px]"
           style={{

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -14,24 +14,24 @@ interface Props {
   icon: React.ReactNode;
   accent: ShelfAccent;
   count: number;
-  /** Stan podświetlenia ramy: cel upuszczenia / aktywne przeciąganie / spoczynek. */
+  /** Frame highlight state: drop target / active drag / at rest. */
   highlight?: "idle" | "target" | "dragging";
-  /** Dodatkowa treść po prawej w gzymsie (np. przycisk skanu, „upuść tutaj"). */
+  /** Extra content on the right of the cornice (e.g. scan button, „upuść tutaj"). */
   headerExtra?: React.ReactNode;
-  /** Handlery drag&drop montowane na korpusie mebla. */
+  /** Drag&drop handlers mounted on the furniture body. */
   rootProps?: React.HTMLAttributes<HTMLDivElement>;
   children: React.ReactNode;
 }
 
 /**
- * Drewniany korpus regału (gzyms + boki + cokół) z ozdobami Mechanicus.
- * Wnętrze („plecy" regału) trzyma przekazane grzbiety/okładki. Reużywalne przez
- * obie półki i sekcję „Wyróżnione".
+ * Wooden shelf body (cornice + sides + plinth) with Mechanicus ornaments.
+ * The interior (the shelf's „back") holds the passed-in spines/covers. Reusable by
+ * both shelves and the „Wyróżnione" section.
  */
 export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highlight = "idle", headerExtra, rootProps, children }) => {
   const a = ACCENT[accent];
-  // Idle: kolor obwódki i poświata pochodzą ze skóry (`--sk-frame-*`) — brąz w
-  // Relikwiarzu, cyan-glow w Holo+. Stany target/dragging nadpisują klasą.
+  // Idle: border color and glow come from the skin (`--sk-frame-*`) — brown in
+  // Relikwiarz, cyan-glow in Holo+. The target/dragging states override via class.
   const stateRing =
     highlight === "target" ? `${a.ring} ${a.glow}` :
     highlight === "dragging" ? "border-amber-400/30 border-dashed" :
@@ -47,9 +47,9 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
         ...(highlight === "idle" ? { borderColor: "var(--sk-frame-border)" } : {}),
       }}
     >
-      {/* Boczne słupki + cokół tworzy padding; gzyms nakładamy górnym paddingiem */}
+      {/* Side posts + plinth form the padding; the cornice is applied via top padding */}
       <div className="px-3 pb-4 pt-[52px] sm:px-4">
-        {/* Gzyms (cornice) */}
+        {/* Cornice */}
         <div
           className="absolute top-0 inset-x-0 h-[46px] rounded-t-[16px] flex items-center gap-3 px-4 overflow-hidden"
           style={{
@@ -57,21 +57,21 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
             boxShadow: "inset 0 -2px 5px rgba(0,0,0,.6), inset 0 1px 0 rgba(var(--noo-glow),.14)",
           }}
         >
-          {/* Sygil koła zębatego */}
+          {/* Cog-wheel sigil */}
           <CogSigil className="w-7 h-7 shrink-0 drop-shadow-[0_1px_2px_rgba(0,0,0,.6)]" />
           <span className={a.text}>{icon}</span>
           <h3 className="text-sm font-display font-bold uppercase tracking-[0.22em] text-amber-100/90 whitespace-nowrap drop-shadow-[0_1px_2px_rgba(0,0,0,.7)]">
             {title}
           </h3>
           <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
-          {/* Ticker danych (przewijany) — wypełnia wolną przestrzeń gzymsu */}
+          {/* Data ticker (scrolling) — fills the free space of the cornice */}
           <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ NOOSPHERA·SYNC ++ 01001101·01000001·01010011 ++ AVE·OMNISSIAH ++" />
           <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
-          {/* Delikatna listwa świetlna pod gzymsem (w kolorze oprawy Regału) */}
+          {/* Subtle light strip under the cornice (in the color of the Regał frame) */}
           <div className="absolute bottom-0 inset-x-6 h-px" style={{ background: "linear-gradient(90deg, transparent, rgba(var(--sk-frame-accent),.28), transparent)" }} />
         </div>
 
-        {/* Wnętrze regału — ciemne „plecy" z pionowymi deskami + warstwa holo */}
+        {/* Shelf interior — dark „back" with vertical boards + holo layer */}
         <div
           className="relative rounded-lg p-3 pt-4 overflow-hidden"
           style={{
@@ -84,7 +84,7 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
         </div>
       </div>
 
-      {/* Godło holo (projekcja) + narożniki HUD */}
+      {/* Holo emblem (projection) + HUD corners */}
       <NoosphericCrest className="absolute -top-[22px] left-1/2 -translate-x-1/2 z-20" size={46} />
       <HudCorner corner="tl" />
       <HudCorner corner="tr" />

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 
 /**
- * Ozdoby regału w klimacie Adeptus Mechanicus („atrybuty z fabuły" + kwiatki):
- * mosiężne narożniki, pieczęć czystości na wstędze, sygil koła zębatego.
- * Czysto dekoracyjne (aria-hidden) — nie wpływają na drag&drop.
+ * Shelf ornaments in the Adeptus Mechanicus vibe („lore attributes" + flourishes):
+ * brass corners, purity seal on a ribbon, cog-wheel sigil.
+ * Purely decorative (aria-hidden) — they don't affect drag&drop.
  */
 
 type Corner = "tl" | "tr" | "bl" | "br";
 
 /**
- * Sygil koła zębatego Mechanicus (cog-skull). Kolory pochodzą ze zmiennych skóry
- * (`--sk-cog-*`), więc przełączenie skóry przemalowuje go bez zmiany komponentu.
+ * Mechanicus cog-wheel sigil (cog-skull). Colors come from the skin variables
+ * (`--sk-cog-*`), so switching the skin repaints it without changing the component.
  */
 export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) => (
   <svg aria-hidden viewBox="0 0 48 48" className={className}>
@@ -21,7 +21,7 @@ export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) =
       <circle cx="24" cy="24" r="15.5" />
     </g>
     <circle cx="24" cy="24" r="11" style={{ fill: "var(--sk-cog-disc)" }} />
-    {/* Stylizowana czaszka Mechanicus — pół twarz, pół czacha */}
+    {/* Stylized Mechanicus skull — half face, half cranium */}
     <circle cx="24" cy="21" r="6" style={{ fill: "var(--sk-cog-skull)" }} />
     <circle cx="21.6" cy="21" r="1.4" style={{ fill: "var(--sk-cog-disc)" }} />
     <circle cx="26.4" cy="21" r="1.4" style={{ fill: "var(--sk-cog-disc)" }} />
@@ -29,15 +29,15 @@ export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) =
   </svg>
 );
 
-/* ===================== Warstwa cyfrowa / noosferyczna ===================== */
-/* Kolor poświaty pochodzi ze zmiennej skóry `--noo-glow` (triplet RGB). */
+/* ===================== Digital / noospheric layer ===================== */
+/* The glow color comes from the skin variable `--noo-glow` (RGB triplet). */
 const GLOW = (a: number) => `rgba(var(--noo-glow), ${a})`;
 const ACCENT2 = (a: number) => `rgba(var(--noo-accent2), ${a})`;
 
 /**
- * Godło Mechanicus jako **projekcja holo**: cog-skull + wolno obracająca się
- * przerywana aureola noosfery (drugi pierścień w akcencie skóry) + pulsujący glow.
- * Czysto dekoracyjne.
+ * Mechanicus emblem as a **holo projection**: cog-skull + a slowly rotating
+ * dashed noosphere halo (a second ring in the skin accent) + a pulsing glow.
+ * Purely decorative.
  */
 export const NoosphericCrest: React.FC<{ size?: number; className?: string }> = ({ size = 46, className = "" }) => (
   <div className={className} aria-hidden style={{ width: size, height: size }}>
@@ -53,7 +53,7 @@ export const NoosphericCrest: React.FC<{ size?: number; className?: string }> = 
   </div>
 );
 
-/** Przewijający się (marquee) ticker danych — inkantacje binarne / machine-cant. */
+/** Scrolling (marquee) data ticker — binary incantations / machine-cant. */
 export const DataTicker: React.FC<{ text: string; tone?: "glow" | "accent"; slow?: boolean; className?: string }> = ({ text, tone = "glow", slow, className = "" }) => {
   const color = tone === "accent" ? ACCENT2(1) : GLOW(1);
   return (
@@ -71,7 +71,7 @@ export const DataTicker: React.FC<{ text: string; tone?: "glow" | "accent"; slow
   );
 };
 
-/** Nakładka: subtelna siatka noosfery + przesuwający się skanline (CRT). */
+/** Overlay: subtle noosphere grid + a moving scanline (CRT). */
 export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) => (
   <div className={`pointer-events-none absolute inset-0 overflow-hidden ${className}`} aria-hidden>
     <div
@@ -90,8 +90,8 @@ export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) 
   </div>
 );
 
-/** Narożnik HUD (celownik) — w kolorze OPRAWY Regału (`--sk-frame-accent`, amber),
- *  pulsujący. Lokalnie nadpisuje `--noo-glow`, by pulsujący glow też był w akcencie ramki. */
+/** HUD corner (reticle) — in the color of the Regał FRAME (`--sk-frame-accent`, amber),
+ *  pulsing. Locally overrides `--noo-glow` so the pulsing glow is also in the frame accent. */
 export const HudCorner: React.FC<{ corner: Corner }> = ({ corner }) => {
   const base = "absolute w-4 h-4 z-20 pointer-events-none noo-pulse";
   const c = "rgb(var(--sk-frame-accent))";

--- a/src/components/shelf/ShelfRow.tsx
+++ b/src/components/shelf/ShelfRow.tsx
@@ -15,9 +15,9 @@ export const PLANK_STYLE: React.CSSProperties = {
 };
 
 /**
- * Szczelina precyzyjnego dropu: `beforeId` = wstaw przed tą książką; `afterId`
- * (ostatnia granica rzędu) = wstaw za tą książką — Shelf mapuje ją na `beforeId`
- * następnika w globalnej sekwencji (lub koniec półki).
+ * A precise-drop gap: `beforeId` = insert before this book; `afterId`
+ * (the last boundary of the row) = insert after this book — Shelf maps it to the `beforeId`
+ * of the successor in the global sequence (or the end of the shelf).
  */
 export interface GapBoundary {
   x: number;
@@ -25,7 +25,7 @@ export interface GapBoundary {
   afterId?: string;
 }
 
-/** Kursor wstawienia (stan trzymany w Shelf; rząd rysuje swój fragment). */
+/** Insertion caret (state held in Shelf; the row draws its own fragment). */
 export interface GapCaret {
   row: number;
   x: number;
@@ -35,32 +35,32 @@ export interface GapCaret {
 interface Props {
   row: PlacedItem[];
   slotByKey: Map<string, RenderSlot>;
-  /** Szerokość toru (well) — do wykrycia tabliczek wychodzących poza prawą krawędź. */
+  /** Track (well) width — to detect plates extending past the right edge. */
   rowWidth: number;
-  /** Indeks rzędu na stronie (adresowanie kursora wstawienia). */
+  /** Row index on the page (addressing the insertion caret). */
   rowIndex: number;
-  /** Precyzyjny drop aktywny (knob włączony + trwa przeciąganie). */
+  /** Precise drop active (knob enabled + dragging in progress). */
   preciseActive: boolean;
-  /** Kursor wstawienia, jeśli wskazuje ten rząd. */
+  /** Insertion caret, if it points to this row. */
   caret: GapCaret | null;
-  /** Najechanie na szczelinę (rząd, granica) / opuszczenie rzędu / drop w kursor. */
+  /** Hovering over a gap (row, boundary) / leaving the row / dropping into the caret. */
   onGapOver: (rowIndex: number, boundary: GapBoundary) => void;
   onGapLeave: () => void;
-  onGapDrop: () => boolean; // true = obsłużone precyzyjnie (zatrzymaj propagację)
+  onGapDrop: () => boolean; // true = handled precisely (stop propagation)
   onDragStart: (book: BookIndexEntry) => void;
   onDragEnd: () => void;
 }
 
-/** Jeden rząd półki: woluminy na pozycjach z fizyki + drewniana deska pod spodem. */
+/** One shelf row: volumes at physics-computed positions + a wooden plank underneath. */
 export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, preciseActive, caret, onGapOver, onGapLeave, onGapDrop, onDragStart, onDragEnd }) => {
-  // Rozmieszczenie tabliczek dekad (góra/dół + lewo/prawo) — unika kolizji i wyjścia poza półkę.
+  // Placement of decade plates (top/bottom + left/right) — avoids collisions and going off the shelf.
   const placement = assignDividerPlacement(row, (k) => {
     const s = slotByKey.get(k);
     return s && s.kind === "divider" ? s.label : undefined;
   }, rowWidth);
 
-  // Granice szczelin: start każdego slotu-książki (wstaw przed pierwszym woluminem
-  // slotu; kupka = jeden slot) + prawa krawędź ostatniego slotu (wstaw za ostatnim).
+  // Gap boundaries: start of each book slot (insert before the slot's first volume;
+  // a stack = one slot) + right edge of the last slot (insert after the last one).
   const boundaries = useMemo<GapBoundary[]>(() => {
     const items = row.filter((p) => p.kind !== "divider").slice().sort((a, b) => a.x - b.x);
     const out: GapBoundary[] = [];
@@ -83,7 +83,7 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, 
   const dragHandlers = preciseActive ? {
     onDragOver: (e: React.DragEvent<HTMLDivElement>) => {
       if (boundaries.length === 0) return;
-      e.preventDefault(); // szczeliny przyjmują drop (bez stopPropagation — rama dalej podświetla cel)
+      e.preventDefault(); // gaps accept the drop (no stopPropagation — the frame keeps highlighting the target)
       const x = e.clientX - e.currentTarget.getBoundingClientRect().left;
       let nearest = boundaries[0];
       for (const b of boundaries) if (Math.abs(b.x - x) < Math.abs(nearest.x - x)) nearest = b;
@@ -93,7 +93,7 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, 
       if (!e.currentTarget.contains(e.relatedTarget as Node)) onGapLeave();
     },
     onDrop: (e: React.DragEvent<HTMLDivElement>) => {
-      // Obsłużone precyzyjnie → zatrzymaj (inaczej rama zrobi globalny drop drugi raz).
+      // Handled precisely → stop (otherwise the frame does the global drop a second time).
       if (onGapDrop()) { e.preventDefault(); e.stopPropagation(); }
     },
   } : {};
@@ -101,7 +101,7 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, 
   return (
   <div>
     <div className="relative" style={{ height: SHELF_ROW_H }} {...dragHandlers}>
-      {/* Warstwa 1: grzbiety/kupki + deseczki przekładek (z-20, nad tłem i deską). */}
+      {/* Layer 1: spines/stacks + divider boards (z-20, above the background and plank). */}
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
         if (slot.kind === "divider") {
@@ -131,7 +131,7 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, 
           </div>
         );
       })}
-      {/* Warstwa 2: same tabliczki dekad — ZAWSZE na wierzchu (z-40), nigdy pod deseczką sąsiada. */}
+      {/* Layer 2: just the decade plates — ALWAYS on top (z-40), never under a neighbor's board. */}
       {row.map((p) => {
         const slot = slotByKey.get(p.key)!;
         if (slot.kind !== "divider") return null;
@@ -142,7 +142,7 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, 
           </div>
         );
       })}
-      {/* Kursor wstawienia — neonowa kreska w najbliższej szczelinie (cyan = OK, róż = zła dekada). */}
+      {/* Insertion caret — a neon line at the nearest gap (cyan = OK, pink = wrong decade). */}
       {rowCaret && (
         <div
           className="absolute pointer-events-none rounded-[2px]"
@@ -162,7 +162,7 @@ export const ShelfRow: React.FC<Props> = ({ row, slotByKey, rowWidth, rowIndex, 
   );
 };
 
-/** Pusta półka (dla wyrównania stałej wysokości regału) — sama deska. */
+/** Empty shelf row (to align the shelf's fixed height) — just the plank. */
 export const EmptyShelfRow: React.FC = () => (
   <div>
     <div style={{ height: SHELF_ROW_H }} />

--- a/src/components/stats/AvailabilityCard.tsx
+++ b/src/components/stats/AvailabilityCard.tsx
@@ -4,9 +4,9 @@ import { Compass, Package, Library, ShoppingCart, HelpCircle } from "lucide-reac
 import { AvailabilityStats } from "../../hooks/useStats";
 
 /**
- * Zagregowana dostępność nieprzeczytanych — „skąd zdobyć" w jednym miejscu.
- * Partycja priorytetowa (posiadane > biblioteka > Vinted > brak śladu), więc słupek
- * sumuje się do `totalUnread`. Łączy trzy skanery (posiadanie / OPAC / Vinted).
+ * Aggregated availability of unread books — „where to get it" in one place.
+ * A priority partition (owned > library > Vinted > no trace), so the bar
+ * sums to `totalUnread`. Combines three scanners (ownership / OPAC / Vinted).
  */
 
 const SEGMENTS: { key: keyof Omit<AvailabilityStats, "totalUnread">; label: string; icon: typeof Package; bar: string; text: string; dot: string }[] = [
@@ -41,7 +41,7 @@ export const AvailabilityCard: React.FC<{ stats: AvailabilityStats }> = ({ stats
             <span className="text-xs text-slate-500 uppercase tracking-widest font-bold">woluminów do zdobycia</span>
           </div>
 
-          {/* Słupek zbiorczy (partycja) */}
+          {/* Aggregate bar (partition) */}
           <div className="h-3 w-full rounded-full overflow-hidden flex bg-slate-950 border border-slate-800">
             {SEGMENTS.map((s) => {
               const w = pct(stats[s.key]);
@@ -49,7 +49,7 @@ export const AvailabilityCard: React.FC<{ stats: AvailabilityStats }> = ({ stats
             })}
           </div>
 
-          {/* Legenda + liczby */}
+          {/* Legend + numbers */}
           <div className="grid grid-cols-2 gap-3">
             {SEGMENTS.map((s) => {
               const Icon = s.icon;

--- a/src/components/stats/AwardCoverageGrid.tsx
+++ b/src/components/stats/AwardCoverageGrid.tsx
@@ -5,7 +5,7 @@ interface Props {
   coverage: AwardCoverageStat[];
 }
 
-/** Siatka pokrycia poszczególnych nagród — procent zdobytych z całości. */
+/** Coverage grid of individual awards — percent obtained out of the total. */
 export const AwardCoverageGrid: React.FC<Props> = ({ coverage }) => (
   <div className="pt-4 space-y-3">
     <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2">Pokrycie Poszczególnych Nagród</p>

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -13,15 +13,15 @@ const SORTS: { mode: CycleSortMode; label: string }[] = [
 const volStatus = (v: HarvestVolume) => {
   if (v.read) return { icon: Check, cls: "text-cyan-400", label: "przeczytana" };
   if (v.owned) return { icon: Package, cls: "text-emerald-400", label: "posiadana" };
-  // Tomy są teraz wierszami bazy — brak posiadania/przeczytania = „do zdobycia".
-  // Łagodny znacznik (dashed circle) zamiast trójkąta ostrzegawczego — poboczne
-  // tomy to zaproszenie do skompletowania, nie błąd.
+  // Volumes are now database rows — not owned/not read = „do zdobycia".
+  // A gentle marker (dashed circle) instead of a warning triangle — sibling
+  // volumes are an invitation to complete the set, not an error.
   return { icon: CircleDashed, cls: "text-amber-400/70", label: "do zdobycia" };
 };
 
 /**
- * Archiwum Cykli — zbiorczy widok tomów cykli (wiersze bazy z pola `Cykl`). Pokazuje
- * ile tomów masz / do zdobycia i pozwala oznaczać tomy przeczytane/posiadane w miejscu.
+ * Archiwum Cykli — an aggregate view of cycle volumes (database rows from the `Cykl` field). Shows
+ * how many volumes you have / still need, and lets you mark volumes read/owned in place.
  */
 export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refreshSignal }) => {
   const { view, loading, error, busyId, fetchHarvest, toggleSource } = useCyclesHarvest();
@@ -29,9 +29,9 @@ export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refres
   const [sortMode, setSortMode] = useState<CycleSortMode>("easywins");
   const sortedCycles = useMemo(() => (view ? sortCycles(view.cycles, sortMode) : []), [view, sortMode]);
 
-  // „Odśwież Dane" (StatsSection) inkrementuje refreshSignal → dociągnij świeże cykle
-  // (silent = bez migania kartą, fresh = pomiń cache). Pomiń pierwszy przebieg (mount
-  // już pobiera w hooku), by nie dublować żądania.
+  // „Odśwież Dane" (StatsSection) increments refreshSignal → pull fresh cycles
+  // (silent = no card flicker, fresh = skip cache). Skip the first run (mount
+  // already fetches in the hook), to avoid duplicating the request.
   const firstRun = useRef(true);
   useEffect(() => {
     if (firstRun.current) { firstRun.current = false; return; }
@@ -94,10 +94,10 @@ export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refres
         <div className="space-y-2 max-h-[460px] overflow-y-auto pr-2 custom-scrollbar">
           {sortedCycles.map((c) => {
             const isOpen = open === c.cycle;
-            // Cykl przeczytany w całości → wygaszony (nic nie zostało do nadrobienia).
+            // Cycle read in full → dimmed (nothing left to catch up on).
             const done = c.total > 0 && c.read === c.total;
-            // Dwie NIEZALEŻNE luki (dotąd zlane w jeden licznik „missing"):
-            // do zdobycia = nieposiadane; do przeczytania = nieprzeczytane.
+            // Two INDEPENDENT gaps (previously merged into one „missing" counter):
+            // to acquire = not owned; to read = not read.
             const toAcquire = c.total - c.owned;
             const toRead = c.total - c.read;
             return (

--- a/src/components/stats/DecadeHistogram.tsx
+++ b/src/components/stats/DecadeHistogram.tsx
@@ -4,9 +4,9 @@ import { BarChart3, Crown } from "lucide-react";
 import { DecadeStat } from "../../hooks/useStats";
 
 /**
- * Oś czasu / dekady — histogram rozkładu kolekcji po dekadach wydania (aplikacja
- * już myśli dekadami przez regał). Słupek = total; wypełnienie = przeczytane.
- * Wyróżniona „złota era" (najliczniejsza dekada).
+ * Timeline / decades — a histogram of the collection's distribution by publication decade (the app
+ * already thinks in decades via the shelf). Bar = total; fill = read.
+ * Highlights the „golden era" (the most populous decade).
  */
 export const DecadeHistogram: React.FC<{ decades: DecadeStat[] }> = ({ decades }) => {
   const max = Math.max(1, ...decades.map((d) => d.total));
@@ -37,7 +37,7 @@ export const DecadeHistogram: React.FC<{ decades: DecadeStat[] }> = ({ decades }
         <p className="text-slate-400 text-sm italic text-center py-8">Brak dat wydania w kolekcji.</p>
       ) : (
         <>
-          {/* Histogram — słupki pionowe, wypełnienie = przeczytane */}
+          {/* Histogram — vertical bars, fill = read */}
           <div className="flex items-end gap-1.5 h-[160px] pt-2">
             {decades.map((d) => {
               const h = (d.total / max) * 100;
@@ -52,7 +52,7 @@ export const DecadeHistogram: React.FC<{ decades: DecadeStat[] }> = ({ decades }
                       style={{ height: `${Math.max(h, 2)}%` }}
                       title={`${d.decade}–${d.decade + 9}: ${d.total} (przecz. ${d.read}, posiad. ${d.owned})`}
                     >
-                      {/* Wypełnienie = przeczytane (od dołu) */}
+                      {/* Fill = read (from the bottom) */}
                       <div
                         className={`absolute bottom-0 inset-x-0 ${isPeak ? "bg-gradient-to-t from-amber-500 to-amber-400" : "bg-gradient-to-t from-cyan-500 to-cyan-400"}`}
                         style={{ height: `${readH}%` }}
@@ -65,7 +65,7 @@ export const DecadeHistogram: React.FC<{ decades: DecadeStat[] }> = ({ decades }
             })}
           </div>
 
-          {/* Legenda */}
+          {/* Legend */}
           <div className="flex items-center justify-center gap-5 text-[10px] text-slate-500 uppercase tracking-widest font-bold">
             <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-cyan-400" /> Przeczytane</span>
             <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-slate-700/60" /> Pozostałe</span>

--- a/src/components/stats/IdentifiedLibraryItem.tsx
+++ b/src/components/stats/IdentifiedLibraryItem.tsx
@@ -11,7 +11,7 @@ interface IdentifiedLibraryItemProps {
   onStop: () => void;
   onMarkAsRead: (pageId: string, tag?: string) => void;
   markingId: string | null;
-  // Klucze „{tag}:{pageId}" pozycji już oznaczonych znacznikiem filii.
+  // Keys „{tag}:{pageId}" of items already marked with the branch tag.
   markedIds: Set<string>;
   isChecking: boolean;
   progress: any;

--- a/src/components/stats/MarketCard.tsx
+++ b/src/components/stats/MarketCard.tsx
@@ -4,10 +4,10 @@ import { Coins, Tag, TrendingDown, Users, ExternalLink } from "lucide-react";
 import { MarketStats } from "../../hooks/useStats";
 
 /**
- * „Rynek" — statystyki z blobu VintedData: koszt skompletowania kolekcji (suma
- * najtańszych ofert chcianych książek), najtańsze okazje, świeże spadki cen,
- * sprzedawcy z największą liczbą chcianych książek (naturalne paczki). Actionable —
- * linki wiodą wprost do ofert.
+ * „Rynek" — statistics from the VintedData blob: cost to complete the collection (sum of
+ * the cheapest offers for wanted books), the cheapest deals, fresh price drops,
+ * sellers with the most wanted books (natural bundles). Actionable —
+ * links lead straight to the offers.
  */
 
 const money = (n: number, cur: string) => `${n.toLocaleString("pl-PL", { maximumFractionDigits: 0 })} ${cur}`;
@@ -41,7 +41,7 @@ export const MarketCard: React.FC<{ market: MarketStats }> = ({ market }) => {
         <p className="text-slate-400 text-sm italic text-center py-8">Brak składowanych ofert — uruchom Rytuał Skanowania Vinted.</p>
       ) : (
         <>
-          {/* Koszt skompletowania */}
+          {/* Completion cost */}
           <div className="p-4 rounded-2xl bg-gradient-to-br from-rose-500/10 to-slate-950/40 border border-rose-500/20">
             <div className="flex items-baseline gap-2">
               <span className="text-3xl font-bold font-display text-rose-200 tabular-nums">{money(market.completionCost, cur)}</span>
@@ -51,7 +51,7 @@ export const MarketCard: React.FC<{ market: MarketStats }> = ({ market }) => {
             </p>
           </div>
 
-          {/* Najtańsze okazje */}
+          {/* Cheapest deals */}
           <div className="space-y-2">
             <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Tag className="w-3 h-3" /> Najtańsze okazje</h4>
             <div className="space-y-1.5 max-h-[160px] overflow-y-auto pr-1 custom-scrollbar">
@@ -63,7 +63,7 @@ export const MarketCard: React.FC<{ market: MarketStats }> = ({ market }) => {
             </div>
           </div>
 
-          {/* Świeże spadki cen */}
+          {/* Fresh price drops */}
           {market.priceDrops.length > 0 && (
             <div className="space-y-2">
               <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><TrendingDown className="w-3 h-3 text-emerald-400" /> Spadki cen</h4>
@@ -79,7 +79,7 @@ export const MarketCard: React.FC<{ market: MarketStats }> = ({ market }) => {
             </div>
           )}
 
-          {/* Sprzedawcy z paczką */}
+          {/* Sellers with a bundle */}
           {market.topSellers.length > 0 && (
             <div className="space-y-2">
               <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Users className="w-3 h-3" /> Sprzedawcy z paczką</h4>

--- a/src/components/stats/OwnedUnreadItem.tsx
+++ b/src/components/stats/OwnedUnreadItem.tsx
@@ -3,12 +3,12 @@ import { CheckCircle2, Loader2 } from "lucide-react";
 
 interface Props {
   book: { id: string; title: string; author: string; year?: number | null };
-  marking: boolean;      // czy trwa oznaczanie tej konkretnej pozycji
-  disabled: boolean;     // czy jakiekolwiek oznaczanie jest w toku (blokada)
+  marking: boolean;      // whether this specific item is being marked
+  disabled: boolean;     // whether any marking is in progress (lock)
   onMarkAsRead: (pageId: string) => void;
 }
 
-/** Wiersz pozycji posiadanej, lecz nieprzeczytanej, z akcją „oznacz jako przeczytane". */
+/** A row for an owned but unread item, with a „mark as read" action. */
 export const OwnedUnreadItem: React.FC<Props> = ({ book, marking, disabled, onMarkAsRead }) => (
   <div className="flex items-start gap-3 p-3 bg-slate-950/30 rounded-xl border border-slate-800/50 group/book">
     <div className="flex-1">

--- a/src/components/stats/PublishingCard.tsx
+++ b/src/components/stats/PublishingCard.tsx
@@ -4,10 +4,10 @@ import { Building2, Layers, Repeat } from "lucide-react";
 import { PublisherStat, SeriesStat, CycleStats } from "../../hooks/useStats";
 
 /**
- * Wydawnictwa / Serie / Cykle — dane z rytuałów publisher/series/cycles, dotąd
- * niepokazywane. Każdy pasek pokazuje POSTĘP wg swojej etykiety, nie rozmiar:
- * Wydawnictwa = przeczytane/tytuły, Serie = posiadane/total (luki), Cykle =
- * udział „części cyklu" w kolekcji. Lista i tak posortowana malejąco po liczbie.
+ * Publishers / Series / Cycles — data from the publisher/series/cycles rituals, not
+ * shown until now. Each bar shows PROGRESS by its own label, not size:
+ * Publishers = read/titles, Series = owned/total (gaps), Cycles =
+ * the share of „części cyklu" in the collection. The list is sorted descending by count anyway.
  */
 
 const barRow = (label: string, value: number, max: number, sub: string, color: string) => (
@@ -37,7 +37,7 @@ export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: Ser
         Oficyny, Serie i Cykle
       </h3>
 
-      {/* Cykle — pasek udziału */}
+      {/* Cycles — share bar */}
       <div className="p-3 rounded-2xl bg-slate-950/40 border border-white/5 space-y-2">
         <div className="flex items-center gap-2 text-xs text-slate-400">
           <Repeat className="w-3.5 h-3.5 text-purple-400" />
@@ -51,7 +51,7 @@ export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: Ser
         </div>
       </div>
 
-      {/* Top wydawnictwa */}
+      {/* Top publishers */}
       <div className="space-y-3">
         <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Building2 className="w-3 h-3" /> Top oficyny</h4>
         {publishers.length === 0 ? (
@@ -63,7 +63,7 @@ export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: Ser
         )}
       </div>
 
-      {/* Serie z lukami */}
+      {/* Series with gaps */}
       <div className="space-y-3">
         <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Layers className="w-3 h-3" /> Serie (posiadane/total)</h4>
         {series.length === 0 ? (

--- a/src/components/stats/RitualButton.tsx
+++ b/src/components/stats/RitualButton.tsx
@@ -8,18 +8,18 @@ interface RitualButtonProps {
   title: string;
   subtitle: string;
   onClick: () => void;
-  /** Animuj ikonę: „spin" (loader) lub „pulse" (aktywny rytuał). */
+  /** Animate the icon: „spin" (loader) or „pulse" (active ritual). */
   animate?: "spin" | "pulse";
   disabled?: boolean;
-  /** Dodatkowe klasy układu, np. `sm:col-span-2`. */
+  /** Extra layout classes, e.g. `sm:col-span-2`. */
   className?: string;
 }
 
 /**
- * Przycisk w stylu rytuału z liturgii synchronizacji (zob. OtherToolsCard): ciemna baza
- * slate-950, ikona w boxie, kolorowy akcent border/glow/scale na hover, tytuł „Rytuał X"
- * + uppercase podtytuł. Kolor bierze z centralnego motywu `ritualButtonTheme`. Stan
- * (bieg/stop/loader) ustala wołający, podając odpowiedni kolor/ikonę/tytuł.
+ * A ritual-style button from the sync liturgies (see OtherToolsCard): dark
+ * slate-950 base, icon in a box, colored border/glow/scale accent on hover, „Rytuał X" title
+ * + uppercase subtitle. Color comes from the central `ritualButtonTheme`. The state
+ * (run/stop/loader) is set by the caller, passing the right color/icon/title.
  */
 export const RitualButton: React.FC<RitualButtonProps> = ({
   color, icon: Icon, title, subtitle, onClick, animate, disabled, className,

--- a/src/components/stats/VintedCheckItem.tsx
+++ b/src/components/stats/VintedCheckItem.tsx
@@ -21,23 +21,23 @@ interface VintedCheckItemProps {
 
 export const VintedCheckItem: React.FC<VintedCheckItemProps> = ({ results, searchAttempts, onCheck, onStop, isChecking, progress }) => {
   const [showLogs, setShowLogs] = React.useState(false);
-  // Okno „Kontynuuj" z konfiguracji (knob `vinted.resumeHours`).
+  // The „Kontynuuj" window from config (knob `vinted.resumeHours`).
   const resumeHours = useEffectiveConfig().vinted.resumeHours;
-  // Wznawianie: domyślnie pomijamy książki skanowane < RESUME_HOURS h (bieżąca partia),
-  // resztę skanujemy od najstarszych — kontynuacja przerwanego przebiegu, nie od zera.
+  // Resuming: by default we skip books scanned < RESUME_HOURS h ago (current batch),
+  // and scan the rest from oldest first — continuation of an interrupted run, not from scratch.
   const [resumeScan, setResumeScan] = React.useState(true);
   const { isResolving, resolveProgress, resolveResult, resolveError, runResolve, stopResolve } = useVintedResolveSellers();
   const { stored, isLoadingStored, storedError, loadStored, clearStored } = useVintedStored();
 
-  // Źródło danych: baza (jeśli wczytana) lub bieżący skan. Kafelki i paczki renderują to samo UI.
+  // Data source: the database (if loaded) or the current scan. Tiles and bundles render the same UI.
   const usingStored = !!stored && stored.results.length > 0;
   const displayResults = usingStored ? stored!.results : results;
-  // Sprzedawcy (do paczek) pochodzą wyłącznie z bazy — live scan pokazuje same kafelki.
+  // Sellers (for bundles) come solely from the database — a live scan shows only tiles.
   const displaySellers = usingStored ? stored!.sellersByUrl : {};
 
   const onScanToggle = () => {
     if (isChecking) { onStop(); return; }
-    // Wyjdź z widoku bazy, żeby świeże wyniki skanu były widoczne (nie pinowane do stored).
+    // Exit the database view so fresh scan results are visible (not pinned to stored).
     clearStored();
     onCheck(resumeScan ? { skipScannedWithinHours: resumeHours } : undefined);
   };

--- a/src/components/stats/vinted/VintedBookResultList.tsx
+++ b/src/components/stats/vinted/VintedBookResultList.tsx
@@ -43,7 +43,7 @@ const OfferRow: React.FC<{ item: Offer; result: VintedResult; isCheapest: boolea
         )}
       </div>
 
-      {/* Cena — najmocniej eksponowana, stała szerokość, nie zawija się */}
+      {/* Price — most prominently displayed, fixed width, does not wrap */}
       <div className={`shrink-0 text-right tabular-nums font-bold leading-none ${hasPrice ? (isCheapest ? "text-emerald-300 text-lg" : "text-rose-300 text-base") : "text-slate-500 text-[11px] font-medium italic"}`}>
         {hasPrice ? formatVintedPrice(item.priceValue, item.currency) : "cena w ofercie"}
         {isCheapest && hasPrice && <div className="text-[8px] text-emerald-400/80 uppercase tracking-widest font-bold mt-0.5">najtańsza</div>}
@@ -53,7 +53,7 @@ const OfferRow: React.FC<{ item: Offer; result: VintedResult; isCheapest: boolea
   );
 };
 
-/** Siatka wyników per książka (kafelek + oferty posortowane od najtańszej). */
+/** Results grid per book (tile + offers sorted cheapest first). */
 export const VintedBookResultList: React.FC<{ results: VintedResult[] }> = ({ results }) => (
   <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} className="grid grid-cols-1 lg:grid-cols-2 gap-4 overflow-hidden">
     {sortResultsByCheapest(results).map((result) => {

--- a/src/components/stats/vinted/VintedBundleList.tsx
+++ b/src/components/stats/vinted/VintedBundleList.tsx
@@ -16,7 +16,7 @@ const SORTS: { mode: BundleSortMode; label: string }[] = [
   { mode: "price", label: "Najtańsza paczka" },
 ];
 
-/** Paczki od jednego sprzedawcy (z bazy) + przełącznik sortowania. */
+/** Bundles from a single seller (from the database) + sort toggle. */
 export const VintedBundleList: React.FC<Props> = ({ results, sellers, usingStored }) => {
   const [bundleSort, setBundleSort] = useState<BundleSortMode>("count");
   const rawBundles = useMemo(() => groupBySeller(results, sellers), [results, sellers]);

--- a/src/components/stats/vinted/VintedDebugLog.tsx
+++ b/src/components/stats/vinted/VintedDebugLog.tsx
@@ -4,7 +4,7 @@ import { ExternalLink, Loader2, Bug, CheckCircle2, XCircle, AlertCircle } from "
 import { VintedSearchAttempt } from "../../../hooks/useVintedCheck";
 import { formatDebug } from "../../../utils/vintedFormat";
 
-/** Zwijany panel logów skanowania (diagnostyka per próba). */
+/** Collapsible scan log panel (diagnostics per attempt). */
 export const VintedDebugLog: React.FC<{ searchAttempts: VintedSearchAttempt[]; show: boolean }> = ({ searchAttempts, show }) => (
   <AnimatePresence>
     {show && searchAttempts.length > 0 && (

--- a/src/components/stats/vinted/VintedResolveStatus.tsx
+++ b/src/components/stats/vinted/VintedResolveStatus.tsx
@@ -16,7 +16,7 @@ interface Props {
   displayCount: number;
 }
 
-/** Paski/banery statusu: identyfikacja sprzedawców + źródło danych z bazy. */
+/** Status bars/banners: seller identification + data source from the database. */
 export const VintedResolveStatus: React.FC<Props> = ({
   isResolving, resolveProgress, resolveError, resolveResult, storedError, stored, isLoadingStored, usingStored, displayCount,
 }) => (

--- a/src/components/stats/vinted/VintedScanControls.tsx
+++ b/src/components/stats/vinted/VintedScanControls.tsx
@@ -4,7 +4,7 @@ import { RitualButton } from "../RitualButton";
 
 
 interface Props {
-  /** Okno „Kontynuuj" (h) z konfiguracji — tylko do tooltipa. */
+  /** The „Kontynuuj" window (h) from config — for the tooltip only. */
   resumeHours: number;
   isChecking: boolean;
   isResolving: boolean;
@@ -21,7 +21,7 @@ interface Props {
   onClearStored: () => void;
 }
 
-/** Nagłówek skanera + rytuały (skan / identyfikacja handlarzy / przywołanie z bazy). */
+/** Scanner header + rituals (scan / seller identification / summon from the database). */
 export const VintedScanControls: React.FC<Props> = ({
   resumeHours,
   isChecking, isResolving, isLoadingStored, usingStored, hasAttempts,
@@ -57,7 +57,7 @@ export const VintedScanControls: React.FC<Props> = ({
       </div>
     </div>
 
-    {/* Rytuały skanera — w stylu liturgii synchronizacji */}
+    {/* Scanner rituals — in the style of the sync liturgies */}
     <div className="grid sm:grid-cols-2 gap-3">
       <RitualButton
         className="sm:col-span-2"

--- a/src/components/stats/vinted/VintedScanProgress.tsx
+++ b/src/components/stats/vinted/VintedScanProgress.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { motion } from "motion/react";
 import { formatETA } from "../../../utils/time";
 
-/** Pasek postępu aktywnego skanu (message + ETA + current/total). */
+/** Progress bar for the active scan (message + ETA + current/total). */
 export const VintedScanProgress: React.FC<{ progress: any }> = ({ progress }) => {
   if (!progress) return null;
   return (

--- a/src/components/sync/FullSyncSummary.tsx
+++ b/src/components/sync/FullSyncSummary.tsx
@@ -5,7 +5,7 @@ import { getRitualDot } from "../../theme/ritualColors";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { StatCard } from "./StatCard";
 
-/** Podsumowanie „Wielkiego Rytuału" — agregat wszystkich kroków pełnej synchronizacji. */
+/** „Wielki Rytuał" summary — aggregate of all steps of the full synchronization. */
 export const FullSyncSummary: React.FC<{ results: any[]; onClose: () => void }> = ({ results, onClose }) => {
   const { copied, copy } = useCopyToClipboard();
 
@@ -39,7 +39,7 @@ export const FullSyncSummary: React.FC<{ results: any[]; onClose: () => void }> 
           {results.map((res) => (
             <div key={res.name} className="p-3 rounded-xl bg-slate-900/40 border border-slate-800/50 flex items-center justify-between">
               <div className="flex items-center gap-3">
-                {/* Tailwind nie generuje klas budowanych dynamicznie — mapuj statycznie */}
+                {/* Tailwind doesn't generate dynamically built classes — map them statically */}
                 <div className={`w-2 h-2 rounded-full ${getRitualDot(res.color)}`} />
                 <span className="text-xs font-bold text-slate-300 uppercase tracking-wider">{res.name}</span>
               </div>

--- a/src/components/sync/SingleSyncSummary.tsx
+++ b/src/components/sync/SingleSyncSummary.tsx
@@ -7,7 +7,7 @@ import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { StatCard } from "./StatCard";
 import { SummaryDetailPanel } from "./SummaryDetailPanel";
 
-/** Podsumowanie pojedynczego rytuału (dodane / zaktualizowane / pominięte / duplikaty). */
+/** Summary of a single ritual (added / updated / skipped / duplicates). */
 export const SingleSyncSummary: React.FC<{ sync: ReturnType<typeof useSync>; onClose: () => void }> = ({ sync, onClose }) => {
   const { copied, copy } = useCopyToClipboard();
 
@@ -15,7 +15,7 @@ export const SingleSyncSummary: React.FC<{ sync: ReturnType<typeof useSync>; onC
   const color = sync.state.color || "cyan";
   const summary = activeResult?.summary;
 
-  // Motyw rytuału (patrz src/theme/ritualColors.ts). Tu bg = miękkie tło karty.
+  // Ritual theme (see src/theme/ritualColors.ts). Here bg = soft card background.
   const t = getRitualTheme(color);
   const theme = { text: t.text, border: t.border, bg: t.bgSoft };
 

--- a/src/components/sync/StatCard.tsx
+++ b/src/components/sync/StatCard.tsx
@@ -3,13 +3,13 @@ import React from "react";
 interface Props {
   label: string;
   count: number;
-  color: string;   // klasa koloru liczby, np. "text-emerald-400"
-  bg: string;      // klasa tła karty, np. "bg-emerald-500/10"
-  countClass?: string;  // rozmiar liczby (full-sync: text-2xl, single: text-3xl)
-  labelClass?: string;  // rozmiar etykiety (full-sync: text-[10px], single: text-xs)
+  color: string;   // number color class, e.g. "text-emerald-400"
+  bg: string;      // card background class, e.g. "bg-emerald-500/10"
+  countClass?: string;  // number size (full-sync: text-2xl, single: text-3xl)
+  labelClass?: string;  // label size (full-sync: text-[10px], single: text-xs)
 }
 
-/** Kafelek liczbowy podsumowania (Dodano / Zaktualizowano / …). */
+/** Numeric summary tile (Added / Updated / …). */
 export const StatCard: React.FC<Props> = ({ label, count, color, bg, countClass = "text-2xl", labelClass = "text-[10px]" }) => (
   <div className={`p-4 rounded-2xl ${bg} border border-white/5`}>
     <div className={`${labelClass} font-bold text-slate-500 uppercase tracking-widest mb-1`}>{label}</div>

--- a/src/components/sync/SummaryDetailPanel.tsx
+++ b/src/components/sync/SummaryDetailPanel.tsx
@@ -5,20 +5,20 @@ interface Props {
   title: string;
   count: number;
   icon: React.ReactNode;
-  /** Kolor nagłówka, np. "text-emerald-400". */
+  /** Header color, e.g. "text-emerald-400". */
   accentClass: string;
-  /** Klasy obramowania + tła wiersza, np. "border-emerald-500/30 bg-emerald-500/5". */
+  /** Row border + background classes, e.g. "border-emerald-500/30 bg-emerald-500/5". */
   rowClass: string;
-  /** Kolor tekstu wiersza (domyślnie slate-300). */
+  /** Row text color (defaults to slate-300). */
   rowTextClass?: string;
   items: string[];
-  /** Opcjonalny przycisk kopiowania listy (używane przez panel duplikatów). */
+  /** Optional list-copy button (used by the duplicates panel). */
   onCopy?: () => void;
   copied?: boolean;
   copyTitle?: string;
 }
 
-/** Panel listy podsumowania (Nowe / Zaktualizowane / Pominięte / Duplikaty) — jeden wzorzec. */
+/** Summary list panel (New / Updated / Skipped / Duplicates) — one pattern. */
 export const SummaryDetailPanel: React.FC<Props> = ({ title, count, icon, accentClass, rowClass, rowTextClass = "text-slate-300", items, onCopy, copied, copyTitle }) => (
   <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
     <div className="flex items-center justify-between mb-4">

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -1,89 +1,89 @@
 /**
- * Schemat konfiguracji aplikacji (knoby z zakładki „Konfiguracja").
+ * App configuration schema (the knobs from the „Konfiguracja" tab).
  *
- * Moduł WSPÓŁDZIELONY frontend/backend (czysty TS, zero zależności Node) — frontend
- * bierze stąd typy i DEFAULT_CONFIG (formularz + reset), backend merge/clamp/diff.
- * Zasada przechowywania: w Notion (opis kolumny `AppConfig`) ląduje wyłącznie
- * **diff od defaultów** — mały blob, a nowe knoby w kodzie dostają defaulty bez
- * migracji. Wartości domyślne = dokładnie dotychczasowe zachowanie aplikacji.
+ * A SHARED frontend/backend module (pure TS, zero Node deps) — the frontend
+ * takes its types and DEFAULT_CONFIG from here (form + reset), the backend merge/clamp/diff.
+ * Storage principle: only the **diff from defaults** lands in Notion (the `AppConfig`
+ * column description) — a small blob, and new knobs in the code get defaults without
+ * a migration. The default values = exactly the app's existing behavior.
  */
 
 export interface LibraryBranch {
   id: string;
   name: string;
   code: string;
-  /** Tag „Źródło" dopisywany po oznaczeniu książki jako dostępnej w tej filii. */
+  /** „Źródło" tag added after marking a book as available in this branch. */
   sourceTag: string;
 }
 
 export interface AwardPage {
   name: string;
-  /** Tytuł strony w Archiwum Encyklopedii Fantastyki. */
+  /** Page title in the Archiwum Encyklopedii Fantastyki. */
   title: string;
 }
 
 export interface AppConfig {
   vinted: {
-    /** Okno „Kontynuuj": pomiń książki skanowane w ostatnich N h. */
+    /** „Kontynuuj" window: skip books scanned in the last N h. */
     resumeHours: number;
-    /** Minimalny odstęp między żądaniami (ms). */
+    /** Minimum interval between requests (ms). */
     throttleMinMs: number;
-    /** Losowy jitter dokładany do odstępu (ms). */
+    /** Random jitter added to the interval (ms). */
     throttleJitterMs: number;
-    /** Timeout pojedynczego żądania HTTP (ms). NIE skracaj pochopnie — patrz backlog. */
+    /** Timeout of a single HTTP request (ms). Do NOT shorten rashly — see backlog. */
     requestTimeoutMs: number;
-    /** Liczba prób withRetry. */
+    /** Number of withRetry attempts. */
     retryAttempts: number;
-    /** Bazowy backoff między próbami (ms). */
+    /** Base backoff between attempts (ms). */
     retryBackoffMs: number;
-    /** Kategoria katalogu Vinted (2319 = beletrystyka). */
+    /** Vinted catalog category (2319 = fiction). */
     catalogId: number;
-    /** Filtr języka ofert (6440 = polski). */
+    /** Offer language filter (6440 = Polish). */
     languageId: number;
-    /** Dolny próg ceny (odcina oferty-śmieci). */
+    /** Lower price threshold (cuts off junk offers). */
     priceFrom: number;
     currency: string;
-    /** Sortowanie wyników katalogu. */
+    /** Catalog results sorting. */
     order: string;
-    /** Limit ustaleń sprzedawców na przebieg; 0 = bez limitu. */
+    /** Cap on seller resolutions per run; 0 = no cap. */
     sellerResolveCap: number;
-    /** Tagi „Źródło" wykluczające książkę ze skanu Vinted. */
+    /** „Źródło" tags that exclude a book from the Vinted scan. */
     excludedSources: string[];
-    /** Rozgrzej sesję (GET strony głównej → ciasteczko Cloudflare) przed skanem. */
+    /** Warm up the session (GET the homepage → Cloudflare cookie) before the scan. */
     primeSession: boolean;
   };
   scraping: {
-    /** Pula User-Agentów (rotacja per żądanie). Odświeżaj co kilka miesięcy. */
+    /** User-Agent pool (rotated per request). Refresh every few months. */
     userAgents: string[];
   };
   library: {
     branches: LibraryBranch[];
-    /** Równoległość zapytań OPAC. */
+    /** OPAC query concurrency. */
     concurrency: number;
-    /** Tagi wykluczające ze skanu bibliotecznego (celowo osobna lista — bez „Audioteka"). */
+    /** Tags excluding from the library scan (intentionally a separate list — without „Audioteka"). */
     excludedSources: string[];
   };
   sync: {
-    /** Strony nagród na wiki (Hugo/Nebula/Locus) — źródło pełnej synchronizacji i diagnostyki. */
+    /** Award pages on the wiki (Hugo/Nebula/Locus) — source for full sync and diagnostics. */
     awards: AwardPage[];
-    /** Równoległość zapisów do Notion (bookSync / cycles). */
+    /** Notion write concurrency (bookSync / cycles). */
     writeConcurrency: number;
-    /** Próg podobieństwa autorów przy wykrywaniu duplikatów (0–1). */
+    /** Author similarity threshold for duplicate detection (0–1). */
     dupAuthorThreshold: number;
-    /** Próg podobieństwa tytułów (PL i oryginalnego) przy duplikatach (0–1). */
+    /** Title similarity threshold (PL and original) for duplicates (0–1). */
     dupTitleThreshold: number;
   };
   ui: {
-    /** Liczba rzędów regału na stronę (Regał N/M). */
+    /** Number of shelf rows per page (Regał N/M). */
     shelfRowsPerPage: number;
-    /** Precyzyjny drag&drop na regale (wstawianie w szczelinę w obrębie dekady). */
+    /** Precise drag&drop on the shelf (inserting into a slot within a decade). */
     preciseShelfDrop: boolean;
-    /** Kolejność kart w „Analizie Zasobów" (id sekcji). Puste = domyślna kolejność z kodu. */
+    /** Card order in „Analizie Zasobów" (section ids). Empty = default order from code. */
     statsOrder: string[];
   };
 }
 
-/** Głęboki partial konfiguracji (kształt nadpisań składowanych w Notion). */
+/** Deep partial of the config (shape of the overrides stored in Notion). */
 export type ConfigOverrides = {
   [S in keyof AppConfig]?: Partial<AppConfig[S]>;
 };
@@ -141,7 +141,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   },
 };
 
-/* ==================== Normalizacja / clampy ==================== */
+/* ==================== Normalization / clamps ==================== */
 
 const clamp = (v: unknown, min: number, max: number, dflt: number): number => {
   const n = typeof v === "number" && isFinite(v) ? v : NaN;
@@ -167,7 +167,7 @@ const cleanStringList = (v: unknown, dflt: string[], maxItems = 30, maxLen = 400
   return out.length > 0 ? out : [...dflt];
 };
 
-/** Lista identyfikatorów (np. kolejność kart) — dozwolona pusta, dedup, przycięcie. */
+/** List of identifiers (e.g. card order) — empty allowed, dedup, truncation. */
 const cleanIdList = (v: unknown, maxItems = 40, maxLen = 40): string[] => {
   if (!Array.isArray(v)) return [];
   const seen = new Set<string>();
@@ -212,9 +212,9 @@ const cleanAwards = (v: unknown, dflt: AwardPage[]): AwardPage[] => {
 };
 
 /**
- * Scala nadpisania z defaultami i clampuje każdą wartość do bezpiecznego zakresu.
- * Nieznane pola są ignorowane, złe typy wracają do defaultu — funkcja NIGDY nie
- * rzuca (uszkodzony blob w Notion nie może zabić aplikacji).
+ * Merges overrides with defaults and clamps every value to a safe range.
+ * Unknown fields are ignored, bad types fall back to the default — the function NEVER
+ * throws (a corrupted blob in Notion must not kill the app).
  */
 export function mergeConfig(overrides?: unknown): AppConfig {
   const o = (overrides && typeof overrides === "object" ? overrides : {}) as ConfigOverrides;
@@ -266,8 +266,8 @@ export function mergeConfig(overrides?: unknown): AppConfig {
 const eq = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
 
 /**
- * Diff pełnej konfiguracji względem defaultów — do składowania trzymamy tylko to,
- * co user faktycznie zmienił (mały blob + nowe knoby dziedziczą defaulty z kodu).
+ * Diff of the full config against the defaults — for storage we keep only what
+ * the user actually changed (small blob + new knobs inherit defaults from code).
  */
 export function diffFromDefaults(cfg: AppConfig): ConfigOverrides {
   const out: ConfigOverrides = {};
@@ -283,7 +283,7 @@ export function diffFromDefaults(cfg: AppConfig): ConfigOverrides {
   return out;
 }
 
-/** Parsuje blob z Notion; pusty/uszkodzony → null (mergeConfig dostanie undefined = same defaulty). */
+/** Parses the blob from Notion; empty/corrupted → null (mergeConfig gets undefined = defaults only). */
 export function parseStoredConfig(raw: string | null | undefined): ConfigOverrides | null {
   if (!raw || !raw.trim()) return null;
   try {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,12 @@
 import { DEFAULT_CONFIG } from "./configSchema";
 
 /**
- * Stałe-fallbacki DERYWOWANE z DEFAULT_CONFIG (jedno źródło prawdy w configSchema).
- * Żywe wartości pochodzą z konfiguracji (`useEffectiveConfig` → GET /api/app-config);
- * te listy służą jako stan początkowy zanim odpowiedź dotrze.
+ * Fallback constants DERIVED from DEFAULT_CONFIG (single source of truth in configSchema).
+ * Live values come from the configuration (`useEffectiveConfig` → GET /api/app-config);
+ * these lists serve as initial state before the response arrives.
  */
 
-/** Pseudo-nagroda pełnej synchronizacji — opcja UI, nie strona wiki. */
+/** Pseudo-award for a full sync — a UI option, not a wiki page. */
 export const SYNC_ALL_AWARD = { name: "Wszystkie Nagrody", title: "Wszystkie" };
 
 export const PREDEFINED_AWARDS = [...DEFAULT_CONFIG.sync.awards, SYNC_ALL_AWARD];

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useState } from "react";
 import { AppConfig, DEFAULT_CONFIG, mergeConfig } from "../configSchema";
 
 /**
- * Konfiguracja aplikacji po stronie frontu.
+ * Front-end application configuration.
  *
- * - `useEffectiveConfig` — dla KONSUMENTÓW (regał, skanery, nagrody): jedno pobranie
- *   na sesję (cache modułowy współdzielony między hookami), `DEFAULT_CONFIG` do czasu
- *   odpowiedzi, brak stanów błędu (konsument zawsze dostaje działającą konfigurację).
- * - `useAppConfig` — dla PANELU (zakładka Konfiguracja): świeże pobranie, edycja
- *   lokalna, zapis PUT; po zapisie unieważnia cache konsumentów.
+ * - `useEffectiveConfig` — for CONSUMERS (shelf, scanners, awards): a single fetch
+ *   per session (module cache shared between hooks), `DEFAULT_CONFIG` until the
+ *   response arrives, no error states (the consumer always gets a working config).
+ * - `useAppConfig` — for the PANEL (Configuration tab): fresh fetch, local edit,
+ *   PUT save; after saving it invalidates the consumers' cache.
  */
 
 let cachedConfig: AppConfig | null = null;
@@ -18,7 +18,7 @@ const listeners = new Set<(cfg: AppConfig) => void>();
 async function fetchConfig(force = false): Promise<AppConfig> {
   const res = await fetch(`/api/app-config${force ? "?force=1" : ""}`);
   if (!res.ok) throw new Error(`Błąd serwera: ${res.status}`);
-  // mergeConfig = pas bezpieczeństwa po stronie klienta (i clamp starych odpowiedzi).
+  // mergeConfig = client-side safety belt (and clamp for old responses).
   return mergeConfig(await res.json());
 }
 
@@ -31,29 +31,30 @@ function loadShared(): Promise<AppConfig> {
         listeners.forEach((l) => l(cfg));
         return cfg;
       })
-      .catch(() => DEFAULT_CONFIG) // sieć/500 → defaulty; nie zapisujemy do cache, kolejny mount spróbuje znów
+      .catch(() => DEFAULT_CONFIG) // network/500 → defaults; not cached, the next mount tries again
       .finally(() => { inflight = null; });
   }
   return inflight;
 }
 
-/** Po zapisie w panelu: podmień cache i powiadom zamontowanych konsumentów. */
+/** After a save in the panel: swap the cache and notify mounted consumers. */
 export function publishEffectiveConfig(cfg: AppConfig): void {
   cachedConfig = cfg;
   listeners.forEach((l) => l(cfg));
 }
 
 /**
- * Utrwala kolejność kart statystyk (`ui.statsOrder`) bez otwierania panelu.
- * Optymistycznie publikuje nową kolejność od razu (płynny reorder), a zapis do
- * Notion leci w tle — błąd sieci nie cofa układu na tę sesję. Nie klobruje innych
- * knobów: bierze bieżącą efektywną konfigurację i podmienia tylko to pole.
+ * Persists the stats card order (`ui.statsOrder`) without opening the panel.
+ * Optimistically publishes the new order right away (smooth reorder), while the
+ * write to Notion runs in the background — a network error does not revert the
+ * layout for this session. Does not clobber other knobs: it takes the current
+ * effective config and swaps only this field.
  */
 export async function persistStatsOrder(order: string[]): Promise<void> {
   await loadShared();
-  // Jeśli wczytanie configu się nie powiodło (`cachedConfig` puste, `loadShared` zwrócił
-  // DEFAULT_CONFIG), NIE zapisujemy — inaczej PUT defaultów skasowałby realne knoby
-  // (filie, ustawienia) na serwerze. Reorder poczeka na sprawną sesję.
+  // If loading the config failed (`cachedConfig` empty, `loadShared` returned
+  // DEFAULT_CONFIG), DON'T save — otherwise a PUT of defaults would wipe real knobs
+  // (branches, settings) on the server. The reorder waits for a healthy session.
   if (!cachedConfig) return;
   const next: AppConfig = { ...cachedConfig, ui: { ...cachedConfig.ui, statsOrder: order } };
   publishEffectiveConfig(next);
@@ -65,11 +66,11 @@ export async function persistStatsOrder(order: string[]): Promise<void> {
     });
     if (res.ok) publishEffectiveConfig(mergeConfig(await res.json()));
   } catch {
-    /* zostaje wersja optymistyczna na tę sesję */
+    /* the optimistic version stays for this session */
   }
 }
 
-/** Efektywna konfiguracja dla konsumentów — defaulty do czasu pobrania, potem live. */
+/** Effective config for consumers — defaults until fetched, then live. */
 export function useEffectiveConfig(): AppConfig {
   const [cfg, setCfg] = useState<AppConfig>(cachedConfig ?? DEFAULT_CONFIG);
   useEffect(() => {
@@ -81,7 +82,7 @@ export function useEffectiveConfig(): AppConfig {
   return cfg;
 }
 
-/** Stan panelu konfiguracji: draft do edycji + load/save. */
+/** Configuration panel state: editable draft + load/save. */
 export function useAppConfig() {
   const [draft, setDraft] = useState<AppConfig | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -2,14 +2,14 @@ import { useState, useEffect, useCallback } from "react";
 import { BookIndexEntry } from "../types";
 
 /**
- * Pobiera odchudzony indeks książek z `GET /api/books` RAZ i trzyma w stanie.
- * Cała wyszukiwarka „Skryptorium" filtruje ten indeks w pamięci (client-side),
- * więc żaden znak w polu wyszukiwania nie uderza do sieci ani do Notion.
+ * Fetches the slimmed-down book index from `GET /api/books` ONCE and holds it in state.
+ * The whole „Skryptorium" search filters this index in memory (client-side),
+ * so no keystroke in the search field hits the network or Notion.
  */
 export function useBooks() {
   const [books, setBooks] = useState<BookIndexEntry[] | null>(null);
-  // Startujemy w stanie ładowania — fetch leci od razu w useEffect (po paint), więc
-  // bez tego pierwsza klatka pokazywałaby pusty stan zamiast spinnera.
+  // Start in loading state — the fetch fires right away in useEffect (after paint), so
+  // without this the first frame would show an empty state instead of a spinner.
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -24,7 +24,7 @@ export function useConfig() {
       setConfigStatus({ ...configData, isSyncing: health.isSyncing, loading: false });
     } catch (err) {
       console.error("Config fetch error:", err);
-      // Nie zostawiaj karty statusu w wiecznej "Inicjalizacji Duchów Maszyny"
+      // Don't leave the status card stuck forever in "Inicjalizacji Duchów Maszyny"
       setConfigStatus(prev => ({ ...prev, loading: false }));
     }
   }, []);

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 
-/** Kopiowanie do schowka z krótkim stanem „skopiowano" (do ikonki ✓). */
+/** Copy to clipboard with a brief „copied" state (for the ✓ icon). */
 export function useCopyToClipboard(resetMs = 2000) {
   const [copied, setCopied] = useState(false);
   const copy = useCallback((text: string) => {

--- a/src/hooks/useCycle.ts
+++ b/src/hooks/useCycle.ts
@@ -17,8 +17,8 @@ export interface CycleView {
 }
 
 /**
- * Podgląd cyklu na żądanie (GET /api/cycle). Cache per (tytuł|autor) w ref — ponowne
- * otwarcie panelu dla tej samej książki nie odpytuje serwera. Backend też cache'uje.
+ * On-demand cycle preview (GET /api/cycle). Cache per (title|author) in a ref — reopening
+ * the panel for the same book does not re-query the server. The backend caches too.
  */
 export function useCycle() {
   const [view, setView] = useState<CycleView | null>(null);

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -32,8 +32,8 @@ export interface CyclesHarvest {
 }
 
 /**
- * Zebrane cykle (GET /api/cycles-harvest) — agregacja WIERSZY cykli (pole `Cykl`)
- * materializowanych Rytuałem Żniw. Odczyt lekki (agregacja serwera z cache książek).
+ * Harvested cycles (GET /api/cycles-harvest) — aggregation of cycle ROWS (the `Cykl` field)
+ * materialized by the „Rytuał Żniw". Lightweight read (server aggregation off the book cache).
  */
 export function useCyclesHarvest() {
   const [view, setView] = useState<CyclesHarvest | null>(null);
@@ -41,8 +41,8 @@ export function useCyclesHarvest() {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
 
-  // `silent` = odświeżenie w tle (po oznaczeniu tomu) bez migania całą kartą.
-  // `fresh` = pomiń 5-min cache książek na serwerze (ręczne „Odśwież Dane").
+  // `silent` = background refresh (after marking a volume) without flashing the whole card.
+  // `fresh` = skip the 5-min book cache on the server (manual „Odśwież Dane").
   const fetchHarvest = useCallback(async (silent = false, fresh = false) => {
     if (!silent) setLoading(true);
     setError(null);
@@ -58,11 +58,11 @@ export function useCyclesHarvest() {
   }, []);
 
   /**
-   * Przełącza znacznik „Źródło" (Przeczytane/Posiadam) na wierszu tomu i odświeża
-   * widok. `active=true` dopisuje, `false` usuwa (endpoint mark/unmark-as-read).
+   * Toggles the „Źródło" tag (Przeczytane/Posiadam) on a volume row and refreshes
+   * the view. `active=true` adds it, `false` removes it (mark/unmark-as-read endpoint).
    */
   const toggleSource = useCallback(async (id: string, tag: "Przeczytane" | "Posiadam", active: boolean) => {
-    if (!id) return; // bez ID nie ma czego oznaczać (i pusty busyId rozbrajałby blokadę)
+    if (!id) return; // without an ID there's nothing to mark (and an empty busyId would disarm the lock)
     setBusyId(id);
     setError(null);
     try {

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -9,8 +9,8 @@ export function useLibraryCheck() {
   const [checkingLibrary, setCheckingLibrary] = useState<string | null>(null);
   const [checkProgress, setCheckProgress] = useState<{ current: number; total: number; message: string; startTime: number | null } | null>(null);
   const [libraryError, setLibraryError] = useState<string | null>(null);
-  // Ref zamiast stanu w strażniku — stan w domknięciu bywa nieaktualny
-  // (dwa kliknięcia w tym samym ticku uruchamiały dwa równoległe skany)
+  // Ref instead of state in the guard — state in the closure can be stale
+  // (two clicks in the same tick launched two parallel scans)
   const isCheckingRef = useRef(false);
   const { run } = useSSEStream("/api/library-check");
 
@@ -50,7 +50,7 @@ export function useLibraryCheck() {
       }
     });
 
-    // Błąd nie przerywa całości — `checkAllLibraries` leci dalej do kolejnej filii.
+    // An error does not abort the whole thing — `checkAllLibraries` moves on to the next branch.
     if (!result.ok && result.error) setLibraryError(result.error);
     isCheckingRef.current = false;
     setCheckingLibrary(null);
@@ -69,10 +69,10 @@ export function useLibraryCheck() {
     if (isCheckingRef.current) return;
 
     for (const branch of branches) {
-      // checkLibrary jest teraz zwykłym async i rozwiązuje się po zakończeniu strumienia
-      // (bez ręcznego opakowania w Promise) — czekamy na każdą filię po kolei.
+      // checkLibrary is now a plain async and resolves once the stream ends
+      // (no manual Promise wrapping) — we wait for each branch in turn.
       await checkLibrary(branch.id, branch.code);
-      // Krótka przerwa między filiami.
+      // Short pause between branches.
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
   }, [checkLibrary]);

--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -12,13 +12,13 @@ interface Deps {
 }
 
 /**
- * Oznaczanie pozycji jako przeczytanej (`POST /api/mark-as-read`).
- * `markingId` blokuje równoległe zapisy; `markedIds` (klucz „{tag}:{pageId}")
- * trzyma pozycje otagowane w tej sesji — skan biblioteki wyklucza już
- * otagowane książki, więc rekord ma zostać widoczny, lecz z wyłączonym haczykiem.
+ * Marking an item as read (`POST /api/mark-as-read`).
+ * `markingId` blocks parallel writes; `markedIds` (key „{tag}:{pageId}")
+ * holds items tagged in this session — the library scan excludes already
+ * tagged books, so the record should stay visible but with its checkbox off.
  *
- * tag domyślnie „Przeczytane" (zasoby posiadane / statystyki biblioteczne);
- * skaner filii przekazuje znacznik filii („Biblioteka" / „Biblioteka 9").
+ * tag defaults to „Przeczytane" (owned resources / library stats);
+ * the branch scanner passes a branch tag („Biblioteka" / „Biblioteka 9").
  */
 export function useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchStats }: Deps) {
   const [markingId, setMarkingId] = useState<string | null>(null);
@@ -37,10 +37,10 @@ export function useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchS
       const sourceTag = tag ?? "Przeczytane";
       setMarkedIds(prev => new Set(prev).add(`${sourceTag}:${pageId}`));
 
-      // Tag filii dopisuje pozycję wyłącznie do sekcji „Książki dostępne w
-      // bibliotekach" — aktualizujemy ją optymistycznie (natychmiast, odporne na
-      // opóźnienie odczytu Notiona). „Przeczytane" zmienia wiele przekrojów
-      // (autorzy, chronologia, posiadane), więc tam robimy pełny refetch.
+      // A branch tag adds the item only to the „Książki dostępne w
+      // bibliotekach" section — we update it optimistically (immediately, resilient to
+      // Notion's read lag). „Przeczytane" changes many cross-sections
+      // (authors, chronology, owned), so there we do a full refetch.
       if (LIBRARY_TAGS.includes(sourceTag)) {
         const book = Object.values(identifiedBooks).flat().find(b => b.id === pageId);
         if (book) addBookToLibrarySection(sourceTag, book);

--- a/src/hooks/useMarkRead.ts
+++ b/src/hooks/useMarkRead.ts
@@ -2,9 +2,9 @@ import { useCallback } from "react";
 import { READ_TAG } from "../utils/bookshelf";
 
 /**
- * Zapis stanu „przeczytane" do Notion: `mark-as-read` dodaje tag „Przeczytane"
- * w kolumnie „Źródło", `unmark-as-read` go usuwa. Rzuca przy błędzie — wołający
- * (regał) robi optymistyczny ruch i cofa go, jeśli zapis się nie powiedzie.
+ * Writing the „read" state to Notion: `mark-as-read` adds the „Przeczytane" tag
+ * in the „Źródło" column, `unmark-as-read` removes it. Throws on error — the caller
+ * (shelf) makes an optimistic move and reverts it if the write fails.
  */
 export function useMarkRead() {
   const setRead = useCallback(async (pageId: string, read: boolean): Promise<void> => {

--- a/src/hooks/useSSEStream.ts
+++ b/src/hooks/useSSEStream.ts
@@ -4,25 +4,25 @@ import { consumeSSE } from "../utils/sse";
 import { createStallWatchdog } from "../utils/stallWatchdog";
 
 export interface SSEStreamResult {
-  /** Strumień przebiegł bez błędu HTTP / rzutu / stalla. (complete vs error rozstrzyga `onEvent`.) */
+  /** The stream ran without an HTTP error / throw / stall. (complete vs error is decided by `onEvent`.) */
   ok: boolean;
-  /** Komunikat błędu (HTTP, rzucony przez `onEvent`, lub domyślny stall) — null gdy `ok`. */
+  /** Error message (HTTP, thrown by `onEvent`, or the default stall) — null when `ok`. */
   error: string | null;
-  /** Czy watchdog przerwał połączenie z powodu ciszy (pozwala nadpisać komunikat po stronie wołającego). */
+  /** Whether the watchdog aborted the connection due to silence (lets the caller override the message). */
   stalled: boolean;
 }
 
-/** Domyślny komunikat o zawieszeniu strumienia (sekundy z `timeoutMs`). */
+/** Default stream-stall message (seconds from `timeoutMs`). */
 export function defaultStallMessage(timeoutMs: number): string {
   return `Połączenie z serwerem zawisło (brak odpowiedzi przez ${Math.round(timeoutMs / 1000)} s). Możliwe buforowanie strumienia przez hosting. Odśwież i spróbuj ponownie.`;
 }
 
 /**
- * Wspólny transport SSE dla hooków (useSync, useVintedCheck, useLibraryCheck): jeden
- * POST, sprawdzenie `res.ok`, `consumeSSE` z watchdogiem przeciw zawieszeniu i
- * derywacja komunikatu błędu (HTTP / rzut z `onEvent` / stall). NIE trzyma stanu UI —
- * wołający posiada swój stan i ustawia go w `onEvent` oraz wokół `run`, decydując co
- * zrobić z wynikiem. Dzięki temu każdy hook różni się tylko routingiem zdarzeń.
+ * Shared SSE transport for hooks (useSync, useVintedCheck, useLibraryCheck): one
+ * POST, `res.ok` check, `consumeSSE` with a stall watchdog and derivation of the
+ * error message (HTTP / throw from `onEvent` / stall). Does NOT hold UI state —
+ * the caller owns its state and sets it in `onEvent` and around `run`, deciding what
+ * to do with the result. This way each hook differs only in its event routing.
  */
 export function useSSEStream(endpoint: string, opts?: { timeoutMs?: number }) {
   const timeoutMs = opts?.timeoutMs ?? 30000;
@@ -44,11 +44,11 @@ export function useSSEStream(endpoint: string, opts?: { timeoutMs?: number }) {
       const res = await fetch(endpoint, fetchOptions);
       if (!res.ok) {
         let message = `Błąd serwera: ${res.status}`;
-        try { const j = await res.json(); message = j.error || message; } catch { /* nie-JSON */ }
+        try { const j = await res.json(); message = j.error || message; } catch { /* non-JSON */ }
         throw new Error(message);
       }
 
-      // onChunk = watchdog.arm (keepalive też liczy się jako aktywność).
+      // onChunk = watchdog.arm (keepalive also counts as activity).
       await consumeSSE(res.body, onEvent, watchdog.arm);
       return { ok: true, error: null, stalled: false };
     } catch (err: any) {

--- a/src/hooks/useSchemaMutations.ts
+++ b/src/hooks/useSchemaMutations.ts
@@ -1,9 +1,9 @@
 import { useState, useCallback } from "react";
 
 /**
- * Mutacje opcji schematu Notion (dodanie/usunięcie w kolumnie select/multi_select).
- * Trzyma stan operacji (`updatingProperty`, `error`, wpisywane nazwy) i wspólny
- * `PATCH /api/notion/schema` — add/delete to cienkie przypadki na jednym zapisie.
+ * Notion schema option mutations (add/remove in a select/multi_select column).
+ * Holds the operation state (`updatingProperty`, `error`, entered names) and a shared
+ * `PATCH /api/notion/schema` — add/delete are thin cases over a single write.
  */
 export function useSchemaMutations(schema: any, onSchemaUpdated: () => void) {
   const [updatingProperty, setUpdatingProperty] = useState<string | null>(null);

--- a/src/hooks/useShelfOrder.ts
+++ b/src/hooks/useShelfOrder.ts
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 
 /**
- * Zapis ręcznych kluczy porządku regału (precyzyjny drag&drop → POST /api/shelf-order).
- * Sam transport sieciowy — optymistyczny override i rollback zostają w komponencie
- * (to stan UI). Wydzielone z `BookshelfSection`, by komponent nie robił własnego I/O (§2).
+ * Persists manual shelf order keys (precise drag&drop → POST /api/shelf-order).
+ * Network transport only — the optimistic override and rollback stay in the component
+ * (that's UI state). Extracted from `BookshelfSection` so the component does no I/O of its own (§2).
  */
 export function useShelfOrder() {
   const saveOrders = useCallback(async (orders: { pageId: string; order: number }[]): Promise<void> => {

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -31,21 +31,21 @@ export interface IdentifiedBook {
   title: string;
   author: string;
   year?: number | null;
-  // Wypełniane przez skan biblioteki (OPAC) — tytuł/autor odczytany z katalogu
+  // Filled by the library scan (OPAC) — title/author read from the catalog
   extractedTitle?: string | null;
   extractedAuthor?: string | null;
 }
 
-/** Zagregowana dostępność nieprzeczytanych — partycja priorytetowa (każda książka raz). */
+/** Aggregated availability of unread items — priority partition (each book once). */
 export interface AvailabilityStats {
   totalUnread: number;
-  /** Posiadane, ale nieprzeczytane. */
+  /** Owned but unread. */
   owned: number;
-  /** Dostępne do wypożyczenia w bibliotece (tag filii), nieposiadane. */
+  /** Available to borrow from the library (branch tag), not owned. */
   library: number;
-  /** Dostępne na Vinted (≥1 składowana oferta), nieposiadane i nie w bibliotece. */
+  /** Available on Vinted (≥1 stored offer), not owned and not in the library. */
   vinted: number;
-  /** Bez śladu — brak posiadania, biblioteki i ofert. */
+  /** No trace — not owned, no library, no offers. */
   none: number;
 }
 
@@ -107,11 +107,11 @@ export function useStats() {
     }
   }, []);
 
-  // Optymistyczne dopisanie książki do sekcji „Książki dostępne w bibliotekach"
-  // zaraz po otagowaniu (Biblioteka / Biblioteka 9), bez czekania na kolejny
-  // refetch — Notion bywa opóźniony w odczycie tuż po zapisie, więc pełne
-  // odświeżenie potrafi jeszcze nie widzieć nowego tagu. `libraryStats[].id`
-  // to nazwa tagu, więc dopasowujemy filię po znaczniku.
+  // Optimistically add a book to the „Książki dostępne w bibliotekach" section
+  // right after tagging (Biblioteka / Biblioteka 9), without waiting for the next
+  // refetch — Notion can lag on reads just after a write, so a full refresh may
+  // not see the new tag yet. `libraryStats[].id` is the tag name, so we match the
+  // branch by its tag.
   const addBookToLibrarySection = useCallback((tag: string, book: { id: string; title: string; author: string; year?: number | null }) => {
     setStats(prev => {
       if (!prev) return prev;

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { SyncState } from "../types";
 import { useSSEStream } from "./useSSEStream";
 
-// Dłuższy wariant komunikatu o zawieszeniu (dopisek o Diagnostyce) — specyficzny dla rytuałów sync.
+// Longer variant of the stall message (with the „Diagnostyka" note) — specific to sync rituals.
 const SYNC_STALL_MESSAGE =
   "Połączenie z serwerem zawisło (brak odpowiedzi przez 30 s). Możliwe buforowanie strumienia przez hosting. Odśwież stronę i spróbuj ponownie; jeśli się powtarza, uruchom Diagnostykę.";
 
@@ -42,8 +42,8 @@ export function useSync(endpoint: string, stopEndpoint: string, initialState: Pa
       startTime: Date.now()
     }));
 
-    // Wynik complete/error łapiemy do `outcome`, bo callback nie może bezpośrednio
-    // wyjść z startSync; sam transport (fetch + watchdog + SSE) żyje w useSSEStream.
+    // We capture the complete/error outcome into `outcome`, because the callback can't
+    // directly return out of startSync; the transport itself (fetch + watchdog + SSE) lives in useSSEStream.
     let outcome: { type: "complete"; result: any } | { type: "error" } | null = null;
     const streamResult = await run(params, (data) => {
       if (data.type === "status") {
@@ -78,8 +78,8 @@ export function useSync(endpoint: string, stopEndpoint: string, initialState: Pa
       return false;
     }
 
-    // Strumień zakończył się bez complete/error (np. anulowanie po stronie serwera) —
-    // nie zostawiaj UI w wiecznym stanie ładowania.
+    // The stream ended without complete/error (e.g. server-side cancellation) —
+    // don't leave the UI stuck in a loading state forever.
     setState(prev => ({ ...prev, loading: false, statusMessage: null, progress: null }));
     return false;
   }, [endpoint, run]);

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -4,18 +4,18 @@ import { PREDEFINED_AWARDS, SYNC_ALL_AWARD } from "../constants";
 import { useEffectiveConfig } from "./useAppConfig";
 
 /**
- * Orkiestracja wszystkich rytuałów synchronizacji po stronie frontendu.
+ * Front-end orchestration of all synchronization rituals.
  *
- * Trzyma dziewięć instancji `useSync` (po jednej na rytuał), wzajemne czyszczenie
- * stanu, sekwencyjny "Wielki Rytuał" (full sync) oraz wynik zbiorczy. Wyniesione
- * z `App.tsx`, żeby komponent został przy renderowaniu, a logika żyła w hooku
- * (zob. COGITATOR_GUIDELINES §2 "Logic Isolation").
+ * Holds nine `useSync` instances (one per ritual), mutual state clearing, the
+ * sequential „Wielki Rytuał" (full sync), and an aggregate result. Extracted
+ * from `App.tsx` so the component stays with rendering and the logic lives in the hook
+ * (see COGITATOR_GUIDELINES §2 "Logic Isolation").
  */
 export function useSyncManager() {
   const [fullSyncResults, setFullSyncResults] = useState<any[] | null>(null);
 
-  // Lista nagród z konfiguracji (+ pseudo-opcja pełnej synchronizacji);
-  // PREDEFINED_AWARDS służy tylko jako stan początkowy do czasu pobrania.
+  // List of awards from config (+ the full-sync pseudo-option);
+  // PREDEFINED_AWARDS serves only as the initial state until the fetch completes.
   const cfg = useEffectiveConfig();
   const awardOptions = [...cfg.sync.awards, SYNC_ALL_AWARD];
 
@@ -52,8 +52,8 @@ export function useSyncManager() {
     return await syncService.startSync(params, undefined, statusMessage);
   };
 
-  // Przyjmuje samą NAZWĘ nagrody (nie zdarzenie DOM) — manager pozostaje
-  // niezależny od prezentacji (parsowanie <select> zostaje w komponencie).
+  // Takes just the award NAME (not a DOM event) — the manager stays
+  // independent of presentation (<select> parsing remains in the component).
   const handleAwardChange = (selectedName: string) => {
     const predefined = awardOptions.find(a => a.name === selectedName);
 
@@ -81,9 +81,9 @@ export function useSyncManager() {
     });
   };
 
-  // „Wielki Rytuał" — sekwencja kroków opisana danymi (nie 7× copy-paste).
-  // Kroki `abortOnFail` przerywają całość przy błędzie i porzucają wyniki; ostatni
-  // (Lp) tylko dopisuje wynik, jeśli jest, i zawsze domyka podsumowanie.
+  // „Wielki Rytuał" — a data-described step sequence (not 7× copy-paste).
+  // `abortOnFail` steps abort the whole thing on error and drop results; the last one
+  // (Lp) only appends its result if present, and always closes the summary.
   const FULL_SYNC_STEPS: { sync: any; name: string; color: string; label: string; params?: any; abortOnFail: boolean }[] = [
     { sync: schemaSync, name: "Schemat", color: "emerald", label: "Krok 1/7: Rytuał Inicjacji Schematu...", abortOnFail: true },
     { sync: purifySync, name: "Puryfikacja", color: "amber", label: "Krok 2/7: Rytuał Puryfikacji...", abortOnFail: true },
@@ -102,7 +102,7 @@ export function useSyncManager() {
       clearOthers(step.sync);
       const res = await step.sync.startSync(step.params ?? {}, undefined, step.label);
       if (step.abortOnFail) {
-        if (!res || res.success === false) return; // przerwij i porzuć częściowe wyniki
+        if (!res || res.success === false) return; // abort and drop partial results
         results.push({ name: step.name, result: res, color: step.color });
       } else if (res) {
         results.push({ name: step.name, result: res, color: step.color });
@@ -135,14 +135,14 @@ export function useSyncManager() {
   };
 
   return {
-    // Instancje rytuałów (przekazywane do komponentów prezentacyjnych)
+    // Ritual instances (passed to presentational components)
     sync, publisherSync, seriesSync, cyclesSync, cyclesHarvestSync, lpSync, integritySync, duplicatesSync, purifySync, schemaSync,
-    // Lista nagród z konfiguracji (dropdown w SyncAwards)
+    // List of awards from config (dropdown in SyncAwards)
     awardOptions,
-    // Stan zbiorczy
+    // Aggregate state
     syncs, anyError, isAnySyncLoading,
     fullSyncResults, clearFullSyncResults: () => setFullSyncResults(null),
-    // Akcje
+    // Actions
     handleAwardChange, handleSync, handleFullSync, handleResetSync,
     handleSyncSchema, handleSyncPurify, handleSyncPublisher, handleSyncSeries,
     handleCyclesSync, handleCyclesHarvest, handleSyncLp, handleSyncDuplicates,

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -6,17 +6,17 @@ export interface VintedResult {
   title: string;
   author: string;
   searchUrl?: string;
-  /** Rok wydania (kolumna „Rok"; dane z bazy). */
+  /** Publication year (the „Rok" column; from the database). */
   year?: string;
-  /** Część cyklu (kolumna „Część cyklu"; dane z bazy) — ryzyko „kolejny tom". */
+  /** Part of a cycle (the „Część cyklu" column; from the database) — risk of the „next volume". */
   partOfCycle?: boolean;
-  /** Nazwa cyklu (kolumna „Cykl"; z żniw) — do etykiety kafelka cyklu. */
+  /** Cycle name (the „Cykl" column; from harvest) — for the cycle tile label. */
   cykl?: string;
-  /** Numer tomu w cyklu (kolumna „CyklNr"; z żniw). */
+  /** Volume number in the cycle (the „CyklNr" column; from harvest). */
   cyklNr?: number;
-  /** Znacznik świeżości — kiedy skanowano tę książkę (tylko dla danych z bazy, etap 3). */
+  /** Freshness marker — when this book was scanned (only for database data, stage 3). */
   scannedAt?: string;
-  /** Kiedy zestaw ofert ostatnio się zmienił (dane z bazy). Gdy == scannedAt → zmiana w ostatnim skanie. */
+  /** When the offer set last changed (from the database). When == scannedAt → changed in the last scan. */
   changedAt?: string;
   vintedItems: {
     id?: string;
@@ -26,9 +26,9 @@ export interface VintedResult {
     currency: string;
     url: string;
     photo?: string | null;
-    /** Cena z poprzedniego skanu (dane z bazy) — spadek, gdy priceValue < prevPrice. */
+    /** Price from the previous scan (from the database) — a drop when priceValue < prevPrice. */
     prevPrice?: number | null;
-    /** Kiedy oferta pojawiła się po raz pierwszy (dane z bazy) — „nowa", gdy == scannedAt książki. */
+    /** When the offer first appeared (from the database) — „new" when == the book's scannedAt. */
     firstSeenAt?: string;
   }[];
 }
@@ -40,8 +40,8 @@ export interface VintedSearchAttempt {
   url: string;
   status: "pending" | "success" | "no_results" | "blocked" | "error";
   itemCount: number;
-  // Diagnostyka (Krok 2) — pomaga odróżnić realny brak ofert od bloku / gubienia
-  // ofert przez parser. Kształt zależny od ścieżki (HTML vs błąd sieci).
+  // Diagnostics (Step 2) — helps tell a genuine lack of offers from a block / the parser
+  // dropping offers. Shape depends on the path (HTML vs network error).
   debug?: {
     chars?: number;
     hasCatalogJson?: boolean;
@@ -53,11 +53,11 @@ export interface VintedSearchAttempt {
     error?: string;
     code?: string;
     httpStatus?: number;
-    // Diagnostyka OOM (Krok 2): pamięć procesu po każdej próbie. Rosnące rssMb ku
-    // limitowi hostingu (Render free = 512 MB) tuż przed śmiercią skanu = OOM-kill.
+    // OOM diagnostics (Step 2): process memory after each attempt. rssMb rising toward
+    // the hosting limit (Render free = 512 MB) right before the scan dies = OOM-kill.
     rssMb?: number;
     heapMb?: number;
-    // Diff względem poprzedniego skanu (wykrywanie zmian): nowe/zniknięte/spadek/wzrost ceny.
+    // Diff against the previous scan (change detection): added/removed/price drop/price rise.
     changes?: { added: number; removed: number; priceDropped: number; priceRaised: number };
   };
 }
@@ -68,13 +68,13 @@ export function useVintedCheck() {
   const [isChecking, setIsChecking] = useState(false);
   const [checkProgress, setCheckProgress] = useState<{ current: number; total: number; message: string; startTime: number | null } | null>(null);
   const [vintedError, setVintedError] = useState<string | null>(null);
-  // Ref zamiast stanu w strażniku — stan w domknięciu bywa nieaktualny
+  // Ref instead of state in the guard — state in the closure can be stale
   const isCheckingRef = useRef(false);
 
-  // Skaner Vinted potrafi milczeć długo na jednej książce: withRetry(3, 4000) przy
-  // timeout 30 s daje worst-case ~102 s ciszy na wolnej/blokowanej pozycji (serwer
-  // śle tylko keepalive, a Render go buforuje). 120 s pokrywa ten worst-case bez
-  // ruszania timingu scrapera (nie zmniejsza trafień).
+  // The Vinted scanner can go silent for a long time on a single book: withRetry(3, 4000)
+  // with a 30 s timeout gives a worst-case ~102 s of silence on a slow/blocked item (the
+  // server sends only keepalive, and Render buffers it). 120 s covers that worst-case without
+  // touching the scraper's timing (doesn't reduce hits).
   const { run } = useSSEStream("/api/vinted-check", { timeoutMs: 120000 });
 
   const runVintedCheck = useCallback(async (opts?: { skipScannedWithinHours?: number }) => {

--- a/src/hooks/useVintedResolveSellers.ts
+++ b/src/hooks/useVintedResolveSellers.ts
@@ -3,9 +3,9 @@ import { consumeSSE } from "../utils/sse";
 import { createStallWatchdog } from "../utils/stallWatchdog";
 
 /**
- * Etap 2: przyrostowe dociąganie sprzedawców do SKŁADOWANYCH ofert (Notion), wznawialne
- * między przebiegami. Nie zależy od bieżącego skanu — działa na bazie. Wzorzec SSE jak
- * w useVintedCheck (watchdog 120 s). Zwraca postęp i podsumowanie (resolved/remaining).
+ * Stage 2: incrementally fetching sellers for STORED offers (Notion), resumable
+ * between runs. Doesn't depend on the current scan — works off the database. SSE pattern
+ * like in useVintedCheck (120 s watchdog). Returns progress and a summary (resolved/remaining).
  */
 export function useVintedResolveSellers() {
   const [isResolving, setIsResolving] = useState(false);

--- a/src/hooks/useVintedStored.ts
+++ b/src/hooks/useVintedStored.ts
@@ -2,13 +2,13 @@ import { useState, useCallback, useRef } from "react";
 import { storedToView, StoredView } from "../utils/vintedSellers";
 
 /**
- * Etap 3: wczytuje SKŁADOWANE wyniki Vinted z Notion (`GET /api/vinted-stored`) i mapuje
- * na widok renderowalny tym samym UI co skan live — kafelki i paczki lecą z bazy, bez
- * re-scrape. Zwykły GET (odczyt Notion, nie Cloudflare), więc bez SSE/watchdoga.
+ * Stage 3: loads STORED Vinted results from Notion (`GET /api/vinted-stored`) and maps
+ * them to a view renderable by the same UI as a live scan — tiles and bundles come from the
+ * database, without re-scrape. A plain GET (Notion read, not Cloudflare), so no SSE/watchdog.
  *
- * Ochrona przed wyścigiem: `genRef` + AbortController — gdy w trakcie wolnego GET-a
- * użytkownik ruszy skan/resolucję (które wołają `clearStored`), przestarzała odpowiedź
- * jest porzucana i nie „porywa" widoku (nie ustawia `stored` po fakcie).
+ * Race protection: `genRef` + AbortController — if during a slow GET the
+ * user starts a scan/resolution (which call `clearStored`), the stale response
+ * is dropped and doesn't „hijack" the view (doesn't set `stored` after the fact).
  */
 export function useVintedStored() {
   const [stored, setStored] = useState<StoredView | null>(null);
@@ -27,13 +27,13 @@ export function useVintedStored() {
     setStoredError(null);
     try {
       const res = await fetch("/api/vinted-stored", { signal: ac.signal });
-      if (gen !== genRef.current) return; // unieważnione (clear/nowe żądanie)
+      if (gen !== genRef.current) return; // invalidated (clear/new request)
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({}));
         throw new Error(errorData.error || `Błąd serwera: ${res.status}`);
       }
       const data = await res.json();
-      if (gen !== genRef.current) return; // sprawdź ponownie po await
+      if (gen !== genRef.current) return; // re-check after await
       setStored(storedToView(data.books || []));
     } catch (err: any) {
       if (err?.name === "AbortError" || gen !== genRef.current) return;
@@ -44,7 +44,7 @@ export function useVintedStored() {
   }, []);
 
   const clearStored = useCallback(() => {
-    // Unieważnij każdy load w locie (bump pokolenia + abort) i wyjdź z widoku bazy.
+    // Invalidate any in-flight load (bump the generation + abort) and leave the database view.
     genRef.current++;
     abortRef.current?.abort();
     setIsLoadingStored(false);

--- a/src/theme/ritualColors.ts
+++ b/src/theme/ritualColors.ts
@@ -1,13 +1,13 @@
 /**
- * Centralny motyw kolorów rytuałów.
+ * Central ritual color theme.
  *
- * Każdy rytuał (synchronizacja) niesie swój kolor w `SyncState.color`; paski
- * postępu, karty podsumowań i kropki kroków dziedziczą go, by wzmacniać tożsamość
- * rytuału (zob. COGITATOR_GUIDELINES §2 "Dynamic UI"). Wcześniej te same mapy
- * klas Tailwinda były duplikowane w kilku komponentach — tutaj są w jednym miejscu.
+ * Every ritual (sync) carries its color in `SyncState.color`; progress bars,
+ * summary cards and step dots inherit it to reinforce the ritual's identity
+ * (see COGITATOR_GUIDELINES §2 "Dynamic UI"). Previously these same Tailwind
+ * class maps were duplicated across several components — here they live in one place.
  *
- * UWAGA: klasy muszą być pełnymi literałami (`text-cyan-400`, nie `text-${c}-400`),
- * inaczej skaner JIT Tailwinda ich nie wykryje i nie trafią do builda.
+ * NOTE: classes must be full literals (`text-cyan-400`, not `text-${c}-400`),
+ * otherwise Tailwind's JIT scanner won't detect them and they won't reach the build.
  */
 
 export type RitualColor =
@@ -21,17 +21,17 @@ export type RitualColor =
   | "emerald";
 
 export interface RitualTheme {
-  /** Tekst akcentu, np. nagłówki (text-*-400). */
+  /** Accent text, e.g. headings (text-*-400). */
   text: string;
-  /** Obramowanie kart (border-*-500/20). */
+  /** Card border (border-*-500/20). */
   border: string;
-  /** Miękkie tło panelu/karty (bg-*-500/10). */
+  /** Soft panel/card background (bg-*-500/10). */
   bgSoft: string;
-  /** Pełne tło, np. wypełnienie paska postępu (bg-*-500). */
+  /** Solid background, e.g. progress bar fill (bg-*-500). */
   bgSolid: string;
-  /** Poświata paska postępu (shadow-[…0.4]). */
+  /** Progress bar glow (shadow-[…0.4]). */
   glow: string;
-  /** Kropka kroku na osi rytuałów (bg-*-500 + mniejsza poświata). */
+  /** Step dot on the ritual timeline (bg-*-500 + smaller glow). */
   dot: string;
 }
 
@@ -46,14 +46,14 @@ export const ritualTheme: Record<RitualColor, RitualTheme> = {
   emerald: { text: "text-emerald-400", border: "border-emerald-500/20", bgSoft: "bg-emerald-500/10", bgSolid: "bg-emerald-500", glow: "shadow-[0_0_15px_rgba(16,185,129,0.4)]",  dot: "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]" },
 };
 
-/** Pełny motyw rytuału z bezpiecznym fallbackiem do cyan. */
+/** Full ritual theme with a safe fallback to cyan. */
 export const getRitualTheme = (color?: string | null): RitualTheme =>
   ritualTheme[(color as RitualColor)] ?? ritualTheme.cyan;
 
 /**
- * Klasy przycisku-rytuału (styl „liturgii synchronizacji": ciemna baza slate-950,
- * kolorowy akcent border/glow na hover, ikona w boxie). Pełne literały — patrz uwaga
- * o skanerze JIT Tailwinda na górze pliku. Używane przez komponent `RitualButton`.
+ * Ritual-button classes (the „liturgii synchronizacji" style: dark slate-950 base,
+ * colored border/glow accent on hover, icon in a box). Full literals — see the note
+ * about Tailwind's JIT scanner at the top of the file. Used by the `RitualButton` component.
  */
 export interface RitualButtonTheme {
   hoverBorder: string;
@@ -77,13 +77,13 @@ export const ritualButtonTheme: Record<RitualColor, RitualButtonTheme> = {
 export const getRitualButtonTheme = (color?: string | null): RitualButtonTheme =>
   ritualButtonTheme[(color as RitualColor)] ?? ritualButtonTheme.cyan;
 
-/** Sama kropka kroku (z fallbackiem do cyan). */
+/** Just the step dot (with a fallback to cyan). */
 export const getRitualDot = (color?: string | null): string => getRitualTheme(color).dot;
 
 /**
- * Gradientowe paski postępu (ProgressBar / AuthorProgressItem). Osobna mapa, bo
- * gradient ma inny kolor docelowy niż nazwa rytuału (cyan→blue, purple→indigo,
- * orange→red, emerald→teal). Fallback: emerald (zgodnie z poprzednim zachowaniem).
+ * Gradient progress bars (ProgressBar / AuthorProgressItem). Separate map because
+ * the gradient's target color differs from the ritual name (cyan→blue, purple→indigo,
+ * orange→red, emerald→teal). Fallback: emerald (matching prior behavior).
  */
 export interface RitualGradient {
   gradient: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,26 +46,26 @@ export interface NotionBook {
   currentWydawnictwo?: string;
   currentSeria?: string;
   currentCzesccyklu?: boolean;
-  /** Kategoria wiersza: „Nagroda" (domyślnie/pusto) vs „Tom cyklu" (poboczny tom cyklu). */
+  /** Row category: „Nagroda" (default/empty) vs „Tom cyklu" (sibling cycle volume). */
   kategoria?: string;
   lp?: string;
   zrodlo?: string[];
   plTitleRichText?: NotionRichTextItem[];
   origTitleRichText?: NotionRichTextItem[];
-  /** Blob JSON składowanych wyników Vinted (pole „VintedData") — parsowany przez vintedStore. */
+  /** JSON blob of stored Vinted results (field „VintedData") — parsed by vintedStore. */
   vintedData?: string;
-  /** Nazwa cyklu (pole „Cykl") — grupuje wiersze jednego cyklu (kotwica + poboczne tomy). */
+  /** Cycle name (field „Cykl") — groups the rows of one cycle (anchor + sibling volumes). */
   cykl?: string;
-  /** Pozycja w cyklu (pole „CyklNr", number) — kolejność czytania. */
+  /** Position within the cycle (field „CyklNr", number) — reading order. */
   cyklNr?: number;
-  /** Ręczny klucz porządku na regale (kolumna „ShelfOrder"; skala ułamkowych lat). */
+  /** Manual shelf ordering key (column „ShelfOrder"; fractional-year scale). */
   shelfOrder?: number;
 }
 
 /**
- * Odchudzony rekord książki dla wyszukiwarki „Skryptorium" (`GET /api/books`).
- * Świadomie BEZ ciężkich pól (`vintedData` blob, `*RichText`) — to indeks do
- * filtrowania client-side, nie pełny model. Współdzielony przez serwer i front.
+ * Slimmed-down book record for the „Skryptorium" search (`GET /api/books`).
+ * Deliberately WITHOUT heavy fields (`vintedData` blob, `*RichText`) — this is an
+ * index for client-side filtering, not the full model. Shared by server and front.
  */
 export interface BookIndexEntry {
   id: string;
@@ -77,7 +77,7 @@ export interface BookIndexEntry {
   zrodlo: string[];
   series: string;
   partOfCycle: boolean;
-  /** Ręczny klucz porządku na regale (precyzyjny drag&drop); brak → sort po roku. */
+  /** Manual shelf ordering key (precise drag&drop); absent → sort by year. */
   shelfOrder?: number;
 }
 
@@ -95,8 +95,8 @@ export interface SyncState {
 }
 
 export interface SyncEvent {
-  // "match" / "search_attempt" są emitowane przez skanery (Vinted/Biblioteka)
-  // "seller_resolved" — grupowanie Vinted per sprzedawca (dociąganie sprzedawcy oferty)
+  // "match" / "search_attempt" are emitted by the scanners (Vinted/Biblioteka)
+  // "seller_resolved" — Vinted grouping per seller (resolving the offer's seller)
   type: "status" | "progress" | "complete" | "error" | "match" | "search_attempt" | "seller_resolved";
   message?: string;
   error?: string;

--- a/src/utils/bookSearch.ts
+++ b/src/utils/bookSearch.ts
@@ -1,10 +1,10 @@
 import { BookIndexEntry } from "../types";
 
 /**
- * Fold diakrytyków PER ZNAK (nie NFD): mapuje polskie litery na łacińskie
- * odpowiedniki i lowercase'uje. Świadomie NIE używamy `normalize('NFD')` —
- * NFD nie rozkłada „ł" (U+0142), a fold per-znak jest 1:1 na długość, dzięki
- * czemu indeksy trafień mapują wprost na oryginalny tekst (podświetlanie).
+ * Per-CHARACTER diacritic fold (not NFD): maps Polish letters to their Latin
+ * equivalents and lowercases. We deliberately do NOT use `normalize('NFD')` —
+ * NFD doesn't decompose „ł" (U+0142), whereas a per-character fold is 1:1 in
+ * length, so hit indices map straight onto the original text (highlighting).
  */
 const FOLD: Record<string, string> = {
   ą: "a", ć: "c", ę: "e", ł: "l", ń: "n", ó: "o", ś: "s", ż: "z", ź: "z",
@@ -16,20 +16,20 @@ export function fold(s: string): string {
   return out;
 }
 
-/** Rozbija zapytanie na tokeny (spacje) po foldzie. */
+/** Splits the query into tokens (on spaces) after folding. */
 function tokenize(query: string): string[] {
   return fold(query).split(/\s+/).filter(Boolean);
 }
 
 /**
- * Filtruje + rankuje indeks po tytule (PL + oryginalny) i autorze. Każdy token
- * musi trafić (AND) jako substring w KTÓRYMKOLWIEK z pól — dzięki temu „simmons
- * hyperion" łączy autora z tytułu. Puste zapytanie → cały zbiór (tryb przeglądu).
- * Ranking: prefiks tytułu > substring tytułu > tytuł oryginalny > autor.
+ * Filters + ranks the index by title (PL + original) and author. Each token
+ * must match (AND) as a substring in ANY of the fields — so that „simmons
+ * hyperion" combines author with title. Empty query → whole set (browse mode).
+ * Ranking: title prefix > title substring > original title > author.
  */
 export function matchBooks(query: string, index: BookIndexEntry[]): BookIndexEntry[] {
   const tokens = tokenize(query);
-  // Tytuł efektywny = polski, a gdy go brak — oryginalny (rekordy nieprzetłumaczone).
+  // Effective title = Polish, and when missing — original (untranslated records).
   const displayTitle = (b: BookIndexEntry) => b.plTitle || b.origTitle;
   const byTitle = (a: BookIndexEntry, b: BookIndexEntry) => displayTitle(a).localeCompare(displayTitle(b), "pl");
 
@@ -62,18 +62,18 @@ export interface HighlightSegment {
 }
 
 /**
- * Dzieli tekst na segmenty trafione/nietrafione względem zapytania. Bazuje na
- * foldzie 1:1 (indeks w folded == indeks w oryginale), więc podświetla we
- * właściwym miejscu mimo diakrytyków. Podświetla tylko tokeny obecne w TYM
- * tekście (token trafiony w innym polu tu nie da zakresu).
+ * Splits text into hit/non-hit segments relative to the query. Relies on the
+ * 1:1 fold (index in folded == index in original), so it highlights in the
+ * right place despite diacritics. Highlights only tokens present in THIS
+ * text (a token matched in another field yields no range here).
  */
 export function highlight(text: string, query: string): HighlightSegment[] {
   const tokens = tokenize(query);
   if (!tokens.length || !text) return [{ text, hit: false }];
 
   const folded = fold(text);
-  // Zabezpieczenie: gdyby lowercase zmienił długość (rzadkie unicode), fallback
-  // bez podświetlenia zamiast rozjechanych indeksów.
+  // Safeguard: if lowercase changed the length (rare unicode), fall back to
+  // no highlighting instead of misaligned indices.
   if (folded.length !== text.length) return [{ text, hit: false }];
 
   const ranges: [number, number][] = [];
@@ -107,24 +107,24 @@ export function highlight(text: string, query: string): HighlightSegment[] {
   return segs;
 }
 
-// ── „Czy chodziło Ci o…" — fuzzy podpowiedzi na literówki ──────────────────
+// ── „Czy chodziło Ci o…" — fuzzy suggestions for typos ──────────────────
 
 export interface VocabTerm {
-  /** Znormalizowane (fold) słowo — po tym liczymy dystans. */
+  /** Normalized (folded) word — distance is computed against this. */
   folded: string;
-  /** Wariant do pokazania użytkownikowi (oryginalna pisownia). */
+  /** Variant to show the user (original spelling). */
   display: string;
 }
 
-/** Słowa (≥3 znaki) z tekstu, rozbite na granicach nie-liter/cyfr. */
+/** Words (≥3 chars) from the text, split on non-letter/digit boundaries. */
 function wordsOf(s: string): string[] {
   return s.split(/[^\p{L}\p{N}]+/u).filter((w) => w.length >= 3);
 }
 
 /**
- * Buduje słownik terminów (słowa tytułów PL+oryg i autorów) do fuzzy-podpowiedzi.
- * Dedupe po foldzie; jako `display` preferuje wariant z wielką literą. Liczony raz
- * na zbiór (memoizowany w komponencie), nie na każdy znak.
+ * Builds a term dictionary (words from PL+orig titles and authors) for fuzzy
+ * suggestions. Dedupes by fold; prefers the capitalized variant as `display`.
+ * Computed once per set (memoized in the component), not on every keystroke.
  */
 export function buildSearchVocab(index: BookIndexEntry[]): VocabTerm[] {
   const map = new Map<string, string>();
@@ -145,7 +145,7 @@ export function buildSearchVocab(index: BookIndexEntry[]): VocabTerm[] {
   return [...map.entries()].map(([folded, display]) => ({ folded, display }));
 }
 
-/** Dystans Levenshteina (dwa bufory wierszy — O(min·max) pamięci liniowej). */
+/** Levenshtein distance (two row buffers — O(min·max) linear memory). */
 function levenshtein(a: string, b: string): number {
   const m = a.length;
   const n = b.length;
@@ -165,10 +165,10 @@ function levenshtein(a: string, b: string): number {
 }
 
 /**
- * „Czy chodziło Ci o…" — dla (zwykle zerowego) zapytania zwraca do `limit`
- * najbliższych terminów ze słownika. Porównuje OSTATNI token zapytania (tam
- * zwykle siedzi literówka), z progiem zależnym od długości. Odsiew po różnicy
- * długości (Levenshtein ≥ |Δlen|) tnie koszt. Pomija trafienie dokładne.
+ * „Czy chodziło Ci o…" — for a (usually zero-hit) query returns up to `limit`
+ * of the closest dictionary terms. Compares the LAST query token (where the
+ * typo usually sits), with a threshold that depends on length. Pre-filtering
+ * by length difference (Levenshtein ≥ |Δlen|) cuts the cost. Skips exact hits.
  */
 export function didYouMean(query: string, vocab: VocabTerm[], limit = 3): string[] {
   const qWord = fold(query).split(/\s+/).filter(Boolean).pop() ?? "";
@@ -197,9 +197,9 @@ export function didYouMean(query: string, vocab: VocabTerm[], limit = 3): string
 }
 
 /**
- * Podmienia OSTATNI token zapytania na `term`, zachowując wcześniejsze słowa —
- * bo `didYouMean` poprawia właśnie ostatni token. „Greg Vear" + „Bear" →
- * „Greg Bear". Puste / same spacje → zwraca sam `term`.
+ * Replaces the LAST query token with `term`, keeping the earlier words —
+ * because `didYouMean` corrects exactly the last token. „Greg Vear" + „Bear" →
+ * „Greg Bear". Empty / only spaces → returns just `term`.
  */
 export function replaceLastToken(query: string, term: string): string {
   const m = query.match(/^(.*?)(\S+)\s*$/);

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -1,37 +1,37 @@
 import { BookIndexEntry } from "../types";
 
-/** Znacznik „Źródło" oznaczający pozycję przeczytaną. */
+/** „Źródło" tag marking an item as read. */
 export const READ_TAG = "Przeczytane";
 
-/** Która półka: przeczytane vs do przeczytania. */
+/** Which shelf: read vs to-read. */
 export type ShelfId = "read" | "toRead";
 
-/** Lokalne nadpisania stanu „przeczytane" (optymistyczny drag&drop przed potwierdzeniem z API). */
+/** Local overrides of the „przeczytane" state (optimistic drag&drop before API confirmation). */
 export type ReadOverrides = Record<string, boolean>;
 
-/** Czy książka jest przeczytana — z uwzględnieniem optymistycznego nadpisania. */
+/** Whether the book is read — taking optimistic overrides into account. */
 export function isRead(book: BookIndexEntry, overrides: ReadOverrides = {}): boolean {
   if (Object.prototype.hasOwnProperty.call(overrides, book.id)) return overrides[book.id];
   return book.zrodlo.includes(READ_TAG);
 }
 
-/** Deterministyczny wygląd grzbietu — stały dla danego tytułu (bez migotania przy re-renderze). */
+/** Deterministic spine appearance — stable per title (no flicker on re-render). */
 export interface SpineStyle {
-  color: string;   // stonowany kolor „płótna" (skóra Relikwiarz)
-  app: string;     // akcent z palety aplikacji (skóra Holo+) — hex
-  appRgb: string;  // ten sam akcent jako „r,g,b" (do rgba(var(...), a))
+  color: string;   // muted bookbinding-cloth color (Relikwiarz skin)
+  app: string;     // accent from the app palette (Holo+ skin) — hex
+  appRgb: string;  // the same accent as „r,g,b" (for rgba(var(...), a))
   width: number;   // px
   height: number;  // px
 }
 
-/** Paleta „płótna introligatorskiego" — stonowana, autentyczna (Relikwiarz). */
+/** Bookbinding-cloth palette — muted, authentic (Relikwiarz). */
 export const CLOTH_PALETTE = [
   "#7f1d2e", "#0f5132", "#1e3a5f", "#7c5410", "#3f2d52", "#2b2b2b",
   "#5a2a1e", "#14504f", "#4a3b16", "#5b1f3a", "#243b53", "#6b2737",
 ];
 
-/** Paleta akcentów aplikacji (cyan/niebieski/indygo/fiolet/purpura) — Holo+.
- *  Równoległa do `CLOTH_PALETTE` (ten sam indeks = ta sama książka). */
+/** App accent palette (cyan/blue/indigo/violet/purple) — Holo+.
+ *  Parallel to `CLOTH_PALETTE` (same index = same book). */
 export const APP_PALETTE: readonly (readonly [string, string])[] = [
   ["#06b6d4", "6,182,212"], ["#3b82f6", "59,130,246"], ["#6366f1", "99,102,241"], ["#8b5cf6", "139,92,246"],
   ["#a855f7", "168,85,247"], ["#14b8a6", "20,184,166"], ["#0ea5e9", "14,165,233"], ["#4f46e5", "79,70,229"],
@@ -52,12 +52,12 @@ export function spineStyle(book: BookIndexEntry): SpineStyle {
     color: CLOTH_PALETTE[idx],
     app, appRgb,
     width: 16 + (h % 12),          // 16–27 px
-    height: 124 + ((h >>> 3) % 48), // 124–171 px (unsigned shift — h bywa >2^31)
+    height: 124 + ((h >>> 3) % 48), // 124–171 px (unsigned shift — h can be >2^31)
   };
 }
 
-/** Avalanche-mix (xxHash-style) — rozprasza bity, by rozkład póz był równomierny
- *  niezależnie od korpusu tytułów (goły rolling-hash sąsiednich napisów jest skośny). */
+/** Avalanche-mix (xxHash-style) — scrambles bits so the pose distribution is even
+ *  regardless of the title corpus (a bare rolling-hash of adjacent strings is skewed). */
 function mix32(n: number): number {
   let x = n >>> 0;
   x ^= x >>> 16; x = Math.imul(x, 0x7feb352d);
@@ -71,11 +71,11 @@ function seed(book: BookIndexEntry): number {
 }
 
 /**
- * Slot na półce — deterministyczny plan ułożenia. Każdy wolumin trafia dokładnie
- * do jednego slotu:
- * - `spine` — grzbiet stojący (prosto, `lean === 0`) lub lekko przechylony (`lean` °),
- * - `stack` — kupka LEŻĄCYCH książek; **każda warstwa to osobny, prawdziwy wolumin**
- *   (własny tytuł/kolor/nagroda/drag), a nie jeden grzbiet udający stos.
+ * A shelf slot — a deterministic layout plan. Each volume lands in exactly
+ * one slot:
+ * - `spine` — a standing spine (upright, `lean === 0`) or slightly tilted (`lean` °),
+ * - `stack` — a pile of LYING books; **each layer is a separate, real volume**
+ *   (its own title/color/award/drag), not one spine pretending to be a stack.
  */
 export type ShelfSlot =
   | { kind: "spine"; book: BookIndexEntry; lean: number }
@@ -84,14 +84,14 @@ export type ShelfSlot =
 export const MAX_LEAN_DEG = 6;
 
 /**
- * Planuje sloty dla posortowanej listy woluminów. Decyzja per książka jest
- * deterministyczna (hasz tytułu); kupkę tworzy kilka KOLEJNYCH prawdziwych
- * książek (starter „pożera" następne). Zdecydowana większość stoi prosto,
- * ~12 % lekko przechylone, a kupki (po 4–7 realnych woluminów) są rzadkie.
+ * Plans slots for a sorted list of volumes. The per-book decision is
+ * deterministic (title hash); a pile is formed by several CONSECUTIVE real
+ * books (the starter swallows the ones that follow). The vast majority stand
+ * upright, ~12 % slightly tilted, and piles (of 4–7 real volumes) are rare.
  *
- * Reguły ułożenia:
- * - **dwie kupki nigdy nie sąsiadują** (po kupce następny slot to zawsze grzbiet),
- * - **grzbiety sąsiadujące z kupką przechylają się w jej stronę** (`LEAN_TOWARD`).
+ * Layout rules:
+ * - **two piles never sit adjacent** (after a pile the next slot is always a spine),
+ * - **spines adjacent to a pile tilt toward it** (`LEAN_TOWARD`).
  */
 export const LEAN_TOWARD = 5;
 
@@ -102,9 +102,9 @@ export function planShelf(books: BookIndexEntry[]): ShelfSlot[] {
     const b = books[i];
     const x = seed(b);
     const sel = x % 100;
-    // Kupka tylko gdy: los trafił (rzadko), są ≥2 książki i poprzedni slot NIE był kupką.
+    // Pile only when: the draw hit (rarely), there are ≥2 books and the previous slot was NOT a pile.
     if (sel >= 95 && books.length - i >= 2 && !prevWasStack) {
-      const size = Math.min(4 + ((x >>> 17) % 4), books.length - i); // 4–7 realnych książek
+      const size = Math.min(4 + ((x >>> 17) % 4), books.length - i); // 4–7 real books
       slots.push({ kind: "stack", books: books.slice(i, i + size) });
       i += size;
       prevWasStack = true;
@@ -114,16 +114,16 @@ export function planShelf(books: BookIndexEntry[]): ShelfSlot[] {
       i += 1;
       prevWasStack = false;
     } else {
-      // prosto (także zablokowana kupka spada tutaj)
+      // upright (a blocked pile also falls here)
       slots.push({ kind: "spine", book: b, lean: 0 });
       i += 1;
       prevWasStack = false;
     }
   }
 
-  // Grzbiety tuż obok kupki przechylają się w jej stronę (nadpisuje losową pozę).
-  // Sąsiad kupki jest zawsze grzbitem (dwie kupki nie sąsiadują). Wierzch grzbietu
-  // pochyla się do środka: lewy sąsiad w prawo (+), prawy sąsiad w lewo (−).
+  // Spines right next to a pile tilt toward it (overrides the random pose).
+  // A pile's neighbor is always a spine (two piles don't sit adjacent). The spine's
+  // top tilts inward: left neighbor to the right (+), right neighbor to the left (−).
   for (let k = 0; k < slots.length; k++) {
     if (slots[k].kind !== "stack") continue;
     const left = slots[k - 1], right = slots[k + 1];
@@ -133,14 +133,14 @@ export function planShelf(books: BookIndexEntry[]): ShelfSlot[] {
   return slots;
 }
 
-// Przybliżona szerokość znaku względem rozmiaru czcionki (font bold) — celowo
-// zawyżona, by CAŁY tytuł na pewno się zmieścił (bez ucinania / wielokropka).
+// Approximate character width relative to font size (bold font) — deliberately
+// overestimated so the WHOLE title definitely fits (no truncation / ellipsis).
 const CHAR_W = 0.6;
 
 /**
- * Rozmiar czcionki tytułu na STOJĄCYM grzbiecie. Tekst biegnie wzdłuż wysokości
- * grzbietu, więc dłuższy tytuł dostaje mniejszą czcionkę, tak by pełna nazwa
- * zmieściła się na całej wysokości (bez ucinania). Zakres 6–11 px.
+ * Title font size on a STANDING spine. The text runs along the spine's height,
+ * so a longer title gets a smaller font, so that the full name fits across the
+ * whole height (no truncation). Range 6–11 px.
  */
 export function spineFontSize(style: SpineStyle, title: string): number {
   const len = Math.max(1, title.length);
@@ -148,22 +148,22 @@ export function spineFontSize(style: SpineStyle, title: string): number {
   return Math.max(6, Math.min(11, f));
 }
 
-/** Wymiary LEŻĄCEJ książki tak, by cała nazwa się zmieściła (pozioma, wzdłuż grzbietu). */
+/** Dimensions of a LYING book so the whole name fits (horizontal, along the spine). */
 export interface FlatBookLayout { width: number; fontSize: number; thickness: number; lines: 1 | 2 }
 
-/** Górny limit szerokości leżącej książki — powyżej niego tytuł ZAWIJAMY do 2 linii. */
+/** Upper width limit for a lying book — above it we WRAP the title to 2 lines. */
 export const FLAT_MAX_W = 150;
 
 /**
- * Dobiera szerokość, czcionkę, grubość i liczbę linii leżącej książki tak, by
- * zmieścić PEŁNY tytuł BEZ poszerzania ponad `FLAT_MAX_W`: krótki tytuł → 1 linia
- * (książka dokładnie na tekst), dłuższy → 2 linie (książka trochę grubsza, nie
- * szersza). Bardzo długi tytuł dodatkowo zmniejsza czcionkę, aż połowa zmieści
- * się w jednej linii (2 linie zawsze wystarczą). Nic nie jest ucinane.
+ * Picks width, font, thickness and line count of a lying book so as to fit
+ * the FULL title WITHOUT widening past `FLAT_MAX_W`: a short title → 1 line
+ * (book exactly as wide as the text), longer → 2 lines (book a bit thicker,
+ * not wider). A very long title additionally shrinks the font until half fits
+ * in one line (2 lines always suffice). Nothing is truncated.
  */
 export function flatBookLayout(book: BookIndexEntry): FlatBookLayout {
   const len = Math.max(1, displayTitle(book).length);
-  const PAD_X = 20;                       // lewy margines tekstu + prawa krawędź kartek
+  const PAD_X = 20;                       // left text margin + right edge of the pages
   const availW = FLAT_MAX_W - PAD_X;
   const oneLine = (f: number) => len * CHAR_W * f;
 
@@ -182,7 +182,7 @@ export function flatBookLayout(book: BookIndexEntry): FlatBookLayout {
   return { width, fontSize, thickness, lines };
 }
 
-// ─── Ułożenie kupki ───────────────────────────────────────────────────────
+// ─── Pile layout ───────────────────────────────────────────────────────
 export type StackAlign = "left" | "right" | "center";
 
 function stackSeed(books: BookIndexEntry[]): number {
@@ -190,8 +190,8 @@ function stackSeed(books: BookIndexEntry[]): number {
 }
 
 /**
- * Wyrównanie kupki: **często do lewej, często do prawej, BARDZO RZADKO symetryczna
- * piramida** (center). Deterministyczne z pierwszej książki + rozmiaru kupki.
+ * Pile alignment: **often left, often right, VERY RARELY a symmetric
+ * pyramid** (center). Deterministic from the first book + pile size.
  */
 export function stackAlign(books: BookIndexEntry[]): StackAlign {
   const s = stackSeed(books) % 100;
@@ -200,13 +200,13 @@ export function stackAlign(books: BookIndexEntry[]): StackAlign {
   return "center"; // ~10 %
 }
 
-/** Poziom „chaosu" ułożenia w px: 0 = równo, ~⅓ kupek dostaje 3–7 px rozjazdu. */
+/** Layout „chaos" level in px: 0 = even, ~⅓ of piles get 3–7 px of spread. */
 export function stackChaos(books: BookIndexEntry[]): number {
   const s = mix32(stackSeed(books) ^ 0x85ebca6b);
   return (s % 100) < 34 ? 3 + (s % 5) : 0;
 }
 
-/** Deterministyczny luz pojedynczej książki w kupce, znormalizowany do [-1, 1). */
+/** Deterministic slack of a single book in a pile, normalized to [-1, 1). */
 export function layerJitter(book: BookIndexEntry): number {
   const s = mix32(seed(book) ^ 0xc2b2ae35);
   return ((s % 1000) / 500) - 1;
@@ -216,11 +216,11 @@ export interface StackLayoutLayer extends FlatBookLayout { book: BookIndexEntry;
 export interface StackLayout { cellW: number; height: number; align: StackAlign; chaos: number; layers: StackLayoutLayer[] }
 
 /**
- * Pełne ułożenie kupki: sortuje książki **od największej (dół) do najmniejszej
- * (góra)**, wybiera wyrównanie (`stackAlign`) i poziom chaosu (`stackChaos`),
- * i liczy poziomy offset `x` każdej warstwy. Gwarancja: `0 ≤ x ≤ cellW − width`
- * (nic nie wystaje poza komórkę → brak nachodzenia na sąsiednie sloty).
- * `layers[0]` to spód kupki (renderować przez `flex-col-reverse`).
+ * Full pile layout: sorts books **from largest (bottom) to smallest
+ * (top)**, picks alignment (`stackAlign`) and chaos level (`stackChaos`),
+ * and computes the horizontal offset `x` of each layer. Guarantee: `0 ≤ x ≤ cellW − width`
+ * (nothing sticks out of the cell → no overlap onto adjacent slots).
+ * `layers[0]` is the bottom of the pile (render via `flex-col-reverse`).
  */
 export function layoutStack(books: BookIndexEntry[]): StackLayout {
   const align = stackAlign(books);
@@ -237,68 +237,68 @@ export function layoutStack(books: BookIndexEntry[]): StackLayout {
     x = Math.max(0, Math.min(slack, x));
     return { ...l, x };
   });
-  // Wysokość kupki: suma grubości warstw + 1 px marginesu między nimi.
+  // Pile height: sum of layer thicknesses + 1 px margin between them.
   const height = layers.reduce((s, l) => s + l.thickness, 0) + Math.max(0, layers.length - 1);
   return { cellW, height, align, chaos, layers };
 }
 
-/** Tytuł do pokazania (polski, a gdy brak — oryginalny). */
+/** Title to display (Polish, and when missing — original). */
 export function displayTitle(book: BookIndexEntry): string {
   return book.plTitle || book.origTitle;
 }
 
-// ─── Geometria regału (deski) ─────────────────────────────────────────────
-// Rzędy grzbietów mają STAŁĄ wysokość, dzięki czemu każdy zawinięty wiersz
-// zaczyna się na tej samej wysokości i można pod nim narysować drewnianą deskę
-// jednym powtarzalnym gradientem — niezależnie od szerokości ekranu i liczby
-// książek w wierszu. `ROW_H` > najwyższy grzbiet (171 px), `GAP` mieści deskę.
-export const SHELF_ROW_H = 178;   // px — wysokość toru jednego rzędu
-export const SHELF_PLANK_H = 15;  // px — grubość widocznej deski
-export const SHELF_ROW_GAP = 30;  // px — prześwit pod rzędem (deska + cień + luz)
+// ─── Regał geometry (planks) ─────────────────────────────────────────────
+// Spine rows have a FIXED height, so every wrapped line starts at the same
+// height and a wooden plank can be drawn under it with a single repeating
+// gradient — regardless of screen width and the number of books in a line.
+// `ROW_H` > tallest spine (171 px), `GAP` fits the plank.
+export const SHELF_ROW_H = 178;   // px — height of one row's track
+export const SHELF_PLANK_H = 15;  // px — thickness of the visible plank
+export const SHELF_ROW_GAP = 30;  // px — gap under the row (plank + shadow + slack)
 
 /**
- * Tło powtarzalne rysujące drewnianą deskę tuż pod spodem każdego rzędu grzbietów.
- * Grzbiety są wyrównane do dołu toru `SHELF_ROW_H`, więc deska ląduje dokładnie
- * pod nimi (w prześwicie `SHELF_ROW_GAP`). Zwraca gotowy `background` (CSS).
+ * A repeating background drawing a wooden plank just beneath each row of spines.
+ * Spines are aligned to the bottom of the `SHELF_ROW_H` track, so the plank lands
+ * exactly under them (in the `SHELF_ROW_GAP` gap). Returns a ready `background` (CSS).
  */
 export function shelfPlankBackground(): { backgroundImage: string } {
-  const top = SHELF_ROW_H;                        // górna krawędź deski (linia książek)
-  const bot = SHELF_ROW_H + SHELF_PLANK_H;        // dolna krawędź deski
-  const period = SHELF_ROW_H + SHELF_ROW_GAP;     // skok pionowy na jeden rząd
+  const top = SHELF_ROW_H;                        // top edge of the plank (book line)
+  const bot = SHELF_ROW_H + SHELF_PLANK_H;        // bottom edge of the plank
+  const period = SHELF_ROW_H + SHELF_ROW_GAP;     // vertical step per row
   const backgroundImage =
     `repeating-linear-gradient(180deg,` +
     ` rgba(0,0,0,0) 0px,` +
     ` rgba(0,0,0,0) ${top}px,` +
-    ` rgba(255,214,160,0.45) ${top}px,` +          // rozświetlona krawędź (blat)
-    ` #5a3a1e ${top + 1}px,` +                      // drewno — góra
+    ` rgba(255,214,160,0.45) ${top}px,` +          // lit edge (top surface)
+    ` #5a3a1e ${top + 1}px,` +                      // wood — top
     ` #3a2413 ${top + Math.round(SHELF_PLANK_H * 0.55)}px,` +
-    ` #1c1108 ${bot - 1}px,` +                      // drewno — dół
-    ` rgba(0,0,0,0.85) ${bot}px,` +                 // cień rzucany pod deską
+    ` #1c1108 ${bot - 1}px,` +                      // wood — bottom
+    ` rgba(0,0,0,0.85) ${bot}px,` +                 // shadow cast under the plank
     ` rgba(0,0,0,0) ${bot + 6}px,` +
     ` rgba(0,0,0,0) ${period}px)`;
   return { backgroundImage };
 }
 
-/** Znacznik zdobytej NAGRODY (nie nominacji) z color-code do pieczęci na grzbiecie. */
+/** Marker of a WON award (not a nomination) with a color-code for the spine seal. */
 export interface AwardMark { key: "hugo" | "nebula" | "locus"; color: string; label: string }
 
 const AWARD_MARKS: Record<AwardMark["key"], AwardMark> = {
-  hugo: { key: "hugo", color: "#fbbf24", label: "Hugo" },      // złoto (rakieta)
-  nebula: { key: "nebula", color: "#c084fc", label: "Nebula" }, // fiolet (mgławica)
-  locus: { key: "locus", color: "#38bdf8", label: "Locus" },   // błękit
+  hugo: { key: "hugo", color: "#fbbf24", label: "Hugo" },      // gold (rocket)
+  nebula: { key: "nebula", color: "#c084fc", label: "Nebula" }, // violet (nebula)
+  locus: { key: "locus", color: "#38bdf8", label: "Locus" },   // blue
 };
 
 /**
- * Zdobyte nagrody książki z color-code. Bierze TYLKO wygrane („Nagroda …" lub
- * „Wszystkie" = Hugo+Nebula+Locus) — **nominacje pomijamy**. Zdeduplikowane,
- * w stałej kolejności Hugo → Nebula → Locus.
+ * A book's won awards with a color-code. Takes ONLY wins („Nagroda …" or
+ * „Wszystkie" = Hugo+Nebula+Locus) — **nominations are skipped**. Deduplicated,
+ * in a fixed order Hugo → Nebula → Locus.
  */
 export function awardWins(book: BookIndexEntry): AwardMark[] {
   const won = new Set<AwardMark["key"]>();
   for (const a of book.awards) {
     const s = a.toLowerCase().trim();
     if (s === "wszystkie") { won.add("hugo"); won.add("nebula"); won.add("locus"); continue; }
-    if (!s.startsWith("nagroda ")) continue;        // pomijamy „Nominacja …" i inne
+    if (!s.startsWith("nagroda ")) continue;        // skip „Nominacja …" and others
     if (s.includes("hugo")) won.add("hugo");
     else if (s.includes("nebula")) won.add("nebula");
     else if (s.includes("locus")) won.add("locus");
@@ -306,15 +306,15 @@ export function awardWins(book: BookIndexEntry): AwardMark[] {
   return (["hugo", "nebula", "locus"] as const).filter((k) => won.has(k)).map((k) => AWARD_MARKS[k]);
 }
 
-/** Czy pozycja ma zdobytą nagrodę (do pieczęci na grzbiecie i półki „Wyróżnione"). */
+/** Whether the item has a won award (for the spine seal and the „Wyróżnione" shelf). */
 export function hasAward(book: BookIndexEntry): boolean {
   return awardWins(book).length > 0;
 }
 
 /**
- * Rok wydania z pola daty. Pole bywa wielokrotne („1965/1966", „1965, 1966",
- * „1965 (wyd. pol. 1970)") — bierzemy **pierwszy 4-cyfrowy rok z brzegu**, żeby
- * pozycja i tak trafiła do swojej dekady. Brak roku → `null`.
+ * Publication year from the date field. The field is sometimes multi-valued
+ * („1965/1966", „1965, 1966", „1965 (wyd. pol. 1970)") — we take **the first
+ * 4-digit year from the edge**, so the item still lands in its decade. No year → `null`.
  */
 export function parseYear(year: string): number | null {
   const m = String(year ?? "").match(/\d{4}/);
@@ -322,21 +322,22 @@ export function parseYear(year: string): number | null {
   return Number.isFinite(y) && y > 0 ? y : null;
 }
 
-/** Rok wydania jako liczba do sortowania; brak → na koniec. */
+/** Publication year as a number for sorting; missing → at the end. */
 export function pubYear(b: BookIndexEntry): number {
   return parseYear(b.year) ?? Infinity;
 }
 
-/** Klucz dekady książki (1950, 1960, …); brak roku → Infinity (sekcja „bez daty" na końcu). */
+/** Book's decade key (1950, 1960, …); no year → Infinity („bez daty" section at the end). */
 export function decadeKeyOf(b: BookIndexEntry): number {
   const y = parseYear(b.year);
   return y === null ? Infinity : Math.floor(y / 10) * 10;
 }
 
 /**
- * Efektywny klucz porządku na półce: ręczny `shelfOrder` (precyzyjny drag&drop),
- * o ile mieści się w dekadzie książki — klucz spoza dekady jest STALE (rok książki
- * zmienił dekadę po nadaniu klucza) i wraca do sortu po roku. Skala: ułamkowe lata.
+ * Effective shelf-ordering key: the manual `shelfOrder` (precise drag&drop),
+ * as long as it falls within the book's decade — a key outside the decade is STALE
+ * (the book's year changed decade after the key was assigned) and falls back to
+ * sorting by year. Scale: fractional years.
  */
 export function effShelfKey(b: BookIndexEntry): number {
   const dec = decadeKeyOf(b);
@@ -346,15 +347,15 @@ export function effShelfKey(b: BookIndexEntry): number {
 }
 
 /**
- * Porządek na regale: dekada → efektywny klucz (ręczny lub rok) → tytuł.
- * Bez ręcznych kluczy równoważny dawnemu sortowi po roku (dekada rośnie z rokiem).
+ * Order on the Regał: decade → effective key (manual or year) → title.
+ * Without manual keys, equivalent to the old sort by year (decade grows with year).
  */
 export const byShelfPosition = (a: BookIndexEntry, b: BookIndexEntry) =>
   decadeKeyOf(a) - decadeKeyOf(b) || effShelfKey(a) - effShelfKey(b) || displayTitle(a).localeCompare(displayTitle(b), "pl");
 
 /**
- * Dzieli księgozbiór na dwie półki wg stanu „przeczytane" (z nadpisaniami),
- * każda posortowana porządkiem regału (`byShelfPosition`).
+ * Splits the collection into two shelves by „przeczytane" state (with overrides),
+ * each sorted in Regał order (`byShelfPosition`).
  */
 export function splitShelves(books: BookIndexEntry[], overrides: ReadOverrides = {}): Record<ShelfId, BookIndexEntry[]> {
   const read: BookIndexEntry[] = [];
@@ -366,8 +367,8 @@ export function splitShelves(books: BookIndexEntry[], overrides: ReadOverrides =
 }
 
 /**
- * Półka „Wyróżnione" (okładki twarzą): przeczytane pozycje z nagrodą.
- * Brak daty przeczytania w danych → kolejność wg roku malejąco, potem tytuł.
+ * The „Wyróżnione" shelf (covers facing out): read items with an award.
+ * No read-date in the data → order by year descending, then title.
  */
 export function featuredReads(books: BookIndexEntry[], overrides: ReadOverrides = {}, limit = 12): BookIndexEntry[] {
   return books

--- a/src/utils/cycleSort.ts
+++ b/src/utils/cycleSort.ts
@@ -1,13 +1,13 @@
 import { HarvestCycle } from "../hooks/useCyclesHarvest";
 
 /**
- * Sortowanie kart „Archiwum Cykli":
- * - `easywins` — najmniej DO PRZECZYTANIA na górze (`total − read` rosnąco) → „szybkie
- *   zwycięstwa"; ukończone (przeczytane w całości) spadają na sam dół. Remis: mniej do
- *   zdobycia, potem nazwa.
- * - `acquire` — najwięcej BRAKÓW na górze (`missing` = ani posiadane, ani przeczytane) —
- *   dawne zachowanie (co jeszcze skompletować).
- * Czysta funkcja (zwraca kopię).
+ * Sorting of „Archiwum Cykli" cards:
+ * - `easywins` — fewest TO READ on top (`total − read` ascending) → quick
+ *   wins; completed (fully read) drop to the very bottom. Tie: fewer to
+ *   acquire, then name.
+ * - `acquire` — most MISSING on top (`missing` = neither owned nor read) —
+ *   the old behavior (what's left to complete).
+ * Pure function (returns a copy).
  */
 export type CycleSortMode = "easywins" | "acquire";
 
@@ -19,7 +19,7 @@ export function sortCycles(cycles: HarvestCycle[], mode: CycleSortMode): Harvest
   const copy = [...cycles];
   if (mode === "easywins") {
     return copy.sort((a, b) => {
-      // Ukończone zawsze na dół (nic nie zostało do nadrobienia).
+      // Completed always at the bottom (nothing left to catch up on).
       if (isDone(a) !== isDone(b)) return isDone(a) ? 1 : -1;
       return toRead(a) - toRead(b) || toAcquire(a) - toAcquire(b) || a.cycle.localeCompare(b.cycle, "pl");
     });

--- a/src/utils/encyclopedia.ts
+++ b/src/utils/encyclopedia.ts
@@ -1,8 +1,8 @@
 /**
- * Jedno źródło prawdy dla linku do strony w Archiwum Encyklopedii Fantastyki.
- * Tytuł tomu/książki = nazwa strony wiki; spacje → „_", potem `encodeURIComponent`.
- * Współdzielone przez front (panele cyklu) i backend (żniwa — link przy tytule).
- * Moduł czysty, bez zależności Node/DOM (wzorzec jak `configSchema.ts`).
+ * Single source of truth for the link to a page in the Archiwum Encyklopedii Fantastyki.
+ * Volume/book title = wiki page name; spaces → „_", then `encodeURIComponent`.
+ * Shared by the frontend (cycle panels) and backend (harvest — link next to the title).
+ * Pure module, no Node/DOM dependencies (pattern like `configSchema.ts`).
  */
 export function encyclopediaUrl(title: string): string {
   return `https://encyklopediafantastyki.pl/index.php?title=${encodeURIComponent((title || "").replace(/ /g, "_"))}`;

--- a/src/utils/popoverPosition.ts
+++ b/src/utils/popoverPosition.ts
@@ -1,9 +1,9 @@
 /**
- * Pozycjonowanie popovera „w miejscu kliknięcia" (podgląd cyklu). Zakotwiczony pod
- * (lub nad) triggerem, przycięty do viewportu. Stronę (nad/pod) wybiera wg tego, gdzie
- * jest więcej miejsca, a `maxHeight` = dostępna przestrzeń — treść krótsza kurczy się
- * do liczby pozycji, dłuższa scrolluje wewnątrz (nic nie ucieka poza ekran / nie jest
- * ucinane). Czysta funkcja (bez DOM) — łatwa do przetestowania.
+ * Positioning of the popover „at the click location" (cycle preview). Anchored below
+ * (or above) the trigger, clamped to the viewport. Picks the side (above/below) by
+ * where there's more room, and `maxHeight` = available space — shorter content shrinks
+ * to the number of items, longer scrolls inside (nothing escapes the screen / gets
+ * truncated). Pure function (no DOM) — easy to test.
  */
 
 export interface AnchorRect {
@@ -23,11 +23,11 @@ export interface PopoverPosition {
   left: number;
   width: number;
   placement: "below" | "above";
-  /** px od GÓRY viewportu — ustawione, gdy placement === "below". */
+  /** px from the TOP of the viewport — set when placement === "below". */
   top?: number;
-  /** px od DOŁU viewportu — ustawione, gdy placement === "above". */
+  /** px from the BOTTOM of the viewport — set when placement === "above". */
   bottom?: number;
-  /** Górny limit wysokości; dłuższa lista scrolluje w środku. */
+  /** Upper height limit; a longer list scrolls inside. */
   maxHeight: number;
 }
 

--- a/src/utils/shelfInsertion.ts
+++ b/src/utils/shelfInsertion.ts
@@ -2,43 +2,43 @@ import { BookIndexEntry } from "../types";
 import { decadeKeyOf, effShelfKey } from "./bookshelf";
 
 /**
- * Czysty planer precyzyjnego wstawienia na regał.
+ * Pure planner for precise insertion onto the Regał.
  *
- * Wejście: posortowana sekwencja półki docelowej BEZ przeciąganej książki,
- * przeciągana książka i cel (`insertBeforeId` — id książki, przed którą wstawiamy;
- * null = na sam koniec półki). Wyjście: partia zapisów `ShelfOrder` (skala
- * ułamkowych lat) — zwykle 1 wpis (klucz-środek między sąsiadami); przy remisie
- * kluczy (książki z tego samego roku bez ręcznych kluczy) renumerowany jest tylko
- * ZWIĄZANY przedział, nie cała dekada.
+ * Input: the sorted sequence of the target shelf WITHOUT the dragged book,
+ * the dragged book and the target (`insertBeforeId` — id of the book we insert
+ * before; null = at the very end of the shelf). Output: a batch of `ShelfOrder`
+ * writes (fractional-years scale) — usually 1 entry (a midpoint key between
+ * neighbors); on a key tie (books from the same year without manual keys) only
+ * the BOUND range is renumbered, not the whole decade.
  *
- * Walidacja rocznikowa: wstawić można wyłącznie w szczelinę, której sąsiad (lewy
- * lub prawy) należy do dekady przeciąganej książki — czyli wewnątrz jej sekcji
- * albo na jej brzegach. Książki „bez daty" nie mają skali → precyzyjny drop off.
+ * Year validation: you can only insert into a gap whose neighbor (left or
+ * right) belongs to the dragged book's decade — i.e. inside its section or
+ * at its edges. „bez daty" books have no scale → precise drop off.
  */
 
 export interface InsertionPlan {
-  /** Zapisy ShelfOrder do wysłania (id → klucz). Zawsze zawiera przeciąganą książkę. */
+  /** ShelfOrder writes to send (id → key). Always includes the dragged book. */
   orders: { pageId: string; order: number }[];
 }
 
-/** Maks. partia zapisów (spójna z limitem POST /api/shelf-order). */
+/** Max write batch (consistent with the POST /api/shelf-order limit). */
 const MAX_ORDERS = 40;
 
-/** Czy szczelina PRZED książką `insertBeforeId` (null = koniec) przyjmie tę książkę (dekada się zgadza)? */
+/** Will the gap BEFORE book `insertBeforeId` (null = end) accept this book (decade matches)? */
 export function canInsertAt(seq: BookIndexEntry[], dragged: BookIndexEntry, insertBeforeId: string | null): boolean {
   const dec = decadeKeyOf(dragged);
-  if (!isFinite(dec)) return false; // „bez daty" — brak skali porządku
+  if (!isFinite(dec)) return false; // „bez daty" — no ordering scale
   const idx = insertBeforeId === null ? seq.length : seq.findIndex((b) => b.id === insertBeforeId);
   if (insertBeforeId !== null && idx < 0) return false;
   const L = idx > 0 ? seq[idx - 1] : undefined;
   const R = idx < seq.length ? seq[idx] : undefined;
-  if (!L && !R) return true; // pusta półka — zwykły drop, bez klucza
+  if (!L && !R) return true; // empty shelf — plain drop, no key
   return (L !== undefined && decadeKeyOf(L) === dec) || (R !== undefined && decadeKeyOf(R) === dec);
 }
 
 /**
- * Plan zapisów dla wstawienia. `null` gdy szczelina nieprawidłowa (zła dekada /
- * nieznany cel / partia ponad limit) — wołający robi fallback do zwykłego dropu.
+ * Write plan for the insertion. `null` when the gap is invalid (wrong decade /
+ * unknown target / batch over limit) — the caller falls back to a plain drop.
  */
 export function planInsertion(seq: BookIndexEntry[], dragged: BookIndexEntry, insertBeforeId: string | null): InsertionPlan | null {
   if (!canInsertAt(seq, dragged, insertBeforeId)) return null;
@@ -47,29 +47,29 @@ export function planInsertion(seq: BookIndexEntry[], dragged: BookIndexEntry, in
   const L = idx > 0 ? seq[idx - 1] : undefined;
   const R = idx < seq.length ? seq[idx] : undefined;
 
-  if (!L && !R) return { orders: [] }; // pusta półka — pozycja wynika z roku
+  if (!L && !R) return { orders: [] }; // empty shelf — position follows from the year
 
-  // Granice tylko z sąsiadów WEWNĄTRZ dekady; sąsiad z innej dekady = otwarty brzeg sekcji.
+  // Bounds only from neighbors INSIDE the decade; a neighbor from another decade = open section edge.
   const kL = L && decadeKeyOf(L) === dec ? effShelfKey(L) : null;
   const kR = R && decadeKeyOf(R) === dec ? effShelfKey(R) : null;
 
-  const lo = dec;            // dolna krawędź skali dekady
-  const hi = dec + 9.99;     // górna krawędź (klucz musi zostać < dec+10)
+  const lo = dec;            // lower edge of the decade scale
+  const hi = dec + 9.99;     // upper edge (key must stay < dec+10)
 
   if (kL !== null && kR !== null) {
     if (kL < kR) return { orders: [{ pageId: dragged.id, order: (kL + kR) / 2 }] };
-    // Remis kluczy (ten sam rok bez ręcznych kluczy): renumeruj związany przedział
-    // [wszystkie kolejne wpisy o kluczu == kL wokół szczeliny] + wstawiana.
+    // Key tie (same year without manual keys): renumber the bound range
+    // [all consecutive entries with key == kL around the gap] + the inserted one.
     const tie = kL;
     let start = idx - 1;
     while (start - 1 >= 0 && decadeKeyOf(seq[start - 1]) === dec && effShelfKey(seq[start - 1]) === tie) start--;
-    let end = idx; // pierwszy indeks ZA przedziałem
+    let end = idx; // first index PAST the range
     while (end < seq.length && decadeKeyOf(seq[end]) === dec && effShelfKey(seq[end]) === tie) end++;
     const run = seq.slice(start, end);
     const insertPos = idx - start;
     const finalRun: BookIndexEntry[] = [...run.slice(0, insertPos), dragged, ...run.slice(insertPos)];
     if (finalRun.length > MAX_ORDERS) return null;
-    // Rozłóż klucze w [tie, min(tie+0.98, hi)] — poniżej następnego rocznika.
+    // Distribute keys in [tie, min(tie+0.98, hi)] — below the next year.
     const top = Math.min(tie + 0.98, hi);
     const stepSpan = top - tie;
     const orders = finalRun.map((b, i) => ({ pageId: b.id, order: tie + (stepSpan * (i + 1)) / (finalRun.length + 1) }));
@@ -77,9 +77,9 @@ export function planInsertion(seq: BookIndexEntry[], dragged: BookIndexEntry, in
   }
 
   if (kL !== null) {
-    // Koniec sekcji dekady — klucz między kL a górną krawędzią.
+    // End of the decade section — key between kL and the upper edge.
     return { orders: [{ pageId: dragged.id, order: kL + (hi - kL) / 2 }] };
   }
-  // kR !== null: początek sekcji — klucz między dolną krawędzią a kR.
+  // kR !== null: start of the section — key between the lower edge and kR.
   return { orders: [{ pageId: dragged.id, order: lo + ((kR as number) - lo) / 2 }] };
 }

--- a/src/utils/shelfLayout.ts
+++ b/src/utils/shelfLayout.ts
@@ -2,39 +2,39 @@ import { BookIndexEntry } from "../types";
 import { ShelfSlot, spineStyle, planShelf, layoutStack, displayTitle, parseYear } from "./bookshelf";
 import { PackItem, PlacedItem } from "./shelfPacking";
 
-/** Slot do renderu: wolumin/kupka (`ShelfSlot`) albo tabliczka-przekładka sekcji. */
+/** Render slot: a volume/pile (`ShelfSlot`) or a section divider plate. */
 export type RenderSlot = ShelfSlot | { kind: "divider"; label: string };
 
-/** Poziom, na którym maluje się pozioma tabliczka dekady: u góry (domyślnie) albo u dołu. */
+/** The level at which the horizontal decade plate is painted: at the top (default) or at the bottom. */
 export type DividerLevel = "top" | "bottom";
-/** Kierunek rozwijania tabliczki od deseczki: w prawo (domyślnie) albo w lewo (przy prawej krawędzi). */
+/** Direction the plate unfolds from the board: to the right (default) or to the left (at the right edge). */
 export type DividerDir = "right" | "left";
-/** Rozmieszczenie tabliczki przekładki: poziom (góra/dół) + kierunek (lewo/prawo). */
+/** Placement of the divider plate: level (top/bottom) + direction (left/right). */
 export interface DividerPlacement { level: DividerLevel; dir: DividerDir; }
 
-/** Footprint deseczki na półce (px) — spójny z `DIVIDER_W` / `ShelfDivider width`. */
+/** Board footprint on the shelf (px) — consistent with `DIVIDER_W` / `ShelfDivider width`. */
 const PLATE_BOARD_W = 10;
 
 /**
- * Estymowana szerokość poziomej tabliczki rocznika (px) — do wykrywania kolizji.
- * Sygil koła (13) + gap (6) + padding `px-[9px]` (2×9) + tekst (mono 11px z
- * `letterSpacing 0.06em` ≈ 7.3 px/znak). To heurystyka, nie pomiar DOM — celuje
- * w wykrycie „wąskich dekad", nie w subpikselową dokładność.
+ * Estimated width of the horizontal year plate (px) — for collision detection.
+ * Circle sigil (13) + gap (6) + padding `px-[9px]` (2×9) + text (mono 11px with
+ * `letterSpacing 0.06em` ≈ 7.3 px/char). This is a heuristic, not a DOM measurement —
+ * it aims to catch „narrow decades", not subpixel accuracy.
  */
 export function plateWidth(label: string): number {
   return Math.ceil(37 + label.length * 7.3);
 }
 
 /**
- * Rozmieszcza tabliczki dekad w JEDNYM rzędzie, tak by nie nachodziły na siebie ani
- * nie wychodziły poza półkę:
- *  - **kierunek**: tabliczka rozwija się w prawo od deseczki; jeśli sięgnęłaby poza
- *    prawą krawędź półki (`rowWidth`), rozwija się w lewo (prawy brzeg przy deseczce);
- *  - **poziom**: zachłannie od lewej — tabliczka zostaje na górze, o ile jej przedział
- *    poziomy nie zderza się z ostatnią górną; inaczej ląduje na dole; a gdy i dół zajęty
- *    (rzadka potrójna kolizja) — wraca na górę (akceptujemy).
- * Zwraca mapę `key→{level,dir}` dla KAŻDEJ przekładki (domyślnie `{top,right}`).
- * `rowWidth ≤ 0` (nieznana szerokość) wyłącza detekcję krawędzi — wszystko w prawo.
+ * Places decade plates in ONE row so they neither overlap each other nor
+ * spill past the shelf:
+ *  - **direction**: the plate unfolds to the right of the board; if it would reach past
+ *    the right edge of the shelf (`rowWidth`), it unfolds to the left (right edge at the board);
+ *  - **level**: greedily from the left — the plate stays on top as long as its horizontal
+ *    span doesn't collide with the last top one; otherwise it lands on the bottom; and when
+ *    the bottom is taken too (a rare triple collision) — it returns to the top (accepted).
+ * Returns a map `key→{level,dir}` for EVERY divider (default `{top,right}`).
+ * `rowWidth ≤ 0` (unknown width) disables edge detection — everything to the right.
  */
 export function assignDividerPlacement(
   row: PlacedItem[],
@@ -43,7 +43,7 @@ export function assignDividerPlacement(
   gap = 6,
 ): Map<string, DividerPlacement> {
   const dividers = row.filter((p) => p.kind === "divider");
-  // Kierunek + przedział poziomy [left,right] każdej tabliczki (uwzględnia zawinięcie w lewo).
+  // Direction + horizontal span [left,right] of each plate (accounts for left wrapping).
   const spans = dividers.map((d) => {
     const w = plateWidth(labelOf(d.key) ?? "");
     const overflow = rowWidth > 0 && d.x + w > rowWidth;
@@ -59,32 +59,32 @@ export function assignDividerPlacement(
     let level: DividerLevel;
     if (s.left >= topRight) { level = "top"; topRight = s.right + gap; }
     else if (s.left >= botRight) { level = "bottom"; botRight = s.right + gap; }
-    else { level = "top"; topRight = s.right + gap; } // potrójna kolizja → góra
+    else { level = "top"; topRight = s.right + gap; } // triple collision → top
     out.set(s.key, { level, dir: s.dir });
   }
   return out;
 }
 
-const DIVIDER_W = 10;   // cienka deseczka (footprint na półce)
-const DIVIDER_H = 168;  // = BOARD_H w ShelfDivider — realna podpora dla pochyłego sąsiada
+const DIVIDER_W = 10;   // thin board (footprint on the shelf)
+const DIVIDER_H = 168;  // = BOARD_H in ShelfDivider — real support for a tilted neighbor
 
-/** Dekada roku wydania (np. 1954 → 1950); pola wielodatowe → pierwszy rok; brak → `null`. */
+/** Decade of the publication year (e.g. 1954 → 1950); multi-date fields → first year; missing → `null`. */
 export function decadeOf(year: string): number | null {
   const y = parseYear(year);
   return y === null ? null : Math.floor(y / 10) * 10;
 }
 
-/** Etykieta tabliczki dekady, np. „1950–1959" (albo „bez daty"). */
+/** Decade plate label, e.g. „1950–1959" (or „bez daty"). */
 export function decadeLabel(dec: number | null): string {
   return dec === null ? "bez daty" : `${dec}–${dec + 9}`;
 }
 
 /**
- * Buduje `PackItem[]` (do fizyki `packAndLayout`) i mapę `slotByKey` (do renderu).
- * Woluminy przychodzą już posortowane po dacie wydania; na **granicy każdej dekady**
- * wstawiamy przekładkę (`divider`) — cienką deseczkę na półce z poziomą tabliczką
- * rocznika u góry (render: `ShelfDivider`). Kupki nie przekraczają granicy dekady
- * (planShelf liczony osobno per dekada). Wspólne dla wszystkich widoków regału.
+ * Builds `PackItem[]` (for the `packAndLayout` physics) and the `slotByKey` map (for rendering).
+ * Volumes arrive already sorted by publication date; at **each decade boundary**
+ * we insert a divider (`divider`) — a thin board on the shelf with a horizontal year
+ * plate on top (render: `ShelfDivider`). Piles don't cross a decade boundary
+ * (planShelf computed separately per decade). Shared by all Regał views.
  */
 export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; slotByKey: Map<string, RenderSlot> } {
   const slotByKey = new Map<string, RenderSlot>();
@@ -97,12 +97,12 @@ export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; s
     let j = i;
     while (j < books.length && decadeOf(books[j].year) === dec) j++;
 
-    // Tabliczka na początku sekcji dekady.
+    // Plate at the start of the decade section.
     const dkey = `div:${divN++}`;
     slotByKey.set(dkey, { kind: "divider", label: decadeLabel(dec) });
     items.push({ key: dkey, kind: "divider", bw: DIVIDER_W, h: DIVIDER_H, leanDir: 0 });
 
-    // Woluminy tej dekady (kupki/pochyły w obrębie dekady).
+    // Volumes of this decade (piles/tilts within the decade).
     for (const slot of planShelf(books.slice(i, j))) {
       if (slot.kind === "stack") {
         const key = `stack:${slot.books[0].id}`;
@@ -121,7 +121,7 @@ export function buildShelfItems(books: BookIndexEntry[]): { items: PackItem[]; s
   return { items, slotByKey };
 }
 
-/** Dzieli tablicę na porcje po `size` (np. rzędy → segmenty-regały). */
+/** Splits an array into chunks of `size` (e.g. rows → shelf segments). */
 export function chunk<T>(arr: T[], size: number): T[][] {
   if (size <= 0) return [arr];
   const out: T[][] = [];

--- a/src/utils/shelfPacking.ts
+++ b/src/utils/shelfPacking.ts
@@ -1,47 +1,47 @@
 import { MAX_LEAN_DEG } from "./bookshelf";
 
 /**
- * Fizyczne rozłożenie woluminów na półkach regału.
+ * Physical arrangement of volumes on the Regał shelves.
  *
- * Zasady „fizyki":
- * - **Każda półka jest wypełniona bez pustych dziur** — luz rzędu pochłaniają w
- *   pierwszej kolejności pochyłe (oparcie), a resztę wchłania POGRUBIENIE stojących
- *   grzbietów (grubsze książki), bo nikt nie stawia książek z przerwami między
- *   nimi. Dopiero gdyby pogrubienie osiągnęło limity, znikomy resztek luzu idzie
- *   równo w szczeliny.
- * - **Książka pochyla się tylko wtedy, gdy ma się o co oprzeć.** Kąt wynika z
- *   geometrii: `θ = atan(szczelina / wysokość_podpory)`, więc wierzch dokładnie
- *   dosięga górnej krawędzi sąsiada/kupki (opiera się o niego), a nie wisi
- *   bezwładnie pod kątem. Brak szczeliny → książka stoi prosto. Kąt ≤ MAX_LEAN.
+ * „Physics" rules:
+ * - **Every shelf is filled with no empty gaps** — a row's slack is absorbed
+ *   first by tilts (leaning), and the rest is absorbed by THICKENING the
+ *   standing spines (thicker books), because nobody stands books with gaps
+ *   between them. Only if thickening hits its limits does a tiny slack remnant
+ *   go evenly into the gaps.
+ * - **A book tilts only when it has something to lean on.** The angle follows
+ *   from geometry: `θ = atan(gap / support_height)`, so the top exactly
+ *   reaches the top edge of the neighbor/pile (leans on it), rather than
+ *   hanging limply at an angle. No gap → the book stands upright. Angle ≤ MAX_LEAN.
  */
 
 export interface PackItem {
   key: string;
   kind: "spine" | "stack" | "divider";
-  bw: number;          // szerokość podstawy (footprint na półce), px
-  h: number;           // wysokość widoczna (jako podpora dla sąsiada), px
-  leanDir: -1 | 0 | 1; // zamierzony kierunek pochylenia (−1 w lewo, +1 w prawo, 0 brak)
-  stretch?: number;    // ile px grzbiet MOŻE zgrubieć, by wypełnić luz (0 = nie pogrubiamy)
+  bw: number;          // base width (footprint on the shelf), px
+  h: number;           // visible height (as support for a neighbor), px
+  leanDir: -1 | 0 | 1; // intended tilt direction (−1 left, +1 right, 0 none)
+  stretch?: number;    // how many px the spine MAY thicken to fill slack (0 = don't thicken)
 }
 
 export interface PlacedItem {
   key: string;
   kind: "spine" | "stack" | "divider";
   bw: number;
-  w: number;           // szerokość do wyrenderowania (≥ bw — po ewentualnym pogrubieniu)
-  x: number;           // lewa krawędź, px
-  deg: number;         // rzeczywisty kąt pochylenia (0 = prosto)
+  w: number;           // width to render (≥ bw — after any thickening)
+  x: number;           // left edge, px
+  deg: number;         // actual tilt angle (0 = upright)
 }
 
 export interface PackOpts {
   rowWidth: number;
-  minGap?: number;     // minimalny odstęp rezerwowany przy pakowaniu
+  minGap?: number;     // minimum spacing reserved during packing
   maxLeanDeg?: number;
 }
 
 const DEG = Math.PI / 180;
 
-/** Zachłanne pakowanie woluminów w rzędy o zadanej szerokości. */
+/** Greedy packing of volumes into rows of the given width. */
 export function packRows(items: PackItem[], rowWidth: number, minGap = 2): PackItem[][] {
   const rows: PackItem[][] = [];
   let row: PackItem[] = [];
@@ -61,8 +61,8 @@ export function packRows(items: PackItem[], rowWidth: number, minGap = 2): PackI
 }
 
 /**
- * Rozkłada jeden rząd na całą szerokość i liczy kąty pochylenia „z podparciem".
- * Zwraca pozycje `x` (lewa krawędź) i kąt `deg` każdego woluminu.
+ * Lays out one row across the full width and computes „supported" tilt angles.
+ * Returns each volume's `x` position (left edge) and `deg` angle.
  */
 export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LEAN_DEG): PlacedItem[] {
   const n = row.length;
@@ -74,10 +74,10 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
   }
 
   const gaps = new Array(n - 1).fill(0);
-  const extra = new Array(n).fill(0); // pogrubienie każdego grzbietu (px)
+  const extra = new Array(n).fill(0); // thickening of each spine (px)
   const tanMax = Math.tan(maxLeanDeg * DEG);
 
-  // Która szczelina jest „szczeliną oparcia" (książka pochyla się w nią na sąsiada).
+  // Which gap is a „lean gap" (a book tilts into it onto a neighbor).
   type Lean = { leaner: number; support: number; cap: number };
   const leanAt: (Lean | undefined)[] = new Array(n - 1).fill(undefined);
   for (let i = 0; i < n; i++) {
@@ -91,22 +91,22 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
   const leanIdx = leanAt.map((l, i) => (l ? i : -1)).filter((i) => i >= 0);
   const freeIdx = gaps.map((_, i) => i).filter((i) => !leanAt[i]);
 
-  // Rozdział luzu.
+  // Slack distribution.
   let rem = slack;
   const leanCapSum = leanIdx.reduce((s, i) => s + leanAt[i]!.cap, 0);
   if (leanCapSum <= rem) {
-    // 1) Pochyłe książki opierają się o sąsiada (szczelina oparcia do limitu).
+    // 1) Tilted books lean on a neighbor (lean gap up to the limit).
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap;
     rem -= leanCapSum;
-    // 2) Resztę WCHŁANIA pogrubienie stojących grzbietów — grubsze książki
-    //    wypełniają rząd zamiast zostawiać nienaturalne przerwy. Nie pogrubiamy
-    //    kupek ani książek, które się pochylają.
+    // 2) The rest is ABSORBED by thickening the standing spines — thicker books
+    //    fill the row instead of leaving unnatural gaps. We don't thicken
+    //    piles or books that tilt.
     const leaners = new Set(leanIdx.map((i) => leanAt[i]!.leaner));
     const widenable = row
       .map((it, i) => (it.kind === "spine" && !leaners.has(i) ? i : -1))
       .filter((i) => i >= 0 && (row[i].stretch ?? 0) > 0);
     rem = widenEvenly(rem, widenable, (i) => row[i].stretch ?? 0, extra);
-    // 3) Znikomy resztek (gdy pogrubienie osiągnęło limity) — równo w szczeliny.
+    // 3) A tiny remnant (when thickening hit its limits) — evenly into the gaps.
     if (rem > 1e-6) {
       if (freeIdx.length) {
         const per = rem / freeIdx.length;
@@ -117,12 +117,12 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
       }
     }
   } else {
-    // luz mniejszy niż suma limitów oparcia — skalujemy szczeliny proporcjonalnie
+    // slack smaller than the sum of lean limits — scale the gaps proportionally
     const scale = leanCapSum > 0 ? rem / leanCapSum : 0;
     for (const i of leanIdx) gaps[i] = leanAt[i]!.cap * scale;
   }
 
-  // Pozycje (szerokość = podstawa + pogrubienie).
+  // Positions (width = base + thickening).
   const placed: PlacedItem[] = [];
   let x = 0;
   for (let i = 0; i < n; i++) {
@@ -131,7 +131,7 @@ export function layoutRow(row: PackItem[], rowWidth: number, maxLeanDeg = MAX_LE
     if (i < n - 1) x += w + gaps[i];
   }
 
-  // Kąty oparcia: θ = atan(szczelina / wysokość_podpory), znak wg strony podpory.
+  // Lean angles: θ = atan(gap / support_height), sign per the support's side.
   for (const i of leanIdx) {
     const { leaner, support } = leanAt[i]!;
     const gap = gaps[i];
@@ -148,9 +148,9 @@ function strip(it: PackItem): Omit<PlacedItem, "x" | "deg" | "w"> {
 }
 
 /**
- * Rozdziela `rem` px na pogrubienie grzbietów `idx`, każdy do limitu `capOf(i)`.
- * Water-filling: równe dokładanie do jeszcze-nienasyconych, aż zabraknie luzu lub
- * miejsca. Zapisuje przyrost do `extra` i zwraca niewykorzystany luz.
+ * Distributes `rem` px across thickening of spines `idx`, each up to the `capOf(i)` limit.
+ * Water-filling: adding equally to the not-yet-saturated ones until slack or room
+ * runs out. Writes the increment into `extra` and returns the unused slack.
  */
 function widenEvenly(rem: number, idx: number[], capOf: (i: number) => number, extra: number[]): number {
   let active = idx.filter((i) => capOf(i) - extra[i] > 1e-6);
@@ -173,7 +173,7 @@ function widenEvenly(rem: number, idx: number[], capOf: (i: number) => number, e
   return rem;
 }
 
-/** Pakuje i rozkłada wszystkie woluminy na wypełnione rzędy. */
+/** Packs and lays out all volumes into filled rows. */
 export function packAndLayout(items: PackItem[], opts: PackOpts): PlacedItem[][] {
   if (opts.rowWidth <= 0) return [];
   const rows = packRows(items, opts.rowWidth, opts.minGap ?? 2);

--- a/src/utils/shelfSkin.ts
+++ b/src/utils/shelfSkin.ts
@@ -1,6 +1,6 @@
 /**
- * Skóry regału — sterowane wyłącznie zmiennymi CSS (`.skin-*` w `index.css`),
- * więc przełączenie to tylko podmiana klasy na wrapperze. Wybór trwa w localStorage.
+ * Regał skins — driven solely by CSS variables (`.skin-*` in `index.css`),
+ * so switching is just swapping the class on the wrapper. The choice persists in localStorage.
  */
 export type ShelfSkin = "holo" | "noospheric";
 
@@ -13,7 +13,7 @@ const KEY = "shelfSkin";
 
 export const skinClass = (s: ShelfSkin): string => (s === "holo" ? "skin-holo" : "skin-noospheric");
 
-/** Domyślnie **Holo+**; odczyt odporny na brak/uszkodzony localStorage. */
+/** Default **Holo+**; read resilient to missing/corrupt localStorage. */
 export function loadSkin(): ShelfSkin {
   try {
     const s = localStorage.getItem(KEY);
@@ -27,6 +27,6 @@ export function saveSkin(s: ShelfSkin): void {
   try {
     localStorage.setItem(KEY, s);
   } catch {
-    /* prywatny tryb / brak dostępu — wybór po prostu nie przetrwa reloadu */
+    /* private mode / no access — the choice simply won't survive a reload */
   }
 }

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -1,14 +1,14 @@
 import { SyncEvent } from "../types";
 
 /**
- * Wspólny odczyt strumienia SSE dla wszystkich hooków (useSync, useLibraryCheck,
- * useVintedCheck). Buforuje fragmenty między odczytami TCP — pojedyncze zdarzenie
- * SSE bywa rozcięte na granicy chunku, a `JSON.parse` na połówce wywala skan.
- * Dzieli po `\n\n`, zachowuje resztę, parsuje linie `data: ` i woła `onEvent`.
+ * Shared SSE stream reader for all hooks (useSync, useLibraryCheck,
+ * useVintedCheck). Buffers fragments between TCP reads — a single SSE event
+ * is sometimes cut at a chunk boundary, and `JSON.parse` on a half crashes the scan.
+ * Splits on `\n\n`, keeps the remainder, parses `data: ` lines and calls `onEvent`.
  *
- * `onEvent` może zwrócić `true` (lub `"stop"`), by zakończyć konsumpcję wcześniej
- * (np. po zdarzeniu `complete`/`error`). `onChunk` odpala się po każdym odczycie —
- * useSync używa go do resetu watchdoga (keepalive też liczy się jako aktywność).
+ * `onEvent` may return `true` (or `"stop"`) to end consumption early
+ * (e.g. after a `complete`/`error` event). `onChunk` fires after every read —
+ * useSync uses it to reset the watchdog (keepalive also counts as activity).
  */
 export async function consumeSSE(
   body: ReadableStream<Uint8Array> | null | undefined,
@@ -46,11 +46,11 @@ export async function consumeSSE(
       }
     }
   } finally {
-    // Gdy wychodzimy wcześniej (stop na complete/error albo rzut z onEvent),
-    // strumień fetch zostałby zablokowany i nieanulowany. Anuluj czytnik, by
-    // zwolnić połączenie — poza przypadkiem naturalnego końca (done).
+    // When we exit early (stop on complete/error or a throw from onEvent),
+    // the fetch stream would be left locked and uncancelled. Cancel the reader to
+    // free the connection — except on the natural end (done).
     if (!finished) {
-      try { await reader.cancel(); } catch { /* czytnik może nie wspierać cancel */ }
+      try { await reader.cancel(); } catch { /* the reader may not support cancel */ }
     }
   }
 }

--- a/src/utils/stallWatchdog.ts
+++ b/src/utils/stallWatchdog.ts
@@ -1,18 +1,18 @@
 /**
- * Watchdog przeciw zawieszeniu strumienia SSE. Hosting/proxy potrafi zbuforować
- * odpowiedź tak, że `reader.read()` nigdy nie wraca — bez tego skan zostawiał
- * wieczny spinner. Serwer wysyła keepalive co 5 s, więc na zdrowym połączeniu
- * `arm()` (wołane per chunk przez consumeSSE) stale resetuje odliczanie i abort
- * nigdy nie następuje; po `timeoutMs` ciszy sygnał jest przerywany.
+ * Watchdog against SSE stream hangs. Hosting/proxy can buffer the
+ * response such that `reader.read()` never returns — without this the scan left
+ * an eternal spinner. The server sends keepalive every 5 s, so on a healthy connection
+ * `arm()` (called per chunk by consumeSSE) keeps resetting the countdown and the abort
+ * never happens; after `timeoutMs` of silence the signal is aborted.
  */
 export interface StallWatchdog {
-  /** Przekaż do `fetch(..., { signal })`. */
+  /** Pass to `fetch(..., { signal })`. */
   signal: AbortSignal;
-  /** Zresetuj odliczanie (wołaj po każdym odebranym fragmencie strumienia). */
+  /** Reset the countdown (call after every received stream fragment). */
   arm: () => void;
-  /** Zatrzymaj watchdog (wołaj w finally). */
+  /** Stop the watchdog (call in finally). */
   clear: () => void;
-  /** Czy watchdog przerwał połączenie z powodu ciszy. */
+  /** Whether the watchdog aborted the connection due to silence. */
   readonly stalled: boolean;
 }
 

--- a/src/utils/statsLayout.ts
+++ b/src/utils/statsLayout.ts
@@ -1,15 +1,15 @@
 /**
- * Czyste helpery kolejności kart statystyk (drag&drop w „Analizie Zasobów").
+ * Pure helpers for stat-card ordering (drag&drop in „Analiza Zasobów").
  *
- * Kolejność użytkownika trzymamy jako listę id sekcji (`ui.statsOrder`). Kod jest
- * odporny na dryf: nowe karty dodane w kodzie, których nie ma w zapisanej liście,
- * dopisujemy na końcu w kolejności kodu; id z zapisu, których już nie ma w kodzie,
- * ignorujemy. Dzięki temu zapisany blob nigdy nie „gubi" ani nie duplikuje karty.
+ * The user's order is kept as a list of section ids (`ui.statsOrder`). The code is
+ * resilient to drift: new cards added in code that aren't in the saved list are
+ * appended at the end in code order; ids from the save that no longer exist in code
+ * are ignored. So the saved blob never „loses" or duplicates a card.
  */
 
 /**
- * Ustala finalną kolejność id: najpierw zapisane (przefiltrowane do istniejących,
- * bez duplikatów), potem pozostałe z `allIds` w kolejności kodu.
+ * Determines the final id order: first the saved ones (filtered to existing,
+ * no duplicates), then the rest from `allIds` in code order.
  */
 export function orderByIds(allIds: string[], savedOrder: string[]): string[] {
   const known = new Set(allIds);
@@ -25,10 +25,10 @@ export function orderByIds(allIds: string[], savedOrder: string[]): string[] {
 }
 
 /**
- * Rozkłada elementy na `cols` kolumn round-robin (element i → kolumna i % cols),
- * zachowując czytanie „wiersz po wierszu": 0 i 2 i 4 w lewej, 1 i 3 i 5 w prawej.
- * Każda kolumna pakuje się potem niezależnie (brak sprzężenia wysokości = brak dziur),
- * a kolejność odczytu lewo→prawo, góra→dół pozostaje 0,1,2,3,... Zwraca `cols` list.
+ * Distributes items across `cols` columns round-robin (item i → column i % cols),
+ * preserving „row by row" reading: 0 and 2 and 4 on the left, 1 and 3 and 5 on the right.
+ * Each column then packs independently (no height coupling = no gaps),
+ * while the reading order left→right, top→bottom stays 0,1,2,3,... Returns `cols` lists.
  */
 export function distributeColumns<T>(items: T[], cols: number): T[][] {
   const n = Math.max(1, Math.floor(cols));
@@ -38,9 +38,9 @@ export function distributeColumns<T>(items: T[], cols: number): T[][] {
 }
 
 /**
- * Przenosi `dragId` na pozycję `targetId` (wstawienie przed elementem docelowym w
- * jego bieżącym miejscu). Zwraca nową listę; wejście pozostaje nietknięte.
- * No-op gdy któreś id nie istnieje lub są równe.
+ * Moves `dragId` to the position of `targetId` (inserting before the target element at
+ * its current place). Returns a new list; the input stays untouched.
+ * No-op when either id doesn't exist or they're equal.
  */
 export function moveId(order: string[], dragId: string, targetId: string): string[] {
   if (dragId === targetId) return order.slice();

--- a/src/utils/vintedFormat.ts
+++ b/src/utils/vintedFormat.ts
@@ -2,7 +2,7 @@ import { VintedResult, VintedSearchAttempt } from "../hooks/useVintedCheck";
 
 type Offer = VintedResult["vintedItems"][number];
 
-/** Krótka data „DD.MM" ze znacznika ISO (świeżość danych z bazy). */
+/** Short date „DD.MM" from an ISO timestamp (data freshness from the DB). */
 export function shortDate(iso?: string | null): string {
   if (!iso) return "";
   const d = new Date(iso);
@@ -11,9 +11,9 @@ export function shortDate(iso?: string | null): string {
 }
 
 /**
- * Zwięzła jednolinijkowa diagnostyka próby skanu (Krok 2). Kluczowy sygnał:
- * itemLinks>0 przy parsed:0 i bez markerów = parser zgubił oferty. Rosnące
- * rssMb ku limitowi hostingu = zbliżający się OOM.
+ * Concise one-line diagnostics of a scan attempt (Step 2). Key signal:
+ * itemLinks>0 with parsed:0 and no markers = the parser lost the offers. Rising
+ * rssMb toward the hosting limit = an approaching OOM.
  */
 export function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): string {
   if (d.error) return `⚠ ${d.error}${d.httpStatus ? ` (${d.httpStatus})` : d.code ? ` (${d.code})` : ""}`;
@@ -38,18 +38,18 @@ export function formatDebug(d: NonNullable<VintedSearchAttempt["debug"]>): strin
 }
 
 /**
- * Czy kafelek książki zmienił się w OSTATNIM skanie (`changedAt === scannedAt`).
- * Wymaga baseline — pierwszy skan (bez `changedAt`) nie liczy się jako zmiana.
+ * Whether the book tile changed in the LAST scan (`changedAt === scannedAt`).
+ * Requires a baseline — the first scan (without `changedAt`) doesn't count as a change.
  */
 export function isBookChanged(result: VintedResult): boolean {
   return !!result.changedAt && result.changedAt === result.scannedAt;
 }
 
 export interface OfferBadges {
-  /** „nowa" — oferta pojawiła się w ostatnim skanie, ale tylko gdy ten skan w ogóle
-   * wykrył zmianę (inaczej pierwszy skan oznaczałby wszystkie oferty jako nowe). */
+  /** New — the offer appeared in the last scan, but only when that scan actually
+   * detected a change (otherwise the first scan would mark all offers as new). */
   isNew: boolean;
-  /** Spadek ceny vs poprzedni skan (zł), lub null. */
+  /** Price drop vs the previous scan (zł), or null. */
   drop: number | null;
 }
 

--- a/src/utils/vintedOffers.ts
+++ b/src/utils/vintedOffers.ts
@@ -1,28 +1,28 @@
-// Pomocniki prezentacji ofert Vinted (czyste, testowalne): sortowanie po cenie
-// rosnąco (oferty bez ceny na końcu), zakres cen do nagłówka karty i formatowanie
-// kwoty w polskim stylu.
+// Helpers for presenting Vinted offers (pure, testable): sorting by price
+// ascending (offers without a price at the end), price range for the card header and
+// formatting the amount in Polish style.
 
 export interface OfferLike {
   priceValue?: number | null;
   currency?: string;
 }
 
-/** Waluta do wyświetlenia: PLN → „zł", w innym wypadku kod bez zmian. */
+/** Currency to display: PLN → „zł", otherwise the code unchanged. */
 function currencyLabel(currency?: string): string {
   if (!currency) return "zł";
   const c = currency.trim().toUpperCase();
   return c === "PLN" || c === "ZŁ" ? "zł" : currency;
 }
 
-/** „12,00 zł" dla znanej ceny; „cena w ofercie", gdy nieznana (placeholder). */
+/** „12,00 zł" for a known price; „cena w ofercie" when unknown (placeholder). */
 export function formatVintedPrice(value: number | null | undefined, currency?: string): string {
   if (value === null || value === undefined || !Number.isFinite(value)) return "cena w ofercie";
   return `${value.toFixed(2).replace(".", ",")} ${currencyLabel(currency)}`;
 }
 
 /**
- * Sortuje oferty rosnąco po cenie; oferty bez ceny (priceValue == null) lądują na
- * końcu. Zwraca NOWĄ tablicę (nie mutuje wejścia).
+ * Sorts offers ascending by price; offers without a price (priceValue == null) land at
+ * the end. Returns a NEW array (doesn't mutate the input).
  */
 export function sortOffersByPrice<T extends OfferLike>(items: T[]): T[] {
   return [...items].sort((a, b) => {
@@ -36,9 +36,9 @@ export function sortOffersByPrice<T extends OfferLike>(items: T[]): T[] {
 }
 
 /**
- * Czyści tytuł oferty do wyświetlenia: rozkodowuje encje HTML i odcina „ogon"
- * z opisu Vinted (kondycja „, Stan: …" oraz doklejone kwoty), bo ścieżki HTML
- * parsera biorą atrybut title aukcji z całym opisem i ceną w środku.
+ * Cleans the offer title for display: decodes HTML entities and cuts off the „tail"
+ * from the Vinted description (the „, Stan: …" condition and appended amounts), because the
+ * parser's HTML paths take the listing's title attribute with the whole description and price inside.
  */
 export function cleanOfferTitle(title: string): string {
   let t = (title || "")
@@ -47,12 +47,12 @@ export function cleanOfferTitle(title: string): string {
     .replace(/&#39;/g, "'")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">");
-  t = t.replace(/,\s*Stan:.*$/i, "");                 // odetnij kondycję i wszystko po niej
-  t = t.replace(/,?\s*\d+[.,]\d+\s*(?:zł|PLN).*$/i, ""); // awaryjnie: doklejony ogon cenowy
+  t = t.replace(/,\s*Stan:.*$/i, "");                 // cut off the condition and everything after it
+  t = t.replace(/,?\s*\d+[.,]\d+\s*(?:zł|PLN).*$/i, ""); // fallback: appended price tail
   return t.trim();
 }
 
-/** Minimalna cena (lub null, gdy żadna oferta nie ma ceny) i liczba ofert. */
+/** Minimum price (or null when no offer has a price) and the number of offers. */
 export function offersPriceSummary(items: OfferLike[]): { min: number | null; count: number } {
   const prices = items
     .map((i) => i.priceValue)
@@ -61,9 +61,9 @@ export function offersPriceSummary(items: OfferLike[]): { min: number | null; co
 }
 
 /**
- * Sortuje KARTY wyników po najtańszej ofercie każdej książki (rosnąco). Książki
- * bez żadnej znanej ceny lądują na końcu. Zwraca NOWĄ tablicę (nie mutuje).
- * Używane do dynamicznego układania wyników w trakcie skanu.
+ * Sorts result CARDS by each book's cheapest offer (ascending). Books
+ * without any known price land at the end. Returns a NEW array (doesn't mutate).
+ * Used for dynamically arranging results during the scan.
  */
 export function sortResultsByCheapest<T extends { vintedItems: OfferLike[] }>(results: T[]): T[] {
   return [...results].sort((a, b) => {

--- a/src/utils/vintedSellers.ts
+++ b/src/utils/vintedSellers.ts
@@ -1,6 +1,6 @@
 import { VintedResult } from "../hooks/useVintedCheck";
 
-/** Sprzedawca Vinted (dociągany ze strony oferty, nie z katalogu). */
+/** Vinted seller (fetched from the offer page, not from the catalog). */
 export interface VintedSeller {
   id: string;
   login: string;
@@ -10,30 +10,30 @@ export interface VintedSeller {
 export interface SellerBundleEntry {
   bookTitle: string;
   bookAuthor: string;
-  /** Rok wydania (metadana z Notion). */
+  /** Publication year (metadata from Notion). */
   bookYear?: string;
-  /** Czy książka jest częścią cyklu (metadana z Notion) — ryzyko „kolejny tom". */
+  /** Whether the book is part of a cycle (metadata from Notion) — risk of „another volume". */
   bookPartOfCycle?: boolean;
-  /** Nazwa cyklu (metadana z Notion, z żniw) — do etykiety kafelka cyklu. */
+  /** Cycle name (metadata from Notion, from the harvest) — for the cycle tile label. */
   bookCykl?: string;
-  /** Numer tomu w cyklu (metadana z Notion, z żniw). */
+  /** Volume number within the cycle (metadata from Notion, from the harvest). */
   bookCyklNr?: number;
-  /** Najtańsza kopia tej książki U TEGO sprzedawcy. */
+  /** The cheapest copy of this book FROM THIS seller. */
   item: VintedResult["vintedItems"][number];
-  /** Dopłata vs najtańsza kopia tej książki globalnie (0, gdy to właśnie najtańsza). */
+  /** Surcharge vs the cheapest copy of this book globally (0 when it is the cheapest). */
   premium: number;
 }
 
 export interface SellerBundle {
   seller: VintedSeller;
   entries: SellerBundleEntry[];
-  /** Suma cen (najtańsze kopie u tego sprzedawcy). */
+  /** Sum of prices (cheapest copies from this seller). */
   totalValue: number;
-  /** Łączna dopłata za konsolidację vs kupno każdej książki u najtańszego sprzedawcy. */
+  /** Total consolidation surcharge vs buying each book from the cheapest seller. */
   totalPremium: number;
 }
 
-/** Payload składowanej książki z `GET /api/vinted-stored` (etap 3). */
+/** Payload of a stored book from `GET /api/vinted-stored` (stage 3). */
 export interface StoredBookPayload {
   id: string;
   title: string;
@@ -50,15 +50,15 @@ export interface StoredBookPayload {
 export interface StoredView {
   results: VintedResult[];
   sellersByUrl: Record<string, VintedSeller | null>;
-  /** Najstarszy / najświeższy `scannedAt` w zbiorze (znacznik świeżości). */
+  /** Oldest / newest `scannedAt` in the set (freshness marker). */
   oldest: string | null;
   newest: string | null;
 }
 
 /**
- * Czysta transformacja składowanego payloadu → widok renderowalny tym samym UI co skan
- * live (VintedResult[] + mapa url→sprzedawca + zakres świeżości). Dzięki temu kafelki i
- * paczki lecą z bazy bez re-scrape, reużywając `groupBySeller` i istniejący render.
+ * Pure transformation of the stored payload → a view renderable by the same UI as the
+ * live scan (VintedResult[] + url→seller map + freshness range). This way tiles and
+ * bundles come from the DB without a re-scrape, reusing `groupBySeller` and the existing render.
  */
 export function storedToView(books: StoredBookPayload[]): StoredView {
   const results: VintedResult[] = [];
@@ -97,19 +97,19 @@ export function storedToView(books: StoredBookPayload[]): StoredView {
 }
 
 /**
- * Nakłada mapę `url → sprzedawca` (dociągniętą on-demand) na wyniki skanu i zwraca
- * paczki: sprzedawców mających ≥2 RÓŻNE książki. Dla każdej książki bierze NAJTAŃSZĄ
- * kopię danego sprzedawcy i liczy dopłatę vs najtańsza globalnie — dzięki temu widać
- * tradeoff „dopłacam grosze, ale konsoliduję przesyłkę". Czysta funkcja (bez I/O).
+ * Applies the `url → seller` map (fetched on-demand) onto the scan results and returns
+ * bundles: sellers having ≥2 DIFFERENT books. For each book it takes the CHEAPEST
+ * copy from the given seller and computes the surcharge vs the global cheapest — this way you see
+ * the tradeoff „I pay pennies extra but consolidate the shipment". Pure function (no I/O).
  *
- * Działa w obu trybach: „najtańsze" (tylko najtańsza oferta/książkę ma sprzedawcę →
- * dopłaty = 0) i „wszystkie oferty" (każda oferta ma sprzedawcę → ujawnia many-to-many).
+ * Works in both modes: „najtańsze" (only the cheapest offer/book has a seller →
+ * surcharges = 0) and „wszystkie oferty" (every offer has a seller → reveals many-to-many).
  */
 export function groupBySeller(
   results: VintedResult[],
   sellersByUrl: Record<string, VintedSeller | null>,
 ): SellerBundle[] {
-  // Najtańsza cena każdej książki GLOBALNIE (ze wszystkich jej ofert w skanie).
+  // The cheapest price of each book GLOBALLY (from all its offers in the scan).
   const globalMin = new Map<string, number>();
   for (const r of results) {
     const prices = r.vintedItems
@@ -118,7 +118,7 @@ export function groupBySeller(
     if (prices.length) globalMin.set(r.id, Math.min(...prices));
   }
 
-  // seller.id → (book id → najtańszy wpis tego sprzedawcy dla tej książki)
+  // seller.id → (book id → the cheapest entry from this seller for this book)
   const byId = new Map<string, { seller: VintedSeller; books: Map<string, SellerBundleEntry> }>();
   for (const r of results) {
     for (const item of r.vintedItems) {
@@ -156,17 +156,17 @@ export function groupBySeller(
       totalPremium: entries.reduce((sum, e) => sum + e.premium, 0),
     });
   }
-  // Domyślnie: najpierw najwięcej książek, potem najtańsza suma.
+  // By default: most books first, then the cheapest sum.
   return sortBundles(bundles, "count");
 }
 
-/** Kryterium sortowania paczek w UI. */
+/** Sort criterion for bundles in the UI. */
 export type BundleSortMode = "count" | "price";
 
 /**
- * Zwraca KOPIĘ paczek posortowaną wg trybu:
- * - `count`  — najwięcej książek, remis → najtańsza suma (domyślny);
- * - `price`  — najtańsza suma (`totalValue`), remis → najwięcej książek.
+ * Returns a COPY of the bundles sorted by mode:
+ * - `count`  — most books, tie → cheapest sum (default);
+ * - `price`  — cheapest sum (`totalValue`), tie → most books.
  */
 export function sortBundles(bundles: SellerBundle[], mode: BundleSortMode): SellerBundle[] {
   const copy = [...bundles];

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -21,17 +21,17 @@ import { createLogger, classifyHttpError } from "./logger";
 import { SyncEvent } from "./src/types";
 
 /**
- * Composition root domeny: buduje adaptery, serwisy i orkiestrator SyncManager.
- * Trzymane z dala od `server.ts` (który jest tylko entrypointem HTTP) — dzięki
- * temu kontrolery importują `syncManager` stąd, a nie z modułu serwera, co
- * kasuje cykl server → routes → controller → server.
+ * Domain composition root: builds the adapters, services and the SyncManager orchestrator.
+ * Kept away from `server.ts` (which is only the HTTP entrypoint) — so that
+ * controllers import `syncManager` from here, not from the server module, which
+ * breaks the server → routes → controller → server cycle.
  */
 
 const log = createLogger("SyncManager");
 
 const notionAdapter = new NotionAdapter(process.env.NOTION_API_KEY!, process.env.NOTION_DATABASE_ID!);
 const wikiAdapter = new WikiAdapter();
-/** Konfiguracja aplikacji (knoby) — defaulty + nadpisania z Notion; wstrzykiwana do serwisów. */
+/** App configuration (knobs) — defaults + overrides from Notion; injected into the services. */
 export const configService = new ConfigService(notionAdapter);
 const duplicateSyncService = new DuplicateSyncService(notionAdapter, wikiAdapter, configService);
 const bookSyncService = new BookSyncService(notionAdapter, wikiAdapter, configService);
@@ -53,7 +53,7 @@ interface SyncTask {
   cancelRequested: boolean;
 }
 
-/** Kanoniczne nazwy rytuałów synchronizacji — jedno źródło prawdy dla dispatchu. */
+/** Canonical sync ritual names — single source of truth for dispatch. */
 export type SyncTaskName =
   | "book"
   | "purify"
@@ -72,11 +72,11 @@ export type SyncTaskName =
 type TaskFn = (checkCancellation: () => boolean) => Promise<void>;
 
 /**
- * Rejestr rytuałów: nazwa → fabryka `taskFn`. Każdy serwis ma inaczej nazwaną
- * metodę `run*`, ale wszystkie mają ten sam kontrakt `(sendEvent, checkCancellation)`;
- * rejestr spina je w jedną tablicę, dzięki czemu SyncManager.run() jest jednym
- * generycznym dispatcherem zamiast kilkunastu bliźniaczych metod. `book` i
- * `library` przyjmują dodatkowe parametry z żądania (przez argument `params`).
+ * Ritual registry: name → `taskFn` factory. Each service has a differently named
+ * `run*` method, but they all share the same contract `(sendEvent, checkCancellation)`;
+ * the registry ties them into one table, so SyncManager.run() is a single
+ * generic dispatcher instead of a dozen twin methods. `book` and
+ * `library` take extra parameters from the request (via the `params` argument).
  */
 const TASK_REGISTRY: Record<SyncTaskName, (sendEvent: (data: SyncEvent) => void, params?: any) => TaskFn> = {
   book:       (s, p) => (cc) => bookSyncService.runBookSync(p ?? {}, s, cc),
@@ -111,7 +111,7 @@ class SyncManager {
     return await statsService.getStats();
   }
 
-  /** Odchudzony indeks książek dla wyszukiwarki „Skryptorium" (client-side). */
+  /** Slimmed-down book index for the „Skryptorium" search (client-side). */
   async getBooks() {
     const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
     return toSearchIndex(books);
@@ -132,8 +132,8 @@ class SyncManager {
     try {
       await taskFn(() => task.cancelRequested);
     } finally {
-      // Zwolnij blokadę tylko jeśli nadal należy do tego zadania —
-      // po resetSyncState() mogło już wystartować nowe zadanie
+      // Release the lock only if it still belongs to this task —
+      // after resetSyncState() a new task may have already started
       if (this.currentTask === task) {
         this.currentTask = null;
       }
@@ -141,9 +141,9 @@ class SyncManager {
   }
 
   /**
-   * Generyczny dispatch rytuału: pobiera fabrykę z rejestru, buduje `taskFn`
-   * i uruchamia ją pod blokadą pojedynczego zadania. `params` niosą dane
-   * z żądania dla rytuałów, które ich wymagają (`book`, `library`).
+   * Generic ritual dispatch: takes the factory from the registry, builds `taskFn`
+   * and runs it under the single-task lock. `params` carry data
+   * from the request for rituals that need it (`book`, `library`).
    */
   async run(taskName: SyncTaskName, sendEvent: (data: SyncEvent) => void, params?: any) {
     const makeTaskFn = TASK_REGISTRY[taskName];
@@ -155,32 +155,32 @@ class SyncManager {
     return await this.wiki.fetchLastRevisionDate(pageTitle);
   }
 
-  // Dopisuje znacznik „Źródło" na stronie książki. Domyślnie „Przeczytane"
-  // (przycisk w zasobach posiadanych / bibliotecznych statystykach), ale skaner
-  // bibliotek podaje znacznik filii („Biblioteka" = Felin, „Biblioteka 9" =
-  // Bronowice), aby oznaczyć, w której filii pozycja jest dostępna.
+  // Appends a „Źródło" tag on a book's page. Defaults to „Przeczytane"
+  // (button in owned resources / library stats), but the library scanner
+  // passes a branch tag („Biblioteka" = Felin, „Biblioteka 9" =
+  // Bronowice), to mark which branch the item is available in.
   async markAsRead(pageId: string, tag: string = "Przeczytane") {
     return await this.notion.addTagToMultiSelect(pageId, "Źródło", tag);
   }
 
-  /** Usuwa znacznik „Źródło" (odwrotność `markAsRead`) — drag&drop na regale. */
+  /** Removes a „Źródło" tag (inverse of `markAsRead`) — drag&drop on the shelf. */
   async unmarkRead(pageId: string, tag: string = "Przeczytane") {
     return await this.notion.removeTagFromMultiSelect(pageId, "Źródło", tag);
   }
 
-  /** Zapis ręcznych kluczy porządku regału (precyzyjny drag&drop). */
+  /** Writes manual shelf ordering keys (precise drag&drop). */
   async setShelfOrders(entries: { pageId: string; order: number }[]) {
     return await this.notion.setShelfOrders(entries);
   }
 
-  /** Odczyt składowanych wyników Vinted (kafelki/paczki z bazy — bez re-scrape). */
+  /** Reads stored Vinted results (tiles/bundles from the DB — no re-scrape). */
   async getVintedStored() {
     return await vintedSyncService.getStoredData();
   }
 
-  /** Podgląd cyklu dla książki (na żądanie, bez zapisu do bazy). */
-  /** Zagregowany widok cykli (z wierszy oznaczonych polem `Cykl`) dla Archiwum. */
-  /** `fresh` (ręczne „Odśwież Dane") pomija 5-min cache książek → dane jak w /api/stats. */
+  /** Cycle preview for a book (on demand, no DB writes). */
+  /** Aggregated cycles view (from rows tagged with the `Cykl` field) for the Archiwum. */
+  /** `fresh` (manual „Odśwież Dane") bypasses the 5-min book cache → data as in /api/stats. */
   async getCyclesHarvest(fresh = false) {
     const books = await this.notion.getBooksForStats(undefined, undefined, { cache: !fresh });
     return aggregateCycleRows(books);
@@ -191,10 +191,10 @@ class SyncManager {
   }
 
   /**
-   * Diagnostyka end-to-end: sprawdza połączenie z Notion oraz pobranie i
-   * parsowanie każdej strony nagrody z encyklopedii. Zwraca strukturę JSON,
-   * którą można otworzyć w przeglądarce (GET /api/diagnostics) — jedno miejsce,
-   * by zobaczyć, DLACZEGO sync nie działa (blokada IP, brak strony, 0 książek).
+   * End-to-end diagnostics: checks the Notion connection plus fetching and
+   * parsing each award page from the encyclopedia. Returns a JSON structure
+   * that can be opened in the browser (GET /api/diagnostics) — one place
+   * to see WHY sync doesn't work (IP block, missing page, 0 books).
    */
   async runDiagnostics() {
     const startedAt = Date.now();
@@ -209,7 +209,7 @@ class SyncManager {
       summary: "",
     };
 
-    // 1. Notion — inicjalizacja i lekki odczyt schematu
+    // 1. Notion — initialization and a light schema read
     try {
       await this.notion.init();
       const schema = await this.notion.getSchema();
@@ -220,7 +220,7 @@ class SyncManager {
       log.error("Diagnostics: Notion FAILED", report.notion);
     }
 
-    // 2. Wiki — pobranie każdej strony nagrody z osobna (lista z konfiguracji `sync.awards`)
+    // 2. Wiki — fetch each award page separately (list from the `sync.awards` config)
     const AWARDS = (await configService.getConfig()).sync.awards;
     for (const aw of AWARDS) {
       const t0 = Date.now();
@@ -247,7 +247,7 @@ class SyncManager {
       }
     }
 
-    // 3. Podsumowanie diagnozy
+    // 3. Diagnosis summary
     const wikiOk = report.wiki.filter((w: any) => w.ok);
     const wikiBlocked = report.wiki.filter((w: any) => w.classification === "ip_blocked");
     if (!report.notion.ok) {
@@ -274,14 +274,14 @@ class SyncManager {
   }
 
   resetSyncState() {
-    // Anuluj aktywne zadanie, ale NIE zeruj blokady natychmiast. Wcześniej
-    // resetSyncState od razu ustawiał currentTask = null, przez co isSyncing
-    // stawał się false i kolejny POST /sync-* startował drugie zadanie, gdy
-    // osierocone wciąż pisało do Notion (łamiąc "dokładnie jeden sync naraz").
-    // Zamiast tego sygnalizujemy anulowanie; blokada zwolni się w `finally`
-    // zadania (identity-check), gdy zauważy cancelRequested i wyjdzie — a że
-    // wszystkie rytuały sprawdzają checkCancellation w pętlach i mają ograniczone
-    // timeouty (axios/withRetry), następuje to szybko i bez okna równoległych zapisów.
+    // Cancel the active task, but do NOT reset the lock immediately. Previously
+    // resetSyncState set currentTask = null right away, so isSyncing
+    // became false and the next POST /sync-* started a second task while
+    // the orphaned one was still writing to Notion (breaking "exactly one sync at a time").
+    // Instead we signal cancellation; the lock releases in the task's `finally`
+    // (identity-check) once it notices cancelRequested and exits — and since
+    // all rituals check checkCancellation in their loops and have bounded
+    // timeouts (axios/withRetry), this happens quickly and without a window of concurrent writes.
     this.stopActiveSync();
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import {version} from './metadata.json';
 
 export default defineConfig(() => {
   return {
-    // Wersja aplikacji (źródło prawdy: metadata.json) w kodzie klienta jako __APP_VERSION__.
+    // App version (source of truth: metadata.json) in client code as __APP_VERSION__.
     define: {
       __APP_VERSION__: JSON.stringify(version),
     },

--- a/wiki.adapter.ts
+++ b/wiki.adapter.ts
@@ -21,9 +21,9 @@ const wikiAxios = axios.create({
 });
 
 /**
- * Błąd pobierania z encyklopedii z rozpoznaną klasą przyczyny.
- * Serwisy i diagnostyka mogą odczytać `classification` i `userHint`,
- * żeby pokazać użytkownikowi konkretną, użyteczną informację.
+ * A fetch error from the encyclopedia with a recognized cause class.
+ * Services and diagnostics can read `classification` and `userHint`
+ * to show the user a specific, useful message.
  */
 export class WikiFetchError extends Error {
   classification: ErrorClass;
@@ -44,10 +44,10 @@ export class WikiAdapter {
   private readonly baseUrl = "https://encyklopediafantastyki.pl/api.php";
 
   /**
-   * Zwraca wikitext strony lub "" gdy strona nie istnieje.
-   * Rzuca błąd przy awarii infrastruktury (blokada IP, timeout po retry) —
-   * brak strony i awaria sieci to różne sytuacje i serwisy muszą je rozróżniać,
-   * inaczej pełna awaria raportuje się jako pusty, "udany" sync.
+   * Returns a page's wikitext or "" when the page doesn't exist.
+   * Throws on infrastructure failure (IP block, timeout after retry) —
+   * a missing page and a network failure are different situations and services must
+   * distinguish them, otherwise a full failure reports as an empty, "successful" sync.
    */
   async fetchPageContent(title: string): Promise<string> {
     try {
@@ -63,8 +63,8 @@ export class WikiAdapter {
         }
       }), 3, 2000);
 
-      // Z formatversion=2 pages jest tablicą, a treść leży w rev.content;
-      // obsłuż oba kształty (starsze MediaWiki ignorują formatversion)
+      // With formatversion=2 pages is an array, and the content is in rev.content;
+      // handle both shapes (older MediaWiki ignore formatversion)
       const pages = response.data.query?.pages;
       const page = Array.isArray(pages) ? pages[0] : pages?.[Object.keys(pages ?? {})[0]];
 
@@ -119,9 +119,9 @@ export class WikiAdapter {
   }
 
   /**
-   * Pobiera treść wielu stron. Zwraca mapę treści oraz listę tytułów,
-   * których nie udało się pobrać (awaria chunka) — serwisy raportują je
-   * w podsumowaniu zamiast cicho pomijać książki.
+   * Fetches the content of multiple pages. Returns a content map plus a list of titles
+   * that couldn't be fetched (chunk failure) — services report them in the
+   * summary instead of silently skipping books.
    */
   async fetchPagesContentBulk(titles: string[]): Promise<{ contents: Record<string, string>, failedTitles: string[] }> {
     const results: Record<string, string> = {};
@@ -134,8 +134,8 @@ export class WikiAdapter {
       const titlesParam = chunk.join('|');
 
       try {
-        // MediaWiki tnie duże odpowiedzi (limity rozmiaru rewizji) i zwraca
-        // token continue — podążaj za nim, inaczej część stron cicho przepada
+        // MediaWiki truncates large responses (revision size limits) and returns
+        // a continue token — follow it, otherwise some pages silently disappear
         let continueParams: Record<string, string> = {};
         do {
           const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
@@ -254,7 +254,7 @@ export class WikiAdapter {
     } catch (error: any) {
       const info = classifyHttpError(error);
       log.warn(`Pobieranie kategorii "${category}" nieudane (zwracam ${allTitles.length} zebranych)`, { class: info.class, status: info.status, code: info.code, message: error?.message });
-      // Zwróć to, co udało się zebrać przed awarią, zamiast wyrzucać częściowe wyniki
+      // Return what was collected before the failure, instead of discarding partial results
       return allTitles;
     }
   }

--- a/wiki.parser.ts
+++ b/wiki.parser.ts
@@ -4,10 +4,10 @@ import { normalizeData } from "./services/dataNormalizer";
 
 export class WikiParser {
   /**
-   * Parsuje tabelę wyników nagrody z wikitekstu ({{tabela wydania}} / wikitable)
-   * na listę książek. Czysta funkcja (bez I/O) — pobranie strony i zdarzenia SSE
-   * zostają w BookSyncService.fetchBooksFromMediaWiki. `awardName` decyduje o
-   * etykiecie Nagroda/Nominacja i o wykluczeniu kategorii YA dla Locusa.
+   * Parses an award results table from wikitext ({{tabela wydania}} / wikitable)
+   * into a list of books. A pure function (no I/O) — page fetching and SSE events
+   * stay in BookSyncService.fetchBooksFromMediaWiki. `awardName` determines the
+   * Nagroda/Nominacja label and the exclusion of the YA category for Locus.
    */
   static parseAwardTable(wikitext: string, awardName: string): Book[] {
     const books: Book[] = [];
@@ -90,8 +90,8 @@ export class WikiParser {
         const cellText = parseCell(cells[0]) as string;
         const yearOnly = cellText.replace(/['\[\]]/g, '').trim().match(/^(\d{4})$/);
         if (yearOnly) {
-          // Wiersz zawierający wyłącznie rok (rowspan) — to nowy rocznik,
-          // nie dodatkowy autor poprzedniej książki
+          // A row containing only a year (rowspan) — this is a new year,
+          // not an additional author of the previous book
           lastYear = yearOnly[1];
         } else if (books.length > 0) {
           const extraAuthor = cellText.replace(/\s*\(remis\)/gi, '').trim();
@@ -166,15 +166,15 @@ export class WikiParser {
     let wydawca = "";
     let seria = "";
 
-    // 1. Pobierz wartości ogólne z {{Książka}} (jako fallback)
-    // Wartość może zawierać linki z pipe ([[Cel|Etykieta]]) — dopasowuj całe [[...]]
+    // 1. Get the general values from {{Książka}} (as a fallback)
+    // The value may contain piped links ([[Target|Label]]) — match the whole [[...]]
     const wydawcaMatch = wikitext.match(/\|\s*wydawca\s*=\s*((?:\[\[[^\]]*\]\]|[^\n|])+)/i);
     if (wydawcaMatch) wydawca = this.cleanWikitext(wydawcaMatch[1]);
 
     const seriaMatch = wikitext.match(/\|\s*seria\s*=\s*((?:\[\[[^\]]*\]\]|[^\n|])+)/i);
     if (seriaMatch) seria = this.cleanWikitext(seriaMatch[1]);
 
-    // 2. Pobierz wartości z {{tabela wydania}} (infowydanie) - priorytet dla najwyższego N z danymi
+    // 2. Get the values from {{tabela wydania}} (infowydanie) - priority to the highest N with data
     const infoRegex = /\|\s*informacja(\d+)\s*=\s*\{\{infowydanie\s*\|([\s\S]*?)\}\}/gi;
     
     let match;
@@ -183,11 +183,11 @@ export class WikiParser {
       infos.push({ n: parseInt(match[1], 10), content: match[2] });
     }
 
-    // Sortuj od najwyższego N, aby znaleźć najnowsze wydanie z danymi
+    // Sort from the highest N, to find the newest edition with data
     infos.sort((a, b) => b.n - a.n);
 
     for (const info of infos) {
-      // Kotwica (?:^|\|) — nie dopasowuj wewnątrz innych parametrów (np. "współwydawca")
+      // Anchor (?:^|\|) — don't match inside other parameters (e.g. "współwydawca")
       const infoWydawcaMatch = info.content.match(/(?:^|\|)\s*wydawca\s*=\s*((?:\[\[[^\]]*\]\]|[^\n|])+)/i);
       const infoSeriaMatch = info.content.match(/(?:^|\|)\s*seria\s*=\s*((?:\[\[[^\]]*\]\]|[^\n|])+)/i);
 
@@ -195,9 +195,9 @@ export class WikiParser {
       const foundSeria = infoSeriaMatch ? this.cleanWikitext(infoSeriaMatch[1]) : "";
 
       if (foundWydawca || foundSeria) {
-        // Najnowsze wydanie z danymi jest miarodajne w całości — przypisz OBA pola,
-        // także puste. Nie pozwól, by seria ze starszego wydania (lub z globalnego
-        // fallbacku {{Książka}}) przeciekła, gdy najnowsze wydanie jej nie ma.
+        // The newest edition with data is authoritative in full — assign BOTH fields,
+        // including empty ones. Don't let a series from an older edition (or from the
+        // global {{Książka}} fallback) leak through when the newest edition lacks it.
         wydawca = foundWydawca;
         seria = foundSeria;
         break;
@@ -209,20 +209,20 @@ export class WikiParser {
 
   static extractAuthor(wikitext: string): string {
     // Look for autor, twórca, or redaktor in infoboxes.
-    // Wartość może zawierać szablony/linki z pipe: {{sortname|Ursula K.|Le Guin}},
-    // {{Autor|Jan Kowalski}}, [[Stanisław Lem|Lem, Stanisław]]. Dopasuj całe
-    // [[...]]/{{...}} jako jeden token — inaczej capture `[^\n|]+` ucinał wartość na
-    // pierwszym `|` (np. do "{{sortname"), przez co czyszczenie szablonów w
-    // cleanWikitext nigdy nie miało czego przetworzyć.
+    // The value may contain piped templates/links: {{sortname|Ursula K.|Le Guin}},
+    // {{Autor|Jan Kowalski}}, [[Stanisław Lem|Lem, Stanisław]]. Match the whole
+    // [[...]]/{{...}} as one token — otherwise the capture `[^\n|]+` cut the value at
+    // the first `|` (e.g. down to "{{sortname"), so the template cleanup in
+    // cleanWikitext never had anything to process.
     const authorRegex = /\|\s*(autor|twórca|redaktor|scenariusz|tekst)\s*=\s*((?:\[\[[^\]]*\]\]|\{\{[^{}]*\}\}|[^\n|])+)/gi;
     let match;
     let authors: string[] = [];
 
     while ((match = authorRegex.exec(wikitext)) !== null) {
-      // cleanWikitext rozwija [[Cel|Etykieta]]→Etykieta, {{sortname|a|b}}→"a b",
-      // {{Autor|a}}→a i usuwa pozostałe szablony/znaczniki.
+      // cleanWikitext expands [[Target|Label]]→Label, {{sortname|a|b}}→"a b",
+      // {{Autor|a}}→a and removes the remaining templates/markup.
       const cleaned = this.cleanWikitext(match[2]);
-      // Pusty parametr (np. "| redaktor = " ze spacją) matchuje — odfiltruj
+      // An empty parameter (e.g. "| redaktor = " with a space) matches — filter it out
       if (cleaned) authors.push(cleaned);
     }
     
@@ -239,16 +239,16 @@ export class WikiParser {
   }
 
   /**
-   * Wyciąga informacje o cyklu z infoboksu `{{Książka}}`: nazwę cyklu (`|cykl=`),
-   * sąsiednie tomy (`|poprzednia=` / `|następna=` — łańcuch prev/next, potwierdzony
-   * na realnym rawie) oraz — oportunistycznie — tytuły z linków w szablonie
-   * nawigacyjnym `{{Cykl…}}`. Wołane w podglądzie cyklu (bez zapisu do bazy).
-   * `|następna=`/`|nastepna=` oba warianty (encyklopedia bywa niespójna w ogonku).
+   * Extracts cycle info from the `{{Książka}}` infobox: the cycle name (`|cykl=`),
+   * neighboring volumes (`|poprzednia=` / `|następna=` — the prev/next chain, confirmed
+   * on real raw) and — opportunistically — titles from links in the navigation
+   * template `{{Cykl…}}`. Called in the cycle preview (no DB writes).
+   * `|następna=`/`|nastepna=` both variants (the encyclopedia is sometimes inconsistent in the suffix).
    */
   static extractCycleInfo(wikitext: string): { cycleName: string; prev: string | null; next: string | null; templateVolumes: string[] } {
     if (!wikitext) return { cycleName: "", prev: null, next: null, templateVolumes: [] };
 
-    // Pojedyncza wartość parametru infoboksu (całe [[...]]/{{...}} jako token, ucięcie na następnym `|`).
+    // A single infobox parameter value (whole [[...]]/{{...}} as a token, cut at the next `|`).
     const field = (name: string): string => {
       const re = new RegExp(`\\|\\s*${name}\\s*=\\s*((?:\\[\\[[^\\]]*\\]\\]|\\{\\{[^{}]*\\}\\}|[^\\n|])+)`, "i");
       const m = wikitext.match(re);
@@ -259,7 +259,7 @@ export class WikiParser {
     const prev = field("poprzednia") || field("poprzedni") || "";
     const next = field("następna") || field("nastepna") || field("następny") || field("nastepny") || "";
 
-    // Szablon nawigacyjny {{Cykl…}} — zbierz cele wikilinków [[Tytuł]] w kolejności.
+    // Navigation template {{Cykl…}} — collect the wikilink targets [[Tytuł]] in order.
     const templateVolumes: string[] = [];
     const tplMatch = wikitext.match(/\{\{\s*cykl[^{}]*(?:\{\{[^{}]*\}\}[^{}]*)*\}\}/i);
     if (tplMatch) {


### PR DESCRIPTION
Tłumaczenie wszystkich polskich komentarzy w kodzie na angielski (146 plików) — komentarze liniowe, blokowe, JSDoc i JSX. Zmiana **wyłącznie w komentarzach**:

- Bez zmian w kodzie, literałach stringów, template literals, regexach ani tekście JSX. Polskie UI, komunikaty SSE/statusów/błędów, logi i wartości kolumn/tagów Notion pozostają bajt-w-bajt (UI aplikacji dalej po polsku).
- Polskie literalne identyfikatory, które komentarz nazywa — wartości kolumn/select Notion („Kategoria", „Cykl", „CyklNr", „Źródło", „Tom cyklu", „Nagroda", „Przeczytane", „Posiadam", „Vinted"…), nazwy szablonów/pól MediaWiki (`{{Książka}}`, `|cykl=`) oraz nazwy własne rytuałów/UI (Rytuał Żniw, Skryptorium, Regał, Archiwum Cykli) — zachowane w niezmienionej formie wewnątrz angielskiej już prozy.

Realizacja przez 7 równoległych subagentów (po katalogach), każdy z identycznymi surowymi regułami.

**Weryfikacja:** `tsc --noEmit` czysty; cały suite zielony (407 testów, w tym asercje na dokładne polskie stringi); dodatkowo strukturalnie potwierdzone, że kod przed każdym komentarzem inline jest bajt-w-bajt identyczny (zmienił się tylko tekst komentarza). Bez bumpa wersji (tylko komentarze — precedens PR-ów dokumentacyjnych/komentarzowych).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_