### PR TITLE
fix(theme): light Regał award seals in boho palette + unclipped pager

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.66.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.66.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.66.1** — **Jasny Regał: pieczęcie nagród w palecie boho + fix zjadanej prawej strzałki pagera.**
+  (1) Kropki nagród na grzbiecie (`AWARD_MARKS`: Hugo #fbbf24 / Nebula #c084fc / Locus #38bdf8 — neon) dostały
+  klasy `spine-award spine-award-<key>`; w jasnym motywie `[data-theme="light"] .skin-noospheric .spine-award*`
+  nadpisuje je (`!important` bije inline) na boho: Hugo→ochra `#CE9B3F`, Nebula→sage `#7E8A6B`, Locus→clay
+  `#C07A56`, cienki ciemny pierścień bez poświaty. Ciemny motyw = neon bez zmian. (2) Pager „Regał N / M" był
+  ucinany z prawej przy większym M: w jasnym `DataTicker` (elastyczny spacer `flex-1`) jest `display:none`, więc
+  `whitespace-nowrap` tytuł nie oddawał miejsca, a `overflow-hidden` kornisza zjadał prawą strzałkę. Fix w
+  `ShelfFrame`: tytuł `truncate min-w-0` (oddaje miejsce), chip licznika i wrapper `headerExtra` → `shrink-0`
+  (pager zawsze w całości). Działa też w ciemnym. Suite 463 zielone, lint czysty, build OK.
 - **1.66.0** — **Jasny Regał: kolory grzbietów z makiety + usunięcie 40k + czytelny kremowy tytuł.** (1) Nowa
   `LIGHT_SPINE_PALETTE` (12 boho mid-tone: clay/sage/ochre/brick/tany) równoległa do `CLOTH_PALETTE`; `spineStyle`
   zwraca `light`, komponenty emitują `--spine-light` (BookSpine/BookStack) i `--cml-a/b` (CoverCard). Warstwa

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.66.0",
+      "version": "1.66.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.66.0",
+  "version": "1.66.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/BookSpine.tsx
+++ b/src/components/shelf/BookSpine.tsx
@@ -55,7 +55,7 @@ export const BookSpine: React.FC<Props> = ({ book, style, onDragStart, onDragEnd
       return (
         <span className="absolute bottom-[6px] left-1/2 -translate-x-1/2 flex flex-col-reverse items-center gap-[3px]" title={wins.map((w) => w.label).join(" · ")}>
           {wins.map((w) => (
-            <span key={w.key} className="w-[8px] h-[8px] rounded-full" style={{ background: w.color, boxShadow: `0 0 6px ${w.color}, 0 0 0 1px rgba(var(--noo-glow),.5)` }} />
+            <span key={w.key} className={`spine-award spine-award-${w.key} w-[8px] h-[8px] rounded-full`} style={{ background: w.color, boxShadow: `0 0 6px ${w.color}, 0 0 0 1px rgba(var(--noo-glow),.5)` }} />
           ))}
         </span>
       );

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -60,13 +60,13 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
           {/* Cog-wheel sigil */}
           <CogSigil className="w-7 h-7 shrink-0 drop-shadow-[0_1px_2px_rgba(0,0,0,.6)]" />
           <span className={a.text}>{icon}</span>
-          <h3 className="text-sm font-display font-bold uppercase tracking-[0.22em] text-amber-100/90 whitespace-nowrap drop-shadow-[0_1px_2px_rgba(0,0,0,.7)]">
+          <h3 className="text-sm font-display font-bold uppercase tracking-[0.22em] text-amber-100/90 truncate min-w-0 drop-shadow-[0_1px_2px_rgba(0,0,0,.7)]">
             {title}
           </h3>
-          <span className={`px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
+          <span className={`shrink-0 px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
           {/* Data ticker (scrolling) — fills the free space of the cornice */}
           <DataTicker className="ml-3 hidden sm:flex flex-1 min-w-0 max-w-[280px]" text="++ LIBREM·SYNC ++ 01001101·01000001·01010011 ++ KOLEKCJA·FANTASTYKI ++" />
-          <div className="ml-auto flex items-center gap-3">{headerExtra}</div>
+          <div className="ml-auto shrink-0 flex items-center gap-3">{headerExtra}</div>
           {/* Subtle light strip under the cornice (in the color of the Regał frame) */}
           <div className="absolute bottom-0 inset-x-6 h-px" style={{ background: "linear-gradient(90deg, transparent, rgba(var(--sk-frame-accent),.28), transparent)" }} />
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -312,3 +312,13 @@ body {
   font-weight: 700;
   text-shadow: 0 1px 2px rgba(45,38,28,.72), 0 0 1px rgba(45,38,28,.55);
 }
+
+/* Pieczęcie nagród na grzbiecie: paleta boho zamiast neonu (Hugo→ochra,
+   Nebula→sage, Locus→clay) + cienki ciemny pierścień bez poświaty.
+   `!important` bije style inline (kolor nagrody trzymany w JS dla ciemnego). */
+[data-theme="light"] .skin-noospheric .spine-award {
+  box-shadow: 0 0 0 1px rgba(45,38,28,.42) !important;
+}
+[data-theme="light"] .skin-noospheric .spine-award-hugo   { background: #CE9B3F !important; }
+[data-theme="light"] .skin-noospheric .spine-award-nebula { background: #7E8A6B !important; }
+[data-theme="light"] .skin-noospheric .spine-award-locus  { background: #C07A56 !important; }


### PR DESCRIPTION
Fixes #299

Dwie poprawki jasnego Regału.

## 1. Pieczęcie nagród w palecie boho
Kropki nagród na grzbiecie były neonowe (Hugo `#fbbf24` / Nebula `#c084fc` / Locus `#38bdf8`). Dodane klasy `spine-award spine-award-<key>`; w jasnym motywie warstwa `[data-theme="light"] .skin-noospheric .spine-award*` nadpisuje je (`!important` bije inline) na: **Hugo→ochra `#CE9B3F`, Nebula→sage `#7E8A6B`, Locus→clay `#C07A56`**, z cienkim ciemnym pierścieniem i bez poświaty. Ciemny motyw = neon bez zmian.

## 2. Zjadana prawa strzałka pagera
„Regał N / M" ucinał prawy chevron przy większym M: w jasnym `DataTicker` (elastyczny spacer `flex-1`) ma `display:none`, więc `whitespace-nowrap` tytuł nie oddawał miejsca, a `overflow-hidden` kornisza zjadał strzałkę. `ShelfFrame`: tytuł `truncate min-w-0` (oddaje miejsce), chip licznika i wrapper `headerExtra` → `shrink-0` (pager zawsze w całości). Poprawne też w ciemnym.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_