### PR TITLE
fix(skryptorium): scanner matches a typed old ISBN-10 against the stored ISBN-13

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.56.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.56.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.56.1** — **FIX: skaner też dopasowuje stary ISBN-10 (spójnie z wyszukiwarką).** Luka: `matchIsbnInIndex`
+  (skan + ręczny wpis w oknie skanera) porównywał TYLKO do zapisanych ISBN-13, więc wpisany stary ISBN-10
+  (`8370012256`) nie trafiał w wiersz zapisany jako `9788370012250` (antykwariat!). Fix: skaner dopasowuje
+  teraz do `isbnSearch` (obie formy: 13 + odtworzone 10), dokładnie jak wyszukiwarka; fallback do `isbns`
+  gdy brak `isbnSearch`. Match nadal DOKŁADNY (pełny numer, nie fragment) — cyfrowo, więc myślniki nieważne.
+  +2 testy (stary ISBN-10 wpisany, z myślnikami, oraz e2e mapper→index→match).
 - **1.56.0** — **Skryptorium: wyszukiwanie po ISBN (pełnym/częściowym) + stary ISBN-10.** Dotąd wyszukiwarka
   szukała tylko po tytule/oryginale/autorze — ISBN-ów NIE. Teraz `matchBooks` matchuje też ISBN: token
   numeryczny ≥4 cyfr (po odsianiu myślników) porównywany do blobu ISBN książki (substring → działa fragment).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.56.0",
+      "version": "1.56.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.56.0",
+  "version": "1.56.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/scanFlowIntegration.test.ts
+++ b/services/__tests__/scanFlowIntegration.test.ts
@@ -30,6 +30,13 @@ describe("scan flow integration (mapper → search index → match)", () => {
     expect(matchIsbnInIndex("9788375900019", index)?.plTitle).toBe("Miecz dla Króla");
   });
 
+  it("matches a typed OLD ISBN-10 against a row stored as ISBN-13 (antiquarian case)", () => {
+    // Stored as the modern ISBN-13; the physical old copy prints the ISBN-10.
+    const book = mapPageToBook(page("9788370012250"));
+    const index = toSearchIndex([book]);
+    expect(matchIsbnInIndex("8370012256", index)?.plTitle).toBe("Miecz dla Króla");
+  });
+
   it("DROPS the book from the index when it is a cycle volume (Tom cyklu)", () => {
     const book = mapPageToBook(page("9788375900019", "Tom cyklu"));
     const index = toSearchIndex([book]);

--- a/src/__tests__/barcode.test.ts
+++ b/src/__tests__/barcode.test.ts
@@ -47,4 +47,12 @@ describe("barcode.matchIsbnInIndex", () => {
   it("ignores rows without stored ISBNs", () => {
     expect(matchIsbnInIndex("", index)).toBeNull();
   });
+
+  it("matches a typed OLD ISBN-10 against the stored ISBN-13 (via isbnSearch)", () => {
+    // Slan: stored as ISBN-13, but the antiquarian book prints the pre-2007 ISBN-10.
+    const withOld = [mk({ id: "slan", plTitle: "Slan", isbns: ["9788370012250"], isbnSearch: "9788370012250 8370012256" })];
+    expect(matchIsbnInIndex("8370012256", withOld)?.id).toBe("slan");        // old ISBN-10 typed
+    expect(matchIsbnInIndex("83-7001-225-6", withOld)?.id).toBe("slan");     // with dashes
+    expect(matchIsbnInIndex("9788370012250", withOld)?.id).toBe("slan");     // modern ISBN-13
+  });
 });

--- a/src/utils/barcode.ts
+++ b/src/utils/barcode.ts
@@ -33,13 +33,18 @@ export function looksLikeBookIsbn(raw: string): boolean {
  * Direct match (variant B): find the index entry whose stored ISBNs include the
  * scanned code (compared digit-only, so stored formatting doesn't matter). A book
  * carries the ISBNs of all its editions, so a barcode of any edition matches.
- * Returns null when no row carries that ISBN.
+ *
+ * Matches against `isbnSearch` — every stored ISBN-13 AND its old ISBN-10 form — so a
+ * typed pre-2007 ISBN-10 (e.g. „8370012256", the same book stored as „9788370012250")
+ * still matches, exactly as it does in the search box. Falls back to `isbns` for an
+ * index built without `isbnSearch`. Returns null when no row carries that ISBN.
  */
 export function matchIsbnInIndex(code: string, index: BookIndexEntry[]): BookIndexEntry | null {
   const target = cleanScannedCode(code);
   if (!target) return null;
   for (const b of index) {
-    if (b.isbns?.some((i) => cleanScannedCode(i) === target)) return b;
+    const forms = b.isbnSearch ? b.isbnSearch.split(/\s+/) : (b.isbns || []);
+    if (forms.some((i) => cleanScannedCode(i) === target)) return b;
   }
   return null;
 }


### PR DESCRIPTION
You're right — #280 fixed the **search box** but not the **scanner**. Typing `8370012256` in the scanner's manual field (the antiquarian-shop case) still missed, because `matchIsbnInIndex` compared only against stored **ISBN-13s** (`9788370012250`), and digit-only `8370012256 ≠ 9788370012250`.

## Fix

`matchIsbnInIndex` (used by both the camera scan and the scanner's manual-entry field) now matches against **`isbnSearch`** — every stored ISBN-13 **and** its reconstructed ISBN-10 — exactly like the search box. So a typed pre-2007 ISBN-10 matches the row stored as its ISBN-13. Falls back to `isbns` when `isbnSearch` is absent.

Still an **exact full-code** match (digit-only, so dashes are ignored) — not a partial one, which is correct for a scan.

- +2 tests (typed old ISBN-10 with and without dashes; end-to-end `mapPageToBook` → `toSearchIndex` → `matchIsbnInIndex`).

Full suite green (457), lint clean. Version bump 1.56.0 → 1.56.1.

So in the antique shop: type `8370012256` (or the modern `9788370012250`, or with dashes) in the scanner and it'll find the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_