### PR TITLE
feat(theme): light Regał — mockup spine colors, no 40k, legible spine text

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.65.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.66.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.66.0** — **Jasny Regał: kolory grzbietów z makiety + usunięcie 40k + czytelny kremowy tytuł.** (1) Nowa
+  `LIGHT_SPINE_PALETTE` (12 boho mid-tone: clay/sage/ochre/brick/tany) równoległa do `CLOTH_PALETTE`; `spineStyle`
+  zwraca `light`, komponenty emitują `--spine-light` (BookSpine/BookStack) i `--cml-a/b` (CoverCard). Warstwa
+  `[data-theme="light"] .skin-noospheric .book-spine/.stack-layer/.cover-card` renderuje jaśniejsze grzbiety/
+  okładki z tej palety (ciemny motyw = jewel-tone bez zmian). (2) **Bez 40k w jasnym**: ornamenty/efekty dostały
+  klasę-marker `dc-40k` (CogSigil, NoosphericCrest, DataTicker, HoloField, HudCorner, CogMark-watermark, świeca+
+  płomień, pyłki) → `[data-theme="light"] .dc-40k,.noo-data { display:none }`. Czysty, boho regał (ramka/deski/
+  „pokój" zostają, warm). (3) **Tytuł na grzbiecie**: `[data-theme="light"] .skin-noospheric .spine-title` →
+  kremowa biel `#FBF3E6` + mocny cień = czytelny na jasnym grzbiecie (zamiast bieli zlewającej się z tłem).
+  Fix testu: literał `SpineStyle` w `bookshelf.test.ts` dostał pole `light`. Suite 463 zielone, lint czysty,
+  build OK.
 - **1.65.0** — **Regał w jasnym motywie = jeden wygląd (jak z makiety), bez przełącznika skór.** Skóry różnią się
   grzbietami: `.skin-holo` = neon (`APP_PALETTE`), `.skin-noospheric` = matowe jewel-tone (`CLOTH_PALETTE`).
   Makieta jest matowa → w jasnym motywie **wymuszamy `noospheric`** (`renderedSkin = theme==='light' ?

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.65.0",
+  "version": "1.66.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.65.0",
+  "version": "1.66.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.65.0",
+      "version": "1.66.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.65.0",
+  "version": "1.66.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/__tests__/bookshelf.test.ts
+++ b/src/__tests__/bookshelf.test.ts
@@ -112,7 +112,7 @@ describe("bookshelf.planShelf", () => {
 });
 
 describe("bookshelf.title sizing (pełne nazwy)", () => {
-  const style = { color: "#000", app: "#06b6d4", appRgb: "6,182,212", width: 20, height: 160 };
+  const style = { color: "#000", light: "#B0574A", app: "#06b6d4", appRgb: "6,182,212", width: 20, height: 160 };
   it("spineFontSize shrinks for longer titles, within 6–11 px", () => {
     const short = spineFontSize(style, "Ubik");
     const long = spineFontSize(style, "Opowieści z meekhańskiego pogranicza. Północ-Południe");

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -28,6 +28,7 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       width: style.width,
       height: style.height,
       ["--spine-muted" as string]: style.color,
+      ["--spine-light" as string]: style.light,
       ["--spine-app" as string]: style.app,
       ["--spine-app-rgb" as string]: style.appRgb,
     } as React.CSSProperties}

--- a/src/components/shelf/BookStack.tsx
+++ b/src/components/shelf/BookStack.tsx
@@ -37,6 +37,7 @@ export const BookStack: React.FC<Props> = ({ books, onDragStart, onDragEnd }) =>
               marginLeft: x,
               marginBottom: i === 0 ? 0 : 1,
               ["--spine-muted" as string]: s.color,
+              ["--spine-light" as string]: s.light,
               ["--spine-app" as string]: s.app,
               ["--spine-app-rgb" as string]: s.appRgb,
               boxShadow: "inset 0 1.5px 0 rgba(255,255,255,.12), 0 2px 4px -1px rgba(0,0,0,.5)",

--- a/src/components/shelf/CoverCard.tsx
+++ b/src/components/shelf/CoverCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { BookIndexEntry } from "../../types";
-import { CLOTH_PALETTE, APP_PALETTE, displayTitle } from "../../utils/bookshelf";
+import { CLOTH_PALETTE, LIGHT_SPINE_PALETTE, APP_PALETTE, displayTitle } from "../../utils/bookshelf";
 
 function hash(s: string): number {
   let h = 0;
@@ -20,6 +20,7 @@ export const CoverCard: React.FC<{ book: BookIndexEntry }> = ({ book }) => {
       className="cover-card group relative shrink-0 w-[104px] h-[156px] rounded-[6px_3px_3px_6px] overflow-hidden flex flex-col justify-between p-3 pl-4 transition-transform duration-150 hover:-translate-y-2"
       style={{
         ["--cm-a" as string]: CLOTH_PALETTE[i1], ["--cm-b" as string]: CLOTH_PALETTE[i2],
+        ["--cml-a" as string]: LIGHT_SPINE_PALETTE[i1], ["--cml-b" as string]: LIGHT_SPINE_PALETTE[i2],
         ["--ca-a" as string]: APP_PALETTE[i1][0], ["--ca-b" as string]: APP_PALETTE[i2][0],
         boxShadow: "inset -5px 0 8px -6px rgba(0,0,0,.6), 0 10px 16px -8px rgba(0,0,0,.7)",
       } as React.CSSProperties}

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -4,7 +4,7 @@ import { motion } from "motion/react";
 /** Cog-wheel sigil (Mechanicus) — room decoration. Color via `style`, so
  *  the skin variables resolve (`var(--sk-room-cog*)`). */
 const CogMark: React.FC<{ size: number; color: string; className?: string; style?: React.CSSProperties }> = ({ size, color, className, style }) => (
-  <svg viewBox="0 0 48 48" width={size} height={size} className={className} style={style} aria-hidden>
+  <svg viewBox="0 0 48 48" width={size} height={size} className={`dc-40k ${className ?? ""}`} style={style} aria-hidden>
     <g style={{ fill: color }}>
       {Array.from({ length: 12 }).map((_, i) => (
         <rect key={i} x="22.2" y="0.5" width="3.6" height="9" rx="1" transform={`rotate(${i * 30} 24 24)`} />
@@ -18,7 +18,7 @@ const CogMark: React.FC<{ size: number; color: string; className?: string; style
 
 /** Candle with a flickering flame and warm glow. */
 const Sconce: React.FC<{ className?: string }> = ({ className }) => (
-  <div className={`absolute pointer-events-none ${className ?? ""}`} aria-hidden>
+  <div className={`dc-40k absolute pointer-events-none ${className ?? ""}`} aria-hidden>
     <svg viewBox="0 0 60 70" width="52" height="60">
       <path d="M30 26 V54 M18 54 h24 M22 54 q8 7 16 0" stroke="#b8860b" strokeWidth="3" fill="none" strokeLinecap="round" />
       <ellipse cx="30" cy="24" rx="5" ry="3" fill="#3a2a12" />
@@ -45,7 +45,7 @@ const Mote: React.FC<{ i: number }> = ({ i }) => {
   const dur = 7 + (i % 5) * 1.7;
   return (
     <motion.div
-      className="absolute w-[3px] h-[3px] rounded-full"
+      className="dc-40k absolute w-[3px] h-[3px] rounded-full"
       style={{ left: `${left}%`, top: `${top}%`, filter: "blur(1px)", background: "var(--sk-room-mote)" }}
       animate={{ y: [0, -14, 0], opacity: [0.15, 0.5, 0.15] }}
       transition={{ duration: dur, repeat: Infinity, ease: "easeInOut", delay: (i % 7) * 0.6 }}

--- a/src/components/shelf/ShelfOrnaments.tsx
+++ b/src/components/shelf/ShelfOrnaments.tsx
@@ -13,7 +13,7 @@ type Corner = "tl" | "tr" | "bl" | "br";
  * (`--sk-cog-*`), so switching the skin repaints it without changing the component.
  */
 export const CogSigil: React.FC<{ className?: string }> = ({ className = "" }) => (
-  <svg aria-hidden viewBox="0 0 48 48" className={className}>
+  <svg aria-hidden viewBox="0 0 48 48" className={`dc-40k ${className}`}>
     <g style={{ fill: "var(--sk-cog-ring)" }} stroke="rgba(0,0,0,.4)" strokeWidth="0.6">
       {Array.from({ length: 10 }).map((_, i) => (
         <rect key={i} x="22.4" y="1.5" width="3.2" height="8" rx="1" transform={`rotate(${i * 36} 24 24)`} />
@@ -40,7 +40,7 @@ const ACCENT2 = (a: number) => `rgba(var(--noo-accent2), ${a})`;
  * Purely decorative.
  */
 export const NoosphericCrest: React.FC<{ size?: number; className?: string }> = ({ size = 46, className = "" }) => (
-  <div className={className} aria-hidden style={{ width: size, height: size }}>
+  <div className={`dc-40k ${className}`} aria-hidden style={{ width: size, height: size }}>
     <div className="relative w-full h-full">
       <svg viewBox="0 0 86 86" className="noo-spin absolute inset-[-24%] w-[148%] h-[148%]" style={{ opacity: 0.6 }}>
         <circle cx="43" cy="43" r="40" fill="none" stroke={GLOW(0.5)} strokeWidth="1" strokeDasharray="3 4" />
@@ -58,7 +58,7 @@ export const DataTicker: React.FC<{ text: string; tone?: "glow" | "accent"; slow
   const color = tone === "accent" ? ACCENT2(1) : GLOW(1);
   return (
     <div
-      className={`overflow-hidden rounded-[3px] flex items-center h-[18px] ${className}`}
+      className={`dc-40k overflow-hidden rounded-[3px] flex items-center h-[18px] ${className}`}
       style={{ border: `1px solid ${GLOW(0.3)}`, background: "linear-gradient(180deg,rgba(4,8,14,.9),rgba(2,4,8,.9))", boxShadow: `inset 0 0 8px ${GLOW(0.12)}` }}
       aria-hidden
     >
@@ -73,7 +73,7 @@ export const DataTicker: React.FC<{ text: string; tone?: "glow" | "accent"; slow
 
 /** Overlay: subtle noosphere grid + a moving scanline (CRT). */
 export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) => (
-  <div className={`pointer-events-none absolute inset-0 overflow-hidden ${className}`} aria-hidden>
+  <div className={`dc-40k pointer-events-none absolute inset-0 overflow-hidden ${className}`} aria-hidden>
     <div
       className="absolute inset-0 opacity-50"
       style={{
@@ -93,7 +93,7 @@ export const HoloField: React.FC<{ className?: string }> = ({ className = "" }) 
 /** HUD corner (reticle) — in the color of the Regał FRAME (`--sk-frame-accent`, amber),
  *  pulsing. Locally overrides `--noo-glow` so the pulsing glow is also in the frame accent. */
 export const HudCorner: React.FC<{ corner: Corner }> = ({ corner }) => {
-  const base = "absolute w-4 h-4 z-20 pointer-events-none noo-pulse";
+  const base = "dc-40k absolute w-4 h-4 z-20 pointer-events-none noo-pulse";
   const c = "rgb(var(--sk-frame-accent))";
   const common = { ["--noo-glow" as string]: "var(--sk-frame-accent)" };
   const box: Record<Corner, React.CSSProperties> = {

--- a/src/index.css
+++ b/src/index.css
@@ -288,3 +288,27 @@ body {
 /* Gwiazdka „Wyróżnione" na okładce — ciepły akcent zamiast neonu. */
 [data-theme="light"] .skin-holo .cover-badge,
 [data-theme="light"] .skin-noospheric .cover-badge { color: #C07A56; border-color: #C07A56; }
+
+/* Jasny Regał: bez 40k. Chowamy warhammerowe ornamenty/efekty (cog-skull,
+   ticker binarny, skan-linia, HUD-narożniki, holo-crest, płomień świecy,
+   pyłki, żyły danych) → czysty, boho regał. Ciemny motyw = bez zmian. */
+[data-theme="light"] .dc-40k,
+[data-theme="light"] .noo-data { display: none !important; }
+
+/* Jaśniejsze grzbiety z palety makiety (var `--spine-light`) + jasne okładki. */
+[data-theme="light"] .skin-noospheric .book-spine {
+  background: linear-gradient(90deg, rgba(58,52,43,.20), var(--spine-light) 20%, var(--spine-light) 80%, rgba(58,52,43,.14));
+  box-shadow: inset 1.5px 0 0 rgba(255,255,255,.30), inset -2px 0 4px rgba(58,52,43,.24), 0 6px 12px -7px rgba(58,52,43,.42);
+}
+[data-theme="light"] .skin-noospheric .stack-layer {
+  background: linear-gradient(0deg, rgba(58,52,43,.24) 0, var(--spine-light) 26%, var(--spine-light) 74%, rgba(255,255,255,.22) 100%);
+}
+[data-theme="light"] .skin-noospheric .cover-card { background: linear-gradient(150deg, var(--cml-a), var(--cml-b)); }
+
+/* Tytuł na grzbiecie: kremowa biel + mocny cień = czytelny na jasnym grzbiecie
+   (zamiast bieli zlewającej się z jasnym tłem). */
+[data-theme="light"] .skin-noospheric .spine-title {
+  color: #FBF3E6;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(45,38,28,.72), 0 0 1px rgba(45,38,28,.55);
+}

--- a/src/utils/bookshelf.ts
+++ b/src/utils/bookshelf.ts
@@ -17,17 +17,27 @@ export function isRead(book: BookIndexEntry, overrides: ReadOverrides = {}): boo
 
 /** Deterministic spine appearance — stable per title (no flicker on re-render). */
 export interface SpineStyle {
-  color: string;   // muted bookbinding-cloth color (Relikwiarz skin)
+  color: string;   // muted bookbinding-cloth color (Klasyczny skin, dark)
+  light: string;   // lighter boho color (light „Librem" theme) — mockup palette
   app: string;     // accent from the app palette (Holo+ skin) — hex
   appRgb: string;  // the same accent as „r,g,b" (for rgba(var(...), a))
   width: number;   // px
   height: number;  // px
 }
 
-/** Bookbinding-cloth palette — muted, authentic (Relikwiarz). */
+/** Bookbinding-cloth palette — muted, authentic (Klasyczny / dark). */
 export const CLOTH_PALETTE = [
   "#7f1d2e", "#0f5132", "#1e3a5f", "#7c5410", "#3f2d52", "#2b2b2b",
   "#5a2a1e", "#14504f", "#4a3b16", "#5b1f3a", "#243b53", "#6b2737",
+];
+
+/** Light boho spine palette (jasny motyw „Librem") — jaśniejsze grzbiety w
+ *  paletcie makiety: clay/sage/ochre/brick + ciepłe tany. Parallel to
+ *  `CLOTH_PALETTE` (same index = same book). Mid-tone, żeby kremowy tytuł
+ *  na grzbiecie był czytelny. */
+export const LIGHT_SPINE_PALETTE = [
+  "#B0574A", "#7E8A6B", "#C4933A", "#A9603D", "#9C7B52", "#6F7A58",
+  "#B8623F", "#CF9B3F", "#8A6B46", "#A5524A", "#8F8560", "#C07A56",
 ];
 
 /** App accent palette (cyan/blue/indigo/violet/purple) — Holo+.
@@ -50,6 +60,7 @@ export function spineStyle(book: BookIndexEntry): SpineStyle {
   const [app, appRgb] = APP_PALETTE[idx];
   return {
     color: CLOTH_PALETTE[idx],
+    light: LIGHT_SPINE_PALETTE[idx],
     app, appRgb,
     width: 16 + (h % 12),          // 16–27 px
     height: 124 + ((h >>> 3) % 48), // 124–171 px (unsigned shift — h can be >2^31)


### PR DESCRIPTION
Fixes #297

Jasny Regał staje się czystym, boho regałem.

## 1. Jaśniejsze grzbiety z palety makiety
Nowa `LIGHT_SPINE_PALETTE` (12 boho mid-tone: clay/sage/ochre/brick/tany), równoległa do `CLOTH_PALETTE`. `spineStyle` zwraca `light`; komponenty emitują `--spine-light` (BookSpine/BookStack) i `--cml-a/b` (CoverCard). Warstwa `[data-theme="light"] .skin-noospheric .book-spine/.stack-layer/.cover-card` renderuje z tej palety. Ciemny motyw = jewel-tone bez zmian.

## 2. Bez 40k w jasnym
Ornamenty/efekty dostały klasę-marker `dc-40k`: CogSigil, NoosphericCrest, DataTicker, HoloField (skan-linia), HudCorner, CogMark-watermark, świeca+płomień, pyłki → `[data-theme="light"] .dc-40k, .noo-data { display:none }`. Ramka/deski/„pokój" zostają (ciepłe).

## 3. Czytelny tytuł na grzbiecie
`[data-theme="light"] .skin-noospheric .spine-title` → kremowa biel `#FBF3E6` + mocny cień, czytelny na jaśniejszym grzbiecie (zamiast bieli zlewającej się z tłem).

## Test
- `npm test` — 463 zielone (naprawiony literał `SpineStyle` w `bookshelf.test.ts` — pole `light`)
- `npm run lint` — czysto
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_