### PR TITLE
feat(skryptorium): ISBN scan also finds non-award books (cycle volumes)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.58.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.59.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.58.0** — **Skryptorium mobile: czysty ekran + latarka i większy obszar w skanerze.** (1) Na mobile
+- **1.59.0** — **Skaner ISBN obejmuje też książki bez nagród (tomy cykli).** Dotąd `toSearchIndex` był
+  nagrodowo-only → skan nie znajdował tomów cykli (`Kategoria="Tom cyklu"`). Zmiany: (1) `toSearchIndex(books,
+  awardOnly=true)` — Regał zostaje nagrodowo-only, ale nowy wariant „wszystko"; (2) `getBooks(fresh, all)` +
+  `GET /api/books?all=1`; (3) `useBooks(all)` — **Skryptorium** (`SearchSection`) i skan używają `all=1`
+  (award + tomy cykli), **Regał** (`BookshelfSection`) domyślnie nagrodowo-only; (4) `isbnEnrichService`
+  przetwarza teraz KAŻDY wiersz z tytułem (usunięty filtr `isAwardBook`), więc tomy cykli też dostają ISBN.
+  Efekt: skan tomu cyklu trafia; klasyczne szukanie w Skryptorium też pokazuje tomy cykli (spójne — „szukaj
+  po wszystkim, co śledzę"); Regał i statystyki nagrodowe bez zmian. +2 testy (enrich tomu cyklu, indeks
+  award-only vs all). UWAGA: po redeployie odpal ponownie „Rytuał Sygnatur (ISBN)", żeby dociągnąć ISBN-y
+  do tomów cykli (więcej książek = więcej zapytań, rytuał ręczny — OK). (1) Na mobile
   (`matchMedia max-width:767px`) puste zapytanie NIE listuje pozycji — czysty ekran z podpowiedzią „zeskanuj
   lub wpisz tytuł" (`browseSuppressed`; browse-all pozostaje na desktopie); skan/wpis wypełnia widok. Licznik
   ukryty na czystym ekranie. Guard na brak `matchMedia`. (2) `ScanModal`: przycisk **latarki** (torch) —

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -22,7 +22,9 @@ export const getBooks = async (req: Request, res: Response) => {
     // `fresh=1` bypasses the 5-min server cache — used by the barcode scan so a
     // just-enriched (or manually-edited) ISBN is visible immediately.
     const fresh = req.query.fresh === "1" || req.query.fresh === "true";
-    const books = await syncManager.getBooks(fresh);
+    // `all=1` includes cycle volumes (not just award books) — the full Skryptorium / scan index.
+    const all = req.query.all === "1" || req.query.all === "true";
+    const books = await syncManager.getBooks(fresh, all);
     res.json(books);
   } catch (error: any) {
     console.error("Books Error:", error);

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.58.0",
+  "version": "1.59.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.58.0",
+  "version": "1.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.58.0",
+      "version": "1.59.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.58.0",
+  "version": "1.59.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/isbnEnrichService.test.ts
+++ b/services/__tests__/isbnEnrichService.test.ts
@@ -24,10 +24,9 @@ const complete = (events: any[]) => events.find((e) => e.type === "complete")?.r
 describe("IsbnEnrichService", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("processes every award book (not just empty ones) and writes the edition list", async () => {
+  it("processes every titled book (not just empty ones) and writes the edition list", async () => {
     const notion = makeNotion([
-      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert" },              // no ISBNs yet
-      { id: "3", plTitle: "Tom", origTitle: "", author: "Y", kategoria: "Tom cyklu" },   // not an award → excluded
+      { id: "1", plTitle: "Diuna", origTitle: "Dune", author: "Herbert" },
     ]);
     mockedLookup.mockResolvedValue(["9780441172719", "9788375780635"]);
 
@@ -35,7 +34,7 @@ describe("IsbnEnrichService", () => {
     const svc = new IsbnEnrichService(notion as any);
     await svc.runIsbnEnrich((e) => events.push(e), () => false);
 
-    // Only the award book is looked up — by BOTH its titles (Polish + original).
+    // Looked up by BOTH its titles (Polish + original).
     expect(mockedLookup).toHaveBeenCalledWith("Diuna", "Herbert");
     expect(mockedLookup).toHaveBeenCalledWith("Dune", "Herbert");
     expect(notion.updatePage).toHaveBeenCalledTimes(1);
@@ -45,6 +44,22 @@ describe("IsbnEnrichService", () => {
 
     const result = complete(events);
     expect(result.updated).toBe(1);
+  });
+
+  it("also enriches non-award cycle volumes (so a scan can find them)", async () => {
+    const notion = makeNotion([
+      { id: "1", plTitle: "Nagrodzona", origTitle: "", author: "A" },
+      { id: "2", plTitle: "Tom cyklu 3", origTitle: "", author: "B", kategoria: "Tom cyklu" },
+    ]);
+    mockedLookup.mockResolvedValue(["9788375780635"]);
+
+    const events: any[] = [];
+    const svc = new IsbnEnrichService(notion as any);
+    await svc.runIsbnEnrich((e) => events.push(e), () => false);
+
+    expect(mockedLookup).toHaveBeenCalledWith("Tom cyklu 3", "B"); // the cycle volume IS processed
+    expect(notion.updatePage).toHaveBeenCalledWith("2", { ISBN: expect.anything() });
+    expect(complete(events).updated).toBe(2);
   });
 
   it("MERGES newly-found ISBNs into a row that already has some (e.g. adds the Polish one)", async () => {

--- a/services/__tests__/scanFlowIntegration.test.ts
+++ b/services/__tests__/scanFlowIntegration.test.ts
@@ -48,10 +48,14 @@ describe("scan flow integration (mapper → search index → match)", () => {
     expect(matchIsbnInIndex("8370012256", index)?.plTitle).toBe("Miecz dla Króla");
   });
 
-  it("DROPS the book from the index when it is a cycle volume (Tom cyklu)", () => {
+  it("keeps a cycle volume out of the award-only index, but includes it when awardOnly=false", () => {
     const book = mapPageToBook(page("9788375900019", "Tom cyklu"));
-    const index = toSearchIndex([book]);
-    expect(index).toHaveLength(0);
-    expect(matchIsbnInIndex("9788375900019", index)).toBeNull();
+    // Default (Regał) — award-only → dropped.
+    expect(toSearchIndex([book])).toHaveLength(0);
+    expect(matchIsbnInIndex("9788375900019", toSearchIndex([book]))).toBeNull();
+    // Full (scan / Skryptorium) — included and scannable.
+    const full = toSearchIndex([book], false);
+    expect(full).toHaveLength(1);
+    expect(matchIsbnInIndex("9788375900019", full)?.plTitle).toBe("Miecz dla Króla");
   });
 });

--- a/services/bookSearchIndex.ts
+++ b/services/bookSearchIndex.ts
@@ -20,12 +20,14 @@ function buildIsbnSearch(isbns?: string[]): string | undefined {
  * „Skryptorium" filters/renders on. Keeps a record having ANY
  * title — Polish OR original; untranslated books (original title only)
  * should be searchable too. Only a record with no title at all is dropped (a skeleton).
+ *
+ * `awardOnly` (default true): the Regał shelf stays award-only (side cycle volumes have
+ * their own „Archiwum Cykli" view). Pass `false` for the barcode scan / full Skryptorium
+ * search, so a scan can find a tracked cycle volume too.
  */
-export function toSearchIndex(books: NotionBook[]): BookIndexEntry[] {
+export function toSearchIndex(books: NotionBook[], awardOnly = true): BookIndexEntry[] {
   return books
-    // Regał and Skryptorium stay award-only — side cycle volumes are excluded
-    // (they have their own „Archiwum Cykli" view); optional inclusion will come later.
-    .filter((b) => isAwardBook(b))
+    .filter((b) => !awardOnly || isAwardBook(b))
     .filter((b) => (b.plTitle && b.plTitle.trim().length > 0) || (b.origTitle && b.origTitle.trim().length > 0))
     .map((b) => ({
       id: b.id,

--- a/services/isbnEnrichService.ts
+++ b/services/isbnEnrichService.ts
@@ -2,7 +2,6 @@ import pLimit from "p-limit";
 import { NotionAdapter } from "../notion.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
 import { lookupIsbnsByTitle } from "./isbnLookupService";
-import { isAwardBook } from "./bookCategory";
 import { prioritizeIsbns } from "./isbn";
 import { createLogger } from "../logger";
 
@@ -25,12 +24,12 @@ function isbnListsEqual(a: string[], b: string[]): boolean {
  * identifies the row. Variant A (resolve → fuzzy search) is the fallback when nothing
  * is stored.
  *
- * EVERY award book is (re)processed and results are MERGED into the stored list — a
- * row that already had, say, only the original-language ISBN gains its Polish edition
- * ISBN on a re-run. A row is written only when the merge adds something new (no
- * needless writes). Books are looked up by BOTH their Polish and original titles,
- * because Biblioteka Narodowa indexes the Polish title („Diuna"), not the original
- * („Dune"). Cycle sibling volumes are excluded — barcode lookup is an award concern.
+ * EVERY tracked book with a title is (re)processed — award books AND cycle sibling
+ * volumes (so a scan finds a non-award volume too) — and results are MERGED into the
+ * stored list: a row that already had, say, only the original-language ISBN gains its
+ * Polish edition ISBN on a re-run. A row is written only when the merge adds something
+ * new (no needless writes). Books are looked up by BOTH their Polish and original titles,
+ * because Biblioteka Narodowa indexes the Polish title („Diuna"), not the original („Dune").
  */
 export class IsbnEnrichService {
   constructor(private notion: NotionAdapter) {}
@@ -45,10 +44,10 @@ export class IsbnEnrichService {
 
       if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano Rytuał Sygnatur." }); return; }
 
-      // Every award book with a title — re-processed and merged (not gap-filled), so
-      // already-populated rows still gain newly-found (e.g. Polish) edition ISBNs.
+      // Every tracked book with a title (award books AND cycle volumes) — re-processed and
+      // merged (not gap-filled), so already-populated rows still gain newly-found ISBNs and
+      // a scan can match a non-award cycle volume too.
       const targets = rawBooks
-        .filter(isAwardBook)
         .filter((b) => (b.plTitle && b.plTitle.trim()) || (b.origTitle && b.origTitle.trim()));
 
       // Make sure the column exists before any write (schema ritual may not have run).

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -22,7 +22,8 @@ async function fetchWithTimeout(url: string, ms = 12000): Promise<Response> {
 }
 
 export const SearchSection: React.FC = () => {
-  const { books, loading, error, fetchBooks, setBooks } = useBooks();
+  // Full index (award books + cycle volumes) — so the scan/search finds a non-award volume too.
+  const { books, loading, error, fetchBooks, setBooks } = useBooks(true);
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -68,7 +69,7 @@ export const SearchSection: React.FC = () => {
       let index = books ?? [];
       try {
         // fresh=1 bypasses the server's 5-min cache too, so a just-added ISBN is visible.
-        const fresh = await fetchWithTimeout(`/api/books?fresh=1&t=${Date.now()}`);
+        const fresh = await fetchWithTimeout(`/api/books?fresh=1&all=1&t=${Date.now()}`);
         if (fresh.ok) { index = await fresh.json(); setBooks(index); }
       } catch {
         // Network hiccup / timeout — fall back to the in-memory index.

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -6,7 +6,7 @@ import { BookIndexEntry } from "../types";
  * The whole „Skryptorium" search filters this index in memory (client-side),
  * so no keystroke in the search field hits the network or Notion.
  */
-export function useBooks() {
+export function useBooks(all = false) {
   const [books, setBooks] = useState<BookIndexEntry[] | null>(null);
   // Start in loading state — the fetch fires right away in useEffect (after paint), so
   // without this the first frame would show an empty state instead of a spinner.
@@ -17,7 +17,8 @@ export function useBooks() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/books?t=${Date.now()}`);
+      // `all=1` (Skryptorium/scan) includes cycle volumes; without it (Regał) award-only.
+      const res = await fetch(`/api/books?${all ? "all=1&" : ""}t=${Date.now()}`);
       if (!res.ok) throw new Error("Błąd podczas pobierania rekordów archiwum");
       const data = await res.json();
       setBooks(data);
@@ -26,7 +27,7 @@ export function useBooks() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [all]);
 
   useEffect(() => {
     fetchBooks();

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -118,10 +118,13 @@ class SyncManager {
     return await statsService.getStats();
   }
 
-  /** Slimmed-down book index for the „Skryptorium" search (client-side). `fresh` bypasses the cache. */
-  async getBooks(fresh = false) {
+  /**
+   * Slimmed-down book index for the „Skryptorium" search (client-side). `fresh` bypasses
+   * the cache; `all` includes cycle volumes too (award-only by default, for the Regał).
+   */
+  async getBooks(fresh = false, all = false) {
     const books = await this.notion.getBooksForStats(undefined, undefined, { cache: !fresh });
-    return toSearchIndex(books);
+    return toSearchIndex(books, !all);
   }
 
   /**


### PR DESCRIPTION
The scan matched against an **award-only** index, so tracked cycle volumes (`Kategoria="Tom cyklu"`) could never be found. This adds them — surgically, so the Regał shelf stays award-only.

## Changes

- `toSearchIndex(books, awardOnly = true)` — the Regał shelf keeps its award-only projection; a new **full** variant includes cycle volumes.
- `getBooks(fresh, all)` + `GET /api/books?all=1`; `useBooks(all)`. **Skryptorium** (`SearchSection`) and the **scan** now fetch `all=1` (award books + cycle volumes); the **Regał** (`BookshelfSection`) keeps the award-only default, and award stats/shelf are unchanged.
- `isbnEnrichService` now processes **every titled row** (dropped the `isAwardBook` filter), so cycle volumes also get ISBNs stored to match against.

## Effect

- Scanning a tracked cycle volume now matches its row.
- Classic Skryptorium search also surfaces cycle volumes (coherent — "search everything you track"); the Regał and award statistics are untouched.

+2 tests (enrich a cycle volume; award-only index still drops it, `all` includes it). Full suite green (463), lint clean. Version bump 1.58.0 → 1.59.0.

## Follow-up on deploy

Re-run the **"Rytuał Sygnatur (ISBN)"** once so cycle volumes get their ISBNs too (more books = more lookups, but it's a manual ritual). Until then, cycle volumes are in the index but only match via variant-A resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_