### PR TITLE
fix(skryptorium): ISBN enrichment found nothing — Google Books query encoding

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.52.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.52.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.52.1** — **FIX: rytuał ISBN nic nie znajdował (błędne kodowanie zapytania Google Books).** Root cause:
+  `lookupIsbnsByTitle` łączył człony zapytania literalnym „+" (`intitle:X+inauthor:Y`), a axios koduje „+"
+  jako `%2B` (literalny plus) → Google Books widział JEDEN śmieciowy token → 0 wyników dla KAŻDEJ książki
+  (wszystkie leciały do „Pominięto"). Fix: łączenie SPACJĄ (`intitle:X inauthor:Y`) — axios koduje spację jako
+  „+" (separator AND Google Books). Potwierdzone `axios.getUri` (spacja→`+`, `+`→`%2B`). Dodatkowo hardening:
+  bierzemy TYLKO pierwszego autora z multi-value „Autor" (mniej przeograniczeń) + fallback na zapytanie
+  title-only, gdy wersja z autorem nic nie zwróci. +2 testy (multi-autor, fallback) + asercja „q bez literalnego +".
 - **1.52.0** — **Skaner ISBN: wiele wydań na pozycję (multi-edition) — koniec zastrzeżenia multi-edition.**
   Decyzja użytkownika: use case = „czy w ogóle mam tę książkę", nie „tę konkretną edycję" → zapisujemy
   WSZYSTKIE ISBN-y wydań, nie jeden best-match. `lookupIsbnByTitle`→`lookupIsbnsByTitle` (zbiera zdedupowane

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.52.0",
+      "version": "1.52.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.52.0",
+  "version": "1.52.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbnLookupService.test.ts
+++ b/services/__tests__/isbnLookupService.test.ts
@@ -52,6 +52,25 @@ describe("lookupIsbnsByTitle", () => {
     const q = mockedGet.mock.calls[0][1].params.q;
     expect(q).toContain("intitle:Dune");
     expect(q).toContain("inauthor:Frank Herbert");
+    // Terms MUST be space-joined, never a literal plus (axios escapes it to %2B, giving 0 results).
+    expect(q).not.toContain("+");
+    expect(q).toBe("intitle:Dune inauthor:Frank Herbert");
+  });
+
+  it("uses only the first author from a multi-value author field", async () => {
+    mockedGet.mockResolvedValue({ data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "ISBN_13", identifier: "9780441172719" }] } }] } });
+    await lookupIsbnsByTitle("Dune", "Frank Herbert, Kevin Anderson");
+    expect(mockedGet.mock.calls[0][1].params.q).toBe("intitle:Dune inauthor:Frank Herbert");
+  });
+
+  it("falls back to a title-only query when the author query yields nothing", async () => {
+    mockedGet
+      .mockResolvedValueOnce({ data: { items: [] } }) // author query → empty
+      .mockResolvedValueOnce({ data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "ISBN_13", identifier: "9788375780635" }] } }] } });
+    const r = await lookupIsbnsByTitle("Rare", "Obscure Author");
+    expect(r).toEqual(["9788375780635"]);
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+    expect(mockedGet.mock.calls[1][1].params.q).toBe("intitle:Rare");
   });
 
   it("converts an ISBN-10-only edition to ISBN-13", async () => {
@@ -62,9 +81,9 @@ describe("lookupIsbnsByTitle", () => {
     expect(r).toEqual(["9780306406157"]);
   });
 
-  it("returns [] when no volume carries a usable ISBN", async () => {
+  it("returns [] when no volume carries a usable ISBN (both queries)", async () => {
     mockedGet.mockResolvedValue({ data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "OTHER", identifier: "xyz" }] } }] } });
-    const r = await lookupIsbnsByTitle("Nothing");
+    const r = await lookupIsbnsByTitle("Nothing", "Someone");
     expect(r).toEqual([]);
   });
 });

--- a/services/isbnLookupService.ts
+++ b/services/isbnLookupService.ts
@@ -51,23 +51,8 @@ export async function lookupIsbn(rawCode: string): Promise<IsbnBook | null> {
   }
 }
 
-/**
- * Reverse lookup for the enrichment ritual (barcode "variant B"): given a book's
- * title (+ optional author), collect the canonical ISBN-13s of ALL its editions via
- * Google Books, so any edition's barcode identifies the row. The use case is „do I
- * own this title at all", not „this exact edition" — so we store every ISBN we can
- * resolve (ISBN-13 directly, ISBN-10 converted to 13), deduped. Returns the list
- * (possibly empty). Throws only on an unexpected error so the caller can report it.
- */
-export async function lookupIsbnsByTitle(title: string, author?: string): Promise<string[]> {
-  const cleanTitle = (title || "").trim();
-  if (!cleanTitle) return [];
-  const parts = [`intitle:${cleanTitle}`];
-  const cleanAuthor = (author || "").trim();
-  if (cleanAuthor) parts.push(`inauthor:${cleanAuthor}`);
-
-  const res = await axios.get(GOOGLE_BOOKS, { params: { q: parts.join("+"), maxResults: 20 }, timeout: 10000 });
-  const items: any[] = Array.isArray(res.data?.items) ? res.data.items : [];
+/** Collect deduped canonical ISBN-13s from a Google Books volumes response. */
+function collectIsbns(items: any[]): string[] {
   const found = new Set<string>();
   for (const item of items) {
     const ids: any[] = item?.volumeInfo?.industryIdentifiers || [];
@@ -80,4 +65,37 @@ export async function lookupIsbnsByTitle(title: string, author?: string): Promis
     }
   }
   return Array.from(found);
+}
+
+/** One Google Books query → deduped ISBN-13s. */
+async function queryIsbns(q: string): Promise<string[]> {
+  const res = await axios.get(GOOGLE_BOOKS, { params: { q, maxResults: 20 }, timeout: 10000 });
+  return collectIsbns(Array.isArray(res.data?.items) ? res.data.items : []);
+}
+
+/**
+ * Reverse lookup for the enrichment ritual (barcode "variant B"): given a book's
+ * title (+ optional author), collect the canonical ISBN-13s of ALL its editions via
+ * Google Books, so any edition's barcode identifies the row. The use case is „do I
+ * own this title at all", not „this exact edition" — so we store every ISBN we can
+ * resolve (ISBN-13 directly, ISBN-10 converted to 13), deduped. Returns the list
+ * (possibly empty). Throws only on an unexpected error so the caller can report it.
+ *
+ * The query terms are joined with a SPACE, not a literal „+": axios encodes a space
+ * as „+" (the Google Books AND separator), whereas a literal „+" is escaped to „%2B"
+ * and read as one garbage token — which returns zero results for every book.
+ */
+export async function lookupIsbnsByTitle(title: string, author?: string): Promise<string[]> {
+  const cleanTitle = (title || "").trim();
+  if (!cleanTitle) return [];
+  // Notion „Autor" can be multi-value („A, B") — the first author is enough to disambiguate
+  // and avoids over-constraining the query (some editions list a translator/editor too).
+  const firstAuthor = (author || "").split(",")[0].trim();
+
+  if (firstAuthor) {
+    const withAuthor = await queryIsbns(`intitle:${cleanTitle} inauthor:${firstAuthor}`);
+    if (withAuthor.length > 0) return withAuthor;
+    // Fall back to title-only — some editions aren't indexed under the same author string.
+  }
+  return await queryIsbns(`intitle:${cleanTitle}`);
 }


### PR DESCRIPTION
Fixes #267

The `isbn-enrich` ritual ran and created the `ISBN` column correctly, but every book landed in "skipped" — no ISBNs found.

## Root cause

`lookupIsbnsByTitle` joined the query terms with a literal `+` (`intitle:X+inauthor:Y`). axios encodes `+` as `%2B` (a literal plus sign), so Google Books received `intitle:X%2Binauthor:Y` as a single garbage token → **0 results for every book**. Confirmed with `axios.getUri`: a literal `+` becomes `%2B`, while a **space** becomes `+` (the Google Books AND separator).

## Fix

- Join terms with a **space** — axios then emits the correct `intitle:X+inauthor:Y`.
- Use only the **first author** from a multi-value `Autor` field (some editions list a translator/editor too, which over-constrains the query).
- **Fall back to a title-only query** when the author-qualified query returns nothing (some editions aren't indexed under the same author string).
- +2 tests (multi-author, title-only fallback) plus a regression assertion that the built query never contains a literal `+`.

Full suite green (437 tests), lint clean. Version bump 1.52.0 → 1.52.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_