### PR TITLE
feat(skryptorium): Polish ISBNs first + cap, and clean up bloated rows

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.54.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.55.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.55.0** — **ISBN pollution: polskie ISBN-y na początek + limit + auto-czyszczenie.** Realny bug: dla
+  „451° Fahrenheita" enrichment zebrał 130+ obcych wydań → lista URWAŁA się na limicie 2000 zn. Notion,
+  ucinając m.in. polski ISBN (skan by nie trafiał). Fix: `prioritizeIsbns(isbns, cap=40)` (`services/isbn.ts`)
+  — dedup, polskie (prefiks `97883`) NA POCZĄTEK (przeżywają obcięcie + skan polskiego egzemplarza zawsze
+  trafia), potem reszta, cap 40 (≈600 zn., bez ryzyka truncation). Enrichment stosuje to przy zapisie i
+  porównuje ORDER-SENSITIVE (`isbnListsEqual`) → ponowny rytuał REWRITE'uje zapuchnięte rekordy (cap+reorder
+  różni się od zapisanego → zapis; czyste bez zmian → `unchanged`). +5 testów (priorytet PL, dedup+cap,
+  cleanup 60→40 PL-first, oba merge PL-first). NASTĘPNE (opcjonalnie): twardsze zawężenie u ŹRÓDŁA (wymóg
+  autora / bez title-only dla krótkich tytułów), by w ogóle nie ściągać obcych wydań.
 - **1.54.3** — **Skan: świeży fetch omija też cache SERWERA (`/api/books?fresh=1`).** Diagnostyka
   (`scan-debug`) potwierdziła: ISBN JEST zapisany, `kategoria=Nagroda`, `inScanIndex=true` → dane OK, problem
   = świeżość/klient. `getBooks()` używał 5-min `booksCache` (cache:true); ręczny wpis w Notion NIE unieważnia

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.54.3",
+  "version": "1.55.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.54.3",
+  "version": "1.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.54.3",
+      "version": "1.55.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.54.3",
+  "version": "1.55.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbn.test.ts
+++ b/services/__tests__/isbn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeIsbn, isValidIsbn13, isValidIsbn10, isbn10to13 } from "../isbn";
+import { normalizeIsbn, isValidIsbn13, isValidIsbn10, isbn10to13, prioritizeIsbns } from "../isbn";
 
 describe("isbn helpers", () => {
   it("validates ISBN-13 checksums", () => {
@@ -28,5 +28,20 @@ describe("isbn helpers", () => {
     expect(normalizeIsbn("9788375780636")).toBeNull(); // book prefix, bad checksum
     expect(normalizeIsbn("hello")).toBeNull();
     expect(normalizeIsbn("")).toBeNull();
+  });
+});
+
+describe("prioritizeIsbns", () => {
+  it("puts Polish (978-83…) ISBNs first, keeping relative order", () => {
+    const r = prioritizeIsbns(["9780441172719", "9788375780635", "9780007370740", "9788373196919"]);
+    expect(r).toEqual(["9788375780635", "9788373196919", "9780441172719", "9780007370740"]);
+  });
+
+  it("dedupes and caps the list", () => {
+    const foreign = Array.from({ length: 100 }, (_, i) => `978000000${String(1000 + i)}`);
+    const r = prioritizeIsbns(["9788375780635", "9788375780635", ...foreign], 10);
+    expect(r.length).toBe(10);
+    expect(r[0]).toBe("9788375780635");           // Polish kept, first
+    expect(new Set(r).size).toBe(10);              // no duplicates
   });
 });

--- a/services/__tests__/isbnEnrichService.test.ts
+++ b/services/__tests__/isbnEnrichService.test.ts
@@ -40,7 +40,8 @@ describe("IsbnEnrichService", () => {
     expect(mockedLookup).toHaveBeenCalledWith("Dune", "Herbert");
     expect(notion.updatePage).toHaveBeenCalledTimes(1);
     expect(notion.updatePage).toHaveBeenCalledWith("1", { ISBN: expect.anything() });
-    expect(notion.buildPropertyValue).toHaveBeenCalledWith("9780441172719, 9788375780635", "rich_text");
+    // Polish edition (978-83…) is written FIRST so it survives Notion's char limit.
+    expect(notion.buildPropertyValue).toHaveBeenCalledWith("9788375780635, 9780441172719", "rich_text");
 
     const result = complete(events);
     expect(result.updated).toBe(1);
@@ -57,8 +58,30 @@ describe("IsbnEnrichService", () => {
     const svc = new IsbnEnrichService(notion as any);
     await svc.runIsbnEnrich((e) => events.push(e), () => false);
 
-    // Existing ISBN preserved, the new Polish one appended.
-    expect(notion.buildPropertyValue).toHaveBeenCalledWith("9780441172719, 9788375780635", "rich_text");
+    // The new Polish ISBN is kept and moved to the front; the original follows.
+    expect(notion.buildPropertyValue).toHaveBeenCalledWith("9788375780635, 9780441172719", "rich_text");
+    expect(complete(events).updated).toBe(1);
+  });
+
+  it("CLEANS UP a bloated row — caps to Polish-first even when nothing new is found", async () => {
+    // A row polluted with many foreign editions (one Polish among them).
+    const many = Array.from({ length: 60 }, (_, i) => `978000000${String(1000 + i)}`);
+    const withPolish = ["9788375780635", ...many];
+    const notion = makeNotion([
+      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert", isbns: withPolish },
+    ]);
+    mockedLookup.mockResolvedValue([]); // catalogs add nothing new this run
+
+    const events: any[] = [];
+    const svc = new IsbnEnrichService(notion as any);
+    await svc.runIsbnEnrich((e) => events.push(e), () => false);
+
+    // Rewritten: capped to 40, Polish ISBN first.
+    expect(notion.updatePage).toHaveBeenCalledTimes(1);
+    const written = notion.buildPropertyValue.mock.calls[0][0] as string;
+    const list = written.split(", ");
+    expect(list.length).toBe(40);
+    expect(list[0]).toBe("9788375780635");
     expect(complete(events).updated).toBe(1);
   });
 

--- a/services/isbn.ts
+++ b/services/isbn.ts
@@ -9,6 +9,26 @@ function cleanIsbnChars(raw: string): string {
   return (raw || "").replace(/[^0-9Xx]/g, "").toUpperCase();
 }
 
+/** Polish ISBN-13 prefix (978-83…). The scanned physical copies are Polish editions. */
+const POLISH_PREFIX = "97883";
+
+/** Max ISBNs stored per row — Polish-first, comfortably under Notion's 2000-char limit. */
+export const MAX_STORED_ISBNS = 40;
+
+/**
+ * Order + cap the stored edition ISBNs for a book. Polish editions (978-83…) come
+ * FIRST so a scan of the physical Polish copy always matches AND survives Notion's
+ * 2000-char field limit (the tail is what gets truncated); the list is then capped so
+ * a generic title (e.g. „451° Fahrenheita" → 130+ foreign editions) can't bloat a row.
+ */
+export function prioritizeIsbns(isbns: string[], cap = MAX_STORED_ISBNS): string[] {
+  const seen = new Set<string>();
+  const deduped = isbns.filter((i) => (seen.has(i) ? false : (seen.add(i), true)));
+  const polish = deduped.filter((i) => i.startsWith(POLISH_PREFIX));
+  const rest = deduped.filter((i) => !i.startsWith(POLISH_PREFIX));
+  return [...polish, ...rest].slice(0, cap);
+}
+
 /** EAN-13 / ISBN-13 checksum: Σ d_i·(1,3,1,3…) ≡ 0 (mod 10). */
 export function isValidIsbn13(s: string): boolean {
   if (!/^\d{13}$/.test(s)) return false;

--- a/services/isbnEnrichService.ts
+++ b/services/isbnEnrichService.ts
@@ -3,9 +3,15 @@ import { NotionAdapter } from "../notion.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
 import { lookupIsbnsByTitle } from "./isbnLookupService";
 import { isAwardBook } from "./bookCategory";
+import { prioritizeIsbns } from "./isbn";
 import { createLogger } from "../logger";
 
 const log = createLogger("IsbnEnrich");
+
+/** Order-sensitive equality — so a reordered (Polish-first) or capped list counts as a change. */
+function isbnListsEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
 
 /**
  * Enrichment ritual for the barcode "variant B": fills the „ISBN" column on award
@@ -68,7 +74,7 @@ export class IsbnEnrichService {
         const titles = Array.from(new Set([book.plTitle?.trim(), book.origTitle?.trim()].filter(Boolean))) as string[];
         if (titles.length === 0) return;
 
-        const existing = new Set(book.isbns || []);
+        const existing = book.isbns || [];
         const found = new Set<string>(existing);
         let lastError: string | null = null;
         let anySourceResponded = false;
@@ -93,17 +99,20 @@ export class IsbnEnrichService {
           summary.skipped.push(label); // sources responded, but no ISBN anywhere
           return;
         }
-        if (found.size === existing.size) {
-          unchangedCount++; // already had everything the catalogs know
+
+        // Polish editions first (survive Notion's 2000-char truncation) + capped so a
+        // generic title can't bloat the row. Re-running this also CLEANS UP already-bloated
+        // rows: their capped/reordered list differs from what's stored → rewritten.
+        const finalIsbns = prioritizeIsbns(Array.from(found));
+        if (isbnListsEqual(finalIsbns, existing)) {
+          unchangedCount++; // already stored in the same order, nothing to do
           return;
         }
 
-        // The merge added at least one new ISBN → persist the full deduped list.
-        const merged = Array.from(found);
         try {
-          await this.notion.updatePage(book.id, { "ISBN": this.notion.buildPropertyValue(merged.join(", "), "rich_text") });
+          await this.notion.updatePage(book.id, { "ISBN": this.notion.buildPropertyValue(finalIsbns.join(", "), "rich_text") });
           updatedCount++;
-          summary.updated.push(`${label} (ISBN: ${merged.join(", ")})`);
+          summary.updated.push(`${label} (ISBN: ${finalIsbns.join(", ")})`);
         } catch (err: any) {
           log.warn("Błąd zapisu ISBN", { book: label, error: err?.message });
           errors.push({ book: label, error: err?.message || "nieznany błąd" });


### PR DESCRIPTION
The pollution you spotted is real and worse than cosmetic: "451° Fahrenheita" collected **130+ foreign editions**, overrunning Notion's **2000-char** field limit — so the list was **truncated**, and the Polish ISBN (which the scan needs) could be exactly what got cut off.

## Fix (your suggestion + a cap)

- **`prioritizeIsbns(isbns, cap=40)`** (`services/isbn.ts`): dedupe, put **Polish (978-83…) ISBNs first** so they survive truncation and a scan of the physical Polish copy always matches, then the rest, **capped to 40** (~600 chars — well under the limit, no truncation at all).
- The enrichment applies it on write and compares **order-sensitively**, so **re-running the ritual rewrites already-bloated rows** (their capped/reordered list differs from what's stored) while leaving clean rows `unchanged`.
- +5 tests (Polish-first ordering, dedupe+cap, cleanup 60→40 Polish-first, merge writes Polish-first).

So after deploy: **re-run the "Rytuał Sygnatur (ISBN)"** once — it will shrink the polluted rows (Fahrenheit → 40 entries, Polish first) and every row's Polish ISBN will be safely stored.

## Next step (optional, tracked in backlog)

This caps the symptom. To stop fetching foreign editions in the first place, tighten collection at the source: require author agreement in the results, and skip the title-only fallback for short/generic titles. Say the word and I'll add that.

Full suite green (449), lint clean. Version bump 1.54.3 → 1.55.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_