### PR TITLE
fix(integrity): read award list from config + shared award-page source

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.1** — **[Przegląd architektury — Tier 1, PR1] FIX: kontrola spójności czyta listę nagród z configu +
+  wspólne źródło stron nagród.** Bug: `IntegrityService` miał zahardkodowaną `PREDEFINED_AWARDS`, więc nagroda
+  dodana w Ustawieniach NIE była sprawdzana. Fix: czyta `config.sync.awards` (jak `bookSyncService` i
+  `runDiagnostics`). Dla domyślnej konfiguracji lista jest identyczna → zero zmiany dla dotychczasowych; dla
+  własnych nagród — teraz poprawnie. Przy okazji SRP: nowy `services/awardBooksSource.ts` (`fetchAwardPage` /
+  `fetchAwardBooks`) jako JEDNO źródło „pobierz+sparsuj strony nagród"; `bookSyncService.fetchBooksFromMediaWiki`
+  to teraz cienki pass-through, `IntegrityService` NIE tworzy już własnej instancji `BookSyncService`, a
+  `runDiagnostics` woła `fetchAwardPage` zamiast sięgać w serwis sync. Kontrakt „brak danych vs błąd infra"
+  zachowany (`fetchPageContent` → "" dla braku strony, rzuca przy sieci). +1 test (integrity fetchuje custom
+  nagrodę z configu, nie hardcoded). Suite 464 zielone, lint czysty, build OK.
 - **1.67.0** — **Kolekcja: nagłówkowy rząd 4 KPI (makieta) — responsywny desktop + mobile.** Nowy `KpiRow`
   (`src/components/stats/KpiRow.tsx`) nad kartami, STAŁY (nie wchodzi w masonry z drag&drop — kolejność kart
   zachowana). 4 KPI z `Stats`: **Woluminy** = `awardBooksStats.total`; **Przeczytane** = `read/total%` (+pasek);

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.0",
+      "version": "1.67.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.0",
+  "version": "1.67.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/integrityService.test.ts
+++ b/services/__tests__/integrityService.test.ts
@@ -1,6 +1,8 @@
 import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IntegrityService } from '../integrityService';
+import { ConfigService } from '../configService';
+import { mergeConfig } from '../../src/configSchema';
 import { NotionAdapter } from '../../notion.adapter';
 import { WikiAdapter } from '../../wiki.adapter';
 import { NotionBook, Book } from '../../src/types';
@@ -114,5 +116,23 @@ describe('IntegrityService', () => {
         yearCountMatch: expect.objectContaining({ status: false })
       })
     }));
+  });
+
+  it('fetches the award pages from config (sync.awards), not a hardcoded list', async () => {
+    // Config with a CUSTOM award page — the integrity check must fetch it.
+    const customConfig = {
+      getConfig: async () => mergeConfig({ sync: { awards: [{ name: "Nagroda BSFA", title: "BSFA nagroda powieść" }] } }),
+    } as unknown as ConfigService;
+    const svc = new IntegrityService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter, customConfig);
+
+    mockNotion.queryAllBooks.mockResolvedValue([]);
+    mockWiki.fetchPageContent.mockResolvedValue('');
+
+    await svc.runIntegrityCheck(mockSendEvent, () => false);
+
+    const titles = mockWiki.fetchPageContent.mock.calls.map((c: any) => c[0]);
+    expect(titles).toContain("BSFA nagroda powieść");
+    // ...and does NOT fetch the old hardcoded defaults that aren't in this config.
+    expect(titles).not.toContain("Hugo nagroda powieść");
   });
 });

--- a/services/awardBooksSource.ts
+++ b/services/awardBooksSource.ts
@@ -1,0 +1,60 @@
+import { WikiAdapter } from "../wiki.adapter";
+import { WikiParser } from "../wiki.parser";
+import { Book, SyncEvent } from "../src/types";
+import { createLogger } from "../logger";
+
+const log = createLogger("AwardBooks");
+
+/** One award page from the config (name = award label, title = wiki page title). */
+export interface AwardPageRef {
+  name: string;
+  title: string;
+}
+
+/**
+ * Fetch + parse a SINGLE award page (wiki → Book[]). Shared source for every
+ * consumer of the wiki award lists (book sync, integrity check, diagnostics),
+ * so the "which awards, fetched how" concern lives in one place instead of
+ * being a method reached into on `BookSyncService`.
+ *
+ * "No data" vs "infra failure" is preserved: `fetchPageContent` returns "" for a
+ * missing/renamed page (→ 0 books + a warning) but THROWS on a network failure,
+ * which propagates to the caller.
+ */
+export async function fetchAwardPage(
+  wiki: WikiAdapter,
+  pageTitle: string,
+  awardName: string,
+  sendEvent: (data: SyncEvent) => void,
+): Promise<Book[]> {
+  sendEvent({ type: "status", message: `Inicjacja ekstrakcji danych z Archiwum Encyklopedii: ${awardName}...` });
+  const wikitext = await wiki.fetchPageContent(pageTitle);
+
+  if (!wikitext) {
+    log.warn(`Pusta treść strony "${pageTitle}" — 0 książek dla ${awardName}`, { pageTitle, awardName });
+  }
+
+  sendEvent({ type: "status", message: `Dekodowanie tablic wyników: ${awardName}...` });
+  const books = WikiParser.parseAwardTable(wikitext, awardName);
+  log.info(`Sparsowano ${books.length} książek dla ${awardName}`, { awardName, pageTitle, wikitextLength: wikitext.length, books: books.length });
+  return books;
+}
+
+/**
+ * Fetch + parse a LIST of award pages, honoring cancellation between pages.
+ * `awards` is the effective list from config (`sync.awards`) — the single source
+ * of truth, so adding an award in Ustawienia is picked up everywhere.
+ */
+export async function fetchAwardBooks(
+  wiki: WikiAdapter,
+  awards: AwardPageRef[],
+  sendEvent: (data: SyncEvent) => void,
+  checkCancellation: () => boolean = () => false,
+): Promise<Book[]> {
+  let all: Book[] = [];
+  for (const aw of awards) {
+    if (checkCancellation()) break;
+    all = all.concat(await fetchAwardPage(wiki, aw.title, aw.name, sendEvent));
+  }
+  return all;
+}

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -1,33 +1,21 @@
 import pLimit from "p-limit";
 import { NotionAdapter } from "../notion.adapter";
 import { WikiAdapter } from "../wiki.adapter";
-import { WikiParser } from "../wiki.parser";
 import { calculateSimilarity, countCommonWords, cleanTitle } from "../utils";
 import { Book, NotionBook, SyncEvent, SyncParams } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
 import { buildBookUpdates, buildNewBookProperties } from "./bookDiff";
 import { isCycleVolume, AWARD_CATEGORY } from "./bookCategory";
-import { createLogger } from "../logger";
 import { ConfigService } from "./configService";
-
-const log = createLogger("BookSync");
+import { fetchAwardPage, fetchAwardBooks } from "./awardBooksSource";
 
 export class BookSyncService {
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
 
+  /** Thin pass-through to the shared award-page source (kept for callers that
+   *  fetch a single award page by title). */
   async fetchBooksFromMediaWiki(pageTitle: string, awardName: string, sendEvent: (data: SyncEvent) => void): Promise<Book[]> {
-    sendEvent({ type: "status", message: `Inicjacja ekstrakcji danych z Archiwum Encyklopedii: ${awardName}...` });
-    const wikitext = await this.wiki.fetchPageContent(pageTitle);
-
-    if (!wikitext) {
-      // Page exists in code, but wiki returned empty content (missing page / changed title)
-      log.warn(`Pusta treść strony "${pageTitle}" — 0 książek dla ${awardName}`, { pageTitle, awardName });
-    }
-
-    sendEvent({ type: "status", message: `Dekodowanie tablic wyników: ${awardName}...` });
-    const books = WikiParser.parseAwardTable(wikitext, awardName);
-    log.info(`Sparsowano ${books.length} książek dla ${awardName}`, { awardName, pageTitle, wikitextLength: wikitext.length, books: books.length });
-    return books;
+    return fetchAwardPage(this.wiki, pageTitle, awardName, sendEvent);
   }
 
   async runBookSync(params: SyncParams, sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
@@ -38,13 +26,9 @@ export class BookSyncService {
       if (params.syncAll) {
         // List of award pages from config (knob `sync.awards`) — no copy in code.
         const awards = (await this.config.getConfig()).sync.awards;
-        for (const aw of awards) {
-          if (checkCancellation()) break;
-          const books = await this.fetchBooksFromMediaWiki(aw.title, aw.name, sendEvent);
-          allBooksToSync = allBooksToSync.concat(books);
-        }
+        allBooksToSync = await fetchAwardBooks(this.wiki, awards, sendEvent, checkCancellation);
       } else if (params.pageTitle && params.awardName) {
-        allBooksToSync = await this.fetchBooksFromMediaWiki(params.pageTitle, params.awardName, sendEvent);
+        allBooksToSync = await fetchAwardPage(this.wiki, params.pageTitle, params.awardName, sendEvent);
       }
       if (checkCancellation()) {
         sendEvent({ type: "error", error: "Synchronizacja przerwana przez użytkownika." });

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -1,18 +1,12 @@
 import { NotionAdapter } from "../notion.adapter";
 import { ConfigService } from "./configService";
 import { WikiAdapter } from "../wiki.adapter";
-import { BookSyncService } from "./bookSyncService";
+import { fetchAwardBooks } from "./awardBooksSource";
 import { SyncEvent, NotionBook, Book, IntegrityCheckResult } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
 import { isAwardBook } from "./bookCategory";
 
 export type { IntegrityCheckResult };
-
-const PREDEFINED_AWARDS = [
-  { name: "Nagroda Hugo", title: "Hugo nagroda powieść" },
-  { name: "Nagroda Nebula", title: "Nebula nagroda najlepsza powieść" },
-  { name: "Nagroda Locus", title: "Locus nagroda powieść" }
-];
 
 const IGNORED_LOCUS_TAGS = ["Powieść dla młodzieży", "Locus - Powieść dla młodzieży", "Locus YA"];
 
@@ -22,11 +16,7 @@ interface MergedBook { years: Set<string>; display: string; keys: string[] }
 interface BookEntry { keys: string[]; years: string[]; display: string }
 
 export class IntegrityService {
-  private bookSyncService: BookSyncService;
-
-  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, config: ConfigService) {
-    this.bookSyncService = new BookSyncService(notion, wiki, config);
-  }
+  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
 
   async runIntegrityCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
     try {
@@ -75,13 +65,10 @@ export class IntegrityService {
   }
 
   private async fetchWikiBooks(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean): Promise<Book[]> {
-    let allWikiBooks: Book[] = [];
-    for (const aw of PREDEFINED_AWARDS) {
-      if (checkCancellation()) break;
-      const books = await this.bookSyncService.fetchBooksFromMediaWiki(aw.title, aw.name, sendEvent);
-      allWikiBooks = allWikiBooks.concat(books);
-    }
-    return allWikiBooks;
+    // Award list from config (`sync.awards`) — the single source of truth, so a
+    // custom award added in Ustawienia is checked here too (not a hardcoded copy).
+    const awards = (await this.config.getConfig()).sync.awards;
+    return fetchAwardBooks(this.wiki, awards, sendEvent, checkCancellation);
   }
 
   /**

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -16,6 +16,7 @@ import { CycleLookupService } from "./services/cycleLookupService";
 import { CycleHarvestService } from "./services/cycleHarvestService";
 import { IsbnEnrichService } from "./services/isbnEnrichService";
 import { aggregateCycleRows } from "./services/cycleRows";
+import { fetchAwardPage } from "./services/awardBooksSource";
 import { lookupIsbn } from "./services/isbnLookupService";
 import { toSearchIndex } from "./services/bookSearchIndex";
 import { isAwardBook } from "./services/bookCategory";
@@ -268,7 +269,7 @@ class SyncManager {
     for (const aw of AWARDS) {
       const t0 = Date.now();
       try {
-        const books = await bookSyncService.fetchBooksFromMediaWiki(aw.title, aw.name, () => {});
+        const books = await fetchAwardPage(wikiAdapter, aw.title, aw.name, () => {});
         const entry = {
           award: aw.name, pageTitle: aw.title, ok: true,
           booksParsed: books.length, ms: Date.now() - t0,


### PR DESCRIPTION
Fixes #303

Przegląd architektury — **Tier 1, PR1**.

## Bug
`IntegrityService` używał zahardkodowanej `PREDEFINED_AWARDS`, więc nagroda dodana w Ustawieniach nie była sprawdzana. Teraz czyta `config.sync.awards` — to samo źródło, którego już używają `bookSyncService` i `runDiagnostics`. Dla domyślnej konfiguracji lista jest **bajt w bajt identyczna** → zero zmiany dla dotychczasowych użytkowników; własne nagrody są teraz poprawnie sprawdzane.

## SRP
Nowy `services/awardBooksSource.ts` (`fetchAwardPage` / `fetchAwardBooks`) — JEDNO źródło „pobierz+sparsuj strony nagród":
- `bookSyncService.fetchBooksFromMediaWiki` → cienki pass-through; `runBookSync` (syncAll) używa `fetchAwardBooks`.
- `IntegrityService` **nie tworzy już własnej instancji** `BookSyncService`.
- `runDiagnostics` woła `fetchAwardPage` zamiast sięgać w serwis sync.

Kontrakt „brak danych vs błąd infra" zachowany (`fetchPageContent` → `""` dla braku strony, rzuca przy błędzie sieci).

## Test
+1 test: integrity fetchuje custom nagrodę z configu, nie hardcoded default. `npm test` — **464 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_