### PR TITLE
feat(theme): coherent boho light repaint via Tailwind color vars

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.61.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.62.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.62.0** — **Jasny motyw: spójny repaint boho przez zmienne koloru Tailwinda (start dopieszczania od „Kolekcji").**
+  Zamiast dziesiątek per-utility remapów, warstwa `:root[data-theme="light"]` nadpisuje teraz **`--color-*`**
+  Tailwinda — przez które przechodzą WSZYSTKIE utility: `bg/text/border/from/via/to` **oraz** warianty alpha
+  `…/NN` (color-mix). Efekt: gradienty, wypełnienia pasków (ProgressBar, histogram dekad, publishing) i pigułki
+  robią się lniane naraz (wcześniej remapowane były tylko płaskie kolory → gradienty zostawały cyan/blue).
+  Mapowanie rodzin na paletę makiety: cyan/blue/sky→**clay**, emerald/green/teal/indigo/purple/violet→**sage**,
+  amber/yellow/orange→**ochre**, rose/red/pink→**brick**, slate→ciepłe neutralne (papier/len/inkaust). Zachowane
+  struktury: `.glass-card`, `.text-gradient`, linki, scrollbar, białe-alpha ramki (poza rampą slate), `text-white`
+  (okładki/przyciski). Ciemny motyw (bez `data-theme`/`="dark"`) na defaultach — bez zmian. Repaint dotyka
+  wszystkich zakładek, ale weryfikowany pod „Kolekcję" (KPI/paski/oś czasu/dostępność/oficyny) wg `design/
+  Main.dc.html`. Suite 463 zielone, lint czysty, build OK. NASTĘPNE (opcjonalnie): głębszy re-layout dashboardu
+  „Kolekcja" 1:1 do makiety (rząd KPI + dwie kolumny) — większa zmiana, do potwierdzenia.
 - **1.61.0** — **Pełny rebrand nazewnictwa UI: „Cogitator Omnissiah" → „Librem"** (ciepły, biblioteczny ton
   zamiast liturgicznego 40k). Wordmark `COGITATOR OMNISSIAH`→`LIBREM`, podtytuł→„Twoja kolekcja nagradzanej
   fantastyki". Zakładki: Statystyki Archiwum→**Kolekcja**, Skryptorium→**Katalog**, Liturgie

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.61.0",
+      "version": "1.62.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.61.0",
+  "version": "1.62.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/index.css
+++ b/src/index.css
@@ -163,6 +163,42 @@ body {
   --font-display: "Cormorant Garamond", Georgia, "Times New Roman", serif;
   --font-sans: "Mulish", ui-sans-serif, system-ui, sans-serif;
   color-scheme: light;
+
+  /* --------------------------------------------------------------------
+     Palette remap: nadpisujemy zmienne koloru Tailwinda (`--color-*`),
+     przez które przechodzą WSZYSTKIE utility (bg/text/border/from/via/to
+     + warianty alpha `…/NN` przez color-mix). Jedno źródło prawdy → tła,
+     gradienty, wypełnienia pasków i pigułki robią się lniane naraz.
+     Ciemny motyw (bez `data-theme` / `="dark"`) zostaje na defaultach.
+     Rodziny → boho: cyan/blue/sky = clay, emerald/green/teal/indigo/
+     purple/violet = sage, amber/yellow/orange = ochre, rose/red/pink =
+     brick, slate = ciepłe neutralne (papier/len/inkaust).
+     -------------------------------------------------------------------- */
+  /* Neutralne (slate → papier/len) */
+  --color-slate-50:#FBF6EC;  --color-slate-100:#3A342B; --color-slate-200:#3A342B;
+  --color-slate-300:#5C5344; --color-slate-400:#8C8069; --color-slate-500:#8C8069;
+  --color-slate-600:#9C8F78; --color-slate-700:#D6C6A6; --color-slate-800:#E4D9C4;
+  --color-slate-900:#FBF6EC; --color-slate-950:#F3ECDF;
+  /* Clay (primary) */
+  --color-cyan-300:#DBA98D;  --color-cyan-400:#CD8F6E; --color-cyan-500:#C07A56;
+  --color-cyan-600:#A6603F;  --color-cyan-700:#8F4F31;
+  --color-blue-400:#CD8F6E;  --color-blue-500:#C07A56; --color-blue-600:#A6603F; --color-blue-700:#8F4F31;
+  --color-sky-400:#CD8F6E;   --color-sky-500:#C07A56;
+  /* Sage */
+  --color-emerald-300:#9AA588; --color-emerald-400:#8F9A7C; --color-emerald-500:#7E8A6B; --color-emerald-600:#68735A;
+  --color-green-400:#8F9A7C;  --color-green-500:#7E8A6B;
+  --color-teal-400:#8F9A7C;   --color-teal-500:#7E8A6B;
+  --color-indigo-300:#9AA588; --color-indigo-400:#8F9A7C; --color-indigo-500:#7E8A6B; --color-indigo-600:#68735A;
+  --color-purple-300:#9AA588; --color-purple-400:#8F9A7C; --color-purple-500:#7E8A6B; --color-purple-600:#68735A;
+  --color-violet-400:#8F9A7C; --color-violet-500:#7E8A6B;
+  /* Ochre */
+  --color-amber-300:#DCB97E; --color-amber-400:#D8AD55; --color-amber-500:#CE9B3F; --color-amber-600:#B3822C; --color-amber-700:#96691F;
+  --color-yellow-400:#D8AD55;--color-yellow-500:#CE9B3F;
+  --color-orange-400:#D69663;--color-orange-500:#CE9B3F; --color-orange-600:#B3822C;
+  /* Brick (danger) */
+  --color-rose-300:#C98A7E;  --color-rose-400:#C06E5F; --color-rose-500:#B0574A; --color-rose-600:#974336;
+  --color-red-300:#C98A7E;   --color-red-400:#C06E5F;  --color-red-500:#B0574A; --color-red-600:#974336; --color-red-700:#7E3A2E;
+  --color-pink-400:#C06E5F;  --color-pink-500:#B0574A;
 }
 
 [data-theme="light"] body { background-color: var(--l-paper); color: var(--l-ink); }
@@ -181,56 +217,11 @@ body {
 }
 [data-theme="light"] .text-gradient { background-image: linear-gradient(90deg, #c98a63, #a9603d); }
 
-/* Tła */
-[data-theme="light"] .bg-slate-950 { background-color: var(--l-paper); }
-[data-theme="light"] .bg-slate-900,
-[data-theme="light"] .bg-slate-800,
-[data-theme="light"] .bg-slate-800\/50,
-[data-theme="light"] .bg-slate-900\/40,
-[data-theme="light"] .bg-slate-900\/60,
-[data-theme="light"] .bg-slate-900\/80,
-[data-theme="light"] .bg-slate-950\/60,
-[data-theme="light"] .bg-slate-950\/80 { background-color: var(--l-card); }
-
-/* Tekst */
-[data-theme="light"] .text-white,
-[data-theme="light"] .text-slate-100,
-[data-theme="light"] .text-slate-200,
-[data-theme="light"] .text-slate-300 { color: var(--l-ink); }
-[data-theme="light"] .text-slate-400,
-[data-theme="light"] .text-slate-500,
-[data-theme="light"] .text-slate-600 { color: var(--l-muted); }
-[data-theme="light"] .text-cyan-400,
-[data-theme="light"] .text-cyan-300,
-[data-theme="light"] .text-cyan-100\/90 { color: var(--l-clay); }
-[data-theme="light"] .text-purple-400,
-[data-theme="light"] .text-purple-500,
-[data-theme="light"] .text-purple-100\/90 { color: var(--l-sage); }
-[data-theme="light"] .text-amber-300,
-[data-theme="light"] .text-amber-400 { color: var(--l-ochre); }
-[data-theme="light"] .text-rose-400,
-[data-theme="light"] .text-red-400,
-[data-theme="light"] .text-red-300,
-[data-theme="light"] .text-red-200 { color: var(--l-brick); }
-[data-theme="light"] .text-emerald-400,
-[data-theme="light"] .text-emerald-300 { color: var(--l-sage); }
-
-/* Obramowania */
+/* Białe alpha (poza rampą slate) — cienkie ramki/tła na papierze. */
 [data-theme="light"] .border-white\/10,
-[data-theme="light"] .border-slate-800,
-[data-theme="light"] .border-slate-800\/50,
-[data-theme="light"] .border-slate-700 { border-color: var(--l-line); }
-
-/* Akcenty pigułek zakładek (miękkie, ciepłe) */
-[data-theme="light"] .bg-cyan-500\/20 { background-color: rgba(192,122,86,.16); }
-[data-theme="light"] .border-cyan-500\/50,
-[data-theme="light"] .border-cyan-500\/30 { border-color: rgba(192,122,86,.4); }
-[data-theme="light"] .bg-amber-500\/20 { background-color: rgba(206,155,63,.18); }
-[data-theme="light"] .border-amber-500\/50 { border-color: rgba(206,155,63,.45); }
-[data-theme="light"] .bg-purple-500\/20 { background-color: rgba(126,138,107,.18); }
-[data-theme="light"] .border-purple-500\/50 { border-color: rgba(126,138,107,.45); }
-[data-theme="light"] .bg-rose-500\/20 { background-color: rgba(176,87,74,.14); }
-[data-theme="light"] .border-rose-500\/50 { border-color: rgba(176,87,74,.4); }
+[data-theme="light"] .border-white\/5 { border-color: var(--l-line); }
+[data-theme="light"] .bg-white\/5,
+[data-theme="light"] .bg-white\/10 { background-color: rgba(58,52,43,.05); }
 
 /* Linki */
 [data-theme="light"] a { color: var(--l-clay); }


### PR DESCRIPTION
Fixes #289

Dopieszczenie jasnego motywu „Librem" — start od zakładki **Kolekcja** (dashboard).

## Podejście
Warstwa `:root[data-theme="light"]` nadpisuje teraz **zmienne koloru Tailwinda** (`--color-*`), przez które przechodzą WSZYSTKIE utility: `bg/text/border/from/via/to` **oraz** warianty alpha `…/NN` (przez `color-mix`). Dzięki temu gradienty, wypełnienia pasków (`ProgressBar`, histogram dekad, oficyny) i pigułki robią się lniane naraz — wcześniej remapowane były tylko płaskie kolory, więc gradienty zostawały cyan/blue.

## Mapowanie rodzin → paleta makiety
- cyan / blue / sky → **clay**
- emerald / green / teal / indigo / purple / violet → **sage**
- amber / yellow / orange → **ochre**
- rose / red / pink → **brick**
- slate → ciepłe neutralne (papier / len / inkaust)

## Zachowane
`.glass-card`, `.text-gradient`, linki, scrollbar, białe-alpha ramki (poza rampą slate), `text-white` na okładkach/przyciskach. **Ciemny motyw bez zmian** (overrides tylko pod `[data-theme="light"]`).

Repaint dotyka wszystkich zakładek, ale weryfikowany pod „Kolekcję" (KPI / paski / oś czasu / dostępność / oficyny) wg `design/Main.dc.html`.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

Następny (opcjonalny) krok: głębszy re-layout dashboardu 1:1 do makiety (rząd KPI + dwie kolumny).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_