### PR TITLE
refactor(frontend): Tier 2 — put I/O in the right layer

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.3** — **[Tier 2] Frontend I/O we właściwej warstwie (reużycie prymitywów).** (1) `useVintedResolveSellers`
+  re-implementował pętlę SSE (własny `createStallWatchdog`+fetch+`consumeSSE`+komunikat stall) — jedyne jawne
+  złamanie reguły „transport SSE żyje raz w `useSSEStream`". Przepisany na `useSSEStream("/api/vinted-resolve-
+  sellers", {timeoutMs:120000})`, jak `useVintedCheck` — zostało tylko routowanie eventów. Komunikat stall
+  teraz z `defaultStallMessage` (wspólny). (2) `SearchSection` fetchował inline (`fetchWithTimeout` +
+  `/api/books?fresh=1` + `/api/isbn/…`) — jedyny komponent robiący I/O. Wyciągnięte: `src/utils/http.ts`
+  (`fetchWithTimeout`), `useBooks.refetchFresh()` (świeży indeks, bypass cache, hard timeout — I/O należy do
+  useBooks), `useIsbnLookup` (resolve ISBN→tytuł). `handleScanDetect` to teraz samo UI-wiring (zachowane
+  komunikaty/fallback do indeksu in-memory). Suite 474 zielone, lint czysty, build OK.
 - **1.67.2** — **[Tier 1, PR2] Wspólny `services/bookMatch.ts` (klucz tożsamości + scoring duplikatów) — BEZ
   zmiany reguł.** Konsolidacja rozproszonej logiki dopasowywania rekordów, ale zachowawczo (wybór usera: „tylko
   bezpieczna część"). Trzy prymitywy przeniesione VERBATIM: `robustBookKey` (kanoniczny klucz — z

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.2",
+  "version": "1.67.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.2",
+  "version": "1.67.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.2",
+      "version": "1.67.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.2",
+  "version": "1.67.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useDeferredValue, useRef, useEffect } from "r
 import { motion, AnimatePresence } from "motion/react";
 import { Search, X, Loader2, ScrollText, AlertCircle, ScanBarcode, CheckCircle2, XCircle } from "lucide-react";
 import { useBooks } from "../hooks/useBooks";
+import { useIsbnLookup } from "../hooks/useIsbnLookup";
 import { matchBooks, buildSearchVocab, didYouMean, replaceLastToken } from "../utils/bookSearch";
 import { BookResultCard } from "./search/BookResultCard";
 import { ScanModal } from "./search/ScanModal";
@@ -10,20 +11,10 @@ import { scanSupported, cleanScannedCode, matchIsbnInIndex } from "../utils/barc
 /** Max number of cards we render (DOM guard for an „empty" query = the whole set). */
 const RENDER_CAP = 150;
 
-/** fetch with a hard timeout — a scan must never wedge the UI on a stalled connection. */
-async function fetchWithTimeout(url: string, ms = 12000): Promise<Response> {
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), ms);
-  try {
-    return await fetch(url, { signal: ctrl.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 export const SearchSection: React.FC = () => {
   // Full index (award books + cycle volumes) — so the scan/search finds a non-award volume too.
-  const { books, loading, error, fetchBooks, setBooks } = useBooks(true);
+  const { books, loading, error, fetchBooks, refetchFresh } = useBooks(true);
+  const { lookup } = useIsbnLookup();
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -68,9 +59,7 @@ export const SearchSection: React.FC = () => {
       // so the cached list can be stale exactly for a just-enriched book.
       let index = books ?? [];
       try {
-        // fresh=1 bypasses the server's 5-min cache too, so a just-added ISBN is visible.
-        const fresh = await fetchWithTimeout(`/api/books?fresh=1&all=1&t=${Date.now()}`);
-        if (fresh.ok) { index = await fresh.json(); setBooks(index); }
+        index = await refetchFresh();
       } catch {
         // Network hiccup / timeout — fall back to the in-memory index.
       }
@@ -83,8 +72,7 @@ export const SearchSection: React.FC = () => {
       }
 
       // Not stored on any row → resolve the ISBN to a title and fuzzy-search it (variant A).
-      const res = await fetchWithTimeout(`/api/isbn/${encodeURIComponent(code)}`);
-      const book = res.ok ? await res.json() : null;
+      const book = await lookup(code);
       if (book?.title) {
         setQuery(book.title);
         setScanNotice({ kind: "resolved", text: `Rozpoznano przez ISBN: „${book.title}" — szukam w katalogu` });

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { BookIndexEntry } from "../types";
+import { fetchWithTimeout } from "../utils/http";
 
 /**
  * Fetches the slimmed-down book index from `GET /api/books` ONCE and holds it in state.
@@ -29,9 +30,24 @@ export function useBooks(all = false) {
     }
   }, [all]);
 
+  /**
+   * Fetch the FRESHEST index (bypasses the server's 5-min cache) with a hard
+   * timeout, update state, and return the data. Used by the scan flow: an ISBN
+   * may have been added by the enrichment ritual after this page mounted, so the
+   * in-memory list can be stale exactly for a just-enriched book. Rejects on
+   * failure/timeout so the caller can fall back to the current index.
+   */
+  const refetchFresh = useCallback(async (): Promise<BookIndexEntry[]> => {
+    const res = await fetchWithTimeout(`/api/books?fresh=1&${all ? "all=1&" : ""}t=${Date.now()}`);
+    if (!res.ok) throw new Error("Błąd podczas pobierania książek");
+    const data = await res.json();
+    setBooks(data);
+    return data;
+  }, [all]);
+
   useEffect(() => {
     fetchBooks();
   }, [fetchBooks]);
 
-  return { books, loading, error, fetchBooks, setBooks };
+  return { books, loading, error, fetchBooks, refetchFresh, setBooks };
 }

--- a/src/hooks/useIsbnLookup.ts
+++ b/src/hooks/useIsbnLookup.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { fetchWithTimeout } from "../utils/http";
+
+/** Resolved book from `GET /api/isbn/:code` (variant A — ISBN → title). */
+export interface IsbnLookupResult {
+  title?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Resolves a barcode/ISBN to a book (title) server-side. Keeps the network I/O
+ * out of the component: `SearchSection` only decides what to do with the result.
+ * Returns `null` when the ISBN can't be resolved (non-OK response); network
+ * failure / timeout rejects, so the caller can surface a miss message.
+ */
+export function useIsbnLookup() {
+  const lookup = useCallback(async (code: string): Promise<IsbnLookupResult | null> => {
+    const res = await fetchWithTimeout(`/api/isbn/${encodeURIComponent(code)}`);
+    return res.ok ? await res.json() : null;
+  }, []);
+
+  return { lookup };
+}

--- a/src/hooks/useVintedResolveSellers.ts
+++ b/src/hooks/useVintedResolveSellers.ts
@@ -1,11 +1,11 @@
 import { useState, useCallback, useRef } from "react";
-import { consumeSSE } from "../utils/sse";
-import { createStallWatchdog } from "../utils/stallWatchdog";
+import { useSSEStream } from "./useSSEStream";
 
 /**
  * Stage 2: incrementally fetching sellers for STORED offers (Notion), resumable
- * between runs. Doesn't depend on the current scan — works off the database. SSE pattern
- * like in useVintedCheck (120 s watchdog). Returns progress and a summary (resolved/remaining).
+ * between runs. Doesn't depend on the current scan — works off the database.
+ * Builds on the shared `useSSEStream` transport (120 s watchdog like the Vinted
+ * scan); this hook only routes events to its own progress/result state.
  */
 export function useVintedResolveSellers() {
   const [isResolving, setIsResolving] = useState(false);
@@ -13,6 +13,8 @@ export function useVintedResolveSellers() {
   const [resolveResult, setResolveResult] = useState<{ resolved: number; remaining: number; message: string } | null>(null);
   const [resolveError, setResolveError] = useState<string | null>(null);
   const runningRef = useRef(false);
+
+  const { run } = useSSEStream("/api/vinted-resolve-sellers", { timeoutMs: 120000 });
 
   const runResolve = useCallback(async () => {
     if (runningRef.current) return;
@@ -22,49 +24,29 @@ export function useVintedResolveSellers() {
     setResolveResult(null);
     setResolveError(null);
 
-    const watchdog = createStallWatchdog(120000);
-    try {
-      watchdog.arm();
-      const response = await fetch("/api/vinted-resolve-sellers", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        signal: watchdog.signal,
-      });
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Błąd serwera: ${response.status}`);
+    const result = await run({}, (data) => {
+      if (data.type === "progress" || data.type === "status") {
+        setResolveProgress(prev => ({
+          current: data.current ?? prev?.current ?? 0,
+          total: data.total ?? prev?.total ?? 0,
+          message: data.message ?? "",
+        }));
+      } else if (data.type === "complete") {
+        setResolveResult({
+          resolved: data.result?.resolved ?? 0,
+          remaining: data.result?.remaining ?? 0,
+          message: data.result?.message ?? "",
+        });
+      } else if (data.type === "error") {
+        throw new Error(data.error);
       }
+    });
 
-      await consumeSSE(response.body, (data) => {
-        if (data.type === "progress" || data.type === "status") {
-          setResolveProgress(prev => ({
-            current: data.current ?? prev?.current ?? 0,
-            total: data.total ?? prev?.total ?? 0,
-            message: data.message ?? "",
-          }));
-        } else if (data.type === "complete") {
-          setResolveResult({
-            resolved: data.result?.resolved ?? 0,
-            remaining: data.result?.remaining ?? 0,
-            message: data.result?.message ?? "",
-          });
-        } else if (data.type === "error") {
-          throw new Error(data.error);
-        }
-      }, watchdog.arm);
-    } catch (err: any) {
-      setResolveError(
-        watchdog.stalled
-          ? "Połączenie z serwerem zawisło (brak odpowiedzi przez 120 s). Odśwież i spróbuj ponownie."
-          : err.message
-      );
-    } finally {
-      watchdog.clear();
-      runningRef.current = false;
-      setIsResolving(false);
-      setResolveProgress(null);
-    }
-  }, []);
+    if (!result.ok && result.error) setResolveError(result.error);
+    runningRef.current = false;
+    setIsResolving(false);
+    setResolveProgress(null);
+  }, [run]);
 
   const stopResolve = useCallback(async () => {
     try {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,14 @@
+/**
+ * `fetch` with a hard timeout — a barcode scan (and the fresh-index refetch it
+ * triggers) must never wedge the UI on a stalled connection. On timeout the
+ * request is aborted and the promise rejects (caller decides the fallback).
+ */
+export async function fetchWithTimeout(url: string, ms = 12000): Promise<Response> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, { signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Fixes #307

Przegląd architektury — **Tier 2** (jawne złamania reguł, izolowane fixy).

## 1. `useVintedResolveSellers` → `useSSEStream`
Hook re-implementował pętlę SSE (własny `createStallWatchdog` + fetch + `res.ok` + `consumeSSE` + skopiowany komunikat stall) — jedyne jawne złamanie reguły „transport SSE żyje raz w `useSSEStream`". Przepisany na `useSSEStream("/api/vinted-resolve-sellers", { timeoutMs: 120000 })` dokładnie jak `useVintedCheck`; zostało tylko routowanie eventów. Komunikat stall z wspólnego `defaultStallMessage`.

## 2. `SearchSection` — koniec inline I/O
Jedyny komponent robiący network I/O. Wyciągnięte:
- `src/utils/http.ts` — `fetchWithTimeout`
- `useBooks.refetchFresh()` — świeży indeks (bypass 5-min cache, hard timeout) należy teraz do hooka, który jest właścicielem `/api/books`
- `useIsbnLookup` — resolve ISBN→tytuł

`handleScanDetect` to teraz samo UI-wiring; komunikaty i fallback do indeksu in-memory zachowane.

## Test
`npm test` — **474 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_