### PR TITLE
fix(skryptorium): scan matched a stale in-memory index → false "not found"

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.54.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.54.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.54.1** — **FIX: skaner „nie znaleziono" mimo zapisanego ISBN (nieświeży indeks w apce).** Root cause:
+  `useBooks` pobiera indeks TYLKO przy montowaniu; jeśli apka mobilna była otwarta PRZED rytuałem ISBN, jej
+  lista w pamięci nie miała jeszcze ISBN-ów → `matchIsbnInIndex` szukał w nieświeżych danych → miss (potem
+  wariant A/Google 429 → „nie znaleziono"). Test integracyjny (mapper→index→match) POTWIERDZIŁ, że logika
+  dopasowania jest poprawna (w izolacji trafia), więc problem = dane, nie kod. Fix: przy skanie pobieramy
+  ŚWIEŻY `/api/books` i dopasowujemy do niego (skan to rzadka, świadoma akcja — jeden refetch OK); świeża
+  lista aktualizuje też stan (`setBooks` wystawione z `useBooks`). Komunikat miss doprecyzowany. +3 testy
+  integracyjne (single ISBN, ISBN z listy, tom cyklu wykluczony z indeksu). UWAGA na przyszłość: wiersze
+  `Kategoria="Tom cyklu"` są CELOWO poza indeksem Skryptorium → skan tomu cyklu nie trafi (osobna decyzja,
+  gdyby trzeba skanować też tomy).
 - **1.54.0** — **Rytuał ISBN: merge zamiast gap-fill + zapytanie po OBU tytułach.** Wcześniej rytuał
   POMIJAŁ pozycje, które miały już jakikolwiek ISBN (gap-fill) → książki uzupełnione samym angielskim
   ISBN-em nie dostawały polskiego. Teraz **każda** książka nagrodowa jest przetwarzana, a wynik SCALANY z

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.54.0",
+      "version": "1.54.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.54.0",
+  "version": "1.54.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/scanFlowIntegration.test.ts
+++ b/services/__tests__/scanFlowIntegration.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { mapPageToBook } from "../../notionMapper";
+import { toSearchIndex } from "../bookSearchIndex";
+import { matchIsbnInIndex } from "../../src/utils/barcode";
+
+// Reproduce the exact production path for a scanned Polish ISBN.
+const page = (isbnValue: string, kategoria?: string) => ({
+  id: "p1",
+  properties: {
+    "Lp": { type: "title", title: [{ plain_text: "12" }] },
+    "Tytuł polski": { type: "rich_text", rich_text: [{ plain_text: "Miecz dla Króla" }] },
+    "Autor": { type: "multi_select", multi_select: [{ name: "Autor" }] },
+    "ISBN": { type: "rich_text", rich_text: [{ plain_text: isbnValue }] },
+    ...(kategoria ? { "Kategoria": { type: "select", select: { name: kategoria } } } : {}),
+  },
+}) as any;
+
+describe("scan flow integration (mapper → search index → match)", () => {
+  it("matches a stored single ISBN end-to-end", () => {
+    const book = mapPageToBook(page("9788375900019"));
+    expect(book.isbns).toEqual(["9788375900019"]);
+    const index = toSearchIndex([book]);
+    expect(index[0].isbns).toEqual(["9788375900019"]);
+    expect(matchIsbnInIndex("9788375900019", index)?.plTitle).toBe("Miecz dla Króla");
+  });
+
+  it("matches when the ISBN is one of several stored, comma-joined", () => {
+    const book = mapPageToBook(page("9780553801477, 9788375900019"));
+    const index = toSearchIndex([book]);
+    expect(matchIsbnInIndex("9788375900019", index)?.plTitle).toBe("Miecz dla Króla");
+  });
+
+  it("DROPS the book from the index when it is a cycle volume (Tom cyklu)", () => {
+    const book = mapPageToBook(page("9788375900019", "Tom cyklu"));
+    const index = toSearchIndex([book]);
+    expect(index).toHaveLength(0);
+    expect(matchIsbnInIndex("9788375900019", index)).toBeNull();
+  });
+});

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -11,7 +11,7 @@ import { scanSupported, cleanScannedCode, matchIsbnInIndex } from "../utils/barc
 const RENDER_CAP = 150;
 
 export const SearchSection: React.FC = () => {
-  const { books, loading, error, fetchBooks } = useBooks();
+  const { books, loading, error, fetchBooks, setBooks } = useBooks();
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -35,23 +35,34 @@ export const SearchSection: React.FC = () => {
     setScanNotice(null);
     const code = cleanScannedCode(rawCode);
     if (!code) return;
-
-    const direct = matchIsbnInIndex(code, books ?? []);
-    if (direct) {
-      setQuery(direct.plTitle || direct.origTitle);
-      setScanNotice({ kind: "exact", text: `Trafienie w archiwum: „${direct.plTitle || direct.origTitle}"` });
-      return;
-    }
-
     setScanResolving(true);
     try {
+      // Match against a FRESH index, not the in-memory one: the ISBN may have been added
+      // by the enrichment ritual after this page loaded (useBooks fetches only on mount),
+      // so the cached list can be stale exactly for a just-enriched book.
+      let index = books ?? [];
+      try {
+        const fresh = await fetch(`/api/books?t=${Date.now()}`);
+        if (fresh.ok) { index = await fresh.json(); setBooks(index); }
+      } catch {
+        // Network hiccup — fall back to the in-memory index.
+      }
+
+      const direct = matchIsbnInIndex(code, index);
+      if (direct) {
+        setQuery(direct.plTitle || direct.origTitle);
+        setScanNotice({ kind: "exact", text: `Trafienie w archiwum: „${direct.plTitle || direct.origTitle}"` });
+        return;
+      }
+
+      // Not stored on any row → resolve the ISBN to a title and fuzzy-search it (variant A).
       const res = await fetch(`/api/isbn/${encodeURIComponent(code)}`);
       if (res.ok) {
         const book = await res.json();
         setQuery(book.title || "");
         setScanNotice({ kind: "resolved", text: `Rozpoznano przez ISBN: „${book.title}" — przeszukuję archiwum` });
       } else {
-        setScanNotice({ kind: "miss", text: `Nie rozpoznano kodu ISBN ${code}. Spróbuj wpisać tytuł ręcznie.` });
+        setScanNotice({ kind: "miss", text: `Nie znaleziono w archiwum książki o ISBN ${code}.` });
       }
     } catch {
       setScanNotice({ kind: "miss", text: "Błąd rozpoznawania ISBN — spróbuj ponownie lub wpisz tytuł ręcznie." });

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -32,5 +32,5 @@ export function useBooks() {
     fetchBooks();
   }, [fetchBooks]);
 
-  return { books, loading, error, fetchBooks };
+  return { books, loading, error, fetchBooks, setBooks };
 }


### PR DESCRIPTION
Fixes #275

Scanning `9788375900019` (stored on "Miecz dla Króla") reported "not found". Your instinct was close — the scanner *could* read the list, but it was reading a **stale** list.

## Root cause

`useBooks` fetches the index only on mount. If the mobile app was open **before** the enrichment ritual ran, its in-memory list has no ISBNs yet, so `matchIsbnInIndex` matches against stale data and misses. An end-to-end integration test (`mapPageToBook` → `toSearchIndex` → `matchIsbnInIndex`) confirms the matching logic itself is correct — so it's a data-freshness bug, not a matching bug.

## Fix

- On scan, match against a **freshly fetched** `/api/books` (a scan is deliberate and rare, so one refetch is fine); the fresh list also updates state via `setBooks` (now exposed from `useBooks`).
- Clarify the miss message ("Nie znaleziono w archiwum książki o ISBN …").
- +3 integration tests: single stored ISBN, an ISBN within a comma-joined list, and that a `Tom cyklu` row is (by design) excluded from the award-only index.

Full suite green (445 tests), lint clean. Version bump 1.54.0 → 1.54.1.

## Heads-up

Cycle-volume rows (`Kategoria="Tom cyklu"`) are intentionally **not** in the Skryptorium index, so scanning one won't match. If "Miecz dla Króla" is a cycle volume rather than an award winner, that's why — tell me and I'll add an option to include cycle volumes in the scan lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_