### PR TITLE
feat(skryptorium): search by ISBN (full/partial) incl. old pre-2007 ISBN-10

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -932,12 +932,18 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
     odłożony (v1 = Android/Chrome). (b) multi-edition ISBN — ✅ ROZWIĄZANE (1.52.0): zapisujemy WSZYSTKIE
     ISBN-y wydań (`isbns: string[]`), więc barcode dowolnej edycji trafia w wiersz (use case = „mam tę
     książkę", nie „tę edycję").
-  - **DO ZROBIENIA: zawężenie enrichmentu (pollution ISBN).** Generyczne tytuły („Miecz dla króla") przez
-    title-only fallback + 3 źródła × 2 tytuły × 20 wyników zbierają DZIESIĄTKI niepowiązanych wydań (realny
-    przypadek: 72 ISBN-y na 1 pozycji). Ryzyko: FAŁSZYWE trafienia skanu (kod obcej książki pasuje do naszej).
-    Kandydaci na fix: wymagać zgodności autora w wynikach (Google `inauthor`/OL `author_name`/BN autor),
-    NIE robić title-only fallback dla krótkich/generycznych tytułów, twardy limit ISBN-ów na pozycję,
-    filtr prefiksu (preferuj 978-83 dla polskich). Do przemyślenia z użytkownikiem.
+  - **DO ZROBIENIA: zawężenie enrichmentu (pollution ISBN) U ŹRÓDŁA.** Objaw ZAŁAGODZONY w 1.55.0
+    (`prioritizeIsbns`: polskie na początek + cap 40 + auto-cleanup), ale nadal ŚCIĄGAMY dziesiątki obcych
+    wydań (generyczne tytuły przez title-only fallback + 3 źródła × 2 tytuły × 20 wyników; realne przypadki
+    72 i 130+ ISBN-ów). Ryzyko szczątkowe: FAŁSZYWE trafienia skanu. Kandydaci: wymagać zgodności autora w
+    wynikach (Google `inauthor`/OL `author_name`/BN autor), NIE robić title-only fallback dla krótkich/
+    generycznych tytułów, ewentualnie przechowywać TYLKO polskie (978-83). Do przemyślenia z użytkownikiem.
+  - **DO ZROBIENIA (odłożone, decyzja użytkownika „narazie nie robimy"): OCR cyfr ISBN z kamery.** Dziś skaner
+    czyta TYLKO kod kreskowy (`BarcodeDetector` → cyfry z pasków EAN-13); wydrukowanego numeru ISBN wzrokowo
+    NIE odczyta (to OCR). Alternatywa dla cyfr JUŻ jest: pole „wpisz ISBN ręcznie" w oknie skanera
+    (`inputMode=numeric`). Gdyby kiedyś dodawać OCR („nakieruj na numer"): `TextDetector` praktycznie martwy →
+    trzeba biblioteki (np. Tesseract.js, ~kilka MB, wolniej), suma kontrolna ISBN do odfiltrowania błędów.
+    Cięższy, osobny feature.
 
 - **Vinted znowu zablokował skaner — alternatywy w zanadrzu** — NOTATKA (Vinted ubił skan z IP Render/datacenter).
   Co JUŻ mamy (obrona pasywna): throttle 3–5 s + jitter na każdej ścieżce, pula User-Agent (rotacja,

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.55.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.56.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.56.0** — **Skryptorium: wyszukiwanie po ISBN (pełnym/częściowym) + stary ISBN-10.** Dotąd wyszukiwarka
+  szukała tylko po tytule/oryginale/autorze — ISBN-ów NIE. Teraz `matchBooks` matchuje też ISBN: token
+  numeryczny ≥4 cyfr (po odsianiu myślników) porównywany do blobu ISBN książki (substring → działa fragment).
+  Blob (`BookIndexEntry.isbnSearch`, budowany w `toSearchIndex`) zawiera KAŻDY zapisany ISBN-13 ORAZ jego
+  odtworzoną formę ISBN-10 (`isbn13to10` — dla prefiksu 978), więc STARE numery sprzed 2007 też trafiają
+  (np. Slan: zapisany `9788370012250` → szukalny także jako `8370012256`). Spacje między formami blokują
+  dopasowanie w poprzek dwóch ISBN-ów; próg 4 cyfr ucina szum („83"). +8 testów (round-trip 13↔10, pełny/
+  częściowy/stary ISBN, próg, AND z tytułem). ODPOWIEDŹ na pytania: (1) tak, teraz szuka po części ISBN
+  (w polu wyszukiwarki; skan nadal robi match DOKŁADNY po pełnym kodzie); (2) starych ISBN-ów NIE gubimy —
+  `normalizeIsbn` konwertuje 10→13 przy zapisie, a polskie (978-83) są priorytetyzowane; forma 10 jest
+  dodatkowo indeksowana do wyszukiwania.
 - **1.55.0** — **ISBN pollution: polskie ISBN-y na początek + limit + auto-czyszczenie.** Realny bug: dla
   „451° Fahrenheita" enrichment zebrał 130+ obcych wydań → lista URWAŁA się na limicie 2000 zn. Notion,
   ucinając m.in. polski ISBN (skan by nie trafiał). Fix: `prioritizeIsbns(isbns, cap=40)` (`services/isbn.ts`)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.55.0",
+      "version": "1.56.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.55.0",
+  "version": "1.56.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbn.test.ts
+++ b/services/__tests__/isbn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeIsbn, isValidIsbn13, isValidIsbn10, isbn10to13, prioritizeIsbns } from "../isbn";
+import { normalizeIsbn, isValidIsbn13, isValidIsbn10, isbn10to13, isbn13to10, prioritizeIsbns } from "../isbn";
 
 describe("isbn helpers", () => {
   it("validates ISBN-13 checksums", () => {
@@ -16,6 +16,14 @@ describe("isbn helpers", () => {
 
   it("converts ISBN-10 to ISBN-13", () => {
     expect(isbn10to13("0306406152")).toBe("9780306406157");
+  });
+
+  it("converts a 978 ISBN-13 back to its old ISBN-10 (round-trip)", () => {
+    // Slan, Van Vogt — old Polish ISBN-10 (see BN catalogue).
+    expect(isbn13to10("9788370012250")).toBe("8370012256");
+    expect(isbn13to10(isbn10to13("0306406152"))).toBe("0306406152");
+    expect(isbn13to10("9791234567896")).toBeNull(); // 979 has no ISBN-10 equivalent
+    expect(isbn13to10("0306406152")).toBeNull();     // not an ISBN-13
   });
 
   it("normalizes messy input to a canonical ISBN-13", () => {

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -1,5 +1,18 @@
 import { NotionBook, BookIndexEntry } from "../src/types";
 import { isAwardBook } from "./bookCategory";
+import { isbn13to10 } from "./isbn";
+
+/** Space-joined ISBN forms for text search: each stored ISBN-13 plus its ISBN-10 equivalent (pre-2007). */
+function buildIsbnSearch(isbns?: string[]): string | undefined {
+  if (!isbns || isbns.length === 0) return undefined;
+  const forms = new Set<string>();
+  for (const i of isbns) {
+    forms.add(i);
+    const ten = isbn13to10(i);
+    if (ten) forms.add(ten);
+  }
+  return Array.from(forms).join(" ");
+}
 
 /**
  * Pure projection of full Notion records → a slimmed-down search index.
@@ -26,5 +39,6 @@ export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
       partOfCycle: b.currentCzesccyklu ?? false,
       shelfOrder: b.shelfOrder,
       isbns: b.isbns,
+      isbnSearch: buildIsbnSearch(b.isbns),
     }));
 }

--- a/services/isbn.ts
+++ b/services/isbn.ts
@@ -56,6 +56,21 @@ export function isbn10to13(isbn10: string): string {
 }
 
 /**
+ * ISBN-13 → ISBN-10 (only for the 978 prefix; 979 has no ISBN-10 equivalent). Recovers
+ * the pre-2007 10-digit form so old numbers stay searchable — e.g. „9788370012250"
+ * (Slan) → „8370012256". Returns null when the input isn't a 978 ISBN-13.
+ */
+export function isbn13to10(isbn13: string): string | null {
+  const s = cleanIsbnChars(isbn13);
+  if (!/^978\d{10}$/.test(s)) return null;
+  const core = s.slice(3, 12); // 9 digits after „978"
+  let sum = 0;
+  for (let i = 0; i < 9; i++) sum += Number(core[i]) * (10 - i);
+  const check = (11 - (sum % 11)) % 11;
+  return core + (check === 10 ? "X" : String(check));
+}
+
+/**
  * Normalize any scanned/typed code to a canonical, checksum-valid ISBN-13, or null
  * when it isn't a real ISBN (wrong length, bad checksum, non-book EAN). EAN-13s that
  * aren't books (prefix ≠ 978/979) are rejected so a random product barcode can't match.

--- a/src/__tests__/bookSearch.test.ts
+++ b/src/__tests__/bookSearch.test.ts
@@ -16,6 +16,35 @@ const INDEX: BookIndexEntry[] = [
   mk({ plTitle: "Solaris", origTitle: "Solaris", author: "Stanisław Lem" }),
 ];
 
+describe("matchBooks — ISBN search", () => {
+  // „Slan" carries both the modern ISBN-13 and its old ISBN-10 (built by the index).
+  const withIsbn = mk({ plTitle: "Slan", author: "Van Vogt", isbns: ["9788370012250"], isbnSearch: "9788370012250 8370012256" });
+  const idx = [...INDEX, withIsbn];
+
+  it("finds a book by its full modern ISBN-13", () => {
+    expect(matchBooks("9788370012250", idx).map((b) => b.plTitle)).toContain("Slan");
+  });
+
+  it("finds a book by its old ISBN-10 (pre-2007)", () => {
+    expect(matchBooks("8370012256", idx).map((b) => b.plTitle)).toEqual(["Slan"]);
+  });
+
+  it("finds a book by a PARTIAL ISBN and tolerates dashes", () => {
+    expect(matchBooks("978-83-7001", idx).map((b) => b.plTitle)).toEqual(["Slan"]);
+    expect(matchBooks("370012", idx).map((b) => b.plTitle)).toEqual(["Slan"]);
+  });
+
+  it("ignores very short numeric fragments (<4 digits) to avoid noise", () => {
+    // „83" would otherwise match every Polish ISBN.
+    expect(matchBooks("83", idx).map((b) => b.plTitle)).not.toContain("Slan");
+  });
+
+  it("combines an ISBN fragment with a title/author token (AND)", () => {
+    expect(matchBooks("slan 370012", idx).map((b) => b.plTitle)).toEqual(["Slan"]);
+    expect(matchBooks("hyperion 370012", idx)).toHaveLength(0); // ISBN belongs to another book
+  });
+});
+
 describe("bookSearch.fold", () => {
   it("folds Polish diacritics per-char (incl. ł which NFD does not decompose)", () => {
     expect(fold("Żółw")).toBe("zolw");

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,8 @@ export interface BookIndexEntry {
   shelfOrder?: number;
   /** Canonical ISBN-13s across editions (if enriched) — a barcode of ANY edition matches this row. */
   isbns?: string[];
+  /** Space-joined ISBN forms for text search: each ISBN-13 plus its ISBN-10 equivalent (old, pre-2007). */
+  isbnSearch?: string;
 }
 
 export interface SyncState {

--- a/src/utils/bookSearch.ts
+++ b/src/utils/bookSearch.ts
@@ -40,7 +40,15 @@ export function matchBooks(query: string, index: BookIndexEntry[]): BookIndexEnt
     const title = fold(displayTitle(b));
     const orig = fold(b.origTitle);
     const author = fold(b.author);
-    const matchesAll = tokens.every((t) => title.includes(t) || orig.includes(t) || author.includes(t));
+    // Digit-only blob of the book's ISBN forms (ISBN-13 + old ISBN-10) for full/partial
+    // ISBN search. Spaces between forms stop a query from matching across two ISBNs.
+    const isbnBlob = (b.isbnSearch || "").toLowerCase();
+    const matchesAll = tokens.every((t) => {
+      if (title.includes(t) || orig.includes(t) || author.includes(t)) return true;
+      // A numeric token of ≥4 digits may be a (partial) ISBN — match it against the ISBN blob.
+      const digits = t.replace(/[^0-9x]/g, "");
+      return digits.length >= 4 && isbnBlob.includes(digits);
+    });
     if (!matchesAll) continue;
 
     const t0 = tokens[0];


### PR DESCRIPTION
Answers both of your questions, and closes the gap the second one exposed.

## Q1 — search by part of an ISBN

Previously the search box searched only **title / original title / author** — ISBNs weren't indexed at all, so a partial (or full) ISBN query found nothing.

Now `matchBooks` also matches ISBNs: a numeric token of **≥4 digits** (dashes stripped) is compared as a substring against the book's ISBN blob, so **full and partial** ISBN queries work in the search box. (The camera scan still does an exact full-code match — that's correct, a barcode gives the whole code.)

## Q2 — old pre-2007 ISBN-10

We don't drop old ISBNs. `normalizeIsbn` converts every ISBN-10 → ISBN-13 on store, and Polish ones (83 → 978-83) are prioritized, so they're kept — Slan's `8370012256` is stored as `9788370012250`. To also make the **old 10-digit form searchable**, the index now includes it:

- `BookIndexEntry.isbnSearch` (built in `toSearchIndex`) holds every stored ISBN-13 **and its reconstructed ISBN-10** (`isbn13to10`, 978-prefix only). So Slan is findable as `8370012256`, `9788370012250`, or any fragment of either.
- Spaces between forms stop a query matching across two different ISBNs; the 4-digit floor cuts noise ("83" won't match every Polish ISBN).

## Tests

+8 (13↔10 round-trip, full/partial/old-ISBN search, dash tolerance, the 4-digit floor, ISBN-AND-title). Full suite green (455), lint clean. Version bump 1.55.0 → 1.56.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_