### PR TITLE
feat(stats): Kolekcja KPI header row (mockup) — responsive desktop + mobile

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.66.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.0** — **Kolekcja: nagłówkowy rząd 4 KPI (makieta) — responsywny desktop + mobile.** Nowy `KpiRow`
+  (`src/components/stats/KpiRow.tsx`) nad kartami, STAŁY (nie wchodzi w masonry z drag&drop — kolejność kart
+  zachowana). 4 KPI z `Stats`: **Woluminy** = `awardBooksStats.total`; **Przeczytane** = `read/total%` (+pasek);
+  **Posiadane** = Σ`decadeStats.owned`; **Do zdobycia** = `total − Σowned` (clamp ≥0). Layout: `grid grid-cols-2
+  md:grid-cols-4` → desktop 4 w rzędzie, mobile 2×2; liczby `font-display tabular-nums` `text-3xl md:text-4xl`
+  (serif w jasnym = makieta). Kolory/tło/pasek przez klasy palety (`text-slate-100`/`emerald`/`cyan`/`amber`,
+  `bg-slate-800` track) → spójne w obu motywach automatycznie. Wpięte w `StatsSection` nad hintem układania,
+  po guardach `!stats`. Suite 463 zielone, lint czysty, build OK. (Karty poniżej — histogram/dostępność/oficyny
+  itd. — bez zmian; masonry z reorderem zostaje.)
 - **1.66.1** — **Jasny Regał: pieczęcie nagród w palecie boho + fix zjadanej prawej strzałki pagera.**
   (1) Kropki nagród na grzbiecie (`AWARD_MARKS`: Hugo #fbbf24 / Nebula #c084fc / Locus #38bdf8 — neon) dostały
   klasy `spine-award spine-award-<key>`; w jasnym motywie `[data-theme="light"] .skin-noospheric .spine-award*`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.66.1",
+      "version": "1.67.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.66.1",
+  "version": "1.67.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -16,6 +16,7 @@ import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
 import { MarketCard } from "./stats/MarketCard";
 import { CyclesHarvestCard } from "./stats/CyclesHarvestCard";
+import { KpiRow } from "./stats/KpiRow";
 import { useEffectiveConfig, persistStatsOrder } from "../hooks/useAppConfig";
 import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
 
@@ -335,6 +336,9 @@ export const StatsSection: React.FC = () => {
           </motion.div>
         </button>
       </div>
+
+      {/* „Twoja kolekcja" — stały rząd KPI (nad kartami; nie wchodzi w masonry). */}
+      <KpiRow stats={stats} />
 
       {arranging && (
         <div className="flex items-center justify-center gap-2 text-[11px] text-amber-300/80 uppercase tracking-widest font-bold">

--- a/src/components/stats/KpiRow.tsx
+++ b/src/components/stats/KpiRow.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Library, BookOpenCheck, Package, Compass } from "lucide-react";
+import { Stats } from "../../hooks/useStats";
+
+/**
+ * „Twoja kolekcja" — nagłówkowy rząd 4 KPI (wg makiety `design/Main.dc.html`).
+ * Stały (nie wchodzi w masonry z drag&drop). Responsywny: desktop 4 kolumny,
+ * mobile 2×2. Kolory i `font-display` idą przez zmienne palety, więc działa
+ * spójnie w obu motywach (jasny „Librem" / ciemny „Warhammer").
+ */
+
+interface Kpi {
+  key: string;
+  label: string;
+  value: string;
+  sub?: string;
+  pct?: number;
+  icon: typeof Library;
+  accent: string;   // klasa koloru (remap palety)
+  bar?: string;     // klasa wypełnienia paska
+}
+
+const nf = new Intl.NumberFormat("pl-PL");
+
+export const KpiRow: React.FC<{ stats: Stats }> = ({ stats }) => {
+  const total = stats.awardBooksStats.total;
+  const read = stats.awardBooksStats.read;
+  const owned = stats.decadeStats.reduce((s, d) => s + d.owned, 0);
+  const toGet = Math.max(0, total - owned);
+  const pctRead = total > 0 ? Math.round((read / total) * 100) : 0;
+
+  const kpis: Kpi[] = [
+    { key: "vol", label: "Woluminy", value: nf.format(total), sub: "wydania z listy nagród", icon: Library, accent: "text-slate-100" },
+    { key: "read", label: "Przeczytane", value: `${pctRead}%`, pct: pctRead, icon: BookOpenCheck, accent: "text-emerald-400", bar: "bg-emerald-500" },
+    { key: "owned", label: "Posiadane", value: nf.format(owned), sub: "na półce / w kolekcji", icon: Package, accent: "text-cyan-400" },
+    { key: "toget", label: "Do zdobycia", value: nf.format(toGet), sub: "brakuje w kolekcji", icon: Compass, accent: "text-amber-400" },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
+      {kpis.map((k, i) => (
+        <motion.div
+          key={k.key}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.05 }}
+          className="glass-card rounded-3xl p-4 md:p-5 flex flex-col gap-1.5"
+        >
+          <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">
+            <k.icon className={`w-3.5 h-3.5 ${k.accent}`} />
+            <span className="truncate">{k.label}</span>
+          </div>
+          <div className={`font-display font-bold tabular-nums leading-none text-3xl md:text-4xl ${k.accent}`}>
+            {k.value}
+          </div>
+          {k.pct !== undefined ? (
+            <div className="mt-1.5 h-1.5 rounded-full bg-slate-800 overflow-hidden">
+              <motion.div
+                initial={{ width: 0 }}
+                animate={{ width: `${k.pct}%` }}
+                transition={{ duration: 0.6, ease: "easeOut" }}
+                className={`h-full rounded-full ${k.bar}`}
+              />
+            </div>
+          ) : (
+            <div className="text-[11px] md:text-xs text-slate-500">{k.sub}</div>
+          )}
+        </motion.div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
Fixes #301

Rozszerzenie dashboardu „Kolekcja" o nagłówkowy rząd 4 KPI z makiety.

## Co
Nowy `KpiRow` (`src/components/stats/KpiRow.tsx`) nad kartami, **stały** — nie wchodzi w masonry z drag&drop, więc reorder kart zostaje nietknięty. 4 KPI z `Stats`:
- **Woluminy** = `awardBooksStats.total`
- **Przeczytane** = `read/total %` (+ mini-pasek)
- **Posiadane** = Σ`decadeStats.owned`
- **Do zdobycia** = `total − Σowned` (clamp ≥ 0)

## Desktop + mobile
- `grid grid-cols-2 md:grid-cols-4` → **desktop 4 w rzędzie, mobile 2×2**.
- Liczby `font-display tabular-nums`, `text-3xl` (mobile) / `text-4xl` (desktop) — serif w jasnym motywie = makieta.
- Kolory, karta i pasek przez klasy palety (`text-slate-100`/`emerald`/`cyan`/`amber`, track `bg-slate-800`) → jasny i ciemny działają automatycznie.

Wpięte w `StatsSection` nad hintem układania, po guardach `!stats`. Karty poniżej (histogram/dostępność/oficyny…) bez zmian.

## Test
- `npm test` — 463 zielone
- `npm run lint` — czysto
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_