### PR TITLE
feat(skryptorium): mobile barcode scan UI to look up a book (PR3)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.50.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.51.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.51.0** — **Skryptorium: skaner kodów kreskowych — PR3 (mobilny skan UI, feature domknięty).**
+  Przycisk skanu (ikona ScanBarcode) obok pola wyszukiwarki, widoczny TYLKO gdy natywny `BarcodeDetector`
+  jest dostępny (`scanSupported()` — Android/Chrome). `ScanModal` (`src/components/search/ScanModal.tsx`):
+  strumień tylnej kamery (`getUserMedia facingMode:environment`) → pętla `detector.detect(video)` po
+  `ean_13`/`ean_8`/`upc_a`, pierwszy kod wyglądający na książkowy ISBN (`looksLikeBookIsbn`: 13 cyfr, prefix
+  978/979) → callback; zawsze dostępny fallback ręcznego wpisania ISBN (brak kamery/uprawnień/API). Czysty
+  helper `src/utils/barcode.ts` (`scanSupported`, `cleanScannedCode`, `looksLikeBookIsbn`, `matchIsbnInIndex`)
+  + 6 testów. Logika w `SearchSection`: kod → dopasowanie WPROST po `entry.isbn` (wariant B) → ustaw zapytanie
+  na tytuł + baner „Trafienie w archiwum"; brak → `GET /api/isbn/:code` (wariant A) → ustaw zapytanie na
+  rozpoznany tytuł (fuzzy) + baner „Rozpoznano przez ISBN"; pudło → baner błędu. Sprzątanie strumienia przy
+  zamknięciu/unmount. **Feature skanera kompletny (A+B).** ZASTRZEŻENIA nadal aktualne: iOS bez natywnego API
+  (fallback ZXing odłożony), multi-edition ISBN (wariant A jako sieć).
 - **1.50.0** — **Skryptorium: skaner kodów kreskowych — PR2 (kolumna ISBN + rytuał wzbogacania, wariant B).**
   Baza może teraz TRZYMAĆ ISBN, żeby skan dopasował wiersz wprost (bez zapytania zewnętrznego na skanie).
   Kolumna `ISBN` (rich_text) dodana do `requiredProps` (Rytuał Inicjacji Schematu). Nowy rytuał
@@ -823,7 +835,7 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
 
 ## Otwarte pozycje
 
-- **Skryptorium: skaner kodów kreskowych (mobile) — feature W TOKU (A+B), 3 PR-y.** Cel: LOOKUP
+- **Skryptorium: skaner kodów kreskowych (mobile) — feature ZREALIZOWANY (A+B), 3 PR-y.** Cel: LOOKUP
   („czy ta fizyczna książka to jedna z moich śledzonych nagrodowych?"), NIE dodawanie do bazy. Decyzje
   użytkownika: A+B, zgoda na Google Books (external), sprzęt=Android → natywny `BarcodeDetector` (bez nowej
   zależności skanera). Rdzeń problemu: baza Notion NIE trzyma ISBN → kod nie dopasuje wiersza wprost.
@@ -832,9 +844,9 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
   - **PR2 — kolumna `ISBN` w Notion + rytuał wzbogacania (wariant B)** — ✅ ZREALIZOWANE (1.50.0). Kolumna
     `ISBN` w `requiredProps`; `IsbnEnrichService` (`isbn-enrich`) + `lookupIsbnByTitle`; mapper `isbn`;
     indeks wyszukiwarki `isbn`; przycisk „Rytuał Sygnatur (ISBN)".
-  - **PR3 — frontend skanu (mobile)** — TODO. Przycisk skanu w Skryptorium (tylko gdy `BarcodeDetector`
-    dostępny) → modal kamery → exact match po zapisanym `isbn` (B), inaczej resolve→fuzzy-search (A);
-    ręczny fallback wpisania ISBN.
+  - **PR3 — frontend skanu (mobile)** — ✅ ZREALIZOWANE (1.51.0). Przycisk skanu (gdy `scanSupported()`),
+    `ScanModal` (`BarcodeDetector` + fallback ręczny), `src/utils/barcode.ts`; w `SearchSection` exact-match
+    po `isbn` (B) → tytuł, else `GET /api/isbn/:code` (A) → tytuł, banery wyniku.
   - **ZASTRZEŻENIA / ODŁOŻONE**: (a) iOS Safari NIE ma natywnego `BarcodeDetector` — fallback `@zxing/browser`
     odłożony (v1 = Android/Chrome); (b) multi-edition ISBN — książka ma wiele ISBN wydań, wzbogacanie (B)
     zapisuje JEDNO „najlepsze" z Google Books, często ≠ ISBN fizycznego egzemplarza → wariant A (resolve→tytuł

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.50.0",
+      "version": "1.51.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.50.0",
+  "version": "1.51.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/barcode.test.ts
+++ b/src/__tests__/barcode.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { cleanScannedCode, looksLikeBookIsbn, matchIsbnInIndex } from "../utils/barcode";
+import { BookIndexEntry } from "../types";
+
+const mk = (over: Partial<BookIndexEntry>): BookIndexEntry => ({
+  id: over.id ?? over.plTitle ?? "x", plTitle: "", origTitle: "", author: "", year: "",
+  awards: [], zrodlo: [], series: "", partOfCycle: false, ...over,
+});
+
+describe("barcode.cleanScannedCode", () => {
+  it("strips dashes and spaces to bare digits", () => {
+    expect(cleanScannedCode("978-83-7578-063-5")).toBe("9788375780635");
+    expect(cleanScannedCode("  978 0306406157 ")).toBe("9780306406157");
+  });
+});
+
+describe("barcode.looksLikeBookIsbn", () => {
+  it("accepts a 13-digit Bookland (978/979) code", () => {
+    expect(looksLikeBookIsbn("9788375780635")).toBe(true);
+    expect(looksLikeBookIsbn("9791234567896")).toBe(true);
+  });
+  it("rejects non-book EAN and wrong length", () => {
+    expect(looksLikeBookIsbn("5901234123457")).toBe(false); // product EAN, not a book
+    expect(looksLikeBookIsbn("0306406152")).toBe(false);    // ISBN-10 length
+  });
+});
+
+describe("barcode.matchIsbnInIndex", () => {
+  const index = [
+    mk({ id: "a", plTitle: "Diuna", isbn: "9788375780635" }),
+    mk({ id: "b", plTitle: "Bez ISBN" }),
+    mk({ id: "c", plTitle: "Inna", isbn: "9780306406157" }),
+  ];
+
+  it("finds the entry whose stored ISBN equals the scanned code (digit-only compare)", () => {
+    expect(matchIsbnInIndex("978-83-7578-063-5", index)?.id).toBe("a");
+  });
+
+  it("returns null when no row carries that ISBN", () => {
+    expect(matchIsbnInIndex("9799999999992", index)).toBeNull();
+  });
+
+  it("ignores rows without a stored ISBN", () => {
+    expect(matchIsbnInIndex("", index)).toBeNull();
+  });
+});

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useMemo, useDeferredValue, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Search, X, Loader2, ScrollText, AlertCircle } from "lucide-react";
+import { Search, X, Loader2, ScrollText, AlertCircle, ScanBarcode, CheckCircle2, XCircle } from "lucide-react";
 import { useBooks } from "../hooks/useBooks";
 import { matchBooks, buildSearchVocab, didYouMean, replaceLastToken } from "../utils/bookSearch";
 import { BookResultCard } from "./search/BookResultCard";
+import { ScanModal } from "./search/ScanModal";
+import { scanSupported, cleanScannedCode, matchIsbnInIndex } from "../utils/barcode";
 
 /** Max number of cards we render (DOM guard for an „empty" query = the whole set). */
 const RENDER_CAP = 150;
@@ -14,9 +16,50 @@ export const SearchSection: React.FC = () => {
   const deferredQuery = useDeferredValue(query);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Barcode scan: native BarcodeDetector is Android/Chrome only, so the button
+  // shows only where it works (the modal keeps a manual-ISBN fallback regardless).
+  const canScan = useMemo(() => scanSupported(), []);
+  const [scanOpen, setScanOpen] = useState(false);
+  const [scanResolving, setScanResolving] = useState(false);
+  // Outcome banner after a scan: exact row hit (B), ISBN-resolved title (A), or miss.
+  const [scanNotice, setScanNotice] = useState<{ kind: "exact" | "resolved" | "miss"; text: string } | null>(null);
+
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  // Turn a scanned/typed code into a search: first a direct row match by stored ISBN
+  // (variant B), else resolve the ISBN → title server-side and fuzzy-search it (variant A).
+  const handleScanDetect = async (rawCode: string) => {
+    setScanOpen(false);
+    setScanNotice(null);
+    const code = cleanScannedCode(rawCode);
+    if (!code) return;
+
+    const direct = matchIsbnInIndex(code, books ?? []);
+    if (direct) {
+      setQuery(direct.plTitle || direct.origTitle);
+      setScanNotice({ kind: "exact", text: `Trafienie w archiwum: „${direct.plTitle || direct.origTitle}"` });
+      return;
+    }
+
+    setScanResolving(true);
+    try {
+      const res = await fetch(`/api/isbn/${encodeURIComponent(code)}`);
+      if (res.ok) {
+        const book = await res.json();
+        setQuery(book.title || "");
+        setScanNotice({ kind: "resolved", text: `Rozpoznano przez ISBN: „${book.title}" — przeszukuję archiwum` });
+      } else {
+        setScanNotice({ kind: "miss", text: `Nie rozpoznano kodu ISBN ${code}. Spróbuj wpisać tytuł ręcznie.` });
+      }
+    } catch {
+      setScanNotice({ kind: "miss", text: "Błąd rozpoznawania ISBN — spróbuj ponownie lub wpisz tytuł ręcznie." });
+    } finally {
+      setScanResolving(false);
+      inputRef.current?.focus();
+    }
+  };
 
   const results = useMemo(() => matchBooks(deferredQuery, books ?? []), [deferredQuery, books]);
   const shown = results.slice(0, RENDER_CAP);
@@ -48,28 +91,65 @@ export const SearchSection: React.FC = () => {
       </p>
 
       {/* Search field */}
-      <div className="relative max-w-2xl mx-auto">
-        <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-cyan-400/50 pointer-events-none" />
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Wpisz fragment tytułu lub nazwisko autora…"
-          aria-label="Przeszukaj archiwum"
-          className="w-full pl-14 pr-12 py-4 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-500 transition-all"
-        />
-        {query && (
-          <button
-            onClick={() => setQuery("")}
-            className="absolute right-4 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-slate-500 hover:text-slate-200 hover:bg-white/5 transition-colors"
-            title="Wyczyść"
-            aria-label="Wyczyść zapytanie"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
+      <div className="max-w-2xl mx-auto space-y-3">
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-cyan-400/50 pointer-events-none" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Wpisz fragment tytułu lub nazwisko autora…"
+              aria-label="Przeszukaj archiwum"
+              className="w-full pl-14 pr-12 py-4 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-500 transition-all"
+            />
+            {query && (
+              <button
+                onClick={() => setQuery("")}
+                className="absolute right-4 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-slate-500 hover:text-slate-200 hover:bg-white/5 transition-colors"
+                title="Wyczyść"
+                aria-label="Wyczyść zapytanie"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+          {canScan && (
+            <button
+              onClick={() => setScanOpen(true)}
+              disabled={scanResolving}
+              title="Skanuj kod kreskowy książki"
+              aria-label="Skanuj kod kreskowy"
+              className="shrink-0 px-4 rounded-2xl border border-cyan-500/30 bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 hover:border-cyan-400/50 disabled:opacity-50 transition-all active:scale-95 flex items-center justify-center"
+            >
+              {scanResolving ? <Loader2 className="w-5 h-5 animate-spin" /> : <ScanBarcode className="w-5 h-5" />}
+            </button>
+          )}
+        </div>
+
+        {/* Scan outcome banner */}
+        <AnimatePresence>
+          {scanNotice && (
+            <motion.div
+              initial={{ opacity: 0, y: -6 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -6 }}
+              className={`flex items-center gap-2.5 px-4 py-2.5 rounded-xl text-xs font-medium border ${
+                scanNotice.kind === "miss"
+                  ? "bg-red-500/10 border-red-500/30 text-red-300"
+                  : "bg-cyan-500/10 border-cyan-500/30 text-cyan-200"
+              }`}
+            >
+              {scanNotice.kind === "miss" ? <XCircle className="w-4 h-4 shrink-0" /> : <CheckCircle2 className="w-4 h-4 shrink-0" />}
+              <span className="flex-1">{scanNotice.text}</span>
+              <button onClick={() => setScanNotice(null)} className="p-0.5 opacity-60 hover:opacity-100" aria-label="Zamknij komunikat">
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
+
+      <ScanModal open={scanOpen} onClose={() => setScanOpen(false)} onDetect={handleScanDetect} />
 
       {/* Counter */}
       {books && !loading && (

--- a/src/components/search/ScanModal.tsx
+++ b/src/components/search/ScanModal.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { X, ScanBarcode, Loader2, AlertCircle, Keyboard } from "lucide-react";
+import { looksLikeBookIsbn } from "../../utils/barcode";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the raw scanned/typed code once a book-looking EAN-13 is captured. */
+  onDetect: (code: string) => void;
+}
+
+// The native BarcodeDetector API isn't in the TS DOM lib yet — minimal local shape.
+interface DetectedBarcode { rawValue: string; format: string }
+interface BarcodeDetectorLike { detect(source: CanvasImageSource): Promise<DetectedBarcode[]> }
+type BarcodeDetectorCtor = new (opts?: { formats?: string[] }) => BarcodeDetectorLike;
+
+/**
+ * Mobile barcode scanner for Skryptorium. Streams the rear camera into a <video>
+ * and polls the native BarcodeDetector for an EAN-13 (= book ISBN-13). On a hit it
+ * hands the code up (parent decides: direct row match, ISBN resolve, or „not found").
+ * A manual ISBN field is always available as a fallback (bad light, denied camera,
+ * or a browser without the API).
+ */
+export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const doneRef = useRef(false);
+  const [status, setStatus] = useState<"idle" | "starting" | "scanning" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string>("");
+  const [manual, setManual] = useState("");
+
+  // Stop the camera + detection loop and release the stream.
+  const teardown = () => {
+    if (rafRef.current !== null) { cancelAnimationFrame(rafRef.current); rafRef.current = null; }
+    if (streamRef.current) { streamRef.current.getTracks().forEach((t) => t.stop()); streamRef.current = null; }
+  };
+
+  const finish = (code: string) => {
+    if (doneRef.current) return;
+    doneRef.current = true;
+    teardown();
+    onDetect(code);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    doneRef.current = false;
+    const Ctor = (window as unknown as { BarcodeDetector?: BarcodeDetectorCtor }).BarcodeDetector;
+
+    // No native detector → the modal still opens for the manual ISBN fallback.
+    if (!Ctor) { setStatus("error"); setErrorMsg("Ta przeglądarka nie wspiera skanera — wpisz ISBN ręcznie."); return; }
+
+    let cancelled = false;
+    setStatus("starting");
+    const detector = new Ctor({ formats: ["ean_13", "ean_8", "upc_a"] });
+
+    (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });
+        if (cancelled) { stream.getTracks().forEach((t) => t.stop()); return; }
+        streamRef.current = stream;
+        const video = videoRef.current;
+        if (!video) return;
+        video.srcObject = stream;
+        await video.play();
+        setStatus("scanning");
+
+        const tick = async () => {
+          if (doneRef.current || cancelled) return;
+          try {
+            const codes = await detector.detect(video);
+            const hit = codes.map((c) => c.rawValue).find((v) => looksLikeBookIsbn(v));
+            if (hit) { finish(hit); return; }
+          } catch {
+            // A transient detect() failure (frame not ready) — keep polling.
+          }
+          rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+      } catch (e: any) {
+        if (cancelled) return;
+        setStatus("error");
+        setErrorMsg(
+          e?.name === "NotAllowedError"
+            ? "Brak dostępu do kamery — zezwól w przeglądarce lub wpisz ISBN ręcznie."
+            : "Nie udało się uruchomić kamery — wpisz ISBN ręcznie."
+        );
+      }
+    })();
+
+    return () => { cancelled = true; teardown(); };
+  }, [open]);
+
+  const handleClose = () => { teardown(); onClose(); };
+
+  const submitManual = (e: React.FormEvent) => {
+    e.preventDefault();
+    const code = manual.trim();
+    if (code) finish(code);
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <motion.div
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+            onClick={handleClose}
+            className="absolute inset-0 bg-slate-950/85 backdrop-blur-md"
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.92, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.92, y: 20 }}
+            className="relative w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl shadow-[0_0_50px_rgba(0,0,0,0.8)] overflow-hidden"
+          >
+            <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-cyan-500 to-transparent opacity-50" />
+
+            <div className="p-6">
+              <div className="flex items-center gap-3 mb-5">
+                <div className="p-2.5 bg-cyan-500/10 rounded-full border border-cyan-500/20">
+                  <ScanBarcode className="w-6 h-6 text-cyan-400" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-display font-bold text-slate-100 uppercase tracking-wider">Skan Sygnatury</h3>
+                  <p className="text-xs text-slate-500 font-medium">Nakieruj kamerę na kod kreskowy książki</p>
+                </div>
+              </div>
+
+              {/* Camera viewport */}
+              <div className="relative aspect-[4/3] rounded-xl overflow-hidden bg-slate-950 border border-white/10 mb-5">
+                <video ref={videoRef} playsInline muted className="w-full h-full object-cover" />
+                {(status === "starting" || status === "idle") && (
+                  <div className="absolute inset-0 flex items-center justify-center gap-2 text-slate-400">
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                    <span className="text-xs font-bold uppercase tracking-widest">Uruchamianie kamery…</span>
+                  </div>
+                )}
+                {status === "scanning" && (
+                  <>
+                    <div className="absolute inset-x-8 top-1/2 h-px bg-cyan-400/70 shadow-[0_0_12px_rgba(34,211,238,0.8)]" />
+                    <div className="absolute inset-6 border-2 border-cyan-400/30 rounded-lg" />
+                  </>
+                )}
+                {status === "error" && (
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center px-6 text-red-300">
+                    <AlertCircle className="w-7 h-7" />
+                    <span className="text-xs font-medium leading-relaxed">{errorMsg}</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Manual fallback */}
+              <form onSubmit={submitManual} className="space-y-2">
+                <label className="flex items-center gap-2 text-[11px] text-slate-500 uppercase tracking-widest font-bold">
+                  <Keyboard className="w-3.5 h-3.5" /> Lub wpisz ISBN ręcznie
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={manual}
+                    onChange={(e) => setManual(e.target.value)}
+                    placeholder="978…"
+                    aria-label="Wpisz ISBN ręcznie"
+                    className="flex-1 px-4 py-2.5 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-xl focus:outline-none focus:border-cyan-500/50 placeholder-slate-600"
+                  />
+                  <button
+                    type="submit"
+                    disabled={!manual.trim()}
+                    className="px-5 py-2.5 text-sm font-bold bg-cyan-600/80 hover:bg-cyan-500 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-xl transition-all active:scale-95"
+                  >
+                    Szukaj
+                  </button>
+                </div>
+              </form>
+            </div>
+
+            <button onClick={handleClose} className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-200 transition-colors" aria-label="Zamknij skaner">
+              <X className="w-5 h-5" />
+            </button>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/utils/barcode.ts
+++ b/src/utils/barcode.ts
@@ -1,0 +1,44 @@
+import { BookIndexEntry } from "../types";
+
+/**
+ * Client-side barcode helpers for the Skryptorium scan flow. A physical book's
+ * barcode is an EAN-13, which equals its ISBN-13. Two match paths:
+ *   B (direct) — compare the scanned code to a row's stored `isbn` (enrichment ritual);
+ *   A (resolve) — no stored match → resolve the ISBN to a title server-side and
+ *                 hand that to the existing fuzzy search.
+ * The heavy normalization (checksums, ISBN-10→13) lives server-side in
+ * `services/isbn.ts`; here we only need digit extraction + a direct compare.
+ */
+
+/** True when the browser exposes the native BarcodeDetector API (Android/Chrome). */
+export function scanSupported(): boolean {
+  return typeof window !== "undefined" && "BarcodeDetector" in window;
+}
+
+/** Strip everything but digits (barcode readers/typed input may carry dashes, spaces). */
+export function cleanScannedCode(raw: string): string {
+  return (raw || "").replace(/[^0-9]/g, "");
+}
+
+/**
+ * A scanned code looks like a book EAN-13 when it's 13 digits and starts with the
+ * Bookland prefix 978/979. (A full checksum check happens server-side on resolve.)
+ */
+export function looksLikeBookIsbn(raw: string): boolean {
+  const d = cleanScannedCode(raw);
+  return d.length === 13 && (d.startsWith("978") || d.startsWith("979"));
+}
+
+/**
+ * Direct match (variant B): find the index entry whose stored ISBN equals the
+ * scanned code (compared digit-only, so stored formatting doesn't matter).
+ * Returns null when nothing carries that ISBN.
+ */
+export function matchIsbnInIndex(code: string, index: BookIndexEntry[]): BookIndexEntry | null {
+  const target = cleanScannedCode(code);
+  if (!target) return null;
+  for (const b of index) {
+    if (b.isbn && cleanScannedCode(b.isbn) === target) return b;
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes #263

Completes the mobile barcode-scanning feature (PR1 #260 = resolver, PR2 #262 = ISBN column + enrichment). This is the UI that ties variants A and B together into a book lookup — "is this physical book one of my tracked award books?".

## Changes

- **`src/utils/barcode.ts`** — pure helpers: `scanSupported` (native `BarcodeDetector` present), `cleanScannedCode` (digits only), `looksLikeBookIsbn` (13 digits, 978/979 prefix), `matchIsbnInIndex` (direct match by stored ISBN, digit-only compare).
- **`src/components/search/ScanModal.tsx`** — rear-camera stream (`getUserMedia facingMode:environment`) + `BarcodeDetector` poll (`ean_13`/`ean_8`/`upc_a`); first book-looking ISBN wins. Always-present manual-ISBN fallback for when the camera is denied/absent or the browser lacks the API. Tears the stream down on close/unmount.
- **`SearchSection`** — scan button beside the search field (shown only when supported), plus a scan-outcome banner. On a code: **direct row match** by stored `isbn` (variant B) → set the query to the title + "Trafienie w archiwum"; else **`GET /api/isbn/:code`** (variant A) → set the query to the resolved title (existing fuzzy search) + "Rozpoznano przez ISBN"; miss → a red notice.

## Tests

+6 (`cleanScannedCode`, `looksLikeBookIsbn` accept/reject, `matchIsbnInIndex` hit/miss/no-ISBN). Full suite green (434 tests), lint clean.

## Caveats (deferred, unchanged)

- iOS Safari lacks native `BarcodeDetector` → ZXing fallback deferred (v1 = Android/Chrome).
- Multi-edition ISBN → variant A stays the safety net.

Version bump 1.50.0 → 1.51.0 (minor). Backlog changelog + roadmap marked complete. **Barcode feature (A+B) done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_