### PR TITLE
refactor(services): shared bookMatch (identity key + dup scoring), no rule change

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.2** — **[Tier 1, PR2] Wspólny `services/bookMatch.ts` (klucz tożsamości + scoring duplikatów) — BEZ
+  zmiany reguł.** Konsolidacja rozproszonej logiki dopasowywania rekordów, ale zachowawczo (wybór usera: „tylko
+  bezpieczna część"). Trzy prymitywy przeniesione VERBATIM: `robustBookKey` (kanoniczny klucz — z
+  `integrityService.robustKey`), `scoreDuplicatePair` (pełny 7-regułowy audyt — z `duplicateSyncService`),
+  `isInsertDuplicate` (lekki insert-guard — z `bookSyncService`). Konsumenci: integrity → `robustBookKey`,
+  `duplicateSyncService` → `scoreDuplicatePair`, `bookSyncService` → `isInsertDuplicate` (usunięte lokalne
+  `calculateSimilarity`/`countCommonWords`/`normalizeData` gdzie zbędne). Dwie strategie duplikatów zostają
+  osobne CELOWO (insert-guard vs audyt odpowiadają na różne pytania). **Konwergencja klucza lookup w ścieżce
+  sync na `robustBookKey` ŚWIADOMIE odłożona** — zmieniłaby, które rekordy się matchują (ryzyko duplikatów w
+  Notion). +10 testów `bookMatch` (blokują bieżące reguły). Suite 474 zielone, lint czysty, build OK. ZOSTAJE
+  z Tier 1: divergent normalizery klucza sync (odłożone jw.).
 - **1.67.1** — **[Przegląd architektury — Tier 1, PR1] FIX: kontrola spójności czyta listę nagród z configu +
   wspólne źródło stron nagród.** Bug: `IntegrityService` miał zahardkodowaną `PREDEFINED_AWARDS`, więc nagroda
   dodana w Ustawieniach NIE była sprawdzana. Fix: czyta `config.sync.awards` (jak `bookSyncService` i

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.1",
+  "version": "1.67.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.1",
+  "version": "1.67.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.1",
+      "version": "1.67.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.1",
+  "version": "1.67.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/bookMatch.test.ts
+++ b/services/__tests__/bookMatch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { robustBookKey, scoreDuplicatePair, isInsertDuplicate } from "../bookMatch";
+
+describe("bookMatch.robustBookKey", () => {
+  it("is punctuation/case/whitespace insensitive and sorts multi-authors", () => {
+    const a = robustBookKey("Stanisław Lem", "Solaris");
+    const b = robustBookKey("stanisław  lem", "  Solaris.  ");
+    expect(a).toBe(b);
+    expect(a).toBe("solaris|stanisław lem");
+    // Multi-author order doesn't matter.
+    expect(robustBookKey("A, B", "T")).toBe(robustBookKey("B, A", "T"));
+  });
+
+  it("returns empty key for an empty title (so same-author books don't merge)", () => {
+    expect(robustBookKey("Author", "")).toBe("");
+  });
+});
+
+describe("bookMatch.scoreDuplicatePair (7-rule audit)", () => {
+  const th = { authorThreshold: 0.85, titleThreshold: 0.85 };
+
+  it("matches identical Polish title", () => {
+    expect(scoreDuplicatePair({ plTitle: "Diuna", author: "Herbert" }, { plTitle: "Diuna", author: "Herbert" }, th))
+      .toEqual({ reason: "identyczny tytuł PL" });
+  });
+
+  it("matches identical original title", () => {
+    expect(scoreDuplicatePair({ origTitle: "Dune", author: "Herbert" }, { origTitle: "Dune", author: "Herbert" }, th))
+      .toEqual({ reason: "identyczny tytuł oryg." });
+  });
+
+  it("matches ≥2 common words with the same author", () => {
+    expect(scoreDuplicatePair(
+      { origTitle: "The Left Hand of Darkness", author: "Le Guin" },
+      { origTitle: "Left Hand Darkness Special", author: "Le Guin" }, th,
+    )).toEqual({ reason: "dopasowanie słów + ten sam autor" });
+  });
+
+  it("rejects a clearly different author", () => {
+    expect(scoreDuplicatePair({ plTitle: "Diuna", author: "Herbert" }, { plTitle: "Diuna", author: "Zajdel" }, th)).toBeNull();
+  });
+
+  it("rejects when both records lack any title", () => {
+    expect(scoreDuplicatePair({ author: "X" }, { author: "X" }, th)).toBeNull();
+  });
+});
+
+describe("bookMatch.isInsertDuplicate (insert-guard)", () => {
+  it("flags same author + ≥2 common original-title words", () => {
+    expect(isInsertDuplicate(
+      { author: "Le Guin", originalTitle: "The Left Hand of Darkness" },
+      { author: "Le Guin", origTitle: "Left Hand of Darkness" },
+    )).toBe(true);
+  });
+
+  it("does not flag a different author", () => {
+    expect(isInsertDuplicate(
+      { author: "Herbert", originalTitle: "Dune Messiah" },
+      { author: "Le Guin", origTitle: "Dune Messiah" },
+    )).toBe(false);
+  });
+
+  it("does not flag a single common word", () => {
+    expect(isInsertDuplicate(
+      { author: "Lem", originalTitle: "Solaris" },
+      { author: "Lem", origTitle: "Fiasko" },
+    )).toBe(false);
+  });
+});

--- a/services/bookMatch.ts
+++ b/services/bookMatch.ts
@@ -1,0 +1,108 @@
+import { calculateSimilarity, countCommonWords } from "../utils";
+import { normalizeData } from "./dataNormalizer";
+
+/**
+ * Book-matching primitives — the one place record identity + duplicate scoring
+ * live, instead of each service rolling its own. NOTHING here changes existing
+ * behavior: every function is the verbatim logic previously inlined in a
+ * service. There are deliberately TWO duplicate strategies (they answer
+ * different questions), plus the canonical identity key:
+ *
+ *  - `robustBookKey`      — variation-resistant identity key (integrity merge).
+ *  - `scoreDuplicatePair` — the full 7-rule audit (duplicate-detection ritual).
+ *  - `isInsertDuplicate`  — the lightweight insert-guard (book sync).
+ *
+ * Convergence of the *sync* existing-book lookup key onto `robustBookKey` is
+ * intentionally NOT done here — it would change which records match.
+ */
+
+/**
+ * A variation-resistant book identity key: normalizes the author (mappings),
+ * sorts and cleans names, normalizes the title. Empty title → empty key
+ * (rejected), so "|author" doesn't merge different books by the same author.
+ */
+export function robustBookKey(author: string, title: string): string {
+  const normalizedAuthor = normalizeData(author || "", "author");
+  const authors = normalizedAuthor
+    .split(",")
+    .map((a) =>
+      a
+        .toLowerCase()
+        .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
+        .replace(/\s{2,}/g, " ")
+        .trim(),
+    )
+    .filter(Boolean)
+    .sort();
+  const normAuthor = authors.join(",");
+
+  const normTitle = normalizeData(title || "", "title")
+    .toLowerCase()
+    .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+
+  if (!normTitle) return "";
+  return `${normTitle}|${normAuthor}`;
+}
+
+export interface DupThresholds {
+  /** Author-similarity above which two records count as the same author. */
+  authorThreshold: number;
+  /** Title-similarity above which two titles count as duplicates. */
+  titleThreshold: number;
+}
+
+interface MatchableRecord {
+  plTitle?: string;
+  origTitle?: string;
+  author?: string;
+}
+
+/**
+ * Full duplicate-audit scoring (7 rules), verbatim from `DuplicateSyncService`.
+ * Returns the matched rule's `reason`, or `null` when the pair isn't a duplicate.
+ */
+export function scoreDuplicatePair(
+  a: MatchableRecord,
+  b: MatchableRecord,
+  { authorThreshold, titleThreshold }: DupThresholds,
+): { reason: string } | null {
+  const titleA = (a.plTitle || "").toLowerCase().trim();
+  const titleB = (b.plTitle || "").toLowerCase().trim();
+  const origA = (a.origTitle || "").toLowerCase().trim();
+  const origB = (b.origTitle || "").toLowerCase().trim();
+  const authorA = (a.author || "").toLowerCase().trim();
+  const authorB = (b.author || "").toLowerCase().trim();
+
+  if ((!titleA && !origA) || (!titleB && !origB)) return null;
+
+  const sameAuthor = !!authorA && !!authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > authorThreshold);
+  const differentAuthor = !!authorA && !!authorB && !sameAuthor && calculateSimilarity(authorA, authorB) < 0.5; // Clearly different
+  if (differentAuthor) return null;
+
+  if (titleA && titleB && titleA === titleB) return { reason: "identyczny tytuł PL" };
+  if (origA && origB && origA === origB) return { reason: "identyczny tytuł oryg." };
+  if (titleA && titleB && calculateSimilarity(titleA, titleB) > titleThreshold) return { reason: "wysokie podobieństwo PL" };
+  if (origA && origB && calculateSimilarity(origA, origB) > titleThreshold) return { reason: "wysokie podobieństwo oryg." };
+  if (sameAuthor && ((origA && origB && countCommonWords(origA, origB) >= 2) || (titleA && titleB && countCommonWords(titleA, titleB) >= 2)))
+    return { reason: "dopasowanie słów + ten sam autor" };
+  if (origA && origB && countCommonWords(origA, origB) >= 2) return { reason: "dopasowanie słów oryg." };
+  if (titleA && titleB && countCommonWords(titleA, titleB) >= 2) return { reason: "dopasowanie słów PL" };
+  return null;
+}
+
+/**
+ * Lightweight insert-guard, verbatim from `BookSyncService.runBookSync`: a
+ * candidate wiki book is a duplicate of an existing Notion row when the authors
+ * are (near-)equal AND the original titles share ≥2 significant words.
+ */
+export function isInsertDuplicate(
+  candidate: { author?: string; originalTitle?: string },
+  existing: { author?: string; origTitle?: string },
+): boolean {
+  const authorA = (candidate.author || "").toLowerCase().trim();
+  const authorB = (existing.author || "").toLowerCase().trim();
+  const sameAuthor = !!authorA && !!authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > 0.85);
+  return !!(sameAuthor && candidate.originalTitle && existing.origTitle && countCommonWords(candidate.originalTitle, existing.origTitle) >= 2);
+}

--- a/services/bookSyncService.ts
+++ b/services/bookSyncService.ts
@@ -1,13 +1,14 @@
 import pLimit from "p-limit";
 import { NotionAdapter } from "../notion.adapter";
 import { WikiAdapter } from "../wiki.adapter";
-import { calculateSimilarity, countCommonWords, cleanTitle } from "../utils";
+import { cleanTitle } from "../utils";
 import { Book, NotionBook, SyncEvent, SyncParams } from "../src/types";
 import { normalizeData } from "./dataNormalizer";
 import { buildBookUpdates, buildNewBookProperties } from "./bookDiff";
 import { isCycleVolume, AWARD_CATEGORY } from "./bookCategory";
 import { ConfigService } from "./configService";
 import { fetchAwardPage, fetchAwardBooks } from "./awardBooksSource";
+import { isInsertDuplicate } from "./bookMatch";
 
 export class BookSyncService {
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
@@ -93,21 +94,10 @@ export class BookSyncService {
           
           let isDuplicateFound = false;
           if (!existingBook) {
-            // Check for potential duplicates
+            // Check for potential duplicates (insert-guard: same author + ≥2 common
+            // original-title words). Rule lives in `bookMatch.isInsertDuplicate`.
             for (const [titleWithAuthor, bookData] of existingBooksMap.entries()) {
-              let isDuplicate = false;
-              
-              // Check if authors are similar
-              const authorA = (book.author || "").toLowerCase().trim();
-              const authorB = (bookData.author || "").toLowerCase().trim();
-              const sameAuthor = authorA && authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > 0.85);
-
-              // Strict rule: at least 2 common significant words in original title AND same author
-              if (sameAuthor && book.originalTitle && bookData.origTitle && countCommonWords(book.originalTitle, bookData.origTitle) >= 2) {
-                isDuplicate = true;
-              }
-
-              if (isDuplicate) {
+              if (isInsertDuplicate(book, bookData)) {
                 syncSummary.duplicates.push(`${bookDisplayName} (duplikat: ${bookData.origTitle || titleWithAuthor} - dopasowanie słów + autor)`);
                 isDuplicateFound = true;
                 break;

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -1,7 +1,7 @@
 import { NotionAdapter } from "../notion.adapter";
 import { WikiAdapter } from "../wiki.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
-import { countCommonWords, calculateSimilarity } from "../utils";
+import { scoreDuplicatePair } from "./bookMatch";
 import { ConfigService } from "./configService";
 import { isAwardBook } from "./bookCategory";
 
@@ -30,68 +30,12 @@ export class DuplicateSyncService {
         for (let j = i + 1; j < allBooks.length; j++) {
           const bookA = allBooks[i];
           const bookB = allBooks[j];
-          
-          const titleA = (bookA.plTitle || "").toLowerCase().trim();
-          const titleB = (bookB.plTitle || "").toLowerCase().trim();
-          const origA = (bookA.origTitle || "").toLowerCase().trim();
-          const origB = (bookB.origTitle || "").toLowerCase().trim();
-          const authorA = (bookA.author || "").toLowerCase().trim();
-          const authorB = (bookB.author || "").toLowerCase().trim();
-          
-          if ((!titleA && !origA) || (!titleB && !origB)) continue;
-          
-          let isDuplicate = false;
-          let reason = "";
-          
-          const sameAuthor = authorA && authorB && (authorA === authorB || calculateSimilarity(authorA, authorB) > dupAuthorThreshold);
-          const differentAuthor = authorA && authorB && !sameAuthor && calculateSimilarity(authorA, authorB) < 0.5; // Clearly different
 
-          if (differentAuthor) continue; 
-          
-          // 1. Exact match for Polish title
-          if (titleA && titleB && titleA === titleB) {
-            isDuplicate = true;
-            reason = "identyczny tytuł PL";
-          } 
-          // 2. Exact match for Original title
-          else if (origA && origB && origA === origB) {
-            isDuplicate = true;
-            reason = "identyczny tytuł oryg.";
-          }
-          // 3. High similarity for Polish title
-          else if (titleA && titleB && calculateSimilarity(titleA, titleB) > dupTitleThreshold) {
-            isDuplicate = true;
-            reason = "wysokie podobieństwo PL";
-          }
-          // 4. High similarity for Original title
-          else if (origA && origB && calculateSimilarity(origA, origB) > dupTitleThreshold) {
-            isDuplicate = true;
-            reason = "wysokie podobieństwo oryg.";
-          }
-          // 5. Common words (at least 2) + same author
-          else if (sameAuthor && ((origA && origB && countCommonWords(origA, origB) >= 2) || (titleA && titleB && countCommonWords(titleA, titleB) >= 2))) {
-            isDuplicate = true;
-            reason = "dopasowanie słów + ten sam autor";
-          }
-          // 6. Common words (at least 2) for Original title
-          else if (origA && origB && countCommonWords(origA, origB) >= 2) {
-            isDuplicate = true;
-            reason = "dopasowanie słów oryg.";
-          }
-          // 7. Common words (at least 2) for Polish title
-          else if (titleA && titleB && countCommonWords(titleA, titleB) >= 2) {
-            isDuplicate = true;
-            reason = "dopasowanie słów PL";
-          }
-          
-          if (isDuplicate) {
+          const match = scoreDuplicatePair(bookA, bookB, { authorThreshold: dupAuthorThreshold, titleThreshold: dupTitleThreshold });
+          if (match) {
             const displayA = `${bookA.plTitle || bookA.origTitle || "Unknown"}${bookA.author ? ` - ${bookA.author}` : ""}`;
             const displayB = `${bookB.plTitle || bookB.origTitle || "Unknown"}${bookB.author ? ` - ${bookB.author}` : ""}`;
-            duplicates.push({ 
-              bookA: displayA,
-              bookB: displayB,
-              reason
-            });
+            duplicates.push({ bookA: displayA, bookB: displayB, reason: match.reason });
           }
         }
         

--- a/services/integrityService.ts
+++ b/services/integrityService.ts
@@ -3,7 +3,7 @@ import { ConfigService } from "./configService";
 import { WikiAdapter } from "../wiki.adapter";
 import { fetchAwardBooks } from "./awardBooksSource";
 import { SyncEvent, NotionBook, Book, IntegrityCheckResult } from "../src/types";
-import { normalizeData } from "./dataNormalizer";
+import { robustBookKey } from "./bookMatch";
 import { isAwardBook } from "./bookCategory";
 
 export type { IntegrityCheckResult };
@@ -71,31 +71,6 @@ export class IntegrityService {
     return fetchAwardBooks(this.wiki, awards, sendEvent, checkCancellation);
   }
 
-  /**
-   * A variation-resistant book identity key: normalizes the author (mappings),
-   * sorts and cleans names, normalizes the title. Empty title → empty key
-   * (rejected), so "|author" doesn't merge different books by the same author.
-   */
-  private robustKey(author: string, title: string): string {
-    const normalizedAuthor = normalizeData(author || "", 'author');
-    const authors = normalizedAuthor.split(',').map(a =>
-      a.toLowerCase()
-        .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
-        .replace(/\s{2,}/g, " ")
-        .trim()
-    ).filter(Boolean).sort();
-    const normAuthor = authors.join(",");
-
-    const normTitle = normalizeData(title || "", 'title')
-      .toLowerCase()
-      .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
-      .replace(/\s{2,}/g, " ")
-      .trim();
-
-    if (!normTitle) return "";
-    return `${normTitle}|${normAuthor}`;
-  }
-
   // --- A. Lp uniqueness ---
   private checkLpUniqueness(books: NotionBook[]): string[] {
     const lpMap = new Map<string, number>();
@@ -111,7 +86,7 @@ export class IntegrityService {
     books.forEach(b => {
       const title = pick(b);
       if (!title) return;
-      const key = this.robustKey(b.author || "", title);
+      const key = robustBookKey(b.author || "", title);
       map.set(key, (map.get(key) || 0) + 1);
     });
     return Array.from(map.entries())
@@ -129,7 +104,7 @@ export class IntegrityService {
 
   private notionEntries(notionBooks: NotionBook[]): BookEntry[] {
     return notionBooks.filter(b => this.hasTrackedAward(b)).map(b => ({
-      keys: [this.robustKey(b.author || "", b.origTitle || ""), this.robustKey(b.author || "", b.plTitle || "")].filter(Boolean),
+      keys: [robustBookKey(b.author || "", b.origTitle || ""), robustBookKey(b.author || "", b.plTitle || "")].filter(Boolean),
       years: (b.year || "").split(',').map(y => y.trim()).filter(Boolean),
       display: `"${b.origTitle || b.plTitle}" (${b.author})`,
     }));
@@ -137,7 +112,7 @@ export class IntegrityService {
 
   private wikiEntries(allWikiBooks: Book[]): BookEntry[] {
     return allWikiBooks.map(b => ({
-      keys: [this.robustKey(b.author || "", b.originalTitle || ""), this.robustKey(b.author || "", b.polishTitle || "")].filter(Boolean),
+      keys: [robustBookKey(b.author || "", b.originalTitle || ""), robustBookKey(b.author || "", b.polishTitle || "")].filter(Boolean),
       years: [b.year.toString()],
       display: `"${b.originalTitle || b.polishTitle}" (${b.author})`,
     }));


### PR DESCRIPTION
Fixes #305

Przegląd architektury — **Tier 1, PR2** (tylko bezpieczna część, bez zmiany reguł).

## Co
Nowy `services/bookMatch.ts` — jedno miejsce na dopasowywanie rekordów. Trzy prymitywy przeniesione **verbatim**:
- `robustBookKey` — kanoniczny klucz tożsamości (był `IntegrityService.robustKey`)
- `scoreDuplicatePair` — pełny 7-regułowy audyt (był w `DuplicateSyncService`)
- `isInsertDuplicate` — lekki insert-guard (był w `BookSyncService`)

Konsumenci: `IntegrityService` → `robustBookKey`; `DuplicateSyncService` → `scoreDuplicatePair`; `BookSyncService` → `isInsertDuplicate` (usunięte lokalne `calculateSimilarity`/`countCommonWords`/`normalizeData` tam, gdzie zbędne).

## Świadome decyzje
- Dwie strategie duplikatów zostają **osobne** — insert-guard i pełny audyt odpowiadają na różne pytania.
- Konwergencja klucza lookup w ścieżce **sync** na `robustBookKey` **NIE** jest robiona — zmieniłaby, które rekordy się matchują (ryzyko duplikatów w Notion), nieweryfikowalne bez żywych danych.

## Test
+10 testów `bookMatch` blokujących bieżące reguły. Testy `duplicateSyncService`/`bookSyncService`/`integrityService` bez zmian i zielone → zachowanie zachowane. `npm test` — **474 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_