### PR TITLE
chore: normalizacja lockfile (playwright-core tylko jako optional)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "lucide-react": "^0.546.0",
         "motion": "^12.38.0",
         "p-limit": "^7.3.0",
-        "playwright-core": "*",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },


### PR DESCRIPTION
Usunięcie zbłąkanego wpisu `playwright-core` z `dependencies` roota w `package-lock.json` — `package.json` ma go tylko w `optionalDependencies`, więc lockfile teraz się zgadza. Tylko lockfile, bez bumpa wersji (naprawia dryf, który potrafi wywołać stop-hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_