### PR TITLE
feat(skryptorium): store all edition ISBNs per book (multi-edition barcode match)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.51.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.52.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.52.0** — **Skaner ISBN: wiele wydań na pozycję (multi-edition) — koniec zastrzeżenia multi-edition.**
+  Decyzja użytkownika: use case = „czy w ogóle mam tę książkę", nie „tę konkretną edycję" → zapisujemy
+  WSZYSTKIE ISBN-y wydań, nie jeden best-match. `lookupIsbnByTitle`→`lookupIsbnsByTitle` (zbiera zdedupowane
+  ISBN-13 ze WSZYSTKICH woluminów, `maxResults` 5→20, ISBN-10→13). `IsbnEnrichService` zapisuje listę
+  (`isbns.join(", ")`) w kolumnie `ISBN`; gap-fill po pustej liście (idempotentnie). Mapper parsuje `ISBN`
+  na `NotionBook.isbns: string[]` (split po `,`/`;`/spacji, dedup); indeks niesie `BookIndexEntry.isbns`.
+  Frontend `matchIsbnInIndex` sprawdza przynależność skanu do listy (`isbns.some`) — barcode DOWOLNEGO
+  wydania trafia w wiersz. Testy zaktualizowane (multi-edycja, dedup 10/13). Zastrzeżenie multi-edition
+  z Otwartych pozycji ZDJĘTE.
 - **1.51.0** — **Skryptorium: skaner kodów kreskowych — PR3 (mobilny skan UI, feature domknięty).**
   Przycisk skanu (ikona ScanBarcode) obok pola wyszukiwarki, widoczny TYLKO gdy natywny `BarcodeDetector`
   jest dostępny (`scanSupported()` — Android/Chrome). `ScanModal` (`src/components/search/ScanModal.tsx`):
@@ -848,9 +857,9 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
     `ScanModal` (`BarcodeDetector` + fallback ręczny), `src/utils/barcode.ts`; w `SearchSection` exact-match
     po `isbn` (B) → tytuł, else `GET /api/isbn/:code` (A) → tytuł, banery wyniku.
   - **ZASTRZEŻENIA / ODŁOŻONE**: (a) iOS Safari NIE ma natywnego `BarcodeDetector` — fallback `@zxing/browser`
-    odłożony (v1 = Android/Chrome); (b) multi-edition ISBN — książka ma wiele ISBN wydań, wzbogacanie (B)
-    zapisuje JEDNO „najlepsze" z Google Books, często ≠ ISBN fizycznego egzemplarza → wariant A (resolve→tytuł
-    →fuzzy) jest bezpieczniejszą siecią; docelowo można trzymać listę ISBN wydań, nie jeden.
+    odłożony (v1 = Android/Chrome). (b) multi-edition ISBN — ✅ ROZWIĄZANE (1.52.0): zapisujemy WSZYSTKIE
+    ISBN-y wydań (`isbns: string[]`), więc barcode dowolnej edycji trafia w wiersz (use case = „mam tę
+    książkę", nie „tę edycję").
 
 - **Vinted znowu zablokował skaner — alternatywy w zanadrzu** — NOTATKA (Vinted ubił skan z IP Render/datacenter).
   Co JUŻ mamy (obrona pasywna): throttle 3–5 s + jitter na każdej ścieżce, pula User-Agent (rotacja,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notionMapper.ts
+++ b/notionMapper.ts
@@ -85,8 +85,13 @@ export function mapPageToBook(page: NotionPage): NotionBook {
   const shelfOrderProp = getProp(props, "ShelfOrder");
   const shelfOrder = shelfOrderProp?.type === "number" && typeof shelfOrderProp.number === "number" ? shelfOrderProp.number : undefined;
 
-  // Canonical ISBN-13 (rich_text; filled by the enrichment ritual) — enables a direct barcode match.
-  const isbn = getPlainText(getProp(props, "ISBN")).trim() || undefined;
+  // Canonical ISBN-13s across editions (rich_text; filled by the enrichment ritual). Stored
+  // as a delimited list — ANY of them matching a scanned barcode identifies this book, since
+  // the use case is „do I own this title at all", not „this exact edition".
+  const isbnRaw = getPlainText(getProp(props, "ISBN"));
+  const isbns = isbnRaw
+    ? Array.from(new Set(isbnRaw.split(/[\s,;]+/).map((s) => s.trim()).filter(Boolean)))
+    : [];
 
   return {
     id: page.id,
@@ -107,6 +112,6 @@ export function mapPageToBook(page: NotionPage): NotionBook {
     cykl,
     cyklNr,
     shelfOrder,
-    isbn
+    isbns
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.51.0",
+      "version": "1.52.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.51.0",
+  "version": "1.52.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbnEnrichService.test.ts
+++ b/services/__tests__/isbnEnrichService.test.ts
@@ -4,11 +4,11 @@ import { IsbnEnrichService } from "../isbnEnrichService";
 // The reverse Google Books lookup is mocked — we test the ritual's orchestration
 // (filtering, idempotent skip, writes), not the HTTP call.
 vi.mock("../isbnLookupService", () => ({
-  lookupIsbnByTitle: vi.fn(),
+  lookupIsbnsByTitle: vi.fn(),
 }));
-import { lookupIsbnByTitle } from "../isbnLookupService";
+import { lookupIsbnsByTitle } from "../isbnLookupService";
 
-const mockedLookup = lookupIsbnByTitle as unknown as ReturnType<typeof vi.fn>;
+const mockedLookup = lookupIsbnsByTitle as unknown as ReturnType<typeof vi.fn>;
 
 function makeNotion(books: any[]) {
   return {
@@ -24,13 +24,13 @@ const complete = (events: any[]) => events.find((e) => e.type === "complete")?.r
 describe("IsbnEnrichService", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("enriches only award books that lack an ISBN, and writes the resolved code", async () => {
+  it("enriches only award books that lack ISBNs, and writes all edition codes as a list", async () => {
     const notion = makeNotion([
       { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert" },              // target
-      { id: "2", plTitle: "Ma ISBN", origTitle: "Has ISBN", author: "X", isbn: "9788375780635" }, // already has ISBN → skip
+      { id: "2", plTitle: "Ma ISBN", origTitle: "Has ISBN", author: "X", isbns: ["9788375780635"] }, // already has ISBNs → skip
       { id: "3", plTitle: "Tom", origTitle: "", author: "Y", kategoria: "Tom cyklu" },   // not an award → skip
     ]);
-    mockedLookup.mockResolvedValue("9780441172719");
+    mockedLookup.mockResolvedValue(["9780441172719", "9788375780635"]);
 
     const events: any[] = [];
     const svc = new IsbnEnrichService(notion as any);
@@ -41,15 +41,17 @@ describe("IsbnEnrichService", () => {
     expect(mockedLookup).toHaveBeenCalledWith("Dune", "Herbert");
     expect(notion.updatePage).toHaveBeenCalledTimes(1);
     expect(notion.updatePage).toHaveBeenCalledWith("1", { ISBN: expect.anything() });
+    // The full edition list is joined into the written value.
+    expect(notion.buildPropertyValue).toHaveBeenCalledWith("9780441172719, 9788375780635", "rich_text");
 
     const result = complete(events);
     expect(result.synced).toBe(1);
-    expect(result.skipped).toBe(1); // one award book already had an ISBN
+    expect(result.skipped).toBe(1); // one award book already had ISBNs
   });
 
   it("records a book as skipped when Google Books finds no ISBN (no write)", async () => {
     const notion = makeNotion([{ id: "1", plTitle: "Nieznana", origTitle: "", author: "Z" }]);
-    mockedLookup.mockResolvedValue(null);
+    mockedLookup.mockResolvedValue([]);
 
     const events: any[] = [];
     const svc = new IsbnEnrichService(notion as any);
@@ -63,7 +65,7 @@ describe("IsbnEnrichService", () => {
 
   it("creates the ISBN column before writing", async () => {
     const notion = makeNotion([{ id: "1", plTitle: "T", origTitle: "T", author: "A" }]);
-    mockedLookup.mockResolvedValue("9780441172719");
+    mockedLookup.mockResolvedValue(["9780441172719"]);
 
     const svc = new IsbnEnrichService(notion as any);
     await svc.runIsbnEnrich(() => {}, () => false);

--- a/services/__tests__/isbnLookupService.test.ts
+++ b/services/__tests__/isbnLookupService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import axios from "axios";
-import { lookupIsbn, lookupIsbnByTitle } from "../isbnLookupService";
+import { lookupIsbn, lookupIsbnsByTitle } from "../isbnLookupService";
 
 vi.mock("axios");
 const mockedGet = axios.get as unknown as ReturnType<typeof vi.fn>;
@@ -29,37 +29,42 @@ describe("lookupIsbn", () => {
   });
 });
 
-describe("lookupIsbnByTitle", () => {
+describe("lookupIsbnsByTitle", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns null for an empty title without hitting the API", async () => {
-    const r = await lookupIsbnByTitle("   ", "Herbert");
-    expect(r).toBeNull();
+  it("returns [] for an empty title without hitting the API", async () => {
+    const r = await lookupIsbnsByTitle("   ", "Herbert");
+    expect(r).toEqual([]);
     expect(mockedGet).not.toHaveBeenCalled();
   });
 
-  it("queries intitle+inauthor and returns the first usable ISBN-13", async () => {
+  it("queries intitle+inauthor and collects deduped ISBN-13s across editions", async () => {
     mockedGet.mockResolvedValue({
-      data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "ISBN_10", identifier: "0441172717" }, { type: "ISBN_13", identifier: "9780441172719" }] } }] },
+      data: { items: [
+        { volumeInfo: { industryIdentifiers: [{ type: "ISBN_10", identifier: "0441172717" }, { type: "ISBN_13", identifier: "9780441172719" }] } },
+        { volumeInfo: { industryIdentifiers: [{ type: "ISBN_13", identifier: "9788375780635" }] } },
+        { volumeInfo: { industryIdentifiers: [{ type: "ISBN_13", identifier: "9780441172719" }] } }, // dup edition
+      ] },
     });
-    const r = await lookupIsbnByTitle("Dune", "Frank Herbert");
-    expect(r).toBe("9780441172719");
+    const r = await lookupIsbnsByTitle("Dune", "Frank Herbert");
+    // ISBN-10 of the first volume normalizes to the same 13 as its ISBN_13 → deduped.
+    expect(r).toEqual(["9780441172719", "9788375780635"]);
     const q = mockedGet.mock.calls[0][1].params.q;
     expect(q).toContain("intitle:Dune");
     expect(q).toContain("inauthor:Frank Herbert");
   });
 
-  it("falls back to ISBN-10 and normalizes it to ISBN-13", async () => {
+  it("converts an ISBN-10-only edition to ISBN-13", async () => {
     mockedGet.mockResolvedValue({
       data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "ISBN_10", identifier: "0306406152" }] } }] },
     });
-    const r = await lookupIsbnByTitle("Some Book");
-    expect(r).toBe("9780306406157");
+    const r = await lookupIsbnsByTitle("Some Book");
+    expect(r).toEqual(["9780306406157"]);
   });
 
-  it("returns null when no volume carries a usable ISBN", async () => {
+  it("returns [] when no volume carries a usable ISBN", async () => {
     mockedGet.mockResolvedValue({ data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "OTHER", identifier: "xyz" }] } }] } });
-    const r = await lookupIsbnByTitle("Nothing");
-    expect(r).toBeNull();
+    const r = await lookupIsbnsByTitle("Nothing");
+    expect(r).toEqual([]);
   });
 });

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -25,6 +25,6 @@ export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
       series: b.currentSeria || "",
       partOfCycle: b.currentCzesccyklu ?? false,
       shelfOrder: b.shelfOrder,
-      isbn: b.isbn,
+      isbns: b.isbns,
     }));
 }

--- a/services/isbnEnrichService.ts
+++ b/services/isbnEnrichService.ts
@@ -1,7 +1,7 @@
 import pLimit from "p-limit";
 import { NotionAdapter } from "../notion.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
-import { lookupIsbnByTitle } from "./isbnLookupService";
+import { lookupIsbnsByTitle } from "./isbnLookupService";
 import { isAwardBook } from "./bookCategory";
 import { createLogger } from "../logger";
 
@@ -10,14 +10,14 @@ const log = createLogger("IsbnEnrich");
 /**
  * Enrichment ritual for the barcode "variant B": fills the „ISBN" column on award
  * books that lack one, by looking the book up on Google Books by title (+ author).
- * A stored canonical ISBN-13 lets a mobile scan match a row DIRECTLY, without any
- * on-scan external call.
+ * Stored ISBNs let a mobile scan match a row DIRECTLY, without any on-scan external call.
  *
- * Caveat (see backlog): a title has many edition ISBNs; we store ONE "best match"
- * from Google Books, which often differs from the physical copy in hand — so the
- * scan flow keeps variant A (resolve → fuzzy search) as its safety net.
+ * We store the canonical ISBN-13s of ALL editions we can resolve (a delimited list),
+ * because the use case is „do I own this title at all", not „this exact edition" — so
+ * a barcode of any edition (hardback, paperback, reissue) still identifies the row.
+ * Variant A (resolve → fuzzy search) remains the fallback when nothing is stored.
  *
- * Idempotent: books that already carry an ISBN are skipped, so re-running only fills
+ * Idempotent: books that already carry any ISBN are skipped, so re-running only fills
  * the gaps. Cycle sibling volumes are excluded — barcode lookup is an award concern.
  */
 export class IsbnEnrichService {
@@ -33,10 +33,10 @@ export class IsbnEnrichService {
 
       if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano Rytuał Sygnatur." }); return; }
 
-      // Award books only, and only those still missing an ISBN (idempotent gap-fill).
+      // Award books only, and only those still missing ISBNs (idempotent gap-fill).
       const targets = rawBooks
         .filter(isAwardBook)
-        .filter((b) => !(b.isbn && b.isbn.trim().length > 0))
+        .filter((b) => !(b.isbns && b.isbns.length > 0))
         .filter((b) => (b.plTitle && b.plTitle.trim()) || (b.origTitle && b.origTitle.trim()));
 
       const alreadyHave = rawBooks.filter(isAwardBook).length - targets.length;
@@ -65,14 +65,15 @@ export class IsbnEnrichService {
         if (!title) return;
 
         try {
-          const isbn = await lookupIsbnByTitle(title, book.author);
-          if (!isbn) {
+          const isbns = await lookupIsbnsByTitle(title, book.author);
+          if (isbns.length === 0) {
             summary.skipped.push(label);
             return;
           }
-          await this.notion.updatePage(book.id, { "ISBN": this.notion.buildPropertyValue(isbn, "rich_text") });
+          // Store all edition ISBNs as a delimited list — any of them matches a scan.
+          await this.notion.updatePage(book.id, { "ISBN": this.notion.buildPropertyValue(isbns.join(", "), "rich_text") });
           updatedCount++;
-          summary.updated.push(`${label} (ISBN: ${isbn})`);
+          summary.updated.push(`${label} (ISBN: ${isbns.join(", ")})`);
         } catch (err: any) {
           log.warn("Błąd wzbogacania ISBN", { book: label, error: err?.message });
           errors.push({ book: label, error: err?.message || "nieznany błąd" });

--- a/services/isbnLookupService.ts
+++ b/services/isbnLookupService.ts
@@ -53,28 +53,31 @@ export async function lookupIsbn(rawCode: string): Promise<IsbnBook | null> {
 
 /**
  * Reverse lookup for the enrichment ritual (barcode "variant B"): given a book's
- * title (+ optional author), find its canonical ISBN-13 via Google Books so it can
- * be stored on the row and matched directly by a scan. Picks the first volume that
- * carries a usable ISBN (preferring ISBN-13, falling back to a normalized ISBN-10).
- * Returns the ISBN-13 string, or null when nothing usable is found. Throws only on
- * an unexpected error so the caller can report it per book.
+ * title (+ optional author), collect the canonical ISBN-13s of ALL its editions via
+ * Google Books, so any edition's barcode identifies the row. The use case is „do I
+ * own this title at all", not „this exact edition" — so we store every ISBN we can
+ * resolve (ISBN-13 directly, ISBN-10 converted to 13), deduped. Returns the list
+ * (possibly empty). Throws only on an unexpected error so the caller can report it.
  */
-export async function lookupIsbnByTitle(title: string, author?: string): Promise<string | null> {
+export async function lookupIsbnsByTitle(title: string, author?: string): Promise<string[]> {
   const cleanTitle = (title || "").trim();
-  if (!cleanTitle) return null;
+  if (!cleanTitle) return [];
   const parts = [`intitle:${cleanTitle}`];
   const cleanAuthor = (author || "").trim();
   if (cleanAuthor) parts.push(`inauthor:${cleanAuthor}`);
 
-  const res = await axios.get(GOOGLE_BOOKS, { params: { q: parts.join("+"), maxResults: 5 }, timeout: 10000 });
+  const res = await axios.get(GOOGLE_BOOKS, { params: { q: parts.join("+"), maxResults: 20 }, timeout: 10000 });
   const items: any[] = Array.isArray(res.data?.items) ? res.data.items : [];
+  const found = new Set<string>();
   for (const item of items) {
     const ids: any[] = item?.volumeInfo?.industryIdentifiers || [];
-    // Prefer an ISBN-13; otherwise take an ISBN-10 and let normalizeIsbn convert it.
-    const isbn13 = ids.find((x) => x?.type === "ISBN_13")?.identifier;
-    const isbn10 = ids.find((x) => x?.type === "ISBN_10")?.identifier;
-    const normalized = normalizeIsbn(isbn13 || isbn10 || "");
-    if (normalized) return normalized;
+    for (const id of ids) {
+      // ISBN-13 used directly; ISBN-10 converted; anything else (ISSN, OTHER) skipped by normalizeIsbn.
+      if (id?.type === "ISBN_13" || id?.type === "ISBN_10") {
+        const normalized = normalizeIsbn(id.identifier || "");
+        if (normalized) found.add(normalized);
+      }
+    }
   }
-  return null;
+  return Array.from(found);
 }

--- a/src/__tests__/barcode.test.ts
+++ b/src/__tests__/barcode.test.ts
@@ -27,20 +27,24 @@ describe("barcode.looksLikeBookIsbn", () => {
 
 describe("barcode.matchIsbnInIndex", () => {
   const index = [
-    mk({ id: "a", plTitle: "Diuna", isbn: "9788375780635" }),
+    mk({ id: "a", plTitle: "Diuna", isbns: ["9788375780635", "9788373196919"] }),
     mk({ id: "b", plTitle: "Bez ISBN" }),
-    mk({ id: "c", plTitle: "Inna", isbn: "9780306406157" }),
+    mk({ id: "c", plTitle: "Inna", isbns: ["9780306406157"] }),
   ];
 
-  it("finds the entry whose stored ISBN equals the scanned code (digit-only compare)", () => {
+  it("matches on the first stored edition ISBN (digit-only compare)", () => {
     expect(matchIsbnInIndex("978-83-7578-063-5", index)?.id).toBe("a");
+  });
+
+  it("matches on any OTHER stored edition ISBN too", () => {
+    expect(matchIsbnInIndex("9788373196919", index)?.id).toBe("a");
   });
 
   it("returns null when no row carries that ISBN", () => {
     expect(matchIsbnInIndex("9799999999992", index)).toBeNull();
   });
 
-  it("ignores rows without a stored ISBN", () => {
+  it("ignores rows without stored ISBNs", () => {
     expect(matchIsbnInIndex("", index)).toBeNull();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,8 +60,8 @@ export interface NotionBook {
   cyklNr?: number;
   /** Manual shelf ordering key (column „ShelfOrder"; fractional-year scale). */
   shelfOrder?: number;
-  /** Canonical ISBN-13 (column „ISBN") — filled by the enrichment ritual; enables a direct barcode match. */
-  isbn?: string;
+  /** Canonical ISBN-13s across editions (column „ISBN") — filled by the enrichment ritual; ANY of them matches a barcode. */
+  isbns?: string[];
 }
 
 /**
@@ -81,8 +81,8 @@ export interface BookIndexEntry {
   partOfCycle: boolean;
   /** Manual shelf ordering key (precise drag&drop); absent → sort by year. */
   shelfOrder?: number;
-  /** Canonical ISBN-13 (if enriched) — lets a barcode scan match a row directly. */
-  isbn?: string;
+  /** Canonical ISBN-13s across editions (if enriched) — a barcode of ANY edition matches this row. */
+  isbns?: string[];
 }
 
 export interface SyncState {

--- a/src/utils/barcode.ts
+++ b/src/utils/barcode.ts
@@ -30,15 +30,16 @@ export function looksLikeBookIsbn(raw: string): boolean {
 }
 
 /**
- * Direct match (variant B): find the index entry whose stored ISBN equals the
- * scanned code (compared digit-only, so stored formatting doesn't matter).
- * Returns null when nothing carries that ISBN.
+ * Direct match (variant B): find the index entry whose stored ISBNs include the
+ * scanned code (compared digit-only, so stored formatting doesn't matter). A book
+ * carries the ISBNs of all its editions, so a barcode of any edition matches.
+ * Returns null when no row carries that ISBN.
  */
 export function matchIsbnInIndex(code: string, index: BookIndexEntry[]): BookIndexEntry | null {
   const target = cleanScannedCode(code);
   if (!target) return null;
   for (const b of index) {
-    if (b.isbn && cleanScannedCode(b.isbn) === target) return b;
+    if (b.isbns?.some((i) => cleanScannedCode(i) === target)) return b;
   }
   return null;
 }


### PR DESCRIPTION
Fixes #265

Resolves the multi-edition caveat from the barcode feature. The scan use case is "do I own this title **at all**", not "this exact edition" — so a book now stores the ISBN-13s of **all** its editions, and a barcode of any edition matches the row.

## Changes

- **`lookupIsbnByTitle` → `lookupIsbnsByTitle`** — collects deduped ISBN-13s across all Google Books volumes (not just the first), `maxResults` 5→20, ISBN-10→13.
- **`IsbnEnrichService`** — writes the joined edition list to the `ISBN` column; idempotent gap-fill (skips rows that already carry any ISBN).
- **Mapper** — parses `ISBN` → `NotionBook.isbns: string[]` (split on `,`/`;`/whitespace, deduped); **search index** carries `BookIndexEntry.isbns`.
- **`matchIsbnInIndex`** — checks membership across the list (`isbns.some`), so a scan of any stored edition identifies the book.
- Tests updated for multi-edition collection and 10/13 dedup.

Full suite green (435 tests), lint clean. Version bump 1.51.0 → 1.52.0. Backlog changelog updated and the multi-edition caveat marked resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_