### PR TITLE
feat: theme toggle — light Librem (boho) / dark Warhammer, default light

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.59.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.60.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.60.0** — **Przełącznik motywu: jasny „Librem" (boho) / ciemny „Warhammer" — DOMYŚLNIE JASNY.**
+  Fundament pod pełny rebrand na Librem (makieta zaakceptowana). Silnik motywu: `data-theme` na `<html>`
+  + `localStorage("librem-theme")`; inline-skrypt w `index.html` ustawia motyw przed montażem Reacta
+  (bez FOUC), domyślnie `light`. Hook `src/hooks/useTheme.ts` (`{theme, toggle}`, SSR-safe). W `App.tsx`:
+  przycisk Sun/Moon w headerze, `ParticleBackground` renderowany tylko w `dark`, gradient tytułu zależny
+  od motywu. `src/index.css`: warstwa `:root[data-theme="light"]` — natywne style zostają ciemne
+  (Warhammer, nietknięte), a jasny motyw remapuje najczęstsze klasy utility (slate/cyan/purple/amber/
+  rose/emerald → paleta boho: paper/card/ink/muted/line/clay/sage/ochre/brick) + fonty Cormorant Garamond
+  + Mulish. To FUNDAMENT (szeroki flip) — dopieszczanie per-zakładka do makiety i pełny rebrand nazewnictwa
+  jeszcze przed nami. Suite 463 zielone, lint czysty, build OK.
 - **1.59.0** — **Skaner ISBN obejmuje też książki bez nagród (tomy cykli).** Dotąd `toSearchIndex` był
   nagrodowo-only → skan nie znajdował tomów cykli (`Kategoria="Tom cyklu"`). Zmiany: (1) `toSearchIndex(books,
   awardOnly=true)` — Regał zostaje nagrodowo-only, ale nowy wariant „wszystko"; (2) `getBooks(fresh, all)` +

--- a/design/.gitignore
+++ b/design/.gitignore
@@ -1,0 +1,2 @@
+# Seeded design-canvas output (~2.5 MB, regenerable from the .dc.html + canvas.json via the design skill)
+librem-boho.html

--- a/design/Main.dc.html
+++ b/design/Main.dc.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Mulish:wght@400;500;600;700;800&display=swap">
+  <style>
+    :root{
+      --paper:#F3ECDF; --card:#FBF6EC; --ink:#3A342B; --muted:#8C8069;
+      --line:#E4D9C4; --clay:#C07A56; --sage:#7E8A6B; --ochre:#CE9B3F; --brick:#B0574A;
+      --serif:"Cormorant Garamond", Georgia, serif; --sans:"Mulish", system-ui, sans-serif;
+    }
+    *{box-sizing:border-box;}
+    body{margin:0;background:var(--paper);color:var(--ink);font-family:var(--sans);-webkit-font-smoothing:antialiased;}
+    a{color:var(--clay);text-decoration:none;} a:hover{color:#a6603f;}
+    h1,h2,h3{margin:0;font-family:var(--serif);font-weight:600;letter-spacing:.2px;}
+    .wrap{max-width:1040px;margin:0 auto;padding:44px 40px 60px;}
+    .eyebrow{font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--muted);font-weight:700;}
+    .card{background:var(--card);border:1px solid var(--line);border-radius:22px;box-shadow:0 10px 30px -22px rgba(58,52,43,.5);}
+    .pill{display:inline-flex;align-items:center;gap:9px;padding:11px 18px;border-radius:999px;font-size:13.5px;font-weight:600;color:var(--muted);border:1px solid transparent;}
+    .pill.active{background:#efe4d1;color:var(--ink);border-color:var(--line);box-shadow:inset 0 1px 0 #fff8;}
+    .kpi{font-family:var(--serif);font-weight:700;line-height:1;}
+    .bar{height:9px;border-radius:999px;background:#eaddc6;overflow:hidden;}
+    .barfill{height:100%;border-radius:999px;}
+  </style>
+</helmet>
+
+<div class="wrap" style="display:flex;flex-direction:column;gap:30px;">
+
+  <!-- Header -->
+  <header style="display:flex;align-items:flex-end;justify-content:space-between;gap:24px;">
+    <div style="display:flex;align-items:center;gap:18px;">
+      <div style="width:56px;height:56px;border-radius:18px;background:linear-gradient(150deg,#c98a63,#a9603d);display:flex;align-items:center;justify-content:center;box-shadow:0 12px 24px -14px rgba(169,96,61,.8);">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#fbf3e6" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5.5A2 2 0 0 1 6 4h5v16H6a2 2 0 0 1-2-1.5z"/><path d="M20 5.5A2 2 0 0 0 18 4h-5v16h5a2 2 0 0 0 2-1.5z"/></svg>
+      </div>
+      <div>
+        <div style="display:flex;align-items:baseline;gap:12px;">
+          <h1 style="font-size:40px;letter-spacing:.5px;">Librem</h1>
+          <span style="font-size:11px;font-weight:700;color:var(--clay);background:#f0e0cf;border:1px solid #e6cdb6;border-radius:999px;padding:2px 9px;">v1.59</span>
+        </div>
+        <p style="margin:2px 0 0;color:var(--muted);font-size:14px;font-style:italic;font-family:var(--serif);">Twoja kolekcja nagradzanej fantastyki</p>
+      </div>
+    </div>
+    <button style="width:44px;height:44px;border-radius:14px;background:var(--card);border:1px solid var(--line);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted);">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 0 1-4 0v-.1A1.6 1.6 0 0 0 6.6 19l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1A1.6 1.6 0 0 0 3 13.4H3a2 2 0 0 1 0-4h.1A1.6 1.6 0 0 0 4.6 6.6L4.5 6.5a2 2 0 1 1 2.8-2.8l.1.1A1.6 1.6 0 0 0 10 3V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8"/></svg>
+    </button>
+  </header>
+
+  <!-- Tabs -->
+  <nav style="display:flex;gap:8px;flex-wrap:wrap;padding:7px;background:#efe7d8;border:1px solid var(--line);border-radius:999px;align-self:flex-start;">
+    <span class="pill active">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><rect x="7" y="11" width="3" height="6"/><rect x="12" y="7" width="3" height="10"/><rect x="17" y="13" width="3" height="4"/></svg>
+      Kolekcja</span>
+    <span class="pill">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4v16"/><path d="M8 4v16"/><path d="M12 4v16"/><path d="m16 5 4 15"/></svg>
+      Regał</span>
+    <span class="pill">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+      Katalog</span>
+    <span class="pill">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
+      Synchronizacja</span>
+    <span class="pill">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="20" r="1.4"/><circle cx="18" cy="20" r="1.4"/><path d="M2 3h3l2.2 12.4a1.5 1.5 0 0 0 1.5 1.2h8.4a1.5 1.5 0 0 0 1.5-1.2L21.5 7H6"/></svg>
+      Rynek</span>
+  </nav>
+
+  <div style="display:flex;align-items:center;gap:14px;margin-top:2px;">
+    <h2 style="font-size:26px;">Twoja kolekcja</h2>
+    <span style="height:1px;flex:1;background:linear-gradient(90deg,var(--line),transparent);"></span>
+  </div>
+
+  <!-- KPI row -->
+  <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:18px;">
+    <div class="card" style="padding:22px;">
+      <div class="eyebrow">Woluminy</div>
+      <div class="kpi" style="font-size:44px;margin:10px 0 2px;color:var(--ink);">692</div>
+      <div style="font-size:12.5px;color:var(--muted);">nagrody + tomy cykli</div>
+    </div>
+    <div class="card" style="padding:22px;">
+      <div class="eyebrow">Przeczytane</div>
+      <div class="kpi" style="font-size:44px;margin:10px 0 8px;color:var(--sage);">58%</div>
+      <div class="bar"><div class="barfill" style="width:58%;background:var(--sage);"></div></div>
+    </div>
+    <div class="card" style="padding:22px;">
+      <div class="eyebrow">Posiadane</div>
+      <div class="kpi" style="font-size:44px;margin:10px 0 2px;color:var(--clay);">411</div>
+      <div style="font-size:12.5px;color:var(--muted);">na półce i w bibliotece</div>
+    </div>
+    <div class="card" style="padding:22px;">
+      <div class="eyebrow">Do zdobycia</div>
+      <div class="kpi" style="font-size:44px;margin:10px 0 2px;color:var(--ochre);">149</div>
+      <div style="font-size:12.5px;color:var(--muted);">brakuje w kolekcji</div>
+    </div>
+  </div>
+
+  <!-- Two column -->
+  <div style="display:grid;grid-template-columns:1.35fr 1fr;gap:18px;">
+
+    <!-- Decades -->
+    <div class="card" style="padding:26px;">
+      <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:22px;">
+        <h3 style="font-size:20px;">Oś czasu — dekady</h3>
+        <span style="font-size:12px;color:var(--muted);">wg roku wydania</span>
+      </div>
+      <div style="display:flex;align-items:flex-end;gap:14px;height:150px;">
+        <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end;">
+          <div style="width:100%;height:38%;background:#e7d9bf;border-radius:8px 8px 0 0;"></div><span style="font-size:11px;color:var(--muted);">60s</span></div>
+        <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end;">
+          <div style="width:100%;height:56%;background:#dcc9a6;border-radius:8px 8px 0 0;"></div><span style="font-size:11px;color:var(--muted);">70s</span></div>
+        <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end;">
+          <div style="width:100%;height:82%;background:linear-gradient(180deg,#d5a24c,#c9922f);border-radius:8px 8px 0 0;box-shadow:0 6px 14px -8px #c9922f;"></div><span style="font-size:11px;color:var(--ink);font-weight:700;">80s</span></div>
+        <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end;">
+          <div style="width:100%;height:70%;background:#c98a63;border-radius:8px 8px 0 0;"></div><span style="font-size:11px;color:var(--muted);">90s</span></div>
+        <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end;">
+          <div style="width:100%;height:64%;background:#c07a56;border-radius:8px 8px 0 0;"></div><span style="font-size:11px;color:var(--muted);">00s</span></div>
+        <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end;">
+          <div style="width:100%;height:48%;background:#b06a4a;border-radius:8px 8px 0 0;"></div><span style="font-size:11px;color:var(--muted);">10s</span></div>
+      </div>
+      <p style="margin:18px 0 0;font-size:12.5px;color:var(--muted);"><span style="color:var(--ochre);font-weight:700;">Złota era</span> Twojej kolekcji to lata 80. — 141 woluminów.</p>
+    </div>
+
+    <!-- Availability -->
+    <div class="card" style="padding:26px;">
+      <h3 style="font-size:20px;margin-bottom:20px;">Dostępność nieprzeczytanych</h3>
+      <div style="display:flex;height:16px;border-radius:999px;overflow:hidden;margin-bottom:20px;">
+        <div style="width:44%;background:var(--clay);"></div>
+        <div style="width:22%;background:var(--sage);"></div>
+        <div style="width:17%;background:var(--ochre);"></div>
+        <div style="width:17%;background:#d8ccb4;"></div>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:13px;">
+        <div style="display:flex;align-items:center;gap:10px;font-size:13.5px;"><span style="width:10px;height:10px;border-radius:3px;background:var(--clay);"></span>Posiadane <b style="margin-left:auto;">128</b></div>
+        <div style="display:flex;align-items:center;gap:10px;font-size:13.5px;"><span style="width:10px;height:10px;border-radius:3px;background:var(--sage);"></span>Biblioteka <b style="margin-left:auto;">64</b></div>
+        <div style="display:flex;align-items:center;gap:10px;font-size:13.5px;"><span style="width:10px;height:10px;border-radius:3px;background:var(--ochre);"></span>Vinted <b style="margin-left:auto;">49</b></div>
+        <div style="display:flex;align-items:center;gap:10px;font-size:13.5px;color:var(--muted);"><span style="width:10px;height:10px;border-radius:3px;background:#d8ccb4;"></span>Brak śladu <b style="margin-left:auto;">49</b></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Publishers -->
+  <div class="card" style="padding:26px 28px;">
+    <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:20px;">
+      <h3 style="font-size:20px;">Ulubione oficyny</h3>
+      <span style="font-size:12px;color:var(--muted);">udział przeczytań</span>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:16px;">
+      <div style="display:flex;align-items:center;gap:16px;">
+        <span style="width:130px;font-size:14px;font-weight:600;">Mag</span>
+        <div class="bar" style="flex:1;"><div class="barfill" style="width:76%;background:linear-gradient(90deg,#c98a63,#c07a56);"></div></div>
+        <span style="width:64px;text-align:right;font-size:13px;color:var(--muted);">62 / 82</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:16px;">
+        <span style="width:130px;font-size:14px;font-weight:600;">Rebis</span>
+        <div class="bar" style="flex:1;"><div class="barfill" style="width:54%;background:linear-gradient(90deg,#c98a63,#c07a56);"></div></div>
+        <span style="width:64px;text-align:right;font-size:13px;color:var(--muted);">31 / 57</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:16px;">
+        <span style="width:130px;font-size:14px;font-weight:600;">Zysk i S-ka</span>
+        <div class="bar" style="flex:1;"><div class="barfill" style="width:100%;background:var(--sage);"></div></div>
+        <span style="width:64px;text-align:right;font-size:13px;color:var(--sage);font-weight:700;">komplet</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:16px;">
+        <span style="width:130px;font-size:14px;font-weight:600;">Solaris</span>
+        <div class="bar" style="flex:1;"><div class="barfill" style="width:41%;background:linear-gradient(90deg,#c98a63,#c07a56);"></div></div>
+        <span style="width:64px;text-align:right;font-size:13px;color:var(--muted);">14 / 34</span>
+      </div>
+    </div>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/Regal.dc.html
+++ b/design/Regal.dc.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,600&family=Mulish:wght@400;500;600;700&display=swap">
+  <style>
+    :root{
+      --paper:#F3ECDF; --card:#FBF6EC; --ink:#3A342B; --muted:#8C8069;
+      --line:#E4D9C4; --clay:#C07A56; --sage:#7E8A6B; --ochre:#CE9B3F;
+      --serif:"Cormorant Garamond", Georgia, serif; --sans:"Mulish", system-ui, sans-serif;
+    }
+    *{box-sizing:border-box;}
+    body{margin:0;background:var(--paper);color:var(--ink);font-family:var(--sans);}
+    a{color:var(--clay);} a:hover{color:#a6603f;}
+    h1,h2,h3{margin:0;font-family:var(--serif);font-weight:600;}
+    .eyebrow{font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--muted);font-weight:700;}
+    .spine{width:44px;border-radius:4px 4px 2px 2px;display:flex;align-items:center;justify-content:center;box-shadow:2px 3px 6px -3px rgba(58,52,43,.55), inset 0 0 0 1px rgba(255,255,255,.12);cursor:pointer;position:relative;}
+    .spine span{writing-mode:vertical-rl;transform:rotate(180deg);font-family:var(--serif);font-weight:600;font-size:13px;letter-spacing:.3px;padding:14px 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-height:100%;}
+    .dot{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:5px;height:5px;border-radius:50%;}
+  </style>
+</helmet>
+
+<div style="max-width:1040px;margin:0 auto;padding:44px 40px 60px;display:flex;flex-direction:column;gap:26px;">
+
+  <div style="display:flex;align-items:center;gap:14px;">
+    <div style="width:44px;height:44px;border-radius:13px;background:linear-gradient(150deg,#c98a63,#a9603d);display:flex;align-items:center;justify-content:center;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fbf3e6" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4v16"/><path d="M8 4v16"/><path d="M12 4v16"/><path d="m16 5 4 15"/></svg>
+    </div>
+    <div>
+      <h1 style="font-size:30px;">Regał</h1>
+      <p style="margin:0;color:var(--muted);font-size:13px;font-style:italic;font-family:var(--serif);">Ułożone wg dekady i roku — jak na prawdziwej półce</p>
+    </div>
+  </div>
+
+  <!-- Shelf frame -->
+  <div style="background:linear-gradient(180deg,#efe6d5,#eaddc6);border:1px solid var(--line);border-radius:24px;padding:30px 30px 18px;box-shadow:0 18px 40px -30px rgba(58,52,43,.6);">
+
+    <!-- decade label -->
+    <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+      <span style="font-family:var(--serif);font-size:15px;font-weight:700;color:var(--clay);background:#f7ecdc;border:1px solid #e6cdb6;border-radius:8px;padding:3px 12px;">Lata 80.</span>
+      <span style="height:1px;flex:1;background:#d8c7a8;"></span>
+      <span style="font-size:12px;color:var(--muted);">141 woluminów</span>
+    </div>
+
+    <!-- Row 1 -->
+    <div style="display:flex;align-items:flex-end;gap:7px;height:190px;">
+      <div class="spine" style="height:180px;background:linear-gradient(180deg,#b8623f,#9c4f31);"><span style="color:#f8ebdc;">Neuromancer</span><span class="dot" style="background:#e8b24a;"></span></div>
+      <div class="spine" style="height:168px;background:linear-gradient(180deg,#8b9673,#727e5c);"><span style="color:#f4f1e6;">Hyperion</span></div>
+      <div class="spine" style="height:186px;background:linear-gradient(180deg,#d7ae5a,#c4933a);"><span style="color:#3a2f16;">Diuna</span><span class="dot" style="background:#8b5a2b;"></span></div>
+      <div class="spine" style="height:172px;background:linear-gradient(180deg,#e7dcc6,#d8c9a8);"><span style="color:#5a4d38;">Solaris</span></div>
+      <div class="spine" style="height:180px;background:linear-gradient(180deg,#a9603d,#8c4c2f);"><span style="color:#f7e8dc;">Miecz dla Króla</span></div>
+      <div class="spine" style="height:164px;background:linear-gradient(180deg,#7e8a6b,#67734f);"><span style="color:#f4f1e6;">Slan</span></div>
+      <div class="spine" style="height:188px;background:linear-gradient(180deg,#c98a63,#b06a4a);"><span style="color:#f7e8dc;">Nieustanne wojny</span></div>
+      <div class="spine" style="height:170px;background:linear-gradient(180deg,#cf9b3f,#b7852c);"><span style="color:#3a2f16;">Ubik</span></div>
+      <div class="spine" style="height:178px;background:linear-gradient(180deg,#efe6d0,#ddceac);"><span style="color:#5a4d38;">Fundacja</span></div>
+      <div class="spine" style="height:160px;background:linear-gradient(180deg,#8b9673,#727e5c);"><span style="color:#f4f1e6;">Ród</span></div>
+      <div class="spine" style="height:184px;background:linear-gradient(180deg,#b8623f,#9c4f31);"><span style="color:#f7e8dc;">Gra Endera</span></div>
+      <div class="spine" style="height:174px;background:linear-gradient(180deg,#d7ae5a,#c4933a);"><span style="color:#3a2f16;">Trylogia</span></div>
+    </div>
+
+    <!-- board -->
+    <div style="height:14px;margin:0 -6px 26px;border-radius:4px;background:linear-gradient(180deg,#caa877,#a9835a);box-shadow:0 8px 14px -8px rgba(58,52,43,.7);"></div>
+
+    <!-- Row 2 -->
+    <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+      <span style="font-family:var(--serif);font-size:15px;font-weight:700;color:var(--clay);background:#f7ecdc;border:1px solid #e6cdb6;border-radius:8px;padding:3px 12px;">Lata 90.</span>
+      <span style="height:1px;flex:1;background:#d8c7a8;"></span>
+      <span style="font-size:12px;color:var(--muted);">118 woluminów</span>
+    </div>
+    <div style="display:flex;align-items:flex-end;gap:7px;height:180px;">
+      <div class="spine" style="height:170px;background:linear-gradient(180deg,#8b9673,#727e5c);"><span style="color:#f4f1e6;">Przypływ</span></div>
+      <div class="spine" style="height:182px;background:linear-gradient(180deg,#c98a63,#b06a4a);"><span style="color:#f7e8dc;">Anathem</span></div>
+      <div class="spine" style="height:158px;background:linear-gradient(180deg,#e7dcc6,#d8c9a8);"><span style="color:#5a4d38;">Kwiaty</span></div>
+      <div class="spine" style="height:176px;background:linear-gradient(180deg,#d7ae5a,#c4933a);"><span style="color:#3a2f16;">Snow Crash</span><span class="dot" style="background:#8b5a2b;"></span></div>
+      <div class="spine" style="height:186px;background:linear-gradient(180deg,#a9603d,#8c4c2f);"><span style="color:#f7e8dc;">Wyspa</span></div>
+      <div class="spine" style="height:166px;background:linear-gradient(180deg,#7e8a6b,#67734f);"><span style="color:#f4f1e6;">Riverworld</span></div>
+      <div class="spine" style="height:178px;background:linear-gradient(180deg,#efe6d0,#ddceac);"><span style="color:#5a4d38;">Xenocyd</span></div>
+      <div class="spine" style="height:172px;background:linear-gradient(180deg,#b8623f,#9c4f31);"><span style="color:#f7e8dc;">Cyberiada</span></div>
+      <div class="spine" style="height:162px;background:linear-gradient(180deg,#cf9b3f,#b7852c);"><span style="color:#3a2f16;">Blask</span></div>
+      <div class="spine" style="height:184px;background:linear-gradient(180deg,#c98a63,#b06a4a);"><span style="color:#f7e8dc;">Timescape</span></div>
+      <div class="spine" style="height:168px;background:linear-gradient(180deg,#8b9673,#727e5c);"><span style="color:#f4f1e6;">Startide</span></div>
+    </div>
+    <div style="height:14px;margin:0 -6px 0;border-radius:4px;background:linear-gradient(180deg,#caa877,#a9835a);box-shadow:0 8px 14px -8px rgba(58,52,43,.7);"></div>
+  </div>
+
+  <div style="display:flex;gap:20px;align-items:center;color:var(--muted);font-size:12.5px;">
+    <span style="display:flex;align-items:center;gap:7px;"><span style="width:9px;height:9px;border-radius:50%;background:#e8b24a;"></span>nagroda</span>
+    <span style="display:flex;align-items:center;gap:7px;"><span style="width:9px;height:9px;border-radius:50%;background:#8b5a2b;"></span>przeczytana</span>
+    <span style="margin-left:auto;font-style:italic;font-family:var(--serif);">Przeciągnij grzbiet, aby przestawić na półce</span>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/Skan.dc.html
+++ b/design/Skan.dc.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,600;0,700;1,600&family=Mulish:wght@400;500;600;700&display=swap">
+  <style>
+    :root{
+      --paper:#F3ECDF; --card:#FBF6EC; --ink:#3A342B; --muted:#8C8069;
+      --line:#E4D9C4; --clay:#C07A56; --sage:#7E8A6B; --ochre:#CE9B3F;
+      --serif:"Cormorant Garamond", Georgia, serif; --sans:"Mulish", system-ui, sans-serif;
+    }
+    *{box-sizing:border-box;}
+    body{margin:0;background:var(--paper);color:var(--ink);font-family:var(--sans);}
+    a{color:var(--clay);} a:hover{color:#a6603f;}
+    h1,h2,h3{margin:0;font-family:var(--serif);font-weight:600;}
+  </style>
+</helmet>
+
+<div style="width:390px;height:844px;background:var(--paper);display:flex;flex-direction:column;padding:26px 20px 24px;gap:18px;position:relative;overflow:hidden;">
+
+  <!-- top bar -->
+  <div style="display:flex;align-items:center;justify-content:space-between;">
+    <div style="display:flex;align-items:center;gap:11px;">
+      <div style="width:36px;height:36px;border-radius:11px;background:linear-gradient(150deg,#c98a63,#a9603d);display:flex;align-items:center;justify-content:center;">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#fbf3e6" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5.5A2 2 0 0 1 6 4h5v16H6a2 2 0 0 1-2-1.5z"/><path d="M20 5.5A2 2 0 0 0 18 4h-5v16h5a2 2 0 0 0 2-1.5z"/></svg>
+      </div>
+      <div>
+        <div style="font-family:var(--serif);font-size:22px;font-weight:700;line-height:1;">Librem</div>
+        <div style="font-size:11px;color:var(--muted);letter-spacing:.16em;text-transform:uppercase;font-weight:700;margin-top:2px;">Katalog</div>
+      </div>
+    </div>
+    <div style="width:36px;height:36px;border-radius:11px;border:1px solid var(--line);background:var(--card);display:flex;align-items:center;justify-content:center;color:var(--muted);">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
+    </div>
+  </div>
+
+  <!-- search row -->
+  <div style="display:flex;gap:10px;">
+    <div style="flex:1;display:flex;align-items:center;gap:10px;background:var(--card);border:1px solid var(--line);border-radius:16px;padding:0 14px;height:50px;">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#b6a98a" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+      <span style="color:#b6a98a;font-size:14px;">Tytuł, autor lub ISBN…</span>
+    </div>
+    <button style="width:50px;height:50px;border-radius:16px;background:linear-gradient(150deg,#c98a63,#a9603d);border:none;display:flex;align-items:center;justify-content:center;box-shadow:0 10px 20px -12px #a9603d;">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fbf3e6" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5v14"/><path d="M6 5v14"/><path d="M10 5v14"/><path d="M14 5v14"/><path d="M18 5v14"/><path d="M21 5v14"/></svg>
+    </button>
+  </div>
+
+  <!-- scan sheet -->
+  <div style="margin-top:6px;background:var(--card);border:1px solid var(--line);border-radius:26px;box-shadow:0 24px 50px -30px rgba(58,52,43,.7);padding:20px;display:flex;flex-direction:column;gap:16px;">
+
+    <div style="display:flex;align-items:center;gap:12px;">
+      <div style="width:44px;height:44px;border-radius:50%;background:#f0e0cf;border:1px solid #e6cdb6;display:flex;align-items:center;justify-content:center;color:var(--clay);">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5v14"/><path d="M7 5v14"/><path d="M11 5v14"/><path d="M15 5v14"/><path d="M19 5v14"/></svg>
+      </div>
+      <div style="flex:1;">
+        <div style="font-family:var(--serif);font-size:20px;font-weight:700;">Skan sygnatury</div>
+        <div style="font-size:12.5px;color:var(--muted);">Nakieruj kamerę na kod kreskowy</div>
+      </div>
+      <div style="width:30px;height:30px;border-radius:9px;color:var(--muted);display:flex;align-items:center;justify-content:center;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>
+      </div>
+    </div>
+
+    <!-- camera viewport -->
+    <div style="position:relative;border-radius:18px;overflow:hidden;height:250px;background:radial-gradient(120% 90% at 50% 25%,#4a4136,#2b2620);">
+      <!-- warm vignette + faux depth -->
+      <div style="position:absolute;inset:0;background:linear-gradient(180deg,rgba(206,155,63,.10),transparent 40%);"></div>
+      <!-- guide frame -->
+      <div style="position:absolute;inset:16px;border:2px solid rgba(240,224,207,.35);border-radius:14px;"></div>
+      <!-- corners -->
+      <div style="position:absolute;left:16px;top:16px;width:26px;height:26px;border-left:3px solid var(--ochre);border-top:3px solid var(--ochre);border-radius:8px 0 0 0;"></div>
+      <div style="position:absolute;right:16px;top:16px;width:26px;height:26px;border-right:3px solid var(--ochre);border-top:3px solid var(--ochre);border-radius:0 8px 0 0;"></div>
+      <div style="position:absolute;left:16px;bottom:16px;width:26px;height:26px;border-left:3px solid var(--ochre);border-bottom:3px solid var(--ochre);border-radius:0 0 0 8px;"></div>
+      <div style="position:absolute;right:16px;bottom:16px;width:26px;height:26px;border-right:3px solid var(--ochre);border-bottom:3px solid var(--ochre);border-radius:0 0 8px 0;"></div>
+      <!-- scan line -->
+      <div style="position:absolute;left:30px;right:30px;top:50%;height:2px;background:linear-gradient(90deg,transparent,#e8b24a,transparent);box-shadow:0 0 14px 2px rgba(232,178,74,.55);"></div>
+      <!-- faux barcode being read -->
+      <div style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);display:flex;gap:3px;align-items:center;opacity:.5;">
+        <span style="width:2px;height:44px;background:#f0e0cf;"></span><span style="width:4px;height:44px;background:#f0e0cf;"></span><span style="width:2px;height:44px;background:#f0e0cf;"></span><span style="width:3px;height:44px;background:#f0e0cf;"></span><span style="width:2px;height:44px;background:#f0e0cf;"></span><span style="width:5px;height:44px;background:#f0e0cf;"></span><span style="width:2px;height:44px;background:#f0e0cf;"></span><span style="width:3px;height:44px;background:#f0e0cf;"></span><span style="width:4px;height:44px;background:#f0e0cf;"></span><span style="width:2px;height:44px;background:#f0e0cf;"></span>
+      </div>
+      <!-- torch button (on) -->
+      <button style="position:absolute;top:14px;right:14px;width:42px;height:42px;border-radius:50%;border:1px solid #e9c98f;background:rgba(233,178,74,.92);display:flex;align-items:center;justify-content:center;box-shadow:0 0 20px -2px rgba(232,178,74,.7);">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3a2f16" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2h6l-1 8h-4z"/><path d="M9 10h6l-2 12z"/><path d="M10 6h4"/></svg>
+      </button>
+    </div>
+
+    <!-- manual entry -->
+    <div style="display:flex;flex-direction:column;gap:8px;">
+      <div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);font-weight:700;display:flex;align-items:center;gap:7px;">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M7 10h.01M12 10h.01M17 10h.01M7 14h10"/></svg>
+        Lub wpisz ISBN ręcznie
+      </div>
+      <div style="display:flex;gap:9px;">
+        <div style="flex:1;height:46px;border:1px solid var(--line);border-radius:14px;background:#fff;display:flex;align-items:center;padding:0 14px;color:#b6a98a;font-size:14px;">978…</div>
+        <button style="padding:0 20px;height:46px;border:none;border-radius:14px;background:var(--sage);color:#f6f4ea;font-weight:700;font-size:14px;">Szukaj</button>
+      </div>
+    </div>
+  </div>
+
+  <p style="text-align:center;font-size:12.5px;color:var(--muted);font-style:italic;font-family:var(--serif);margin:4px 0 0;">Zeskanuj książkę w antykwariacie — sprawdzimy, czy jest już w Twojej kolekcji.</p>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/design/canvas.json
+++ b/design/canvas.json
@@ -1,0 +1,11 @@
+{
+  "artboards": [
+    { "file": "Main.dc.html", "x": 0, "y": 0, "w": 1040, "h": 1180, "title": "Kolekcja" },
+    { "file": "Regal.dc.html", "x": 1160, "y": 0, "w": 1040, "h": 760, "title": "Regał" },
+    { "file": "Skan.dc.html", "x": 1160, "y": 880, "w": 390, "h": 844, "title": "Katalog + skaner" }
+  ],
+  "annotations": [
+    { "id": "brief", "x": 0, "y": -150, "w": 620, "text": "Librem — kierunek: jasne boho\nPaleta lniana: oat/paper · glina · szałwia · ochra · atramentowy brąz\nTypografia: Cormorant Garamond (nagłówki) + Mulish (UI)\nNazewnictwo zneutralizowane z 40k → Kolekcja · Regał · Katalog · Synchronizacja · Rynek" }
+  ],
+  "launch": { "view": "canvas" }
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
       type="image/svg+xml"
       href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2064%2064'%3E%3Crect%20width='64'%20height='64'%20rx='14'%20fill='%23020617'/%3E%3Cg%20fill='none'%20stroke='%2322d3ee'%20stroke-width='3.5'%20stroke-linejoin='round'%3E%3Cpath%20d='M32%206v8M32%2050v8M6%2032h8M50%2032h8M13.5%2013.5l5.7%205.7M44.8%2044.8l5.7%205.7M50.5%2013.5l-5.7%205.7M19.2%2044.8l-5.7%205.7'/%3E%3Ccircle%20cx='32'%20cy='32'%20r='16'/%3E%3C/g%3E%3Ccircle%20cx='32'%20cy='32'%20r='6.5'%20fill='%23a855f7'/%3E%3C/svg%3E"
     />
+    <script>
+      // Set the theme before React mounts so there's no flash. Default: light (Librem).
+      (function () {
+        try {
+          var t = localStorage.getItem('librem-theme');
+          document.documentElement.dataset.theme = (t === 'dark' || t === 'light') ? t : 'light';
+        } catch (e) { document.documentElement.dataset.theme = 'light'; }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.59.0",
+      "version": "1.60.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.59.0",
+  "version": "1.60.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart, ScrollText, Library } from "lucide-react";
+import { Database, Terminal, ArrowUp, XCircle, AlertTriangle, RefreshCw, Cog, ShoppingCart, ScrollText, Library, Sun, Moon } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
+import { useTheme } from "./hooks/useTheme";
 import { StatsSection } from "./components/StatsSection";
 import { SearchSection } from "./components/SearchSection";
 import { BookshelfSection } from "./components/BookshelfSection";
@@ -18,6 +19,7 @@ const tabTransition = { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y
 export default function App() {
   const [activeTab, setActiveTab] = useState<TabId>('stats');
   const [showScrollTop, setShowScrollTop] = useState(false);
+  const { theme, toggle: toggleTheme } = useTheme();
 
   // A single manager instance — its `anyError` feeds the global error card (visible
   // on every tab), and the same instance goes to LiturgySection via the `sm` prop.
@@ -40,7 +42,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-200 font-sans selection:bg-cyan-500/30 selection:text-white relative overflow-hidden">
-      <ParticleBackground />
+      {theme === 'dark' && <ParticleBackground />}
 
       <div className="relative z-10 max-w-5xl mx-auto px-6 py-16 space-y-12">
         {/* Header */}
@@ -64,7 +66,9 @@ export default function App() {
           </motion.button>
           <div className="flex-1">
             <h1 className="text-4xl md:text-5xl font-bold tracking-tighter font-display mb-2 flex items-center justify-center md:justify-start gap-3 flex-wrap">
-              <span className="bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]">
+              <span className={theme === 'light'
+                ? "bg-clip-text text-transparent bg-gradient-to-r from-[#c98a63] to-[#a9603d]"
+                : "bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]"}>
                 COGITATOR OMNISSIAH
               </span>
               <span className="text-[10px] font-mono font-bold tracking-widest text-cyan-400/70 bg-cyan-500/10 border border-cyan-500/20 rounded-full px-2 py-0.5 self-center" title="Wersja rytuału">
@@ -76,6 +80,20 @@ export default function App() {
               Protokół Synchronizacji Danych Archiwalnych
             </p>
           </div>
+
+          {/* Theme toggle — jasny „Librem" / ciemny „Warhammer" */}
+          <motion.button
+            whileHover={{ scale: 1.04 }}
+            whileTap={{ scale: 0.96 }}
+            onClick={toggleTheme}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-full bg-slate-900/80 border border-cyan-500/30 text-slate-300 backdrop-blur-md shadow-lg transition-colors hover:border-cyan-400/50"
+            title={theme === 'light' ? 'Przełącz na motyw ciemny' : 'Przełącz na motyw jasny'}
+            aria-label={theme === 'light' ? 'Przełącz na motyw ciemny' : 'Przełącz na motyw jasny'}
+          >
+            {theme === 'light'
+              ? <><Moon className="w-4 h-4" /><span className="text-xs font-bold uppercase tracking-widest">Ciemny</span></>
+              : <><Sun className="w-4 h-4 text-amber-400" /><span className="text-xs font-bold uppercase tracking-widest">Jasny</span></>}
+          </motion.button>
         </motion.header>
 
         <TabNav tabs={tabs} active={activeTab} onSelect={(id) => setActiveTab(id as TabId)} />

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * App theme: „light" = Librem (jasny boho), „dark" = Warhammer (dotychczasowy).
+ * DEFAULT = light. The chosen theme is stored on `<html data-theme>` (an inline
+ * script in index.html sets it before React mounts, so there's no flash) and
+ * persisted in localStorage.
+ */
+export type Theme = "light" | "dark";
+const KEY = "librem-theme";
+
+function readInitial(): Theme {
+  if (typeof document !== "undefined") {
+    const attr = document.documentElement.dataset.theme;
+    if (attr === "light" || attr === "dark") return attr;
+  }
+  try {
+    const stored = localStorage.getItem(KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch { /* private mode / blocked */ }
+  return "light";
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(readInitial);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") document.documentElement.dataset.theme = theme;
+    try { localStorage.setItem(KEY, theme); } catch { /* ignore */ }
+  }, [theme]);
+
+  const toggle = useCallback(() => setTheme((t) => (t === "light" ? "dark" : "light")), []);
+  return { theme, toggle };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&family=Share+Tech+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&family=Share+Tech+Mono&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,600&family=Mulish:wght@400;500;600;700;800&display=swap');
 @import "tailwindcss";
 
 @theme {
@@ -148,3 +148,95 @@ body {
 .skin-holo .cover-card { background: linear-gradient(150deg, var(--ca-a), var(--ca-b)); }
 .skin-noospheric .cover-badge { color: #fcd34d; border-color: #fcd34d; }
 .skin-holo .cover-badge { color: #67e8f9; border-color: #67e8f9; }
+
+/* ============================================================================
+   MOTYW JASNY „Librem" (boho light)
+   Natywne style aplikacji = ciemny „Warhammer" (bez zmian). Poniższa warstwa
+   `[data-theme="light"]` to skóra jasna — domyślna. Przełącznik zmienia tylko
+   atrybut `data-theme` na <html>. Remapujemy najczęstsze klasy narzędziowe
+   (slate/cyan/…) na paletę lnianą, plus fonty (serif + humanistyczny sans).
+   ============================================================================ */
+:root[data-theme="light"] {
+  --l-paper:#F3ECDF; --l-card:#FBF6EC; --l-ink:#3A342B; --l-muted:#8C8069;
+  --l-line:#E4D9C4; --l-clay:#C07A56; --l-clay-deep:#a6603f; --l-sage:#7E8A6B;
+  --l-ochre:#CE9B3F; --l-brick:#B0574A;
+  --font-display: "Cormorant Garamond", Georgia, "Times New Roman", serif;
+  --font-sans: "Mulish", ui-sans-serif, system-ui, sans-serif;
+  color-scheme: light;
+}
+
+[data-theme="light"] body { background-color: var(--l-paper); color: var(--l-ink); }
+[data-theme="light"] ::selection { background: rgba(192,122,86,.28); color: #2e2820; }
+
+/* Nagłówki na serif (klasa font-display używana w całej apce). */
+[data-theme="light"] .font-display { letter-spacing: .2px; }
+
+/* Karty */
+[data-theme="light"] .glass-card {
+  background-color: var(--l-card);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-color: var(--l-line);
+  box-shadow: 0 12px 32px -24px rgba(58,52,43,.55);
+}
+[data-theme="light"] .text-gradient { background-image: linear-gradient(90deg, #c98a63, #a9603d); }
+
+/* Tła */
+[data-theme="light"] .bg-slate-950 { background-color: var(--l-paper); }
+[data-theme="light"] .bg-slate-900,
+[data-theme="light"] .bg-slate-800,
+[data-theme="light"] .bg-slate-800\/50,
+[data-theme="light"] .bg-slate-900\/40,
+[data-theme="light"] .bg-slate-900\/60,
+[data-theme="light"] .bg-slate-900\/80,
+[data-theme="light"] .bg-slate-950\/60,
+[data-theme="light"] .bg-slate-950\/80 { background-color: var(--l-card); }
+
+/* Tekst */
+[data-theme="light"] .text-white,
+[data-theme="light"] .text-slate-100,
+[data-theme="light"] .text-slate-200,
+[data-theme="light"] .text-slate-300 { color: var(--l-ink); }
+[data-theme="light"] .text-slate-400,
+[data-theme="light"] .text-slate-500,
+[data-theme="light"] .text-slate-600 { color: var(--l-muted); }
+[data-theme="light"] .text-cyan-400,
+[data-theme="light"] .text-cyan-300,
+[data-theme="light"] .text-cyan-100\/90 { color: var(--l-clay); }
+[data-theme="light"] .text-purple-400,
+[data-theme="light"] .text-purple-500,
+[data-theme="light"] .text-purple-100\/90 { color: var(--l-sage); }
+[data-theme="light"] .text-amber-300,
+[data-theme="light"] .text-amber-400 { color: var(--l-ochre); }
+[data-theme="light"] .text-rose-400,
+[data-theme="light"] .text-red-400,
+[data-theme="light"] .text-red-300,
+[data-theme="light"] .text-red-200 { color: var(--l-brick); }
+[data-theme="light"] .text-emerald-400,
+[data-theme="light"] .text-emerald-300 { color: var(--l-sage); }
+
+/* Obramowania */
+[data-theme="light"] .border-white\/10,
+[data-theme="light"] .border-slate-800,
+[data-theme="light"] .border-slate-800\/50,
+[data-theme="light"] .border-slate-700 { border-color: var(--l-line); }
+
+/* Akcenty pigułek zakładek (miękkie, ciepłe) */
+[data-theme="light"] .bg-cyan-500\/20 { background-color: rgba(192,122,86,.16); }
+[data-theme="light"] .border-cyan-500\/50,
+[data-theme="light"] .border-cyan-500\/30 { border-color: rgba(192,122,86,.4); }
+[data-theme="light"] .bg-amber-500\/20 { background-color: rgba(206,155,63,.18); }
+[data-theme="light"] .border-amber-500\/50 { border-color: rgba(206,155,63,.45); }
+[data-theme="light"] .bg-purple-500\/20 { background-color: rgba(126,138,107,.18); }
+[data-theme="light"] .border-purple-500\/50 { border-color: rgba(126,138,107,.45); }
+[data-theme="light"] .bg-rose-500\/20 { background-color: rgba(176,87,74,.14); }
+[data-theme="light"] .border-rose-500\/50 { border-color: rgba(176,87,74,.4); }
+
+/* Linki */
+[data-theme="light"] a { color: var(--l-clay); }
+[data-theme="light"] a:hover { color: var(--l-clay-deep); }
+
+/* Pasek przewijania */
+[data-theme="light"] .custom-scrollbar::-webkit-scrollbar-track { background: rgba(228,217,196,.5); }
+[data-theme="light"] .custom-scrollbar::-webkit-scrollbar-thumb { background: rgba(192,122,86,.45); }
+[data-theme="light"] .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: rgba(192,122,86,.7); }


### PR DESCRIPTION
Fixes #285

Silnik motywu, który przełącza całą aplikację między zaakceptowanym jasnym stylem boho „Librem" (domyślny) a dotychczasowym ciemnym Warhammer 40k.

## Zmiany
- **`data-theme` na `<html>` + `localStorage("librem-theme")`**; inline-skrypt w `index.html` ustawia motyw przed montażem Reacta (bez FOUC), domyślnie `light`.
- **`src/hooks/useTheme.ts`** — SSR-safe `{theme, toggle}`.
- **`src/App.tsx`** — przycisk Sun/Moon w headerze, `ParticleBackground` renderowany tylko w motywie ciemnym, gradient tytułu zależny od motywu.
- **`src/index.css`** — warstwa `:root[data-theme="light"]` remapuje najczęstsze klasy utility (slate/cyan/purple/amber/rose/emerald) na paletę boho (paper/card/ink/muted/line/clay/sage/ochre/brick); natywne style zostają ciemne (Warhammer, nietknięte). Dodane fonty Cormorant Garamond + Mulish.

## Uwagi
To **fundament** (szeroki flip) — dopieszczanie per-zakładka do makiety i pełny rebrand nazewnictwa jeszcze przed nami.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_