### PR TITLE
feat(theme): single mockup shelf in light — force matte skin, hide switch

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.64.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.65.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.65.0** — **Regał w jasnym motywie = jeden wygląd (jak z makiety), bez przełącznika skór.** Skóry różnią się
+  grzbietami: `.skin-holo` = neon (`APP_PALETTE`), `.skin-noospheric` = matowe jewel-tone (`CLOTH_PALETTE`).
+  Makieta jest matowa → w jasnym motywie **wymuszamy `noospheric`** (`renderedSkin = theme==='light' ?
+  'noospheric' : skin`) i **chowamy przełącznik „Skóra"** (`theme !== 'light'`). Zapisany wybór skóry ZOSTAJE
+  dla motywu ciemnego (nie nadpisujemy `skin`, tylko klasę renderowaną). `BookshelfSection` używa teraz
+  `useTheme`. Efekt: jasny regał ma spójne matowe grzbiety + ciepłą lnianą oprawę (bez neonu), ciemny „Warhammer"
+  zachowuje Holo+/Klasyczny do wyboru. Suite 463 zielone, lint czysty, build OK.
 - **1.64.0** — **Katalog: tytuły wyników na serif (Cormorant) w jasnym motywie — podpis makiety.** Weryfikacja:
   `BookResultCard`/`HighlightedText`/`ScanModal` używają wyłącznie klas palety (cyan/emerald/blue/amber/purple/
   rose/slate + alpha) → repaint 1.62.0/1.63.0 już je ocieplił, BEZ twardych ciemnych przecieków (inaczej niż

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.64.0",
+      "version": "1.65.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.64.0",
+  "version": "1.65.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -8,6 +8,7 @@ import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../
 import { planInsertion } from "../utils/shelfInsertion";
 import { ShelfSkin, SHELF_SKINS, skinClass, loadSkin, saveSkin } from "../utils/shelfSkin";
 import { useEffectiveConfig } from "../hooks/useAppConfig";
+import { useTheme } from "../hooks/useTheme";
 import { Shelf } from "./shelf/Shelf";
 import { CoverCard } from "./shelf/CoverCard";
 import { ShelfFrame } from "./shelf/ShelfFrame";
@@ -22,6 +23,11 @@ export const BookshelfSection: React.FC = () => {
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
   const [skin, setSkin] = useState<ShelfSkin>(loadSkin);
+  const { theme } = useTheme();
+  // Jasny motyw „Librem" = jeden regał jak z makiety: wymuszamy matową skórę
+  // (`noospheric`) i chowamy przełącznik. Zapisany wybór skóry zostaje dla
+  // motywu ciemnego — nie nadpisujemy `skin`, tylko klasę renderowaną tutaj.
+  const renderedSkin: ShelfSkin = theme === "light" ? "noospheric" : skin;
   // UI knobs: number of „Regał" rows per page + precise drop.
   const uiCfg = useEffectiveConfig().ui;
   const rowsPerPage = uiCfg.shelfRowsPerPage;
@@ -135,22 +141,25 @@ export const BookshelfSection: React.FC = () => {
         Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał N"
       </p>
 
-      {/* „Regał" skin switch (Holo+ / Relikwiarz) — choice persists in localStorage */}
-      <div className="flex items-center justify-center gap-2 -mt-3">
-        <span className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">Skóra</span>
-        <div className="inline-flex rounded-lg border border-white/10 overflow-hidden">
-          {SHELF_SKINS.map((s) => (
-            <button
-              key={s.id}
-              onClick={() => setSkin(s.id)}
-              aria-pressed={skin === s.id}
-              className={`px-3 py-1 text-[11px] font-bold uppercase tracking-wider font-display transition-colors ${skin === s.id ? "bg-cyan-500/20 text-cyan-200" : "text-slate-400 hover:text-slate-200 hover:bg-white/5"}`}
-            >
-              {s.label}
-            </button>
-          ))}
+      {/* „Regał" skin switch (Holo+ / Klasyczny) — choice persists in localStorage.
+          Ukryty w jasnym motywie: tam regał ma jeden wygląd (jak z makiety). */}
+      {theme !== "light" && (
+        <div className="flex items-center justify-center gap-2 -mt-3">
+          <span className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">Skóra</span>
+          <div className="inline-flex rounded-lg border border-white/10 overflow-hidden">
+            {SHELF_SKINS.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => setSkin(s.id)}
+                aria-pressed={skin === s.id}
+                className={`px-3 py-1 text-[11px] font-bold uppercase tracking-wider font-display transition-colors ${skin === s.id ? "bg-cyan-500/20 text-cyan-200" : "text-slate-400 hover:text-slate-200 hover:bg-white/5"}`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {moveError && (
         <div className="glass-card p-4 rounded-2xl border-red-500/30 bg-red-500/5 max-w-2xl mx-auto flex items-center gap-3">
@@ -176,7 +185,7 @@ export const BookshelfSection: React.FC = () => {
           </div>
         </div>
       ) : (
-        <div className={skinClass(skin)}>
+        <div className={skinClass(renderedSkin)}>
         <RoomDecor>
           {/* „Wyróżnione" shelf (covers facing out) */}
           {featured.length > 0 && (


### PR DESCRIPTION
Fixes #295

W jasnym motywie „Librem" Regał ma teraz **jeden wygląd** (jak z makiety), zamiast dwóch przełączanych skór.

## Dlaczego
Skóry różnią się grzbietami: `.skin-holo` = neon (`APP_PALETTE`), `.skin-noospheric` = matowe jewel-tone (`CLOTH_PALETTE`). Makieta jest matowa.

## Zmiana
- W jasnym motywie renderujemy wymuszoną skórę: `renderedSkin = theme === 'light' ? 'noospheric' : skin`.
- Przełącznik „Skóra" ukryty w jasnym (`theme !== 'light'`).
- Zapisany wybór skóry **zostaje dla motywu ciemnego** — nadpisujemy tylko klasę renderowaną, nie persystowany `skin`.
- `BookshelfSection` korzysta teraz z `useTheme`.

Efekt: jasny regał = spójne matowe grzbiety + ciepła lniana oprawa (bez neonu); ciemny „Warhammer" zachowuje Holo+/Klasyczny do wyboru.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_