### PR TITLE
fix(skryptorium): scan bypasses the server-side books cache too (fresh=1)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.54.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.54.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.54.3** — **Skan: świeży fetch omija też cache SERWERA (`/api/books?fresh=1`).** Diagnostyka
+  (`scan-debug`) potwierdziła: ISBN JEST zapisany, `kategoria=Nagroda`, `inScanIndex=true` → dane OK, problem
+  = świeżość/klient. `getBooks()` używał 5-min `booksCache` (cache:true); ręczny wpis w Notion NIE unieważnia
+  tego cache → apka podawała starą listę bez nowego ISBN. Poprzedni „świeży fetch" (1.54.1) omijał tylko cache
+  PRZEGLĄDARKI. Teraz `getBooks(fresh)` + `/api/books?fresh=1` (cache:!fresh) — skan pobiera dane prosto z
+  Notion. Jeśli mimo to pudłuje → stary bundle JS w apce (badge wersji `v{__APP_VERSION__}` w nagłówku pokaże;
+  < 1.54.x = twardy refresh). ODNOTOWANE (osobny problem): enrichment nadmuchał „Miecz dla króla" do 72 ISBN
+  (generyczny tytuł → title-only fallback zebrał masę niepowiązanych wydań) → ryzyko FAŁSZYWYCH trafień skanu
+  innych książek; do zawężenia (wymóg autora / bez title-only dla krótkich tytułów / limit) — patrz Otwarte pozycje.
 - **1.54.2** — **Diagnostyka skanu: `GET /api/scan-debug/:code`.** Skaner dalej „nie znajduje" mimo świeżego
   indeksu → endpoint do ustalenia PRZYCZYNY na żywo (Render). Read-only, bez cache: dla kodu zwraca
   `{ input, normalized, totalBooks, scanIndexSize, matchCount, matches: [{title, kategoria, isbns, inScanIndex}] }`
@@ -914,6 +923,12 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
     odłożony (v1 = Android/Chrome). (b) multi-edition ISBN — ✅ ROZWIĄZANE (1.52.0): zapisujemy WSZYSTKIE
     ISBN-y wydań (`isbns: string[]`), więc barcode dowolnej edycji trafia w wiersz (use case = „mam tę
     książkę", nie „tę edycję").
+  - **DO ZROBIENIA: zawężenie enrichmentu (pollution ISBN).** Generyczne tytuły („Miecz dla króla") przez
+    title-only fallback + 3 źródła × 2 tytuły × 20 wyników zbierają DZIESIĄTKI niepowiązanych wydań (realny
+    przypadek: 72 ISBN-y na 1 pozycji). Ryzyko: FAŁSZYWE trafienia skanu (kod obcej książki pasuje do naszej).
+    Kandydaci na fix: wymagać zgodności autora w wynikach (Google `inauthor`/OL `author_name`/BN autor),
+    NIE robić title-only fallback dla krótkich/generycznych tytułów, twardy limit ISBN-ów na pozycję,
+    filtr prefiksu (preferuj 978-83 dla polskich). Do przemyślenia z użytkownikiem.
 
 - **Vinted znowu zablokował skaner — alternatywy w zanadrzu** — NOTATKA (Vinted ubił skan z IP Render/datacenter).
   Co JUŻ mamy (obrona pasywna): throttle 3–5 s + jitter na każdej ścieżce, pula User-Agent (rotacja,

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -19,7 +19,10 @@ export const getStats = async (req: Request, res: Response) => {
 
 export const getBooks = async (req: Request, res: Response) => {
   try {
-    const books = await syncManager.getBooks();
+    // `fresh=1` bypasses the 5-min server cache — used by the barcode scan so a
+    // just-enriched (or manually-edited) ISBN is visible immediately.
+    const fresh = req.query.fresh === "1" || req.query.fresh === "true";
+    const books = await syncManager.getBooks(fresh);
     res.json(books);
   } catch (error: any) {
     console.error("Books Error:", error);

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.54.2",
+  "version": "1.54.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.54.2",
+  "version": "1.54.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.54.2",
+      "version": "1.54.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.54.2",
+  "version": "1.54.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -42,7 +42,8 @@ export const SearchSection: React.FC = () => {
       // so the cached list can be stale exactly for a just-enriched book.
       let index = books ?? [];
       try {
-        const fresh = await fetch(`/api/books?t=${Date.now()}`);
+        // fresh=1 bypasses the server's 5-min cache too, so a just-added ISBN is visible.
+        const fresh = await fetch(`/api/books?fresh=1&t=${Date.now()}`);
         if (fresh.ok) { index = await fresh.json(); setBooks(index); }
       } catch {
         // Network hiccup — fall back to the in-memory index.

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -118,9 +118,9 @@ class SyncManager {
     return await statsService.getStats();
   }
 
-  /** Slimmed-down book index for the „Skryptorium" search (client-side). */
-  async getBooks() {
-    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: true });
+  /** Slimmed-down book index for the „Skryptorium" search (client-side). `fresh` bypasses the cache. */
+  async getBooks(fresh = false) {
+    const books = await this.notion.getBooksForStats(undefined, undefined, { cache: !fresh });
     return toSearchIndex(books);
   }
 


### PR DESCRIPTION
Follow-up to the `scan-debug` diagnostic (#277). The debug output proved the data is correct:

```
matchCount: 1, matches: [{ title: "Miecz dla króla", kategoria: "Nagroda", inScanIndex: true, isbns: [… 9788375900019 …] }]
```

So the ISBN **is** stored, on an award book, **in** the scan index — the miss is a freshness problem, not a matching bug.

## Root cause

`getBooks()` served the 5-minute `booksCache` (`cache: true`). A manual Notion edit never invalidates that cache, so the app kept serving a stale list without the newly-added ISBN. The earlier "fresh fetch" (1.54.1) only bypassed the **browser** cache, not the server's.

## Fix

- `getBooks(fresh)` → `getBooksForStats({ cache: !fresh })`; `GET /api/books?fresh=1` bypasses the server cache.
- The scan now fetches `/api/books?fresh=1`, so a just-enriched or manually-added ISBN is visible immediately.

If a scan still misses after this, the deployed **frontend bundle is stale** — the `vX.Y.Z` badge in the header shows the running version; anything below 1.54.x means a hard refresh is needed to load the current matcher.

## Separate issue noted (backlog, not fixed here)

The debug output also shows the enrichment **over-collected** ISBNs for the generic title "Miecz dla króla" — **72** ISBNs, most unrelated editions. That risks false-positive scan matches (another book's barcode matching this row). To be narrowed later (require author agreement, drop the title-only fallback for short/generic titles, cap per row, prefer 978-83 for Polish). Tracked in the backlog.

Full suite green (446), lint clean. Version bump 1.54.2 → 1.54.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_