### PR TITLE
feat(theme): serif result titles in Katalog (light) — mockup signature

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.63.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.64.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.64.0** — **Katalog: tytuły wyników na serif (Cormorant) w jasnym motywie — podpis makiety.** Weryfikacja:
+  `BookResultCard`/`HighlightedText`/`ScanModal` używają wyłącznie klas palety (cyan/emerald/blue/amber/purple/
+  rose/slate + alpha) → repaint 1.62.0/1.63.0 już je ocieplił, BEZ twardych ciemnych przecieków (inaczej niż
+  skóry Regału). Jedyny brakujący „makietowy" detal: tytuły książek makiety są serifowe (Cormorant) — dodane
+  `.result-title` na tytule wyniku + reguła `[data-theme="light"] .result-title { font-family: var(--font-
+  display); … }` (tylko jasny; ciemny „Warhammer" zostaje na sans). Laser skanera w `ScanModal` zostaje cyan —
+  jest nad ciemnym obrazem z kamery, więc czyta się dobrze w obu motywach (nie ruszamy arbitralnego shadow).
+  Suite 463 zielone, lint czysty, build OK. Status repaintu: Kolekcja ✅ / Regał ✅ / Katalog ✅; zostają Rynek
+  (bazowo pokryty repaintem) i opcjonalny re-layout Kolekcji 1:1.
 - **1.63.0** — **Regał: jasny wariant skór + FIX kontrastu nagłówków sekcji.** (1) Skóry regału (`.skin-holo`/
   `.skin-noospheric`) niosą własne, twarde gradienty ciemnego drewna/neonu w `--sk-*`/`--noo-*` — NIE przechodzą
   przez `--color-*`, więc w jasnym motywie regał zostawał ciemny na papierze. Dodana warstwa

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.63.0",
+      "version": "1.64.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.63.0",
+  "version": "1.64.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/search/BookResultCard.tsx
+++ b/src/components/search/BookResultCard.tsx
@@ -50,7 +50,7 @@ export const BookResultCard: React.FC<Props> = ({ book, query }) => {
             <HighlightedText
               text={primaryTitle}
               query={query}
-              className="text-base font-bold text-slate-100 leading-tight"
+              className="result-title text-base font-bold text-slate-100 leading-tight"
             />
             <CycleTile title={primaryTitle} author={book.author || ""} partOfCycle={book.partOfCycle} />
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -212,6 +212,16 @@ body {
 /* Nagłówki na serif (klasa font-display używana w całej apce). */
 [data-theme="light"] .font-display { letter-spacing: .2px; }
 
+/* KATALOG: tytuły wyników na serif (Cormorant) — podpis makiety „Librem".
+   Tylko jasny motyw; ciemny „Warhammer" zostaje na sans (bez zmian). */
+[data-theme="light"] .result-title {
+  font-family: var(--font-display);
+  font-size: 1.18rem;
+  line-height: 1.18;
+  font-weight: 600;
+  letter-spacing: .2px;
+}
+
 /* Karty */
 [data-theme="light"] .glass-card {
   background-color: var(--l-card);


### PR DESCRIPTION
Fixes #293

Dopieszczenie **Katalogu** (wyszukiwarka) w jasnym motywie „Librem".

## Weryfikacja
`BookResultCard` / `HighlightedText` / `ScanModal` używają wyłącznie klas palety (cyan/emerald/blue/amber/purple/rose/slate + alpha), więc repaint 1.62/1.63 już je ocieplił — **bez twardych ciemnych przecieków** (inaczej niż skóry Regału).

## Zmiana
Jedyny brakujący detal makiety: tytuły książek są serifowe (Cormorant Garamond). Dodane `.result-title` na tytule wyniku + reguła `[data-theme="light"] .result-title { font-family: var(--font-display); … }` — **tylko jasny motyw**; ciemny „Warhammer" zostaje na sans.

Laser skanera w `ScanModal` zostaje cyan — jest nad ciemnym obrazem z kamery i czyta się dobrze w obu motywach, więc jego arbitralny `shadow` nie jest ruszany.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

Status repaintu: Kolekcja ✅ / Regał ✅ / Katalog ✅. Zostają: Rynek (bazowo pokryty) i opcjonalny re-layout Kolekcji 1:1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_