### PR TITLE
feat(skryptorium): mobile clean screen + scanner torch and larger scan area

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.57.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.58.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.58.0** — **Skryptorium mobile: czysty ekran + latarka i większy obszar w skanerze.** (1) Na mobile
+  (`matchMedia max-width:767px`) puste zapytanie NIE listuje pozycji — czysty ekran z podpowiedzią „zeskanuj
+  lub wpisz tytuł" (`browseSuppressed`; browse-all pozostaje na desktopie); skan/wpis wypełnia widok. Licznik
+  ukryty na czystym ekranie. Guard na brak `matchMedia`. (2) `ScanModal`: przycisk **latarki** (torch) —
+  widoczny tylko gdy track kamery ma `getCapabilities().torch` (Android/Chrome); toggle przez
+  `applyConstraints({advanced:[{torch}]})`, gaśnie przy `track.stop()`; reset stanu przy otwarciu. Obszar
+  skanowania powiększony (modal `max-w-md`→`max-w-lg`, viewport `aspect-[4/5]` na mobile / `4/3` na sm+,
+  ramka `inset-3`). Testy: suite 462 zielone (komponenty skanera bez zmian w logice testowanej).
 - **1.57.0** — **Bughunt skanera/ISBN (3 agenty + weryfikacja) — 7 realnych fixów.** Rdzeń potwierdzony
   czysty (matematyka ISBN, cap, throw-logic, round-trip, brak utraty ISBN-ów). Naprawione: (1) FE — wyszukiwarka
   po ISBN robiła substring → rok „1984" trafiał w każdy ISBN zawierający „1984"; teraz match po PREFIKSIE

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.57.0",
+      "version": "1.58.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.57.0",
+  "version": "1.58.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -39,6 +39,20 @@ export const SearchSection: React.FC = () => {
     inputRef.current?.focus();
   }, []);
 
+  // On mobile, start with a clean screen: books are loaded, but nothing is listed until you
+  // type or scan (the empty-query browse-all is desktop-only). A scan/typed query fills it.
+  const [isMobile, setIsMobile] = useState<boolean>(
+    () => typeof window !== "undefined" && typeof window.matchMedia === "function" && window.matchMedia("(max-width: 767px)").matches
+  );
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    const onChange = () => setIsMobile(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  const browseSuppressed = isMobile && !query.trim();
+
   // Turn a scanned/typed code into a search: first a direct row match by stored ISBN
   // (variant B), else resolve the ISBN → title server-side and fuzzy-search it (variant A).
   const handleScanDetect = async (rawCode: string) => {
@@ -85,7 +99,7 @@ export const SearchSection: React.FC = () => {
   };
 
   const results = useMemo(() => matchBooks(deferredQuery, books ?? []), [deferredQuery, books]);
-  const shown = results.slice(0, RENDER_CAP);
+  const shown = browseSuppressed ? [] : results.slice(0, RENDER_CAP);
   const total = books?.length ?? 0;
 
   // „Czy chodziło Ci o…" — vocab computed once per set; suggestions only on 0 hits.
@@ -174,8 +188,8 @@ export const SearchSection: React.FC = () => {
 
       <ScanModal open={scanOpen} onClose={() => setScanOpen(false)} onDetect={handleScanDetect} />
 
-      {/* Counter */}
-      {books && !loading && (
+      {/* Counter (hidden on the mobile clean screen) */}
+      {books && !loading && !browseSuppressed && (
         <p className="text-center text-xs text-slate-500 font-bold tracking-widest uppercase">
           {query.trim()
             ? `Znaleziono ${results.length} ${results.length === 1 ? "wolumin" : "woluminów"} z ${total}`
@@ -184,7 +198,7 @@ export const SearchSection: React.FC = () => {
         </p>
       )}
 
-      {/* States: loading / error / no hits / grid */}
+      {/* States: loading / error / mobile clean screen / no hits / grid */}
       {loading ? (
         <div className="flex items-center justify-center gap-3 py-16 text-slate-500">
           <Loader2 className="w-5 h-5 animate-spin" />
@@ -202,6 +216,14 @@ export const SearchSection: React.FC = () => {
               Spróbuj ponownie
             </button>
           </div>
+        </div>
+      ) : browseSuppressed ? (
+        <div className="text-center py-20 space-y-3">
+          <ScanBarcode className="w-10 h-10 text-cyan-500/40 mx-auto" />
+          <p className="text-sm text-slate-400 italic">
+            {canScan ? "Zeskanuj kod kreskowy lub wpisz tytuł, aby przeszukać archiwum." : "Wpisz tytuł lub nazwisko autora, aby przeszukać archiwum."}
+          </p>
+          <p className="text-[11px] text-slate-600 uppercase tracking-widest font-bold">{total} woluminów w archiwum</p>
         </div>
       ) : results.length === 0 ? (
         <div className="text-center py-16 space-y-4">

--- a/src/components/search/ScanModal.tsx
+++ b/src/components/search/ScanModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { X, ScanBarcode, Loader2, AlertCircle, Keyboard } from "lucide-react";
+import { X, ScanBarcode, Loader2, AlertCircle, Keyboard, Flashlight, FlashlightOff } from "lucide-react";
 import { looksLikeBookIsbn } from "../../utils/barcode";
 
 interface Props {
@@ -25,17 +25,34 @@ type BarcodeDetectorCtor = new (opts?: { formats?: string[] }) => BarcodeDetecto
 export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const trackRef = useRef<MediaStreamTrack | null>(null);
   const rafRef = useRef<number | null>(null);
   const doneRef = useRef(false);
   const [status, setStatus] = useState<"idle" | "starting" | "scanning" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState<string>("");
   const [manual, setManual] = useState("");
   const [manualErr, setManualErr] = useState("");
+  const [torchAvailable, setTorchAvailable] = useState(false);
+  const [torchOn, setTorchOn] = useState(false);
 
-  // Stop the camera + detection loop and release the stream.
+  // Stop the camera + detection loop and release the stream (also turns the torch off).
   const teardown = () => {
     if (rafRef.current !== null) { cancelAnimationFrame(rafRef.current); rafRef.current = null; }
     if (streamRef.current) { streamRef.current.getTracks().forEach((t) => t.stop()); streamRef.current = null; }
+    trackRef.current = null;
+  };
+
+  // Toggle the phone flashlight via the camera track's `torch` constraint (Android/Chrome).
+  const toggleTorch = async () => {
+    const track = trackRef.current;
+    if (!track) return;
+    const next = !torchOn;
+    try {
+      await track.applyConstraints({ advanced: [{ torch: next }] } as any);
+      setTorchOn(next);
+    } catch {
+      setTorchAvailable(false); // capability lied / not really controllable
+    }
   };
 
   const finish = (code: string) => {
@@ -48,6 +65,8 @@ export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
   useEffect(() => {
     if (!open) return;
     doneRef.current = false;
+    setTorchAvailable(false);
+    setTorchOn(false);
     const Ctor = (window as unknown as { BarcodeDetector?: BarcodeDetectorCtor }).BarcodeDetector;
 
     // No native detector → the modal still opens for the manual ISBN fallback.
@@ -67,6 +86,12 @@ export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
         video.srcObject = stream;
         await video.play();
         setStatus("scanning");
+
+        // Expose the flashlight toggle only if the camera track reports the torch capability.
+        const track = stream.getVideoTracks()[0] || null;
+        trackRef.current = track;
+        const caps = (track?.getCapabilities?.() ?? {}) as any;
+        if (!cancelled && caps.torch) setTorchAvailable(true);
 
         const tick = async () => {
           if (doneRef.current || cancelled) return;
@@ -124,7 +149,7 @@ export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
             initial={{ opacity: 0, scale: 0.92, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.92, y: 20 }}
-            className="relative w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl shadow-[0_0_50px_rgba(0,0,0,0.8)] overflow-hidden"
+            className="relative w-full max-w-lg bg-slate-900 border border-slate-800 rounded-2xl shadow-[0_0_50px_rgba(0,0,0,0.8)] overflow-hidden"
           >
             <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-cyan-500 to-transparent opacity-50" />
 
@@ -139,8 +164,8 @@ export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
                 </div>
               </div>
 
-              {/* Camera viewport */}
-              <div className="relative aspect-[4/3] rounded-xl overflow-hidden bg-slate-950 border border-white/10 mb-5">
+              {/* Camera viewport — a bit larger for easier aiming */}
+              <div className="relative aspect-[4/5] sm:aspect-[4/3] rounded-xl overflow-hidden bg-slate-950 border border-white/10 mb-5">
                 <video ref={videoRef} playsInline muted className="w-full h-full object-cover" />
                 {(status === "starting" || status === "idle") && (
                   <div className="absolute inset-0 flex items-center justify-center gap-2 text-slate-400">
@@ -150,9 +175,23 @@ export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
                 )}
                 {status === "scanning" && (
                   <>
-                    <div className="absolute inset-x-8 top-1/2 h-px bg-cyan-400/70 shadow-[0_0_12px_rgba(34,211,238,0.8)]" />
-                    <div className="absolute inset-6 border-2 border-cyan-400/30 rounded-lg" />
+                    <div className="absolute inset-x-6 top-1/2 h-px bg-cyan-400/70 shadow-[0_0_12px_rgba(34,211,238,0.8)]" />
+                    <div className="absolute inset-3 border-2 border-cyan-400/30 rounded-lg" />
                   </>
+                )}
+                {torchAvailable && status === "scanning" && (
+                  <button
+                    onClick={toggleTorch}
+                    aria-label={torchOn ? "Wyłącz latarkę" : "Włącz latarkę"}
+                    aria-pressed={torchOn}
+                    className={`absolute top-3 right-3 p-2.5 rounded-full border backdrop-blur-sm transition-colors ${
+                      torchOn
+                        ? "bg-amber-400/90 border-amber-300 text-slate-900"
+                        : "bg-slate-950/60 border-white/20 text-slate-200 hover:bg-slate-900/80"
+                    }`}
+                  >
+                    {torchOn ? <Flashlight className="w-5 h-5" /> : <FlashlightOff className="w-5 h-5" />}
+                  </button>
                 )}
                 {status === "error" && (
                   <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center px-6 text-red-300">


### PR DESCRIPTION
Two mobile-focused improvements to Skryptorium.

## 1. Mobile clean screen

On small viewports (`matchMedia (max-width: 767px)`), an empty query no longer lists the whole archive — books are still loaded, but the screen stays clean with a prompt ("Zeskanuj kod kreskowy lub wpisz tytuł…") until you type or scan. Desktop keeps the browse-all behavior. A scan or typed query fills the view immediately; the counter is hidden on the clean screen. `matchMedia` access is guarded for environments without it.

This gives a clean screen for scanner use, while classic search still works — you type a name.

## 2. Scanner: flashlight + larger scan area

- **Torch toggle** in `ScanModal`, shown **only** when the camera track reports the torch capability (`getCapabilities().torch` — Android/Chrome). Toggled via `applyConstraints({ advanced: [{ torch }] })`; turns off automatically when the stream stops; state resets on open. On hardware without a controllable torch the button simply doesn't appear.
- **Larger scan area**: modal `max-w-md` → `max-w-lg`, camera viewport `aspect-[4/5]` on mobile / `4/3` on `sm+`, guide frame widened. (The BarcodeDetector scans the whole frame, so a bigger preview = easier aiming.)

Full suite green (462), lint clean. Version bump 1.57.0 → 1.58.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_