### PR TITLE
feat(diagnostics): GET /api/scan-debug/:code to diagnose barcode "not found"

### DIFF
--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -163,6 +163,23 @@ describe("GET /api/isbn/:code", () => {
   });
 });
 
+describe("GET /api/scan-debug/:code", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NOTION_API_KEY = "test-key";
+    process.env.NOTION_DATABASE_ID = "test-db";
+  });
+
+  it("returns the diagnostic payload for a scanned code", async () => {
+    const payload = { input: "9788375900019", normalized: "9788375900019", totalBooks: 1, scanIndexSize: 1, matchCount: 1, matches: [{ title: "Miecz dla Króla", kategoria: "Nagroda", isbns: ["9788375900019"], inScanIndex: true }] };
+    const spy = vi.spyOn(syncManager, "scanDebug").mockResolvedValue(payload as any);
+    const res = await request(app).get("/api/scan-debug/9788375900019");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(payload);
+    expect(spy).toHaveBeenCalledWith("9788375900019");
+  });
+});
+
 describe("POST /api/mark-as-read", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.54.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.54.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.54.2** — **Diagnostyka skanu: `GET /api/scan-debug/:code`.** Skaner dalej „nie znajduje" mimo świeżego
+  indeksu → endpoint do ustalenia PRZYCZYNY na żywo (Render). Read-only, bez cache: dla kodu zwraca
+  `{ input, normalized, totalBooks, scanIndexSize, matchCount, matches: [{title, kategoria, isbns, inScanIndex}] }`
+  — przeszukuje WSZYSTKIE książki (nie tylko nagrodowe), więc od razu widać: czy ISBN jest zapisany, na
+  której pozycji, jaką ma `Kategoria` i czy jest w indeksie skanera (`inScanIndex`=false gdy „Tom cyklu").
+  Hipotezy do rozstrzygnięcia: (a) książka to tom cyklu → poza indeksem; (b) zapisany ISBN różni się od
+  skanowanego (checksum/format/inne wydanie); (c) stary bundle w cache przeglądarki. +1 test (routing).
 - **1.54.1** — **FIX: skaner „nie znaleziono" mimo zapisanego ISBN (nieświeży indeks w apce).** Root cause:
   `useBooks` pobiera indeks TYLKO przy montowaniu; jeśli apka mobilna była otwarta PRZED rytuałem ISBN, jej
   lista w pamięci nie miała jeszcze ISBN-ów → `matchIsbnInIndex` szukał w nieświeżych danych → miss (potem

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -335,6 +335,17 @@ export const getIsbn = async (req: Request, res: Response) => {
   }
 };
 
+export const getScanDebug = async (req: Request, res: Response) => {
+  const code = typeof req.params.code === "string" ? req.params.code : "";
+  try {
+    const result = await syncManager.scanDebug(code);
+    res.json(result);
+  } catch (error: any) {
+    log.error("Scan debug error", { code, message: error?.message });
+    res.status(500).json({ error: error.message || "Błąd diagnostyki skanu." });
+  }
+};
+
 export const getCyclesHarvest = async (req: Request, res: Response) => {
   try {
     const fresh = req.query.fresh === "1" || req.query.fresh === "true";

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.54.1",
+      "version": "1.54.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.54.1",
+  "version": "1.54.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/routes/syncRoutes.ts
+++ b/routes/syncRoutes.ts
@@ -47,6 +47,7 @@ router.post("/vinted-resolve-sellers/stop", syncController.stopVintedResolveSell
 router.get("/vinted-stored", syncController.getVintedStored);
 router.get("/cycle", syncController.getCycle);
 router.get("/isbn/:code", syncController.getIsbn);
+router.get("/scan-debug/:code", syncController.getScanDebug);
 router.get("/cycles-harvest", syncController.getCyclesHarvest);
 router.post("/library-check", syncController.checkLibraryAvailability);
 

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -18,6 +18,8 @@ import { IsbnEnrichService } from "./services/isbnEnrichService";
 import { aggregateCycleRows } from "./services/cycleRows";
 import { lookupIsbn } from "./services/isbnLookupService";
 import { toSearchIndex } from "./services/bookSearchIndex";
+import { isAwardBook } from "./services/bookCategory";
+import { normalizeIsbn } from "./services/isbn";
 import { ConfigService } from "./services/configService";
 import { createLogger, classifyHttpError } from "./logger";
 import { SyncEvent } from "./src/types";
@@ -120,6 +122,34 @@ class SyncManager {
   async getBooks() {
     const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
     return toSearchIndex(books);
+  }
+
+  /**
+   * Read-only diagnostic for the barcode scan: for a given code, report exactly what the
+   * server sees — whether the ISBN is stored on any row (award or cycle volume), on which
+   * book, its category, and whether that row is in the award-only Skryptorium index (the
+   * only rows a scan can match). Bypasses the cache so it reflects Notion right now.
+   */
+  async scanDebug(rawCode: string) {
+    const normalized = normalizeIsbn(rawCode);
+    const target = (normalized || rawCode).replace(/\D/g, "");
+    const all = await this.notion.getBooksForStats(undefined, undefined, { cache: false });
+    const matches = all
+      .filter((b) => (b.isbns || []).some((i) => i.replace(/\D/g, "") === target))
+      .map((b) => ({
+        title: b.plTitle || b.origTitle || b.id,
+        kategoria: b.kategoria || "Nagroda",
+        isbns: b.isbns || [],
+        inScanIndex: isAwardBook(b),
+      }));
+    return {
+      input: rawCode,
+      normalized,
+      totalBooks: all.length,
+      scanIndexSize: all.filter(isAwardBook).length,
+      matchCount: matches.length,
+      matches,
+    };
   }
 
   async getNotionSchema() {


### PR DESCRIPTION
The scanner still reports "not found" after the stale-index fix. Rather than guess again, this adds a read-only diagnostic so we get ground truth from the live Render instance.

`GET /api/scan-debug/:code` (cache-bypassing) returns, for a scanned code, exactly what the server sees:

```json
{
  "input": "9788375900019",
  "normalized": "9788375900019",
  "totalBooks": 342,
  "scanIndexSize": 300,
  "matchCount": 1,
  "matches": [
    { "title": "Miecz dla Króla", "kategoria": "Tom cyklu", "isbns": ["9788375900019"], "inScanIndex": false }
  ]
}
```

It searches **all** books (not just award ones), so a single request distinguishes the likely causes:
- `matchCount: 0` → the scanned ISBN isn't stored on any row (or differs from what's stored — checksum/format/another edition).
- a match with `inScanIndex: false` → the book is a **cycle volume** (`Kategoria="Tom cyklu"`), which is excluded from the award-only scan index — so a scan can't match it.
- a match with `inScanIndex: true` → the data is correct and in-index, pointing at a client/caching issue (e.g. a stale browser bundle).

+1 route test. Full suite green (446), lint clean. Version bump 1.54.1 → 1.54.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_