### PR TITLE
feat: full Librem naming rebrand across the UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Vitest, organized into `__tests__/` subdirectories: `/__tests__/` (adapters, ser
 ## Conventions
 
 - Tailwind CSS only; glassmorphism theme (`slate-950` background, `cyan-400`/`purple-500` accents); `motion/react` for animations; `lucide-react` icons.
-- UI copy and domain naming use Warhammer 40k "Adeptus Mechanicus" flavor (rituals, Machine Spirit, sanctity) — preserve it.
+- **Branding: "Librem"** — warm, literary "your book collection" voice (Kolekcja, Regał, Katalog, Synchronizacja, Rynek, Ustawienia). The old Warhammer 40k "Adeptus Mechanicus" flavor (rituals, Machine Spirit, sanctity) has been retired from user-facing copy (v1.61.0) — do NOT reintroduce it. Domain/data identifiers stay untouched (Notion column names like `AppConfig`, `Kategoria="Tom cyklu"`, TASK_REGISTRY keys, backend service copy). The dark theme keeps the 40k glassmorphism *visual* look, but its *copy* is Librem like everything else.
 - After major architectural changes, update `COGITATOR_GUIDELINES.md` and `README.md` to match the implementation (see guidelines §8).
 
 ## Workflow rules

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.60.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.61.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.61.0** — **Pełny rebrand nazewnictwa UI: „Cogitator Omnissiah" → „Librem"** (ciepły, biblioteczny ton
+  zamiast liturgicznego 40k). Wordmark `COGITATOR OMNISSIAH`→`LIBREM`, podtytuł→„Twoja kolekcja nagradzanej
+  fantastyki". Zakładki: Statystyki Archiwum→**Kolekcja**, Skryptorium→**Katalog**, Liturgie
+  Synchronizacji→**Synchronizacja**, Skaner Vinted→**Rynek**, Sanktuarium Kalibracji→**Ustawienia** (Regał bez
+  zmian). Zret-owane w całym UI: „Rytuał X"→nazwy opisowe (Porządkowanie tytułów, Oznaczanie cykli, Wydawcy,
+  Serie, Nadawanie ISBN, Wykrywanie duplikatów…), Skaner Sanctity→**Kontrola spójności** ([ZATWIERDZONO]/
+  [HEREZJA]→[SPÓJNE]/[NIESPÓJNE]), Duch Maszyny→**połączenia**, „archiwum"→**katalog/kolekcja**, skórka regału
+  Relikwiarz→**Klasyczny**, ticker AVE·OMNISSIAH→LIBREM. `index.html` title/description/theme-color. **NIE
+  ruszane** (dane): kolumny Notion (`AppConfig`, `Kategoria="Tom cyklu"`), TASK_REGISTRY, `awardName:"Wszystkie
+  Nagrody"`, backendowe copy (`Przerwano Rytuał Wydania.` itp.). Zaktualizowane asercje w `App.test.tsx` +
+  `CLAUDE.md` (konwencja brandingu). Suite 463 zielone, lint czysty, build OK. Ciemny motyw = wygląd 40k, ale
+  copy jak wszędzie = Librem. NASTĘPNE: wizualne dopieszczenie zakładek do makiety Librem.
 - **1.60.0** — **Przełącznik motywu: jasny „Librem" (boho) / ciemny „Warhammer" — DOMYŚLNIE JASNY.**
   Fundament pod pełny rebrand na Librem (makieta zaakceptowana). Silnik motywu: `data-theme` na `<html>`
   + `localStorage("librem-theme")`; inline-skrypt w `index.html` ustawia motyw przed montażem Reacta

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cogitator Omnissiah — Archiwum Nagród Fantastyki</title>
-    <meta name="description" content="Cogitator Omnissiah — rytuał synchronizacji nagród literackich (Hugo, Nebula, Locus) z Archiwum Encyklopedii Fantastyki do osobistego archiwum Notion." />
-    <meta name="theme-color" content="#020617" />
+    <title>Librem — Twoja kolekcja nagradzanej fantastyki</title>
+    <meta name="description" content="Librem — osobista kolekcja nagradzanej fantastyki (Hugo, Nebula, Locus) z Encyklopedii Fantastyki, synchronizowana z Notion." />
+    <meta name="theme-color" content="#F3ECDF" />
     <link
       rel="icon"
       type="image/svg+xml"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.60.0",
+      "version": "1.61.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.60.0",
+  "version": "1.61.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,11 +33,11 @@ export default function App() {
   }, []);
 
   const tabs: TabDef[] = [
-    { id: 'stats', label: 'Statystyki Archiwum', icon: <Database className="w-5 h-5" />, activeClass: 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]' },
+    { id: 'stats', label: 'Kolekcja', icon: <Database className="w-5 h-5" />, activeClass: 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]' },
     { id: 'shelf', label: 'Regał', icon: <Library className="w-5 h-5" />, activeClass: 'bg-amber-500/20 border-amber-500/50 text-amber-300 shadow-[0_0_20px_rgba(251,191,36,0.2)]' },
-    { id: 'search', label: 'Skryptorium', icon: <ScrollText className="w-5 h-5" />, activeClass: 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]' },
-    { id: 'config', label: 'Liturgie Synchronizacji', icon: <Cog className={`w-5 h-5 ${isAnySyncLoading ? 'animate-spin text-purple-400' : ''}`} />, activeClass: 'bg-purple-500/20 border-purple-500/50 text-purple-400 shadow-[0_0_20px_rgba(168,85,247,0.2)]' },
-    { id: 'vinted', label: 'Skaner Vinted', icon: <ShoppingCart className="w-5 h-5" />, activeClass: 'bg-rose-500/20 border-rose-500/50 text-rose-400 shadow-[0_0_20px_rgba(244,63,94,0.2)]' },
+    { id: 'search', label: 'Katalog', icon: <ScrollText className="w-5 h-5" />, activeClass: 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.2)]' },
+    { id: 'config', label: 'Synchronizacja', icon: <Cog className={`w-5 h-5 ${isAnySyncLoading ? 'animate-spin text-purple-400' : ''}`} />, activeClass: 'bg-purple-500/20 border-purple-500/50 text-purple-400 shadow-[0_0_20px_rgba(168,85,247,0.2)]' },
+    { id: 'vinted', label: 'Rynek', icon: <ShoppingCart className="w-5 h-5" />, activeClass: 'bg-rose-500/20 border-rose-500/50 text-rose-400 shadow-[0_0_20px_rgba(244,63,94,0.2)]' },
   ];
 
   return (
@@ -59,8 +59,8 @@ export default function App() {
             className={`p-5 bg-slate-900/80 rounded-2xl border shadow-2xl backdrop-blur-xl cursor-pointer transition-colors ${
               activeTab === 'admin' ? 'border-amber-500/50 shadow-amber-500/20' : 'border-cyan-500/30 shadow-cyan-500/20'
             }`}
-            title="Sanktuarium Kalibracji (konfiguracja)"
-            aria-label="Otwórz konfigurację"
+            title="Ustawienia"
+            aria-label="Otwórz ustawienia"
           >
             <Database className={`w-12 h-12 ${activeTab === 'admin' ? 'text-amber-400' : 'text-cyan-400'}`} />
           </motion.button>
@@ -69,15 +69,15 @@ export default function App() {
               <span className={theme === 'light'
                 ? "bg-clip-text text-transparent bg-gradient-to-r from-[#c98a63] to-[#a9603d]"
                 : "bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]"}>
-                COGITATOR OMNISSIAH
+                LIBREM
               </span>
-              <span className="text-[10px] font-mono font-bold tracking-widest text-cyan-400/70 bg-cyan-500/10 border border-cyan-500/20 rounded-full px-2 py-0.5 self-center" title="Wersja rytuału">
+              <span className="text-[10px] font-mono font-bold tracking-widest text-cyan-400/70 bg-cyan-500/10 border border-cyan-500/20 rounded-full px-2 py-0.5 self-center" title="Wersja aplikacji">
                 v{__APP_VERSION__}
               </span>
             </h1>
             <p className="text-slate-400 text-lg font-medium tracking-wide uppercase flex items-center justify-center md:justify-start gap-2">
               <Terminal className="w-4 h-4 text-purple-500" />
-              Protokół Synchronizacji Danych Archiwalnych
+              Twoja kolekcja nagradzanej fantastyki
             </p>
           </div>
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -81,21 +81,21 @@ describe('App Main Flows', () => {
     });
   });
 
-  it('renders Status Ducha Maszyny and award links', async () => {
+  it('renders Status połączeń and award links', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Status Ducha Maszyny/i)).toBeInTheDocument();
+      expect(screen.getByText(/Status połączeń/i)).toBeInTheDocument();
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
-      expect(screen.getByText(/Baza Zlokalizowana/i)).toBeInTheDocument();
+      expect(screen.getByText(/Połączono/i)).toBeInTheDocument();
+      expect(screen.getByText(/Baza znaleziona/i)).toBeInTheDocument();
     });
 
     // Check award links
@@ -107,16 +107,16 @@ describe('App Main Flows', () => {
   it('shows all award options in the dropdown', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+      expect(screen.getByText(/Połączono/i)).toBeInTheDocument();
     });
 
-    const select = screen.getByLabelText(/Wybierz Nagrodę do Synchronizacji/i) as HTMLSelectElement;
+    const select = screen.getByLabelText(/Wybierz nagrodę do synchronizacji/i) as HTMLSelectElement;
     expect(select).toBeInTheDocument();
     
     const options = Array.from(select.options).map(o => o.value);
@@ -129,16 +129,16 @@ describe('App Main Flows', () => {
   it('handles single award sync flow (UI state)', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+      expect(screen.getByText(/Połączono/i)).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText(/Inicjuj Synchronizację/i);
+    const syncButton = screen.getByText(/Synchronizuj/i);
     fireEvent.click(syncButton);
     
     // Should show loading state (mocking SSE is complex, so we check if it starts)
@@ -148,19 +148,19 @@ describe('App Main Flows', () => {
   it('handles "Wszystkie Nagrody" sync flow', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+      expect(screen.getByText(/Połączono/i)).toBeInTheDocument();
     });
 
-    const select = screen.getByLabelText(/Wybierz Nagrodę do Synchronizacji/i);
+    const select = screen.getByLabelText(/Wybierz nagrodę do synchronizacji/i);
     fireEvent.change(select, { target: { value: 'Wszystkie Nagrody' } });
     
-    const syncButton = screen.getByText(/Inicjuj Synchronizację/i);
+    const syncButton = screen.getByText(/Synchronizuj/i);
     fireEvent.click(syncButton);
     
     expect(mockFetch).toHaveBeenCalledWith('/api/sync', expect.objectContaining({
@@ -176,18 +176,18 @@ describe('App Main Flows', () => {
     (global as any).resetLastStreamController();
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
-    const select = screen.getByLabelText(/Wybierz Nagrodę do Synchronizacji/i) as HTMLSelectElement;
+    const select = screen.getByLabelText(/Wybierz nagrodę do synchronizacji/i) as HTMLSelectElement;
     await act(async () => {
       fireEvent.change(select, { target: { value: 'Nagroda Hugo' } });
     });
     expect(select.value).toBe('Nagroda Hugo');
 
-    const syncButton = screen.getByText(/Inicjuj Synchronizację/i);
+    const syncButton = screen.getByText(/Synchronizuj/i);
     expect(syncButton).not.toBeDisabled();
 
     await act(async () => {
@@ -231,7 +231,7 @@ describe('App Main Flows', () => {
 
     // Check for completion summary
     await waitFor(() => {
-      expect(screen.getByText(/Zapisy Archiwisty Adeptus/i)).toBeInTheDocument();
+      expect(screen.getByText(/Zapisane zmiany/i)).toBeInTheDocument();
       expect(screen.getByText(/Dodano/i)).toBeInTheDocument();
       expect(screen.getByText('5')).toBeInTheDocument();
       expect(screen.getByText(/Zaktualizowano/i)).toBeInTheDocument();
@@ -244,33 +244,33 @@ describe('App Main Flows', () => {
     });
   });
 
-  it('renders other tools: Rytuał Wydania, Rytuał Oznaczania Cykli, Rytuał Rekonstrukcji Liczb', async () => {
+  it('renders other tools: Wydawcy, Oznaczanie cykli, Rekonstrukcja numeracji', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+      expect(screen.getByText(/Połączono/i)).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/Rytuał Wydania/i)).toBeInTheDocument();
-    expect(screen.getByText(/Rytuał Oznaczania Cykli/i)).toBeInTheDocument();
-    expect(screen.getByText(/Rytuał Rekonstrukcji Liczb/i)).toBeInTheDocument();
+    expect(screen.getByText(/Wydawcy/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oznaczanie cykli/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rekonstrukcja numeracji/i)).toBeInTheDocument();
   });
 
   it('renders Schema Editor with correct properties and status', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/Schemat bazy Notion/i)).toBeInTheDocument();
     });
 
     const expandButton = screen.getByRole('button', { name: '' }); // We need to find the chevron button. It's better to find by test id or aria-label, but let's find the section first.
@@ -280,7 +280,7 @@ describe('App Main Flows', () => {
     
     // Instead of adding aria-label, let's just find the button by its icon or class, or just add aria-label to the button in SchemaSection.tsx.
     // Let's just click the button that is next to the heading.
-    const schemaHeading = screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i);
+    const schemaHeading = screen.getByText(/Schemat bazy Notion/i);
     const expandBtn = schemaHeading.parentElement?.nextElementSibling as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(expandBtn);
@@ -308,16 +308,16 @@ describe('App Main Flows', () => {
   it('allows deleting options from Schema Editor except for Autor', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/Schemat bazy Notion/i)).toBeInTheDocument();
     });
 
-    const schemaHeading = screen.getByText(/Katalog Bazy \(Schemat Archiwalny\)/i);
+    const schemaHeading = screen.getByText(/Schemat bazy Notion/i);
     const expandBtn = schemaHeading.parentElement?.nextElementSibling as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(expandBtn);
@@ -348,7 +348,7 @@ describe('App Main Flows', () => {
   it('handles Vinted search flow (UI state)', async () => {
     render(<App />);
     
-    const vintedTabButton = screen.getByRole('button', { name: /Skaner Vinted/i });
+    const vintedTabButton = screen.getByRole('button', { name: /^Rynek$/i });
     await act(async () => {
       fireEvent.click(vintedTabButton);
     });
@@ -357,7 +357,7 @@ describe('App Main Flows', () => {
       expect(screen.getByText(/Katalog Beletrystyka/i)).toBeInTheDocument();
     });
     
-    const searchButton = screen.getByText(/Rytuał Skanowania Vinted/i);
+    const searchButton = screen.getByText(/Skanowanie Vinted/i);
     
     await act(async () => {
       fireEvent.click(searchButton);
@@ -365,23 +365,23 @@ describe('App Main Flows', () => {
     
     // Use waitFor because state update might not be immediate
     await waitFor(() => {
-      expect(screen.getByText(/Przerwij Rytuał Skanowania/i)).toBeInTheDocument();
+      expect(screen.getByText(/Przerwij skanowanie/i)).toBeInTheDocument();
     });
   });
 
   it('handles duplicate sync flow (UI state)', async () => {
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Pieczęć Przyłożona/i)).toBeInTheDocument();
+      expect(screen.getByText(/Połączono/i)).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText(/Rytuał Wykrycia Duplikacji/i);
+    const syncButton = screen.getByText(/Wykrywanie duplikatów/i);
     fireEvent.click(syncButton);
     
     // Should show loading state
@@ -392,12 +392,12 @@ describe('App Main Flows', () => {
     (global as any).resetLastStreamController();
     render(<App />);
     
-    const configTabButton = screen.getByRole('button', { name: /Liturgie Synchronizacji/i });
+    const configTabButton = screen.getByRole('button', { name: /^Synchronizacja$/i });
     await act(async () => {
       fireEvent.click(configTabButton);
     });
     
-    const syncButton = screen.getByText(/Rytuał Wykrycia Duplikacji/i);
+    const syncButton = screen.getByText(/Wykrywanie duplikatów/i);
     expect(syncButton).not.toBeDisabled();
 
     await act(async () => {
@@ -427,7 +427,7 @@ describe('App Main Flows', () => {
 
     // Check for completion summary
     await waitFor(() => {
-      expect(screen.getByText(/Zapisy Archiwisty Adeptus/i)).toBeInTheDocument();
+      expect(screen.getByText(/Zapisane zmiany/i)).toBeInTheDocument();
       expect(screen.getByText(/Solaris <-> Solaris \(aka\)/)).toBeInTheDocument();
       expect(screen.getByText(/Cyberiada <-> Cyberiada \(aka\)/)).toBeInTheDocument();
     });

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -127,7 +127,7 @@ export const BookshelfSection: React.FC = () => {
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
         <div className="flex items-center gap-4">
           <Library className="w-6 h-6 text-amber-300" />
-          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-amber-100/90 whitespace-nowrap">Regał Archiwum</h2>
+          <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-amber-100/90 whitespace-nowrap">Regał</h2>
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
       </div>

--- a/src/components/ConfigSection.tsx
+++ b/src/components/ConfigSection.tsx
@@ -65,7 +65,7 @@ export const ConfigSection: React.FC = () => {
     return (
       <div className="glass-card rounded-3xl p-16 flex items-center justify-center gap-3 text-slate-400">
         <Loader2 className="w-5 h-5 animate-spin text-cyan-400" />
-        <span className="text-sm uppercase tracking-widest font-bold">Wczytywanie kalibracji Cogitatora...</span>
+        <span className="text-sm uppercase tracking-widest font-bold">Wczytywanie ustawień...</span>
       </div>
     );
   }
@@ -90,10 +90,10 @@ export const ConfigSection: React.FC = () => {
         <div className="flex-1">
           <h2 className="text-xl font-bold font-display uppercase tracking-widest text-cyan-400 flex items-center gap-3">
             <Wrench className="w-5 h-5" />
-            Sanktuarium Kalibracji
+            Ustawienia
           </h2>
           <p className="text-xs text-slate-400 mt-1">
-            Knoby Machine Spirit. Wartości poza zakresem są przycinane; zapis trafia do Notion (opis kolumny <span className="font-mono text-cyan-300/80">AppConfig</span>) i przeżywa redeploy.
+            Ustawienia aplikacji. Wartości poza zakresem są przycinane; zapis trafia do Notion (opis kolumny <span className="font-mono text-cyan-300/80">AppConfig</span>) i przeżywa redeploy.
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -124,7 +124,7 @@ export const ConfigSection: React.FC = () => {
       )}
 
       {/* Vinted */}
-      <SectionCard icon={<ShoppingCart className="w-4 h-4" />} title="Skaner Vinted" accent="text-rose-400">
+      <SectionCard icon={<ShoppingCart className="w-4 h-4" />} title="Rynek (Vinted)" accent="text-rose-400">
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
           <NumberField label={'Okno „Kontynuuj” (h)'} hint={'Pomiń książki skanowane w ostatnich N godzinach.'} value={draft.vinted.resumeHours} onChange={(v) => upd("vinted", { resumeHours: v })} />
           <NumberField label="Odstęp min. (ms)" hint="Minimalna przerwa między żądaniami." value={draft.vinted.throttleMinMs} onChange={(v) => upd("vinted", { throttleMinMs: v })} />
@@ -141,7 +141,7 @@ export const ConfigSection: React.FC = () => {
               <option value="relevance">Trafność</option>
             </select>
           </Field>
-          <NumberField label="Limit sprzedawców / przebieg" hint={'0 = bez limitu (rytuał „Ustal sprzedawców”).'} value={draft.vinted.sellerResolveCap} onChange={(v) => upd("vinted", { sellerResolveCap: v })} />
+          <NumberField label="Limit sprzedawców / przebieg" hint={'0 = bez limitu (operacja „Ustal sprzedawców”).'} value={draft.vinted.sellerResolveCap} onChange={(v) => upd("vinted", { sellerResolveCap: v })} />
         </div>
         <ListField label="Źródła wykluczające ze skanu" hint={'Tag „Źródło” = książka pomijana. Jeden tag na linię.'}
           value={draft.vinted.excludedSources} onChange={(v) => upd("vinted", { excludedSources: v })} />
@@ -160,7 +160,7 @@ export const ConfigSection: React.FC = () => {
       </SectionCard>
 
       {/* UA pool */}
-      <SectionCard icon={<Globe className="w-4 h-4" />} title="Kamuflaż noosferyczny (User-Agent)" accent="text-cyan-400">
+      <SectionCard icon={<Globe className="w-4 h-4" />} title="Przeglądarka (User-Agent)" accent="text-cyan-400">
         <ListField label="Pula User-Agentów" rows={7}
           hint={'Rotacja per żądanie (Vinted + biblioteka). Odświeżaj co ~kwartał do bieżących wersji przeglądarek — przestarzałe UA ściągają wykrycie bota. Jeden wpis na linię.'}
           value={draft.scraping.userAgents} onChange={(v) => upd("scraping", { userAgents: v })} />
@@ -190,7 +190,7 @@ export const ConfigSection: React.FC = () => {
       </SectionCard>
 
       {/* Awards */}
-      <SectionCard icon={<Trophy className="w-4 h-4" />} title="Strony nagród (Archiwum Encyklopedii)" accent="text-amber-400">
+      <SectionCard icon={<Trophy className="w-4 h-4" />} title="Strony nagród (Encyklopedia Fantastyki)" accent="text-amber-400">
         <div className="space-y-3">
           {draft.sync.awards.map((a, i) => (
             <div key={i} className="grid grid-cols-[1fr_1.6fr_auto] gap-2 items-end">
@@ -206,7 +206,7 @@ export const ConfigSection: React.FC = () => {
             className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-widest text-amber-300 hover:text-amber-200 transition-colors">
             <Plus className="w-4 h-4" /> Dodaj nagrodę
           </button>
-          <p className={hintCls}>Lista zasila dropdown „Liturgie Synchronizacji", pełną synchronizację („Wszystkie Nagrody") i diagnostykę.</p>
+          <p className={hintCls}>Lista zasila dropdown „Synchronizacja", pełną synchronizację („Wszystkie Nagrody") i diagnostykę.</p>
         </div>
       </SectionCard>
 

--- a/src/components/IntegrityCheckCard.tsx
+++ b/src/components/IntegrityCheckCard.tsx
@@ -25,12 +25,12 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
     return status ? (
       <div className="flex items-center gap-2 text-emerald-400 font-bold text-[9px] uppercase tracking-widest bg-emerald-500/10 px-1.5 py-0.5 rounded border border-emerald-500/20">
         <CheckCircle className="w-2.5 h-2.5" />
-        [ ZATWIERDZONO ]
+        [ SPÓJNE ]
       </div>
     ) : (
       <div className="flex items-center gap-2 text-red-400 font-bold text-[9px] uppercase tracking-widest bg-red-500/10 px-1.5 py-0.5 rounded border border-red-500/20 animate-pulse">
         <AlertTriangle className="w-2.5 h-2.5" />
-        [ HEREZJA ]
+        [ NIESPÓJNE ]
       </div>
     );
   };
@@ -74,20 +74,20 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <ShieldAlert className={`w-4 h-4 text-cyan-400 ${state.loading ? 'animate-pulse' : ''}`} />
-          <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">Skaner Sanctity</h3>
+          <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">Kontrola spójności</h3>
         </div>
         
         <motion.button
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
-          onClick={() => integritySync.startSync({}, undefined, "Inicjowanie Skanera Sanctity...")}
+          onClick={() => integritySync.startSync({}, undefined, "Uruchamianie kontroli spójności...")}
           disabled={isAnySyncLoading}
           className={`p-2 rounded-full border transition-all ${
             state.loading 
               ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_15px_rgba(34,211,238,0.4)] animate-pulse' 
               : 'bg-slate-800/50 border-slate-700 text-slate-500 hover:text-cyan-400 hover:border-cyan-500/30'
           }`}
-          title="Inicjuj Skanowanie Sanctity"
+          title="Uruchom kontrolę spójności"
         >
           {state.loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Activity className="w-4 h-4" />}
         </motion.button>

--- a/src/components/LiturgySection.tsx
+++ b/src/components/LiturgySection.tsx
@@ -36,7 +36,7 @@ export const LiturgySection: React.FC<{ sm: ReturnType<typeof useSyncManager> }>
         <div className="flex items-center gap-4">
           <Cog className="w-6 h-6 text-purple-400" />
           <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-purple-100/90 whitespace-nowrap">
-            Liturgie Synchronizacji
+            Synchronizacja
           </h2>
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-purple-500/20 to-transparent"></div>

--- a/src/components/OtherToolsCard.tsx
+++ b/src/components/OtherToolsCard.tsx
@@ -52,15 +52,15 @@ export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
 }) => {
   // All rituals in one idiom (`RitualButton` + central `ritualButtonTheme`).
   const rituals: { color: RitualColor; icon: typeof Database; title: string; subtitle: string; onClick: () => void; animate?: "spin" | "pulse" }[] = [
-    { color: "emerald", icon: Database, title: "Rytuał Inicjacji Schematu", subtitle: "Weryfikacja i kreacja brakujących kolumn w bazie Notion", onClick: handleSyncSchema, animate: schemaSync.state.loading ? "pulse" : undefined },
-    { color: "amber", icon: Sparkles, title: "Rytuał Puryfikacji", subtitle: "Oczyszczanie tytułów z nadmiarowych znaków i formatowania", onClick: handleSyncPurify, animate: purifySync.state.loading ? "pulse" : undefined },
-    { color: "purple", icon: RefreshCw, title: "Rytuał Rekonstrukcji Liczb", subtitle: "Rekalkulacja i naprawa numeracji porządkowej rekordów", onClick: handleSyncLp, animate: lpSync.state.loading ? "spin" : undefined },
-    { color: "blue", icon: RefreshCw, title: "Rytuał Oznaczania Cykli", subtitle: "Automatyczne przypisywanie książek do cykli wydawniczych", onClick: handleCyclesSync, animate: cyclesSync.state.loading ? "spin" : undefined },
-    { color: "amber", icon: Layers, title: "Rytuał Żniw Cykli", subtitle: "Materializacja sąsiednich tomów cykli jako wiersze bazy (Kategoria: Tom cyklu) — oznaczalne i skanowane na Vinted", onClick: handleCyclesHarvest, animate: cyclesHarvestSync.state.loading ? "spin" : undefined },
-    { color: "rose", icon: BookOpen, title: "Rytuał Wydania", subtitle: "Eksploracja i aktualizacja danych o wydawcach z Encyklopedii", onClick: handleSyncPublisher, animate: publisherSync.state.loading ? "pulse" : undefined },
-    { color: "indigo", icon: Layers, title: "Rytuał Seryjny", subtitle: "Eksploracja i aktualizacja danych o seriach wydawniczych", onClick: handleSyncSeries, animate: seriesSync.state.loading ? "pulse" : undefined },
-    { color: "emerald", icon: Barcode, title: "Rytuał Sygnatur (ISBN)", subtitle: "Nadawanie kodów ISBN z Google Books — umożliwia skan kodu kreskowego w Skryptorium", onClick: handleIsbnEnrich, animate: isbnEnrichSync.state.loading ? "pulse" : undefined },
-    { color: "orange", icon: Search, title: "Rytuał Wykrycia Duplikacji", subtitle: "Identyfikacja i oznaczanie potencjalnych duplikatów w bazie", onClick: handleSyncDuplicates, animate: duplicatesSync.state.loading ? "pulse" : undefined },
+    { color: "emerald", icon: Database, title: "Inicjacja schematu", subtitle: "Weryfikacja i kreacja brakujących kolumn w bazie Notion", onClick: handleSyncSchema, animate: schemaSync.state.loading ? "pulse" : undefined },
+    { color: "amber", icon: Sparkles, title: "Porządkowanie tytułów", subtitle: "Oczyszczanie tytułów z nadmiarowych znaków i formatowania", onClick: handleSyncPurify, animate: purifySync.state.loading ? "pulse" : undefined },
+    { color: "purple", icon: RefreshCw, title: "Rekonstrukcja numeracji", subtitle: "Rekalkulacja i naprawa numeracji porządkowej rekordów", onClick: handleSyncLp, animate: lpSync.state.loading ? "spin" : undefined },
+    { color: "blue", icon: RefreshCw, title: "Oznaczanie cykli", subtitle: "Automatyczne przypisywanie książek do cykli wydawniczych", onClick: handleCyclesSync, animate: cyclesSync.state.loading ? "spin" : undefined },
+    { color: "amber", icon: Layers, title: "Zbieranie tomów cykli", subtitle: "Materializacja sąsiednich tomów cykli jako wiersze bazy (Kategoria: Tom cyklu) — oznaczalne i skanowane na Vinted", onClick: handleCyclesHarvest, animate: cyclesHarvestSync.state.loading ? "spin" : undefined },
+    { color: "rose", icon: BookOpen, title: "Wydawcy", subtitle: "Eksploracja i aktualizacja danych o wydawcach z Encyklopedii", onClick: handleSyncPublisher, animate: publisherSync.state.loading ? "pulse" : undefined },
+    { color: "indigo", icon: Layers, title: "Serie", subtitle: "Eksploracja i aktualizacja danych o seriach wydawniczych", onClick: handleSyncSeries, animate: seriesSync.state.loading ? "pulse" : undefined },
+    { color: "emerald", icon: Barcode, title: "Nadawanie ISBN", subtitle: "Nadawanie kodów ISBN z Google Books — umożliwia skan kodu kreskowego w Katalogu", onClick: handleIsbnEnrich, animate: isbnEnrichSync.state.loading ? "pulse" : undefined },
+    { color: "orange", icon: Search, title: "Wykrywanie duplikatów", subtitle: "Identyfikacja i oznaczanie potencjalnych duplikatów w bazie", onClick: handleSyncDuplicates, animate: duplicatesSync.state.loading ? "pulse" : undefined },
   ];
   return (
     <motion.div 
@@ -71,7 +71,7 @@ export const OtherToolsCard: React.FC<OtherToolsCardProps> = ({
     >
       <h2 className="text-xl font-bold font-display flex items-center gap-3 mb-6 uppercase tracking-widest text-cyan-400">
         <Settings className="w-5 h-5" />
-        Narzędzia Serwomechanizmów Adeptus
+        Narzędzia
       </h2>
       
       <div className="grid grid-cols-1 gap-4 flex-1">

--- a/src/components/ProgressAndResults.tsx
+++ b/src/components/ProgressAndResults.tsx
@@ -36,7 +36,7 @@ export const ProgressAndResults: React.FC<ProgressAndResultsProps> = ({
       <div className="flex items-center justify-between mb-6">
         <div className="flex flex-col">
           <h3 className={`text-lg font-bold font-display ${theme.text} uppercase tracking-widest mb-1`}>
-            {state.statusMessage || "Rytuał w toku..."}
+            {state.statusMessage || "Operacja w toku..."}
           </h3>
           <div className="text-xs text-slate-500 font-bold uppercase tracking-tighter">
             {formatETA(progress.current, progress.total, state.startTime)}

--- a/src/components/SanctityDebugger.tsx
+++ b/src/components/SanctityDebugger.tsx
@@ -66,7 +66,7 @@ export const SanctityDebugger: React.FC<SanctityDebuggerProps> = ({ result }) =>
           <Bug className="w-5 h-5 text-amber-400" />
         </div>
         <div>
-          <h3 className="text-sm font-bold uppercase tracking-[0.3em] text-amber-400">Protokół Debugowania Sanctity</h3>
+          <h3 className="text-sm font-bold uppercase tracking-[0.3em] text-amber-400">Diagnostyka spójności</h3>
           <p className="text-[10px] text-slate-500 font-mono mt-1">ANALIZA ROZBIEŻNOŚCI STRUKTURALNYCH [NOTION vs WIKI]</p>
         </div>
       </div>

--- a/src/components/SchemaSection.tsx
+++ b/src/components/SchemaSection.tsx
@@ -34,7 +34,7 @@ export const SchemaSection: React.FC<SchemaSectionProps> = ({
         <div className="flex items-center gap-3">
           <Database className="w-5 h-5 text-cyan-400" />
           <h2 className="text-xl font-bold font-display uppercase tracking-widest text-cyan-400">
-            Katalog Bazy (Schemat Archiwalny)
+            Schemat bazy Notion
           </h2>
         </div>
         <button 
@@ -53,7 +53,7 @@ export const SchemaSection: React.FC<SchemaSectionProps> = ({
             exit={{ opacity: 0, height: 0 }}
             className="overflow-hidden"
           >
-            <p className="text-slate-400 text-sm mb-6">Edytuj strukturę danych w świętym rejestrze Notion.</p>
+            <p className="text-slate-400 text-sm mb-6">Edytuj strukturę danych w bazie Notion.</p>
             
             <button 
               onClick={fetchSchema}
@@ -61,7 +61,7 @@ export const SchemaSection: React.FC<SchemaSectionProps> = ({
               className="flex items-center gap-2 px-6 py-3 bg-slate-900 hover:bg-slate-800 text-slate-200 border border-slate-800 rounded-2xl font-bold transition-all hover:-translate-y-1 shadow-xl mb-8 disabled:opacity-50"
             >
               <RefreshCw className={`w-5 h-5 ${schemaLoading ? 'animate-spin' : ''}`} />
-              {schemaLoading ? "Przeszukiwanie Archiwów..." : "Odśwież Katalog z Bazy Notion"}
+              {schemaLoading ? "Wczytywanie..." : "Odśwież schemat z bazy Notion"}
             </button>
 
             {schemaError && (

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -78,7 +78,7 @@ export const SearchSection: React.FC = () => {
       const direct = matchIsbnInIndex(code, index);
       if (direct) {
         setQuery(direct.plTitle || direct.origTitle);
-        setScanNotice({ kind: "exact", text: `Trafienie w archiwum: „${direct.plTitle || direct.origTitle}"` });
+        setScanNotice({ kind: "exact", text: `Znaleziono: „${direct.plTitle || direct.origTitle}"` });
         return;
       }
 
@@ -87,9 +87,9 @@ export const SearchSection: React.FC = () => {
       const book = res.ok ? await res.json() : null;
       if (book?.title) {
         setQuery(book.title);
-        setScanNotice({ kind: "resolved", text: `Rozpoznano przez ISBN: „${book.title}" — przeszukuję archiwum` });
+        setScanNotice({ kind: "resolved", text: `Rozpoznano przez ISBN: „${book.title}" — szukam w katalogu` });
       } else {
-        setScanNotice({ kind: "miss", text: `Nie znaleziono w archiwum książki o ISBN ${code}.` });
+        setScanNotice({ kind: "miss", text: `Nie znaleziono w katalogu książki o ISBN ${code}.` });
       }
     } catch {
       setScanNotice({ kind: "miss", text: "Błąd rozpoznawania ISBN — spróbuj ponownie lub wpisz tytuł ręcznie." });
@@ -118,14 +118,14 @@ export const SearchSection: React.FC = () => {
         <div className="flex items-center gap-4">
           <ScrollText className="w-6 h-6 text-cyan-400" />
           <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-cyan-100/90 whitespace-nowrap">
-            Skryptorium
+            Katalog
           </h2>
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent" />
       </div>
 
       <p className="text-center text-[11px] text-slate-500 uppercase tracking-widest font-bold -mt-4">
-        Przeszukiwanie zapisów archiwum — tytuł, tytuł oryginalny, autor
+        Szukaj po tytule, tytule oryginalnym lub autorze
       </p>
 
       {/* Search field */}
@@ -139,7 +139,7 @@ export const SearchSection: React.FC = () => {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Wpisz fragment tytułu lub nazwisko autora…"
-              aria-label="Przeszukaj archiwum"
+              aria-label="Przeszukaj katalog"
               className="w-full pl-14 pr-12 py-4 text-sm bg-slate-950/60 border border-white/10 text-slate-200 rounded-2xl focus:outline-none focus:border-cyan-500/50 focus:ring-4 focus:ring-cyan-500/5 placeholder-slate-500 transition-all"
             />
             {query && (
@@ -194,7 +194,7 @@ export const SearchSection: React.FC = () => {
         <p className="text-center text-xs text-slate-500 font-bold tracking-widest uppercase">
           {query.trim()
             ? `Znaleziono ${results.length} ${results.length === 1 ? "wolumin" : "woluminów"} z ${total}`
-            : `${total} woluminów w archiwum`}
+            : `${total} woluminów w katalogu`}
           {results.length > RENDER_CAP && ` · pokazano ${RENDER_CAP} — zawęź zapytanie`}
         </p>
       )}
@@ -222,16 +222,16 @@ export const SearchSection: React.FC = () => {
         <div className="text-center py-20 space-y-3">
           <ScanBarcode className="w-10 h-10 text-cyan-500/40 mx-auto" />
           <p className="text-sm text-slate-400 italic">
-            {canScan ? "Zeskanuj kod kreskowy lub wpisz tytuł, aby przeszukać archiwum." : "Wpisz tytuł lub nazwisko autora, aby przeszukać archiwum."}
+            {canScan ? "Zeskanuj kod kreskowy lub wpisz tytuł, aby przeszukać katalog." : "Wpisz tytuł lub nazwisko autora, aby przeszukać katalog."}
           </p>
-          <p className="text-[11px] text-slate-600 uppercase tracking-widest font-bold">{total} woluminów w archiwum</p>
+          <p className="text-[11px] text-slate-600 uppercase tracking-widest font-bold">{total} woluminów w katalogu</p>
         </div>
       ) : results.length === 0 ? (
         <div className="text-center py-16 space-y-4">
           <p className="text-sm text-slate-400 italic">
             {query.trim()
-              ? `Archiwum milczy — żaden wolumin nie pasuje do „${query}".`
-              : "Archiwum jest puste — brak rekordów do przeszukania."}
+              ? `Brak wyników — żaden wolumin nie pasuje do „${query}".`
+              : "Katalog jest pusty — brak rekordów do przeszukania."}
           </p>
           {query.trim() && suggestions.length > 0 && (
             <p className="text-sm text-slate-400">

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -65,7 +65,7 @@ export const StatsSection: React.FC = () => {
         >
           <BarChart3 className="w-12 h-12" />
         </motion.div>
-        <p className="text-cyan-400 font-display uppercase tracking-widest animate-pulse">Analiza Logów Archiwalnych...</p>
+        <p className="text-cyan-400 font-display uppercase tracking-widest animate-pulse">Wczytywanie kolekcji...</p>
       </div>
     );
   }
@@ -111,7 +111,7 @@ export const StatsSection: React.FC = () => {
         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6">
           <h3 className="text-sm font-bold font-display uppercase tracking-widest text-purple-500 flex items-center gap-2 mb-4">
             <Award className="w-4 h-4" />
-            Progres Archiwum Nagród
+            Postęp kolekcji
           </h3>
           <div className="space-y-6">
             <ProgressBar current={stats.awardBooksStats.read} total={stats.awardBooksStats.total} label="Polskie wydania z listy nagród" icon={Book} color="purple" />

--- a/src/components/StatusSection.tsx
+++ b/src/components/StatusSection.tsx
@@ -32,21 +32,21 @@ export const StatusSection: React.FC<StatusSectionProps> = ({ configStatus }) =>
     >
       <h2 className="text-xl font-bold font-display flex items-center gap-3 mb-8 uppercase tracking-widest text-cyan-400">
         <Zap className="w-5 h-5" />
-        Status Ducha Maszyny
+        Status połączeń
       </h2>
       
       {configStatus.loading ? (
         <div className="flex items-center gap-4 text-slate-400 animate-pulse">
           <Loader2 className="w-6 h-6 animate-spin" />
-          <span className="font-medium">Inicjalizacja Duchów Maszyny...</span>
+          <span className="font-medium">Sprawdzanie połączeń...</span>
         </div>
       ) : (
         <div className="space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {[
-              { label: "NOTION_API_KEY", status: configStatus.hasNotionKey, ok: "Pieczęć Przyłożona", err: "Brak Autoryzacji" },
-              { label: "NOTION_DATABASE_ID", status: configStatus.hasDatabaseId, ok: "Baza Zlokalizowana", err: "Baza Nieznana" },
-              { label: "STATUS PROCESÓW", status: !configStatus.isSyncing, ok: "Gotowość do Pracy", err: "Synchronizacja w Toku" }
+              { label: "NOTION_API_KEY", status: configStatus.hasNotionKey, ok: "Połączono", err: "Brak autoryzacji" },
+              { label: "NOTION_DATABASE_ID", status: configStatus.hasDatabaseId, ok: "Baza znaleziona", err: "Baza nieznana" },
+              { label: "STATUS PROCESÓW", status: !configStatus.isSyncing, ok: "Gotowe", err: "Synchronizacja w toku" }
             ].map((item, idx) => (
               <motion.div 
                 key={item.label}
@@ -67,7 +67,7 @@ export const StatusSection: React.FC<StatusSectionProps> = ({ configStatus }) =>
           </div>
 
           <div className="pt-4 border-t border-slate-800/50">
-            <div className="text-[10px] font-bold text-slate-500 uppercase tracking-[0.2em] mb-4 ml-1">Sektory Archiwum Encyklopedii</div>
+            <div className="text-[10px] font-bold text-slate-500 uppercase tracking-[0.2em] mb-4 ml-1">Źródła (Encyklopedia Fantastyki)</div>
             <div className="flex flex-wrap gap-4">
               {WIKI_LINKS.map((link, idx) => (
                 <motion.div

--- a/src/components/SyncAwards.tsx
+++ b/src/components/SyncAwards.tsx
@@ -36,12 +36,12 @@ export const SyncAwards: React.FC<SyncAwardsProps> = ({
     >
       <h2 className="text-xl font-bold font-display flex items-center gap-3 mb-6 uppercase tracking-widest text-purple-400">
         <BookOpen className="w-5 h-5" />
-        Rytuał Synchronizacji Nagród
+        Synchronizacja nagród
       </h2>
       
       <div className="space-y-6 flex-1">
         <div className="space-y-2">
-          <label htmlFor="award-select" className="text-xs font-bold text-slate-500 uppercase tracking-widest ml-1">Wybierz Nagrodę do Synchronizacji</label>
+          <label htmlFor="award-select" className="text-xs font-bold text-slate-500 uppercase tracking-widest ml-1">Wybierz nagrodę do synchronizacji</label>
           <select 
             id="award-select"
             value={syncState.awardName || ""} 
@@ -58,7 +58,7 @@ export const SyncAwards: React.FC<SyncAwardsProps> = ({
 
         {syncState.awardName !== "Wszystkie Nagrody" && (
           <div className="space-y-2">
-            <label className="text-xs font-bold text-slate-500 uppercase tracking-widest ml-1">Tytuł Strony w Archiwum Encyklopedii</label>
+            <label className="text-xs font-bold text-slate-500 uppercase tracking-widest ml-1">Tytuł strony w Encyklopedii Fantastyki</label>
             <input 
               type="text" 
               value={syncState.pageTitle || ""} 
@@ -77,7 +77,7 @@ export const SyncAwards: React.FC<SyncAwardsProps> = ({
             className="w-full flex items-center justify-center gap-2 px-6 py-3.5 bg-gradient-to-r from-cyan-600 to-blue-700 hover:from-cyan-500 hover:to-blue-600 text-white rounded-2xl font-bold shadow-xl shadow-cyan-500/20 hover:-translate-y-1 transition-all active:scale-95 disabled:opacity-50 disabled:hover:translate-y-0"
           >
             {syncState.loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <RefreshCw className="w-5 h-5" />}
-            Inicjuj Synchronizację
+            Synchronizuj
           </button>
 
           <button 
@@ -87,9 +87,9 @@ export const SyncAwards: React.FC<SyncAwardsProps> = ({
           >
             <div className="flex items-center gap-2">
               <RefreshCw className={`w-4 h-4 ${isAnySyncLoading ? 'animate-spin' : ''}`} />
-              Rytuał Pełnej Synchronizacji
+              Pełna synchronizacja
             </div>
-            <span className="text-[10px] text-slate-500 uppercase tracking-widest font-medium">Sekwencja 1-7 (Schemat → Puryfikacja → Nagrody → Cykle → Wydania → Serie → Liczby)</span>
+            <span className="text-[10px] text-slate-500 uppercase tracking-widest font-medium">Sekwencja 1–7 (Schemat → Porządkowanie → Nagrody → Cykle → Wydania → Serie → Liczby)</span>
           </button>
         </div>
 

--- a/src/components/VintedSection.tsx
+++ b/src/components/VintedSection.tsx
@@ -14,7 +14,7 @@ export const VintedSection: React.FC = () => {
         <div className="flex items-center gap-4">
           <ShoppingCart className="w-6 h-6 text-rose-400" />
           <h2 className="text-xl font-bold font-display uppercase tracking-[0.4em] text-rose-100/90 whitespace-nowrap">
-            Skaner Vinted
+            Rynek
           </h2>
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-rose-500/20 to-transparent"></div>

--- a/src/components/search/CyclePanel.tsx
+++ b/src/components/search/CyclePanel.tsx
@@ -87,7 +87,7 @@ export const CyclePanel: React.FC<Props> = ({ title, author, anchor, onClose }) 
           {loading && (
             <div className="flex items-center justify-center gap-2.5 py-8 text-slate-400">
               <Loader2 className="w-4 h-4 animate-spin text-amber-400" />
-              <span className="text-xs uppercase tracking-widest font-bold">Odpytywanie Archiwum Cyklu...</span>
+              <span className="text-xs uppercase tracking-widest font-bold">Wczytywanie cyklu...</span>
             </div>
           )}
 

--- a/src/components/search/ScanModal.tsx
+++ b/src/components/search/ScanModal.tsx
@@ -159,7 +159,7 @@ export const ScanModal: React.FC<Props> = ({ open, onClose, onDetect }) => {
                   <ScanBarcode className="w-6 h-6 text-cyan-400" />
                 </div>
                 <div>
-                  <h3 className="text-lg font-display font-bold text-slate-100 uppercase tracking-wider">Skan Sygnatury</h3>
+                  <h3 className="text-lg font-display font-bold text-slate-100 uppercase tracking-wider">Skan sygnatury</h3>
                   <p className="text-xs text-slate-500 font-medium">Nakieruj kamerę na kod kreskowy książki</p>
                 </div>
               </div>

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -65,7 +65,7 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
           </h3>
           <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
           {/* Data ticker (scrolling) — fills the free space of the cornice */}
-          <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ NOOSPHERA·SYNC ++ 01001101·01000001·01010011 ++ AVE·OMNISSIAH ++" />
+          <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ LIBREM·SYNC ++ 01001101·01000001·01010011 ++ KOLEKCJA·FANTASTYKI ++" />
           <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
           {/* Subtle light strip under the cornice (in the color of the Regał frame) */}
           <div className="absolute bottom-0 inset-x-6 h-px" style={{ background: "linear-gradient(90deg, transparent, rgba(var(--sk-frame-accent),.28), transparent)" }} />

--- a/src/components/stats/AvailabilityCard.tsx
+++ b/src/components/stats/AvailabilityCard.tsx
@@ -33,7 +33,7 @@ export const AvailabilityCard: React.FC<{ stats: AvailabilityStats }> = ({ stats
       </h3>
 
       {total === 0 ? (
-        <p className="text-slate-400 text-sm italic text-center py-8">Wszystko przeczytane — Archiwum domknięte.</p>
+        <p className="text-slate-400 text-sm italic text-center py-8">Wszystko przeczytane — kolekcja domknięta.</p>
       ) : (
         <>
           <div className="flex items-baseline gap-2">

--- a/src/components/stats/CyclesHarvestCard.tsx
+++ b/src/components/stats/CyclesHarvestCard.tsx
@@ -47,7 +47,7 @@ export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refres
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-bold font-display uppercase tracking-widest text-amber-400 flex items-center gap-2">
           <Layers className="w-4 h-4" />
-          Archiwum Cykli
+          Cykle
         </h3>
         {view && view.totalCycles > 0 && (
           <span className="text-[10px] font-bold tabular-nums text-slate-500 uppercase tracking-wider">{view.totalCycles} cykli</span>
@@ -71,7 +71,7 @@ export const CyclesHarvestCard: React.FC<{ refreshSignal?: number }> = ({ refres
 
       {view && !loading && view.totalCycles === 0 && (
         <p className="text-slate-400 text-sm italic text-center py-8">
-          Brak zebranych cykli. Uruchom <span className="text-amber-300 not-italic font-bold">Rytuał Żniw Cykli</span> w Liturgiach, aby zebrać sąsiednie tomy z Encyklopedii.
+          Brak zebranych cykli. Uruchom <span className="text-amber-300 not-italic font-bold">Zbieranie tomów cykli</span> w Synchronizacji, aby zebrać sąsiednie tomy z Encyklopedii.
         </p>
       )}
 

--- a/src/components/stats/DecadeHistogram.tsx
+++ b/src/components/stats/DecadeHistogram.tsx
@@ -24,7 +24,7 @@ export const DecadeHistogram: React.FC<{ decades: DecadeStat[] }> = ({ decades }
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-bold font-display uppercase tracking-widest text-amber-400 flex items-center gap-2">
           <BarChart3 className="w-4 h-4" />
-          Oś Czasu Archiwum
+          Oś czasu
         </h3>
         {peak && (
           <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-amber-300/80">

--- a/src/components/stats/MarketCard.tsx
+++ b/src/components/stats/MarketCard.tsx
@@ -34,11 +34,11 @@ export const MarketCard: React.FC<{ market: MarketStats }> = ({ market }) => {
     >
       <h3 className="text-sm font-bold font-display uppercase tracking-widest text-rose-400 flex items-center gap-2 mb-4">
         <Coins className="w-4 h-4" />
-        Rynek Reliktów (Vinted)
+        Rynek (Vinted)
       </h3>
 
       {!hasData ? (
-        <p className="text-slate-400 text-sm italic text-center py-8">Brak składowanych ofert — uruchom Rytuał Skanowania Vinted.</p>
+        <p className="text-slate-400 text-sm italic text-center py-8">Brak zapisanych ofert — uruchom skanowanie Vinted.</p>
       ) : (
         <>
           {/* Completion cost */}

--- a/src/components/stats/PublishingCard.tsx
+++ b/src/components/stats/PublishingCard.tsx
@@ -55,7 +55,7 @@ export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: Ser
       <div className="space-y-3">
         <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Building2 className="w-3 h-3" /> Top oficyny</h4>
         {publishers.length === 0 ? (
-          <p className="text-slate-500 text-xs italic">Brak danych — uruchom Rytuał Wydania.</p>
+          <p className="text-slate-500 text-xs italic">Brak danych — uruchom „Wydawcy".</p>
         ) : (
           <div className="space-y-2.5 max-h-[200px] overflow-y-auto pr-1 custom-scrollbar">
             {publishers.slice(0, 8).map((p) => barRow(p.name, p.read, p.count, `${p.read}/${p.count} przecz.`, p.read >= p.count ? "bg-emerald-500" : "bg-indigo-500"))}
@@ -67,7 +67,7 @@ export const PublishingCard: React.FC<{ publishers: PublisherStat[]; series: Ser
       <div className="space-y-3">
         <h4 className="text-[11px] font-bold uppercase tracking-widest text-slate-500 flex items-center gap-1.5"><Layers className="w-3 h-3" /> Serie (posiadane/total)</h4>
         {series.length === 0 ? (
-          <p className="text-slate-500 text-xs italic">Brak danych — uruchom Rytuał Seryjny.</p>
+          <p className="text-slate-500 text-xs italic">Brak danych — uruchom „Serie".</p>
         ) : (
           <div className="space-y-2.5 max-h-[200px] overflow-y-auto pr-1 custom-scrollbar">
             {series.slice(0, 8).map((s) => barRow(s.name, s.owned, s.count, `${s.owned}/${s.count}${s.owned < s.count ? " · luki" : " · komplet"}`, s.owned >= s.count ? "bg-emerald-500" : "bg-blue-500"))}

--- a/src/components/stats/vinted/VintedBundleList.tsx
+++ b/src/components/stats/vinted/VintedBundleList.tsx
@@ -24,7 +24,7 @@ export const VintedBundleList: React.FC<Props> = ({ results, sellers, usingStore
 
   if (bundles.length === 0) {
     return usingStored ? (
-      <p className="text-xs text-slate-500 italic px-2">Żaden sprzedawca nie ma ≥2 książek z listy — brak paczek do złożenia. (Uzupełnij sprzedawców rytuałem „Identyfikacji Handlarzy".)</p>
+      <p className="text-xs text-slate-500 italic px-2">Żaden sprzedawca nie ma ≥2 książek z listy — brak paczek do złożenia. (Uzupełnij sprzedawców operacją „Identyfikacja sprzedawców".)</p>
     ) : null;
   }
 

--- a/src/components/stats/vinted/VintedScanControls.tsx
+++ b/src/components/stats/vinted/VintedScanControls.tsx
@@ -65,7 +65,7 @@ export const VintedScanControls: React.FC<Props> = ({
         icon={isChecking ? Loader2 : Search}
         animate={isChecking ? "spin" : undefined}
         disabled={!isChecking && isResolving}
-        title={isChecking ? "Przerwij Rytuał Skanowania" : "Rytuał Skanowania Vinted"}
+        title={isChecking ? "Przerwij skanowanie" : "Skanowanie Vinted"}
         subtitle={isChecking ? "Zatrzymanie aktywnego przeszukania katalogu" : "Przeszukanie katalogu Vinted — język polski, od 2 PLN"}
         onClick={onScanToggle}
       />
@@ -75,7 +75,7 @@ export const VintedScanControls: React.FC<Props> = ({
           color={isResolving ? "rose" : "emerald"}
           icon={isResolving ? Loader2 : Database}
           animate={isResolving ? "spin" : undefined}
-          title={isResolving ? "Przerwij Identyfikację" : "Rytuał Identyfikacji Handlarzy"}
+          title={isResolving ? "Przerwij identyfikację" : "Identyfikacja sprzedawców"}
           subtitle={isResolving ? "Zatrzymanie dociągania sprzedawców" : "Dociągnięcie sprzedawców do bazy — wznawialny"}
           onClick={onResolveToggle}
         />
@@ -83,14 +83,14 @@ export const VintedScanControls: React.FC<Props> = ({
 
       {!isChecking && !isResolving && (
         usingStored ? (
-          <RitualButton color="indigo" icon={Trash2} title="Rozwiej Przywołanie" subtitle="Powrót do wyników bieżącego skanu" onClick={onClearStored} />
+          <RitualButton color="indigo" icon={Trash2} title="Wyczyść" subtitle="Powrót do wyników bieżącego skanu" onClick={onClearStored} />
         ) : (
           <RitualButton
             color="indigo"
             icon={isLoadingStored ? Loader2 : HardDriveDownload}
             animate={isLoadingStored ? "spin" : undefined}
             disabled={isLoadingStored}
-            title="Rytuał Przywołania z Archiwum"
+            title="Wczytaj z bazy"
             subtitle="Kafelki i paczki ze składowanych danych — bez skanu"
             onClick={onLoadStored}
           />

--- a/src/components/sync/FullSyncSummary.tsx
+++ b/src/components/sync/FullSyncSummary.tsx
@@ -18,8 +18,8 @@ export const FullSyncSummary: React.FC<{ results: any[]; onClose: () => void }> 
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card p-8 rounded-3xl border-cyan-500/30 bg-cyan-500/5">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h3 className="text-xl font-bold font-display text-cyan-400 uppercase tracking-widest">Podsumowanie Wielkiego Rytuału</h3>
-          <p className="text-[10px] text-slate-500 uppercase font-bold tracking-widest mt-1">Pełna Synchronizacja Archiwów Zakończona</p>
+          <h3 className="text-xl font-bold font-display text-cyan-400 uppercase tracking-widest">Podsumowanie synchronizacji</h3>
+          <p className="text-[10px] text-slate-500 uppercase font-bold tracking-widest mt-1">Pełna synchronizacja zakończona</p>
         </div>
         <button onClick={onClose} className="text-slate-500 hover:text-slate-200 transition-colors" title="Zamknij podsumowanie">
           <XCircle className="w-6 h-6" />

--- a/src/components/sync/SingleSyncSummary.tsx
+++ b/src/components/sync/SingleSyncSummary.tsx
@@ -27,7 +27,7 @@ export const SingleSyncSummary: React.FC<{ sync: ReturnType<typeof useSync>; onC
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className={`glass-card p-8 rounded-3xl ${theme.border}`}>
       <div className="flex items-center justify-between mb-8">
-        <h3 className={`text-xl font-bold font-display ${theme.text} uppercase tracking-widest`}>Zapisy Archiwisty Adeptus</h3>
+        <h3 className={`text-xl font-bold font-display ${theme.text} uppercase tracking-widest`}>Zapisane zmiany</h3>
         <button onClick={onClose} className="text-slate-500 hover:text-slate-200 transition-colors">
           <XCircle className="w-6 h-6" />
         </button>
@@ -43,7 +43,7 @@ export const SingleSyncSummary: React.FC<{ sync: ReturnType<typeof useSync>; onC
           </div>
         ) : (
           <div className={`p-6 ${theme.bg} border ${theme.border} rounded-2xl text-center mb-8`}>
-            <div className={`${theme.text} font-bold uppercase tracking-widest mb-2`}>Rytuał Zakończony Pomyślnie</div>
+            <div className={`${theme.text} font-bold uppercase tracking-widest mb-2`}>Synchronizacja zakończona</div>
             <div className="text-slate-400 text-sm">
               Przetworzono {activeResult.found || 0} woluminów. Zaktualizowano {activeResult.updated || 0} wpisów.
             </div>

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -19,7 +19,7 @@ export function useBooks(all = false) {
     try {
       // `all=1` (Skryptorium/scan) includes cycle volumes; without it (Regał) award-only.
       const res = await fetch(`/api/books?${all ? "all=1&" : ""}t=${Date.now()}`);
-      if (!res.ok) throw new Error("Błąd podczas pobierania rekordów archiwum");
+      if (!res.ok) throw new Error("Błąd podczas pobierania książek");
       const data = await res.json();
       setBooks(data);
     } catch (err: any) {

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -87,13 +87,13 @@ export function useSyncManager() {
   // `abortOnFail` steps abort the whole thing on error and drop results; the last one
   // (Lp) only appends its result if present, and always closes the summary.
   const FULL_SYNC_STEPS: { sync: any; name: string; color: string; label: string; params?: any; abortOnFail: boolean }[] = [
-    { sync: schemaSync, name: "Schemat", color: "emerald", label: "Krok 1/7: Rytuał Inicjacji Schematu...", abortOnFail: true },
-    { sync: purifySync, name: "Puryfikacja", color: "amber", label: "Krok 2/7: Rytuał Puryfikacji...", abortOnFail: true },
-    { sync, name: "Nagrody", color: "cyan", label: "Krok 3/7: Synchronizacja Nagród...", params: { awardName: "Wszystkie Nagrody", syncAll: true }, abortOnFail: true },
-    { sync: cyclesSync, name: "Cykle", color: "blue", label: "Krok 4/7: Rytuał Oznaczania Cykli...", abortOnFail: true },
-    { sync: publisherSync, name: "Wydawcy", color: "rose", label: "Krok 5/7: Rytuał Wydania...", abortOnFail: true },
-    { sync: seriesSync, name: "Serie", color: "indigo", label: "Krok 6/7: Rytuał Seryjny...", abortOnFail: true },
-    { sync: lpSync, name: "Lubimy Czytać", color: "purple", label: "Krok 7/7: Rytuał Rekonstrukcji Liczb...", abortOnFail: false },
+    { sync: schemaSync, name: "Schemat", color: "emerald", label: "Krok 1/7: Inicjacja schematu...", abortOnFail: true },
+    { sync: purifySync, name: "Porządkowanie", color: "amber", label: "Krok 2/7: Porządkowanie tytułów...", abortOnFail: true },
+    { sync, name: "Nagrody", color: "cyan", label: "Krok 3/7: Synchronizacja nagród...", params: { awardName: "Wszystkie Nagrody", syncAll: true }, abortOnFail: true },
+    { sync: cyclesSync, name: "Cykle", color: "blue", label: "Krok 4/7: Oznaczanie cykli...", abortOnFail: true },
+    { sync: publisherSync, name: "Wydawcy", color: "rose", label: "Krok 5/7: Wydawcy...", abortOnFail: true },
+    { sync: seriesSync, name: "Serie", color: "indigo", label: "Krok 6/7: Serie...", abortOnFail: true },
+    { sync: lpSync, name: "Lubimy Czytać", color: "purple", label: "Krok 7/7: Rekonstrukcja numeracji...", abortOnFail: false },
   ];
 
   const handleFullSync = async () => {

--- a/src/utils/shelfSkin.ts
+++ b/src/utils/shelfSkin.ts
@@ -6,7 +6,7 @@ export type ShelfSkin = "holo" | "noospheric";
 
 export const SHELF_SKINS: { id: ShelfSkin; label: string }[] = [
   { id: "holo", label: "Holo+" },
-  { id: "noospheric", label: "Relikwiarz" },
+  { id: "noospheric", label: "Klasyczny" },
 ];
 
 const KEY = "shelfSkin";


### PR DESCRIPTION
Fixes #287

Wycofuje warhammerowe (Adeptus Mechanicus) copy z całego UI na rzecz ciepłego, bibliotecznego tonu „Librem". Wizualny wygląd ciemnego motywu (40k glassmorphism) zostaje — zmienia się tylko warstwa tekstowa.

## Zmiany
- **Tożsamość**: wordmark `COGITATOR OMNISSIAH` → **LIBREM**, podtytuł → „Twoja kolekcja nagradzanej fantastyki"; `index.html` title/description/theme-color.
- **Zakładki**: Statystyki Archiwum → **Kolekcja**, Skryptorium → **Katalog**, Liturgie Synchronizacji → **Synchronizacja**, Skaner Vinted → **Rynek**, Sanktuarium Kalibracji → **Ustawienia** (Regał bez zmian).
- **Copy głębsze**: „Rytuał X" → opisowe nazwy (Porządkowanie tytułów, Oznaczanie cykli, Wydawcy, Serie, Nadawanie ISBN, Wykrywanie duplikatów…); Skaner Sanctity → **Kontrola spójności** (`[SPÓJNE]`/`[NIESPÓJNE]`); Duch Maszyny → **połączenia**; „archiwum" → **katalog/kolekcja**; skórka regału Relikwiarz → **Klasyczny**; ticker `AVE·OMNISSIAH` → `LIBREM`.
- **Nietknięte (dane)**: kolumny Notion (`AppConfig`, `Kategoria="Tom cyklu"`), TASK_REGISTRY, `awardName:"Wszystkie Nagrody"`, backendowe komunikaty (`Przerwano Rytuał Wydania.` itd.).
- **Testy/docs**: zaktualizowane asercje w `App.test.tsx`, konwencja brandingu w `CLAUDE.md`, changelog w `backlog.md`.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

Następny krok: wizualne dopieszczenie zakładek do makiety Librem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_