### PR TITLE
feat(skryptorium): ISBN resolver backend for barcode scan (variant A, PR1)

### DIFF
--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -133,6 +133,36 @@ describe("GET /api/cycles-harvest", () => {
   });
 });
 
+describe("GET /api/isbn/:code", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NOTION_API_KEY = "test-key";
+    process.env.NOTION_DATABASE_ID = "test-db";
+  });
+
+  it("rejects an invalid ISBN with 400 and never calls the resolver", async () => {
+    const spy = vi.spyOn(syncManager, "lookupIsbn").mockResolvedValue(null as any);
+    const res = await request(app).get("/api/isbn/not-an-isbn");
+    expect(res.status).toBe(400);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the ISBN resolves to nothing", async () => {
+    const spy = vi.spyOn(syncManager, "lookupIsbn").mockResolvedValue(null as any);
+    const res = await request(app).get("/api/isbn/9780306406157");
+    expect(res.status).toBe(404);
+    expect(spy).toHaveBeenCalledWith("9780306406157");
+  });
+
+  it("returns the resolved book on a hit", async () => {
+    const book = { isbn: "9780306406157", title: "T", author: "A", source: "google-books" as const };
+    vi.spyOn(syncManager, "lookupIsbn").mockResolvedValue(book);
+    const res = await request(app).get("/api/isbn/0306406152"); // ISBN-10 → normalized to 13
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(book);
+  });
+});
+
 describe("POST /api/mark-as-read", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.48.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.49.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.48.0** — **Vinted anty-blok pkt 2: priming przez headless browser (Playwright).** `browserPrime.ts` —
+- **1.49.0** — **Skryptorium: skaner kodów kreskowych — PR1 (backend resolver ISBN, wariant A).** Fizyczny
+  kod kreskowy = EAN-13 = ISBN-13, ale baza Notion NIE trzyma ISBN → kod nie dopasuje wiersza wprost;
+  potrzebna rezolucja ISBN→tytuł, potem istniejąca rozmyta wyszukiwarka. Czyste helpery `services/isbn.ts`
+  (`normalizeIsbn`: czyszczenie, walidacja sum kontrolnych ISBN-13/10, konwersja 10→13, odrzut nie-książkowych
+  EAN prefix≠978/979). `services/isbnLookupService.ts` (`lookupIsbn`): Google Books `q=isbn:{isbn}` (bez
+  klucza), mapowanie `items[0].volumeInfo`→`{isbn,title,author,year,source}`, cache w pamięci procesu.
+  Wpięcie: `syncManager.lookupIsbn`, `GET /api/isbn/:code` (`getIsbn`: 400 zły ISBN / 404 brak / 200 hit,
+  `normalizeIsbn` na wejściu). +11 testów. NASTĘPNE: PR2 (kolumna `ISBN` w Notion + rytuał wzbogacania po
+  tytule+autorze → wariant B: skan dopasowuje wprost), PR3 (mobilny przycisk skanu w Skryptorium →
+  `BarcodeDetector` → exact match po `isbn` (B) else resolve→fuzzy (A) + ręczny fallback ISBN). priming przez headless browser (Playwright).** `browserPrime.ts` —
   headless Chromium (`playwright-core`, optionalDependency, dynamic import) rozwiązuje wyzwanie JS Cloudflare
   po prawdziwe `cf_clearance` + UA, wpuszczane do `VintedSession` używanej dalej przez lekki axios. Knob
   `vinted.primeWithBrowser` (default off) + checkbox w Kalibracji, wpięte w skan i resolve sprzedawców.
@@ -799,6 +808,24 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 - **1.0.0** — Stan bazowy.
 
 ## Otwarte pozycje
+
+- **Skryptorium: skaner kodów kreskowych (mobile) — feature W TOKU (A+B), 3 PR-y.** Cel: LOOKUP
+  („czy ta fizyczna książka to jedna z moich śledzonych nagrodowych?"), NIE dodawanie do bazy. Decyzje
+  użytkownika: A+B, zgoda na Google Books (external), sprzęt=Android → natywny `BarcodeDetector` (bez nowej
+  zależności skanera). Rdzeń problemu: baza Notion NIE trzyma ISBN → kod nie dopasuje wiersza wprost.
+  - **PR1 — backend resolver ISBN (wariant A)** — ✅ ZREALIZOWANE (1.49.0). `services/isbn.ts` (`normalizeIsbn`)
+    + `services/isbnLookupService.ts` (`lookupIsbn` Google Books, cache) + `GET /api/isbn/:code`.
+  - **PR2 — kolumna `ISBN` w Notion + rytuał wzbogacania (wariant B)** — TODO. Nowa kolumna `ISBN` (rich_text)
+    w `requiredProps` (Rytuał Inicjacji Schematu); rytuał wzbogacania: dla nagrodowych bez ISBN → Google Books
+    po tytule+autorze → zapis „najlepszego dopasowania"; mapper czyta `isbn`; indeks wyszukiwarki dostaje `isbn`
+    (exact-match skanu bez zapytania zewnętrznego).
+  - **PR3 — frontend skanu (mobile)** — TODO. Przycisk skanu w Skryptorium (tylko gdy `BarcodeDetector`
+    dostępny) → modal kamery → exact match po zapisanym `isbn` (B), inaczej resolve→fuzzy-search (A);
+    ręczny fallback wpisania ISBN.
+  - **ZASTRZEŻENIA / ODŁOŻONE**: (a) iOS Safari NIE ma natywnego `BarcodeDetector` — fallback `@zxing/browser`
+    odłożony (v1 = Android/Chrome); (b) multi-edition ISBN — książka ma wiele ISBN wydań, wzbogacanie (B)
+    zapisuje JEDNO „najlepsze" z Google Books, często ≠ ISBN fizycznego egzemplarza → wariant A (resolve→tytuł
+    →fuzzy) jest bezpieczniejszą siecią; docelowo można trzymać listę ISBN wydań, nie jeden.
 
 - **Vinted znowu zablokował skaner — alternatywy w zanadrzu** — NOTATKA (Vinted ubił skan z IP Render/datacenter).
   Co JUŻ mamy (obrona pasywna): throttle 3–5 s + jitter na każdej ścieżce, pula User-Agent (rotacja,

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -3,6 +3,7 @@ import { syncManager, SyncTaskName, configService } from "../syncManager";
 import { SyncParams } from "../src/types";
 import { createLogger } from "../logger";
 import { executeSyncTask } from "./sseStream";
+import { normalizeIsbn } from "../services/isbn";
 
 const log = createLogger("SyncController");
 
@@ -315,6 +316,20 @@ export const getCycle = async (req: Request, res: Response) => {
   } catch (error: any) {
     log.error("Cycle lookup error", { title, message: error?.message });
     res.status(500).json({ error: error.message || "Błąd podglądu cyklu." });
+  }
+};
+
+export const getIsbn = async (req: Request, res: Response) => {
+  const code = typeof req.params.code === "string" ? req.params.code : "";
+  const isbn = normalizeIsbn(code);
+  if (!isbn) return res.status(400).json({ error: "Nieprawidłowy ISBN." });
+  try {
+    const book = await syncManager.lookupIsbn(isbn);
+    if (!book) return res.status(404).json({ error: "Nie znaleziono książki dla tego ISBN." });
+    res.json(book);
+  } catch (error: any) {
+    log.error("ISBN lookup error", { isbn, message: error?.message });
+    res.status(500).json({ error: error.message || "Błąd wyszukiwania ISBN." });
   }
 };
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.48.0",
+      "version": "1.49.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.48.0",
+  "version": "1.49.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -44,6 +44,7 @@ router.post("/vinted-resolve-sellers", syncController.resolveVintedSellers);
 router.post("/vinted-resolve-sellers/stop", syncController.stopVintedResolveSellers);
 router.get("/vinted-stored", syncController.getVintedStored);
 router.get("/cycle", syncController.getCycle);
+router.get("/isbn/:code", syncController.getIsbn);
 router.get("/cycles-harvest", syncController.getCyclesHarvest);
 router.post("/library-check", syncController.checkLibraryAvailability);
 

--- a/services/__tests__/isbn.test.ts
+++ b/services/__tests__/isbn.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { normalizeIsbn, isValidIsbn13, isValidIsbn10, isbn10to13 } from "../isbn";
+
+describe("isbn helpers", () => {
+  it("validates ISBN-13 checksums", () => {
+    expect(isValidIsbn13("9788375780635")).toBe(true); // real ISBN-13
+    expect(isValidIsbn13("9788375780636")).toBe(false); // bad check digit
+    expect(isValidIsbn13("978837578063")).toBe(false);  // 12 digits
+  });
+
+  it("validates ISBN-10 checksums (incl. trailing X)", () => {
+    expect(isValidIsbn10("0306406152")).toBe(true);
+    expect(isValidIsbn10("080442957X")).toBe(true); // X check char
+    expect(isValidIsbn10("0306406153")).toBe(false);
+  });
+
+  it("converts ISBN-10 to ISBN-13", () => {
+    expect(isbn10to13("0306406152")).toBe("9780306406157");
+  });
+
+  it("normalizes messy input to a canonical ISBN-13", () => {
+    expect(normalizeIsbn("978-83-7578-063-5")).toBe("9788375780635");
+    expect(normalizeIsbn(" 0306406152 ")).toBe("9780306406157"); // ISBN-10 → 13
+  });
+
+  it("rejects non-book EAN-13 (prefix not 978/979) and bad checksums", () => {
+    expect(normalizeIsbn("5901234123457")).toBeNull(); // valid EAN, not a book prefix
+    expect(normalizeIsbn("9788375780636")).toBeNull(); // book prefix, bad checksum
+    expect(normalizeIsbn("hello")).toBeNull();
+    expect(normalizeIsbn("")).toBeNull();
+  });
+});

--- a/services/__tests__/isbnLookupService.test.ts
+++ b/services/__tests__/isbnLookupService.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+import { lookupIsbn } from "../isbnLookupService";
+
+vi.mock("axios");
+const mockedGet = axios.get as unknown as ReturnType<typeof vi.fn>;
+
+describe("lookupIsbn", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns null for an invalid ISBN without hitting the API", async () => {
+    const r = await lookupIsbn("not-an-isbn");
+    expect(r).toBeNull();
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("maps a Google Books hit to {isbn,title,author,year}", async () => {
+    mockedGet.mockResolvedValue({
+      data: { items: [{ volumeInfo: { title: "Diuna", subtitle: "Kroniki", authors: ["Frank Herbert"], publishedDate: "1965-08-01" } }] },
+    });
+    const r = await lookupIsbn("978-83-7578-063-5");
+    expect(r).toEqual({ isbn: "9788375780635", title: "Diuna: Kroniki", author: "Frank Herbert", year: "1965", source: "google-books" });
+  });
+
+  it("returns null when Google Books has no volume for the ISBN", async () => {
+    mockedGet.mockResolvedValue({ data: { totalItems: 0, items: [] } });
+    const r = await lookupIsbn("9780306406157");
+    expect(r).toBeNull();
+  });
+});

--- a/services/isbn.ts
+++ b/services/isbn.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure ISBN helpers (no I/O). A scanned book barcode is an EAN-13 = ISBN-13.
+ * We normalize everything to a validated ISBN-13 so lookups and stored values
+ * compare on one canonical form. ISBN-10 (older books) is converted to 13.
+ */
+
+/** Keep only digits and a trailing X (ISBN-10 check char); uppercase the X. */
+function cleanIsbnChars(raw: string): string {
+  return (raw || "").replace(/[^0-9Xx]/g, "").toUpperCase();
+}
+
+/** EAN-13 / ISBN-13 checksum: Σ d_i·(1,3,1,3…) ≡ 0 (mod 10). */
+export function isValidIsbn13(s: string): boolean {
+  if (!/^\d{13}$/.test(s)) return false;
+  let sum = 0;
+  for (let i = 0; i < 13; i++) sum += Number(s[i]) * (i % 2 === 0 ? 1 : 3);
+  return sum % 10 === 0;
+}
+
+/** ISBN-10 checksum: Σ d_i·(10-i) ≡ 0 (mod 11); last digit may be X (=10). */
+export function isValidIsbn10(s: string): boolean {
+  if (!/^\d{9}[0-9X]$/.test(s)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) sum += Number(s[i]) * (10 - i);
+  sum += s[9] === "X" ? 10 : Number(s[9]);
+  return sum % 11 === 0;
+}
+
+/** ISBN-10 → ISBN-13 (prefix 978, recompute the check digit). Assumes a valid ISBN-10. */
+export function isbn10to13(isbn10: string): string {
+  const core = "978" + isbn10.slice(0, 9);
+  let sum = 0;
+  for (let i = 0; i < 12; i++) sum += Number(core[i]) * (i % 2 === 0 ? 1 : 3);
+  const check = (10 - (sum % 10)) % 10;
+  return core + check;
+}
+
+/**
+ * Normalize any scanned/typed code to a canonical, checksum-valid ISBN-13, or null
+ * when it isn't a real ISBN (wrong length, bad checksum, non-book EAN). EAN-13s that
+ * aren't books (prefix ≠ 978/979) are rejected so a random product barcode can't match.
+ */
+export function normalizeIsbn(raw: string): string | null {
+  const s = cleanIsbnChars(raw);
+  if (s.length === 13) {
+    return isValidIsbn13(s) && (s.startsWith("978") || s.startsWith("979")) ? s : null;
+  }
+  if (s.length === 10) {
+    return isValidIsbn10(s) ? isbn10to13(s) : null;
+  }
+  return null;
+}

--- a/services/isbnLookupService.ts
+++ b/services/isbnLookupService.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+import { normalizeIsbn } from "./isbn";
+import { createLogger } from "../logger";
+
+/**
+ * Resolves an ISBN to a book (title + author) via the Google Books API. This is the
+ * engine of the barcode "variant A": the scanned code has no direct row in the base
+ * (we don't store ISBNs by default), so we resolve it to a title and hand that to the
+ * existing Skryptorium fuzzy search. Backend-side to dodge CORS and cache repeats.
+ */
+
+const log = createLogger("IsbnLookup");
+const GOOGLE_BOOKS = "https://www.googleapis.com/books/v1/volumes";
+
+export interface IsbnBook {
+  /** Canonical ISBN-13 that was resolved. */
+  isbn: string;
+  title: string;
+  author: string;
+  year?: string;
+  source: "google-books";
+}
+
+// Process-memory cache keyed by canonical ISBN-13. `null` = looked up, not found
+// (cached to avoid re-hitting the API); transient errors are NOT cached.
+const cache = new Map<string, IsbnBook | null>();
+
+export async function lookupIsbn(rawCode: string): Promise<IsbnBook | null> {
+  const isbn = normalizeIsbn(rawCode);
+  if (!isbn) return null;
+  if (cache.has(isbn)) return cache.get(isbn)!;
+  try {
+    const res = await axios.get(GOOGLE_BOOKS, { params: { q: `isbn:${isbn}` }, timeout: 10000 });
+    const info = res.data?.items?.[0]?.volumeInfo;
+    if (!info?.title) {
+      cache.set(isbn, null);
+      return null;
+    }
+    const book: IsbnBook = {
+      isbn,
+      title: [info.title, info.subtitle].filter(Boolean).join(": "),
+      author: Array.isArray(info.authors) ? info.authors.join(", ") : "",
+      year: typeof info.publishedDate === "string" ? info.publishedDate.slice(0, 4) : undefined,
+      source: "google-books",
+    };
+    cache.set(isbn, book);
+    return book;
+  } catch (e: any) {
+    log.warn("Błąd zapytania Google Books", { isbn, error: e?.message });
+    return null;
+  }
+}

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -15,6 +15,7 @@ import { VintedSyncService } from "./services/vintedSyncService";
 import { CycleLookupService } from "./services/cycleLookupService";
 import { CycleHarvestService } from "./services/cycleHarvestService";
 import { aggregateCycleRows } from "./services/cycleRows";
+import { lookupIsbn } from "./services/isbnLookupService";
 import { toSearchIndex } from "./services/bookSearchIndex";
 import { ConfigService } from "./services/configService";
 import { createLogger, classifyHttpError } from "./logger";
@@ -188,6 +189,11 @@ class SyncManager {
 
   async getCycle(title: string, author: string) {
     return await cycleLookupService.lookup(title, author);
+  }
+
+  /** Resolves a scanned/typed ISBN to a book (title + author) via Google Books. */
+  async lookupIsbn(code: string) {
+    return await lookupIsbn(code);
   }
 
   /**


### PR DESCRIPTION
Fixes #259

First slice of the mobile barcode-scanning feature. A physical barcode is EAN-13 = ISBN-13, but the Notion DB stores no ISBN, so a scanned code cannot match a row directly. PR1 lays the **variant A** resolution engine: ISBN → title (Google Books) → existing fuzzy search.

## Changes

- **`services/isbn.ts`** — pure helpers. `normalizeIsbn` cleans input, validates ISBN-13/10 checksums, converts ISBN-10→13, normalizes to canonical ISBN-13, and rejects non-book EANs (prefix ≠ 978/979) and bad checksums.
- **`services/isbnLookupService.ts`** — `lookupIsbn`: Google Books `q=isbn:{isbn}` (no API key), maps `items[0].volumeInfo` → `{ isbn, title, author, year, source }`, caches results (incl. misses) in-process. Network failure logs a warning and returns null.
- **Wiring** — `syncManager.lookupIsbn` (read-only getter), controller `getIsbn`, route `GET /api/isbn/:code`. `normalizeIsbn` runs on input → 400 for invalid, 404 for no-hit, 200 with the resolved book.

## Tests

+11 tests: ISBN-13/10 checksums, ISBN-10→13 conversion, messy-input normalization, non-book-EAN/bad-checksum rejection; lookup mapping + null paths (mocked axios); route 400/404/200 (incl. ISBN-10 normalization through the route). Full suite green (`npm test`), lint clean (`npm run lint`).

## Follow-ups

- **PR2** — `ISBN` column in Notion + enrichment ritual (Google Books by title+author) + mapper/search-index `isbn` field (variant B: scans match stored ISBNs directly).
- **PR3** — mobile scan button in Skryptorium → native `BarcodeDetector` camera modal → exact match by stored `isbn` (B) else resolve→fuzzy (A) + manual-ISBN fallback.

Version bump 1.48.0 → 1.49.0 (minor, feature). Backlog + roadmap updated with the plan and deferred caveats (iOS/ZXing, multi-edition ISBN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_