### PR TITLE
fix(skryptorium): ISBN enrichment still empty — OpenLibrary fallback + surface errors

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.52.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.52.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.52.2** — **Rytuał ISBN: fallback OpenLibrary + WIDOCZNE błędy (dalej nic nie łapał po 1.52.1).** Po
+  fixie kodowania (1.52.1) na Renderze dalej pusto — HIPOTEZA: Google Books ostro limituje keyless z IP
+  datacenter (Render) → każde zapytanie 429/403 → wszystko leciało do BŁĘDÓW, a `SingleSyncSummary` błędów
+  NIE pokazywał → wyglądało jak „0 znalezionych". Dwie zmiany: (1) **2 źródła** w `lookupIsbnsByTitle` —
+  Google Books, a gdy pusto LUB nieosiągalne → **OpenLibrary** (`openlibrary.org/search.json`, keyless,
+  tolerancyjne dla IP serwerowych; `doc.isbn` = ISBN-y wszystkich wydań). Union, dedup, ISBN-10→13. Rzuca
+  wyjątek TYLKO gdy OBA źródła padną (prawdziwa awaria vs „brak dopasowania" = skip). (2) **Panel „Błędy —
+  nie zapisano"** w `SingleSyncSummary` (czerwony, kopiowalny) — rytuał, który wywalił się na każdej książce,
+  nie wygląda już jak „nic nie znalazł". +3 testy (OL fallback, throw-gdy-oba-padną, [] gdy brak dopasowania).
+  Uwaga: nieweryfikowalne w sandboxie (proxy blokuje OL i limituje Google) — do potwierdzenia na Renderze;
+  jak dalej pusto, panel błędów pokaże DOKŁADNĄ przyczynę (429/403/timeout).
 - **1.52.1** — **FIX: rytuał ISBN nic nie znajdował (błędne kodowanie zapytania Google Books).** Root cause:
   `lookupIsbnsByTitle` łączył człony zapytania literalnym „+" (`intitle:X+inauthor:Y`), a axios koduje „+"
   jako `%2B` (literalny plus) → Google Books widział JEDEN śmieciowy token → 0 wyników dla KAŻDEJ książki

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.52.1",
+      "version": "1.52.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.52.1",
+  "version": "1.52.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbnLookupService.test.ts
+++ b/services/__tests__/isbnLookupService.test.ts
@@ -81,8 +81,25 @@ describe("lookupIsbnsByTitle", () => {
     expect(r).toEqual(["9780306406157"]);
   });
 
-  it("returns [] when no volume carries a usable ISBN (both queries)", async () => {
-    mockedGet.mockResolvedValue({ data: { items: [{ volumeInfo: { industryIdentifiers: [{ type: "OTHER", identifier: "xyz" }] } }] } });
+  it("falls back to OpenLibrary when Google Books finds nothing", async () => {
+    mockedGet
+      .mockResolvedValueOnce({ data: { items: [] } })                                   // google: author query
+      .mockResolvedValueOnce({ data: { items: [] } })                                   // google: title-only
+      .mockResolvedValueOnce({ data: { docs: [{ isbn: ["9788375780635", "0306406152"] }] } }); // openlibrary
+    const r = await lookupIsbnsByTitle("Rare", "Author");
+    // OpenLibrary's isbn array mixes ISBN-10/13 → all normalized to canonical 13, deduped.
+    expect(r).toEqual(["9788375780635", "9780306406157"]);
+    expect(mockedGet).toHaveBeenCalledTimes(3);
+    expect(mockedGet.mock.calls[2][0]).toContain("openlibrary.org");
+  });
+
+  it("throws only when BOTH sources are unreachable (so 'no match' ≠ 'API down')", async () => {
+    mockedGet.mockRejectedValue(new Error("ECONNRESET"));
+    await expect(lookupIsbnsByTitle("X", "Y")).rejects.toThrow(/google-books.*openlibrary/s);
+  });
+
+  it("returns [] (not an error) when sources respond but nothing matches", async () => {
+    mockedGet.mockResolvedValue({ data: { items: [], docs: [] } });
     const r = await lookupIsbnsByTitle("Nothing", "Someone");
     expect(r).toEqual([]);
   });

--- a/services/isbnLookupService.ts
+++ b/services/isbnLookupService.ts
@@ -11,6 +11,7 @@ import { createLogger } from "../logger";
 
 const log = createLogger("IsbnLookup");
 const GOOGLE_BOOKS = "https://www.googleapis.com/books/v1/volumes";
+const OPEN_LIBRARY = "https://openlibrary.org/search.json";
 
 export interface IsbnBook {
   /** Canonical ISBN-13 that was resolved. */
@@ -68,20 +69,46 @@ function collectIsbns(items: any[]): string[] {
 }
 
 /** One Google Books query → deduped ISBN-13s. */
-async function queryIsbns(q: string): Promise<string[]> {
+async function queryGoogle(q: string): Promise<string[]> {
   const res = await axios.get(GOOGLE_BOOKS, { params: { q, maxResults: 20 }, timeout: 10000 });
   return collectIsbns(Array.isArray(res.data?.items) ? res.data.items : []);
 }
 
 /**
+ * OpenLibrary reverse lookup → deduped ISBN-13s. Keyless and tolerant of server/
+ * datacenter IPs (Google Books rate-limits keyless calls hard from cloud hosts like
+ * Render), and each `doc.isbn` already lists every edition's ISBN — ideal here.
+ */
+async function queryOpenLibrary(title: string, author: string): Promise<string[]> {
+  const params: Record<string, string | number> = { title, limit: 5, fields: "isbn" };
+  if (author) params.author = author;
+  const res = await axios.get(OPEN_LIBRARY, { params, timeout: 10000 });
+  const docs: any[] = Array.isArray(res.data?.docs) ? res.data.docs : [];
+  const found = new Set<string>();
+  for (const doc of docs) {
+    const isbns: any[] = Array.isArray(doc?.isbn) ? doc.isbn : [];
+    for (const raw of isbns) {
+      const normalized = normalizeIsbn(String(raw || ""));
+      if (normalized) found.add(normalized);
+    }
+  }
+  return Array.from(found);
+}
+
+/**
  * Reverse lookup for the enrichment ritual (barcode "variant B"): given a book's
- * title (+ optional author), collect the canonical ISBN-13s of ALL its editions via
- * Google Books, so any edition's barcode identifies the row. The use case is „do I
- * own this title at all", not „this exact edition" — so we store every ISBN we can
- * resolve (ISBN-13 directly, ISBN-10 converted to 13), deduped. Returns the list
- * (possibly empty). Throws only on an unexpected error so the caller can report it.
+ * title (+ optional author), collect the canonical ISBN-13s of ALL its editions, so
+ * any edition's barcode identifies the row. The use case is „do I own this title at
+ * all", not „this exact edition" — so we store every ISBN we can resolve, deduped.
  *
- * The query terms are joined with a SPACE, not a literal „+": axios encodes a space
+ * Two sources for resilience: Google Books first, then OpenLibrary if Google finds
+ * nothing OR is unreachable (Google rate-limits keyless calls hard from datacenter
+ * IPs like Render — the enrichment came back empty in production for exactly this).
+ * Returns the deduped union. Returns [] when the sources respond but nothing matches;
+ * throws only when BOTH sources error (a real outage the caller reports per book), so
+ * a genuine „no match" is never confused with „couldn't reach the API".
+ *
+ * Google query terms are joined with a SPACE, not a literal „+": axios encodes a space
  * as „+" (the Google Books AND separator), whereas a literal „+" is escaped to „%2B"
  * and read as one garbage token — which returns zero results for every book.
  */
@@ -92,10 +119,35 @@ export async function lookupIsbnsByTitle(title: string, author?: string): Promis
   // and avoids over-constraining the query (some editions list a translator/editor too).
   const firstAuthor = (author || "").split(",")[0].trim();
 
-  if (firstAuthor) {
-    const withAuthor = await queryIsbns(`intitle:${cleanTitle} inauthor:${firstAuthor}`);
-    if (withAuthor.length > 0) return withAuthor;
-    // Fall back to title-only — some editions aren't indexed under the same author string.
+  const found = new Set<string>();
+  const failures: string[] = [];
+
+  // Source 1: Google Books (title+author, then title-only fallback).
+  try {
+    if (firstAuthor) {
+      (await queryGoogle(`intitle:${cleanTitle} inauthor:${firstAuthor}`)).forEach((x) => found.add(x));
+    }
+    if (found.size === 0) {
+      (await queryGoogle(`intitle:${cleanTitle}`)).forEach((x) => found.add(x));
+    }
+  } catch (e: any) {
+    log.warn("Google Books niedostępne", { title: cleanTitle, error: e?.message });
+    failures.push(`google-books: ${e?.message || "błąd"}`);
   }
-  return await queryIsbns(`intitle:${cleanTitle}`);
+
+  // Source 2: OpenLibrary — only if Google found nothing (or was unreachable).
+  if (found.size === 0) {
+    try {
+      (await queryOpenLibrary(cleanTitle, firstAuthor)).forEach((x) => found.add(x));
+    } catch (e: any) {
+      log.warn("OpenLibrary niedostępne", { title: cleanTitle, error: e?.message });
+      failures.push(`openlibrary: ${e?.message || "błąd"}`);
+    }
+  }
+
+  // Both sources errored AND nothing found → a real outage, surface it to the caller.
+  if (found.size === 0 && failures.length === 2) {
+    throw new Error(failures.join("; "));
+  }
+  return Array.from(found);
 }

--- a/src/components/sync/SingleSyncSummary.tsx
+++ b/src/components/sync/SingleSyncSummary.tsx
@@ -20,6 +20,9 @@ export const SingleSyncSummary: React.FC<{ sync: ReturnType<typeof useSync>; onC
   const theme = { text: t.text, border: t.border, bg: t.bgSoft };
 
   const hasDetails = summary && (summary.added?.length > 0 || summary.updated?.length > 0 || summary.duplicates?.length > 0 || summary.skipped?.length > 0);
+  // Errors are a distinct channel from „skipped" (no match): an API outage / rate-limit
+  // must be visible, or a ritual that errored on every book looks like it just found nothing.
+  const errors: string[] = Array.isArray(activeResult?.errors) ? activeResult.errors : [];
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className={`glass-card p-8 rounded-3xl ${theme.border}`}>
@@ -66,6 +69,14 @@ export const SingleSyncSummary: React.FC<{ sync: ReturnType<typeof useSync>; onC
               />
             )}
           </div>
+        )}
+
+        {errors.length > 0 && (
+          <SummaryDetailPanel
+            title="Błędy — nie zapisano" count={errors.length} icon={<XCircle className="w-4 h-4" />}
+            accentClass="text-red-400" rowClass="border-red-500/30 bg-red-500/5" rowTextClass="text-red-300" items={errors}
+            onCopy={() => copy(errors.join("\n"))} copied={copied} copyTitle="Kopiuj listę błędów"
+          />
         )}
       </div>
     </motion.div>


### PR DESCRIPTION
Fixes #269

After #268 fixed the query encoding, the ritual still found nothing on Render. The most likely cause is that **Google Books rate-limits keyless requests from datacenter IPs** (429/403), so every request errored — and the summary never showed errors, so it looked like "0 found".

## Changes

- **Two sources** in `lookupIsbnsByTitle`: Google Books first, then **OpenLibrary** (`openlibrary.org/search.json` — keyless, tolerant of server IPs; each `doc.isbn` already lists all edition ISBNs) when Google finds nothing or is unreachable. Union + dedup, ISBN-10→13. Throws **only when both sources error**, so a genuine "no match" (→ skipped) is never confused with "API unreachable" (→ error).
- **Error visibility**: `SingleSyncSummary` renders a red **"Błędy — nie zapisano"** panel from `result.errors` (copyable), so a ritual that errored on every book is visible instead of looking empty.
- +3 tests (OpenLibrary fallback, throw-when-both-fail, `[]` on genuine no-match).

Full suite green (439 tests), lint clean. Version bump 1.52.1 → 1.52.2.

> Not reproducible in the sandbox (proxy blocks OpenLibrary and 429s Google Books), so it needs a Render run to confirm. If it's still empty after this, the new error panel will name the exact cause (429/403/timeout) so we can decide the next step (e.g. an optional Google Books API key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_