### PR TITLE
feat(skryptorium): ISBN ritual re-processes every book and merges results

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.53.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.54.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.54.0** — **Rytuał ISBN: merge zamiast gap-fill + zapytanie po OBU tytułach.** Wcześniej rytuał
+  POMIJAŁ pozycje, które miały już jakikolwiek ISBN (gap-fill) → książki uzupełnione samym angielskim
+  ISBN-em nie dostawały polskiego. Teraz **każda** książka nagrodowa jest przetwarzana, a wynik SCALANY z
+  istniejącą listą (`Set(existing) ∪ found`); zapis TYLKO gdy zbiór urósł (bez zbędnych zapisów — licznik
+  `unchanged`). Kluczowe: lookup po OBU tytułach (polski + oryginalny), bo Biblioteka Narodowa indeksuje
+  tytuł POLSKI („Diuna"), a Google/OL oryginalny („Dune") — dwa wywołania `lookupIsbnsByTitle` (każde =
+  unia 3 źródeł), union wyników. Błąd per-książka tylko gdy WSZYSTKIE lookupy padły; istniejące ISBN-y nigdy
+  nie giną. Wynik: `updated`/`unchanged`/`skipped`/`errors`. +4 testy (merge dokłada polski, unchanged bez
+  zapisu, oba tytuły, all-fail→error). KOSZT: każdy przebieg odpytuje każdą książkę (do 2 tytułów × 3 źródła)
+  — rytuał ręczny, akceptowalne.
 - **1.53.0** — **Rytuał ISBN: polskie ISBN-y z Biblioteki Narodowej + unia 3 źródeł.** Skanujemy polskie
   egzemplarze (prefiks 978-83…), których Google/OpenLibrary często nie mają. Dodane 3. źródło:
   **Biblioteka Narodowa** (`data.bn.org.pl/api/institutions/bibs.json`, keyless) — autorytatywne dla polskich

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.53.0",
+      "version": "1.54.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.53.0",
+  "version": "1.54.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbnEnrichService.test.ts
+++ b/services/__tests__/isbnEnrichService.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { IsbnEnrichService } from "../isbnEnrichService";
 
-// The reverse Google Books lookup is mocked — we test the ritual's orchestration
-// (filtering, idempotent skip, writes), not the HTTP call.
+// The reverse catalog lookup is mocked — we test the ritual's orchestration
+// (filtering, merge, writes), not the HTTP calls.
 vi.mock("../isbnLookupService", () => ({
   lookupIsbnsByTitle: vi.fn(),
 }));
@@ -24,11 +24,10 @@ const complete = (events: any[]) => events.find((e) => e.type === "complete")?.r
 describe("IsbnEnrichService", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("enriches only award books that lack ISBNs, and writes all edition codes as a list", async () => {
+  it("processes every award book (not just empty ones) and writes the edition list", async () => {
     const notion = makeNotion([
-      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert" },              // target
-      { id: "2", plTitle: "Ma ISBN", origTitle: "Has ISBN", author: "X", isbns: ["9788375780635"] }, // already has ISBNs → skip
-      { id: "3", plTitle: "Tom", origTitle: "", author: "Y", kategoria: "Tom cyklu" },   // not an award → skip
+      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert" },              // no ISBNs yet
+      { id: "3", plTitle: "Tom", origTitle: "", author: "Y", kategoria: "Tom cyklu" },   // not an award → excluded
     ]);
     mockedLookup.mockResolvedValue(["9780441172719", "9788375780635"]);
 
@@ -36,20 +35,50 @@ describe("IsbnEnrichService", () => {
     const svc = new IsbnEnrichService(notion as any);
     await svc.runIsbnEnrich((e) => events.push(e), () => false);
 
-    // Only the one target book was looked up + written.
-    expect(mockedLookup).toHaveBeenCalledTimes(1);
+    // Only the award book is looked up — by BOTH its titles (Polish + original).
+    expect(mockedLookup).toHaveBeenCalledWith("Diuna", "Herbert");
     expect(mockedLookup).toHaveBeenCalledWith("Dune", "Herbert");
     expect(notion.updatePage).toHaveBeenCalledTimes(1);
     expect(notion.updatePage).toHaveBeenCalledWith("1", { ISBN: expect.anything() });
-    // The full edition list is joined into the written value.
     expect(notion.buildPropertyValue).toHaveBeenCalledWith("9780441172719, 9788375780635", "rich_text");
 
     const result = complete(events);
-    expect(result.synced).toBe(1);
-    expect(result.skipped).toBe(1); // one award book already had ISBNs
+    expect(result.updated).toBe(1);
   });
 
-  it("records a book as skipped when Google Books finds no ISBN (no write)", async () => {
+  it("MERGES newly-found ISBNs into a row that already has some (e.g. adds the Polish one)", async () => {
+    const notion = makeNotion([
+      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert", isbns: ["9780441172719"] },
+    ]);
+    // Catalog now returns the original AND a Polish edition ISBN.
+    mockedLookup.mockResolvedValue(["9780441172719", "9788375780635"]);
+
+    const events: any[] = [];
+    const svc = new IsbnEnrichService(notion as any);
+    await svc.runIsbnEnrich((e) => events.push(e), () => false);
+
+    // Existing ISBN preserved, the new Polish one appended.
+    expect(notion.buildPropertyValue).toHaveBeenCalledWith("9780441172719, 9788375780635", "rich_text");
+    expect(complete(events).updated).toBe(1);
+  });
+
+  it("leaves a row unchanged (no write) when the catalogs add nothing new", async () => {
+    const notion = makeNotion([
+      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert", isbns: ["9780441172719"] },
+    ]);
+    mockedLookup.mockResolvedValue(["9780441172719"]); // already stored
+
+    const events: any[] = [];
+    const svc = new IsbnEnrichService(notion as any);
+    await svc.runIsbnEnrich((e) => events.push(e), () => false);
+
+    expect(notion.updatePage).not.toHaveBeenCalled();
+    const result = complete(events);
+    expect(result.updated).toBe(0);
+    expect(result.unchanged).toBe(1);
+  });
+
+  it("records a book as skipped when the catalogs find no ISBN (no write)", async () => {
     const notion = makeNotion([{ id: "1", plTitle: "Nieznana", origTitle: "", author: "Z" }]);
     mockedLookup.mockResolvedValue([]);
 
@@ -59,8 +88,21 @@ describe("IsbnEnrichService", () => {
 
     expect(notion.updatePage).not.toHaveBeenCalled();
     const result = complete(events);
-    expect(result.synced).toBe(0);
+    expect(result.updated).toBe(0);
     expect(result.summary.skipped).toContain("Nieznana");
+  });
+
+  it("reports a book as errored when every lookup throws (and keeps existing ISBNs)", async () => {
+    const notion = makeNotion([{ id: "1", plTitle: "Diuna", origTitle: "", author: "Z" }]);
+    mockedLookup.mockRejectedValue(new Error("wszystkie źródła 429"));
+
+    const events: any[] = [];
+    const svc = new IsbnEnrichService(notion as any);
+    await svc.runIsbnEnrich((e) => events.push(e), () => false);
+
+    expect(notion.updatePage).not.toHaveBeenCalled();
+    const result = complete(events);
+    expect(result.errors.some((e: string) => e.includes("Diuna"))).toBe(true);
   });
 
   it("creates the ISBN column before writing", async () => {

--- a/services/isbnEnrichService.ts
+++ b/services/isbnEnrichService.ts
@@ -9,16 +9,22 @@ const log = createLogger("IsbnEnrich");
 
 /**
  * Enrichment ritual for the barcode "variant B": fills the „ISBN" column on award
- * books that lack one, by looking the book up on Google Books by title (+ author).
- * Stored ISBNs let a mobile scan match a row DIRECTLY, without any on-scan external call.
+ * books by looking each up across three catalogs (Google Books, OpenLibrary,
+ * Biblioteka Narodowa). Stored ISBNs let a mobile scan match a row DIRECTLY, without
+ * any on-scan external call.
  *
  * We store the canonical ISBN-13s of ALL editions we can resolve (a delimited list),
  * because the use case is „do I own this title at all", not „this exact edition" — so
- * a barcode of any edition (hardback, paperback, reissue) still identifies the row.
- * Variant A (resolve → fuzzy search) remains the fallback when nothing is stored.
+ * a barcode of any edition (hardback, paperback, reissue, Polish or original) still
+ * identifies the row. Variant A (resolve → fuzzy search) is the fallback when nothing
+ * is stored.
  *
- * Idempotent: books that already carry any ISBN are skipped, so re-running only fills
- * the gaps. Cycle sibling volumes are excluded — barcode lookup is an award concern.
+ * EVERY award book is (re)processed and results are MERGED into the stored list — a
+ * row that already had, say, only the original-language ISBN gains its Polish edition
+ * ISBN on a re-run. A row is written only when the merge adds something new (no
+ * needless writes). Books are looked up by BOTH their Polish and original titles,
+ * because Biblioteka Narodowa indexes the Polish title („Diuna"), not the original
+ * („Dune"). Cycle sibling volumes are excluded — barcode lookup is an award concern.
  */
 export class IsbnEnrichService {
   constructor(private notion: NotionAdapter) {}
@@ -33,18 +39,16 @@ export class IsbnEnrichService {
 
       if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano Rytuał Sygnatur." }); return; }
 
-      // Award books only, and only those still missing ISBNs (idempotent gap-fill).
+      // Every award book with a title — re-processed and merged (not gap-filled), so
+      // already-populated rows still gain newly-found (e.g. Polish) edition ISBNs.
       const targets = rawBooks
         .filter(isAwardBook)
-        .filter((b) => !(b.isbns && b.isbns.length > 0))
         .filter((b) => (b.plTitle && b.plTitle.trim()) || (b.origTitle && b.origTitle.trim()));
-
-      const alreadyHave = rawBooks.filter(isAwardBook).length - targets.length;
 
       // Make sure the column exists before any write (schema ritual may not have run).
       await this.notion.createColumnIfNeeded("ISBN", "rich_text");
 
-      let processedCount = 0, updatedCount = 0;
+      let processedCount = 0, updatedCount = 0, unchangedCount = 0;
       const summary = { updated: [] as string[], skipped: [] as string[] };
       const errors: { book: string; error: string }[] = [];
 
@@ -55,27 +59,53 @@ export class IsbnEnrichService {
 
         processedCount++;
         if (processedCount % 10 === 0 || processedCount === targets.length) {
-          sendEvent({ type: "progress", message: "Nadawanie Sygnatur (ISBN) z Google Books...", current: processedCount, total: targets.length });
+          sendEvent({ type: "progress", message: "Nadawanie Sygnatur (ISBN) z katalogów...", current: processedCount, total: targets.length });
         }
 
-        // Prefer the original title for the lookup (Google Books indexes originals better),
-        // fall back to the Polish title.
-        const title = book.origTitle?.trim() || book.plTitle?.trim() || "";
         const label = book.plTitle || book.origTitle || book.id;
-        if (!title) return;
+        // Query by BOTH titles: original (Google/OpenLibrary index it) and Polish
+        // (Biblioteka Narodowa indexes it) — deduped, non-empty.
+        const titles = Array.from(new Set([book.plTitle?.trim(), book.origTitle?.trim()].filter(Boolean))) as string[];
+        if (titles.length === 0) return;
 
-        try {
-          const isbns = await lookupIsbnsByTitle(title, book.author);
-          if (isbns.length === 0) {
-            summary.skipped.push(label);
-            return;
+        const existing = new Set(book.isbns || []);
+        const found = new Set<string>(existing);
+        let lastError: string | null = null;
+        let anySourceResponded = false;
+
+        for (const title of titles) {
+          try {
+            (await lookupIsbnsByTitle(title, book.author)).forEach((x) => found.add(x));
+            anySourceResponded = true;
+          } catch (err: any) {
+            lastError = err?.message || "nieznany błąd";
           }
-          // Store all edition ISBNs as a delimited list — any of them matches a scan.
-          await this.notion.updatePage(book.id, { "ISBN": this.notion.buildPropertyValue(isbns.join(", "), "rich_text") });
+        }
+
+        // All lookups errored and we have nothing → a real outage for this book.
+        if (!anySourceResponded && found.size === 0) {
+          log.warn("Błąd wzbogacania ISBN", { book: label, error: lastError });
+          errors.push({ book: label, error: lastError || "nieznany błąd" });
+          return;
+        }
+
+        if (found.size === 0) {
+          summary.skipped.push(label); // sources responded, but no ISBN anywhere
+          return;
+        }
+        if (found.size === existing.size) {
+          unchangedCount++; // already had everything the catalogs know
+          return;
+        }
+
+        // The merge added at least one new ISBN → persist the full deduped list.
+        const merged = Array.from(found);
+        try {
+          await this.notion.updatePage(book.id, { "ISBN": this.notion.buildPropertyValue(merged.join(", "), "rich_text") });
           updatedCount++;
-          summary.updated.push(`${label} (ISBN: ${isbns.join(", ")})`);
+          summary.updated.push(`${label} (ISBN: ${merged.join(", ")})`);
         } catch (err: any) {
-          log.warn("Błąd wzbogacania ISBN", { book: label, error: err?.message });
+          log.warn("Błąd zapisu ISBN", { book: label, error: err?.message });
           errors.push({ book: label, error: err?.message || "nieznany błąd" });
         }
       }));
@@ -88,7 +118,7 @@ export class IsbnEnrichService {
           found: targets.length,
           synced: updatedCount,
           updated: updatedCount,
-          skipped: alreadyHave,
+          unchanged: unchangedCount,
           summary,
           errors: errors.map((e) => `${e.book}: ${e.error}`),
         },


### PR DESCRIPTION
Fixes #273

Answers the question directly: the old ritual **skipped** rows that already had any ISBN, so it did *not* compare-and-add. This changes it to re-process every book and merge.

## Changes

- **Process every award book** and **merge** found ISBNs into the existing stored set (`Set(existing) ∪ found`). A row is written **only when the set grows** — unchanged rows are counted (`unchanged`), not rewritten, so there's no needless write churn. Existing ISBNs are never lost.
- **Look up by both titles** — Polish *and* original. Biblioteka Narodowa indexes the Polish title ("Diuna"); Google Books / OpenLibrary the original ("Dune"). Two lookups per book (each already a 3-source union), results unioned — so a row that previously held only the original-language ISBN now gains its Polish edition ISBN.
- Per-book **error** only when *every* lookup throws. The completion result reports `updated` / `unchanged` / `skipped` / `errors`.
- +4 tests (merge adds the Polish ISBN, unchanged → no write, both titles queried, all-sources-fail → error).

Full suite green (442 tests), lint clean. Version bump 1.53.0 → 1.54.0.

> Cost note: each run now queries every book (up to 2 titles × 3 sources). The ritual is manual/infrequent, so this is acceptable; re-running it is now the way to backfill Polish ISBNs onto already-enriched rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_