### PR TITLE
refactor(stats): extract statsAggregator from StatsService god-method

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.4** — **[Tier 3] `StatsService.getStats` (~200-liniowa god-metoda) → czysty `statsAggregator.ts`.**
+  11 agregacji (author/awardBooks/ownedUnread/awardCoverage/allAwards/availability/publisher/series/cycle/
+  decade/yearly/library) wyciągnięte VERBATIM jako czyste `books[] → stat` (dołączają do istniejącego
+  `computeMarketStats`). `StatsService` to teraz fetch → filtr (award + niepusty plTitle) → delegacja →
+  złożenie (209→42 linie). Zero zmiany zachowania — test `statsService.test` (end-to-end przez getStats)
+  zielony bez zmian. Suite 474 zielone, lint czysty, build OK.
 - **1.67.3** — **[Tier 2] Frontend I/O we właściwej warstwie (reużycie prymitywów).** (1) `useVintedResolveSellers`
   re-implementował pętlę SSE (własny `createStallWatchdog`+fetch+`consumeSSE`+komunikat stall) — jedyne jawne
   złamanie reguły „transport SSE żyje raz w `useSSEStream`". Przepisany na `useSSEStream("/api/vinted-resolve-

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.3",
+  "version": "1.67.4",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.3",
+  "version": "1.67.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.3",
+      "version": "1.67.4",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.3",
+  "version": "1.67.4",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/statsAggregator.ts
+++ b/services/statsAggregator.ts
@@ -1,0 +1,170 @@
+import { NotionBook } from "../src/types";
+
+/**
+ * Pure stats aggregations: `books[] → stat`. Extracted from `StatsService.getStats`
+ * (which had ~10 aggregations inlined in one ~200-line method) so each is a small,
+ * testable function and the service is just fetch → filter → delegate → assemble.
+ * `computeMarketStats` (marketStats.ts) already followed this pattern; these join it.
+ *
+ * Input is the award-scoped, non-empty-Polish-title book set the service prepares.
+ * Logic here is verbatim — no behavior change.
+ */
+
+const isRead = (b: NotionBook) => (b.zrodlo || []).includes("Przeczytane");
+const isOwned = (b: NotionBook) => (b.zrodlo || []).includes("Posiadam");
+/** First 4-digit year of a (possibly multi-dated) field; missing → 9999 (sorts last). */
+const firstYearNum = (year?: string | null) => parseInt((year ?? "").toString().split(",")[0] || "9999");
+
+export function computeAuthorStats(books: NotionBook[]) {
+  const authorStats: Record<string, { read: number; total: number; books: any[] }> = {};
+  books.forEach((book) => {
+    if (!book.author) return;
+    const authors = book.author.split(",").map((a: string) => a.trim());
+    authors.forEach((author) => {
+      if (!authorStats[author]) authorStats[author] = { read: 0, total: 0, books: [] };
+      authorStats[author].total++;
+      const read = isRead(book);
+      if (read) authorStats[author].read++;
+      authorStats[author].books.push({ id: book.id, title: book.plTitle || book.origTitle, year: book.year, read });
+    });
+  });
+  Object.values(authorStats).forEach((stat) => {
+    stat.books.sort((a, b) => firstYearNum(a.year) - firstYearNum(b.year));
+  });
+  return Object.entries(authorStats)
+    .map(([name, stats]) => ({ name, ...stats }))
+    .sort((a, b) => b.read - a.read)
+    .slice(0, 15); // Top 15 authors
+}
+
+export function computeAwardBooksStats(books: NotionBook[]) {
+  return { read: books.filter(isRead).length, total: books.length };
+}
+
+export function computeOwnedUnread(books: NotionBook[]) {
+  return books
+    .filter((b) => (b.zrodlo || []).includes("Posiadam") && !(b.zrodlo || []).includes("Przeczytane"))
+    .map((b) => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year }))
+    .sort((a, b) => firstYearNum(a.year) - firstYearNum(b.year));
+}
+
+export function computeAwardCoverage(books: NotionBook[]) {
+  const awardCoverage: Record<string, { count: number; total: number }> = {};
+  books.forEach((book) => {
+    (book.awards || []).forEach((nagroda) => {
+      if (!awardCoverage[nagroda]) awardCoverage[nagroda] = { count: 0, total: books.length };
+      awardCoverage[nagroda].count++;
+    });
+  });
+  return Object.entries(awardCoverage)
+    .map(([name, stats]) => ({ name, ...stats }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function computeAllAwardsStats(books: NotionBook[]) {
+  const allAwardsBooks = books.filter((b) => (b.awards || []).includes("Wszystkie"));
+  return { read: allAwardsBooks.filter(isRead).length, total: allAwardsBooks.length };
+}
+
+/**
+ * Aggregate availability of UNREAD books — one "where to get it" counter combining
+ * ownership / libraries (branch tags) / Vinted (offers blob). Priority partition
+ * (owned > library > Vinted > no trace) — each book counted once.
+ */
+export function computeAvailabilityStats(books: NotionBook[], branchTags: Set<string>, hasVintedOffers: (raw?: string) => boolean) {
+  const availability = { owned: 0, library: 0, vinted: 0, none: 0 };
+  let totalUnread = 0;
+  books.forEach((book) => {
+    const zr = book.zrodlo || [];
+    if (zr.includes("Przeczytane")) return;
+    totalUnread++;
+    if (zr.includes("Posiadam")) availability.owned++;
+    else if (zr.some((z) => branchTags.has(z))) availability.library++;
+    else if (hasVintedOffers(book.vintedData)) availability.vinted++;
+    else availability.none++;
+  });
+  return { totalUnread, ...availability };
+}
+
+export function computePublisherStats(books: NotionBook[]) {
+  const publisherMap: Record<string, { count: number; read: number }> = {};
+  books.forEach((book) => {
+    const pub = (book.currentWydawnictwo || "").trim();
+    if (!pub) return;
+    if (!publisherMap[pub]) publisherMap[pub] = { count: 0, read: 0 };
+    publisherMap[pub].count++;
+    if (isRead(book)) publisherMap[pub].read++;
+  });
+  return Object.entries(publisherMap)
+    .map(([name, s]) => ({ name, ...s }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
+    .slice(0, 15);
+}
+
+export function computeSeriesStats(books: NotionBook[]) {
+  const seriesMap: Record<string, { count: number; owned: number; read: number }> = {};
+  books.forEach((book) => {
+    const ser = (book.currentSeria || "").trim();
+    if (!ser) return;
+    if (!seriesMap[ser]) seriesMap[ser] = { count: 0, owned: 0, read: 0 };
+    seriesMap[ser].count++;
+    if (isOwned(book)) seriesMap[ser].owned++;
+    if (isRead(book)) seriesMap[ser].read++;
+  });
+  return Object.entries(seriesMap)
+    .map(([name, s]) => ({ name, ...s }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
+    .slice(0, 15);
+}
+
+export function computeCycleStats(books: NotionBook[]) {
+  const cyclePart = books.filter((b) => b.currentCzesccyklu === true).length;
+  return { partOfCycle: cyclePart, standalone: books.length - cyclePart, total: books.length };
+}
+
+export function computeDecadeStats(books: NotionBook[]) {
+  const decadeMap: Record<number, { total: number; read: number; owned: number }> = {};
+  books.forEach((book) => {
+    const m = (book.year || "").toString().match(/\d{4}/);
+    if (!m) return;
+    const dec = Math.floor(parseInt(m[0], 10) / 10) * 10;
+    if (!decadeMap[dec]) decadeMap[dec] = { total: 0, read: 0, owned: 0 };
+    decadeMap[dec].total++;
+    if (isRead(book)) decadeMap[dec].read++;
+    if (isOwned(book)) decadeMap[dec].owned++;
+  });
+  return Object.entries(decadeMap)
+    .map(([decade, s]) => ({ decade: parseInt(decade, 10), ...s }))
+    .sort((a, b) => a.decade - b.decade);
+}
+
+export function computeYearlyStats(books: NotionBook[]) {
+  const yearlyStats: Record<string, { read: number; total: number; books: any[] }> = {};
+  books.forEach((book) => {
+    if (!book.year) return;
+    const years = book.year.toString().split(",").map((y) => y.trim()).filter(Boolean);
+    years.forEach((year) => {
+      if (!yearlyStats[year]) yearlyStats[year] = { read: 0, total: 0, books: [] };
+      yearlyStats[year].total++;
+      const read = isRead(book);
+      if (read) yearlyStats[year].read++;
+      yearlyStats[year].books.push({ id: book.id, title: book.plTitle || book.origTitle, author: book.author, read });
+    });
+  });
+  return Object.entries(yearlyStats)
+    .map(([year, stats]) => ({ year, ...stats }))
+    .sort((a, b) => parseInt(a.year) - parseInt(b.year));
+}
+
+export function computeLibraryStats(books: NotionBook[], branches: { sourceTag: string; name: string }[]) {
+  // Branches from config (`library.branches`) — adding a branch in Kalibracja immediately
+  // shows up. `id` = the branch's „Źródło" tag (matched by the marker).
+  return branches.map((branch) => ({
+    id: branch.sourceTag,
+    name: branch.name,
+    books: books
+      .filter((b) => (b.zrodlo || []).includes(branch.sourceTag))
+      .map((b) => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year, read: (b.zrodlo || []).includes("Przeczytane") }))
+      .sort((a, b) => firstYearNum(a.year) - firstYearNum(b.year)),
+  }));
+}

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -3,6 +3,11 @@ import { ConfigService } from "./configService";
 import { parseVintedData } from "./vintedStore";
 import { computeMarketStats } from "./marketStats";
 import { isAwardBook } from "./bookCategory";
+import {
+  computeAuthorStats, computeAwardBooksStats, computeOwnedUnread, computeAwardCoverage,
+  computeAllAwardsStats, computeAvailabilityStats, computePublisherStats, computeSeriesStats,
+  computeCycleStats, computeDecadeStats, computeYearlyStats, computeLibraryStats,
+} from "./statsAggregator";
 
 export class StatsService {
   constructor(private notion: NotionAdapter, private config: ConfigService) {}
@@ -14,195 +19,24 @@ export class StatsService {
     // Global filter: only AWARD entries (side cycle volumes have their own view
     // in „Archiwum Cykli") and with a non-empty Polish title.
     books = books.filter(b => isAwardBook(b) && b.plTitle && b.plTitle.trim() !== "");
-    
-    // 1. Author progress
-    const authorStats: Record<string, { read: number; total: number; books: any[] }> = {};
-    books.forEach(book => {
-      if (!book.author) return;
-      const authors = book.author.split(',').map((a: string) => a.trim());
-      authors.forEach(author => {
-        if (!authorStats[author]) authorStats[author] = { read: 0, total: 0, books: [] };
-        authorStats[author].total++;
-        const isRead = (book.zrodlo || []).includes("Przeczytane");
-        if (isRead) {
-          authorStats[author].read++;
-        }
-        authorStats[author].books.push({
-          id: book.id,
-          title: book.plTitle || book.origTitle,
-          year: book.year,
-          read: isRead
-        });
-      });
-    });
 
-    // Sort books for each author by year
-    Object.values(authorStats).forEach(stat => {
-      stat.books.sort((a, b) => {
-        const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
-        const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
-        return yearA - yearB;
-      });
-    });
-
-    // 2. Award books progress
-    const awardBooksRead = books.filter(b => (b.zrodlo || []).includes("Przeczytane")).length;
-    const awardBooksStats = { read: awardBooksRead, total: books.length };
-
-    // 3. Owned but unread
-    const ownedUnread = books
-      .filter(b => (b.zrodlo || []).includes("Posiadam") && !(b.zrodlo || []).includes("Przeczytane"))
-      .map(b => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year }));
-
-    // 4. Award coverage progress
-    const awardCoverage: Record<string, { count: number; total: number }> = {};
-    books.forEach(book => {
-      (book.awards || []).forEach(nagroda => {
-        if (!awardCoverage[nagroda]) awardCoverage[nagroda] = { count: 0, total: books.length };
-        awardCoverage[nagroda].count++;
-      });
-    });
-
-    // 5. "All" awards progress (Przeczytane for books with "Wszystkie" tag)
-    const allAwardsBooks = books.filter(b => (b.awards || []).includes("Wszystkie"));
-    const allAwardsRead = allAwardsBooks.filter(b => (b.zrodlo || []).includes("Przeczytane")).length;
-    const allAwardsStats = { read: allAwardsRead, total: allAwardsBooks.length };
-
-    // 5b. Aggregate availability of UNREAD books — one „skąd zdobyć" counter combining
-    // ownership / libraries (branch tags from config) / Vinted (offers blob). Priority
-    // partition (owned > library > Vinted > no trace) — each book counted once.
     const branchTags = new Set(branches.map(b => b.sourceTag));
     const hasVintedOffers = (raw?: string) => (parseVintedData(raw)?.offers.length ?? 0) > 0;
-    const availability = { owned: 0, library: 0, vinted: 0, none: 0 };
-    let totalUnread = 0;
-    books.forEach(book => {
-      const zr = book.zrodlo || [];
-      if (zr.includes("Przeczytane")) return;
-      totalUnread++;
-      if (zr.includes("Posiadam")) availability.owned++;
-      else if (zr.some(z => branchTags.has(z))) availability.library++;
-      else if (hasVintedOffers(book.vintedData)) availability.vinted++;
-      else availability.none++;
-    });
-    const availabilityStats = { totalUnread, ...availability };
-
-    // 5c. Wydawnictwa / Serie / Cykle — data from the publisher/series/cycles rituals, until now
-    // untouched by stats. All are counted per book with a non-empty field.
-    const isReadBook = (b: typeof books[number]) => (b.zrodlo || []).includes("Przeczytane");
-    const isOwnedBook = (b: typeof books[number]) => (b.zrodlo || []).includes("Posiadam");
-
-    // Top publishers: number of titles + how many read.
-    const publisherMap: Record<string, { count: number; read: number }> = {};
-    books.forEach(book => {
-      const pub = (book.currentWydawnictwo || "").trim();
-      if (!pub) return;
-      if (!publisherMap[pub]) publisherMap[pub] = { count: 0, read: 0 };
-      publisherMap[pub].count++;
-      if (isReadBook(book)) publisherMap[pub].read++;
-    });
-    const publisherStats = Object.entries(publisherMap)
-      .map(([name, s]) => ({ name, ...s }))
-      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
-      .slice(0, 15);
-
-    // Series: how many titles in the series, how many you own (gaps = count − owned).
-    const seriesMap: Record<string, { count: number; owned: number; read: number }> = {};
-    books.forEach(book => {
-      const ser = (book.currentSeria || "").trim();
-      if (!ser) return;
-      if (!seriesMap[ser]) seriesMap[ser] = { count: 0, owned: 0, read: 0 };
-      seriesMap[ser].count++;
-      if (isOwnedBook(book)) seriesMap[ser].owned++;
-      if (isReadBook(book)) seriesMap[ser].read++;
-    });
-    const seriesStats = Object.entries(seriesMap)
-      .map(([name, s]) => ({ name, ...s }))
-      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "pl"))
-      .slice(0, 15);
-
-    // Cycles: share of books that are part of a cycle (currentCzesccyklu) in the collection.
-    const cyclePart = books.filter(b => b.currentCzesccyklu === true).length;
-    const cycleStats = { partOfCycle: cyclePart, standalone: books.length - cyclePart, total: books.length };
-
-    // 5d. Decade distribution — rollup of years into decades (the app already thinks in decades via
-    // the shelf). First 4-digit year from the field; multi-dated → first year. Missing year skipped.
-    const decadeMap: Record<number, { total: number; read: number; owned: number }> = {};
-    books.forEach(book => {
-      const m = (book.year || "").toString().match(/\d{4}/);
-      if (!m) return;
-      const dec = Math.floor(parseInt(m[0], 10) / 10) * 10;
-      if (!decadeMap[dec]) decadeMap[dec] = { total: 0, read: 0, owned: 0 };
-      decadeMap[dec].total++;
-      if (isReadBook(book)) decadeMap[dec].read++;
-      if (isOwnedBook(book)) decadeMap[dec].owned++;
-    });
-    const decadeStats = Object.entries(decadeMap)
-      .map(([decade, s]) => ({ decade: parseInt(decade, 10), ...s }))
-      .sort((a, b) => a.decade - b.decade);
-
-    // 5e. Market — stats from the VintedData blob (completion cost, deals, drops, sellers).
-    const marketStats = computeMarketStats(books);
-
-    // 6. Yearly progress
-    const yearlyStats: Record<string, { read: number; total: number; books: any[] }> = {};
-    books.forEach(book => {
-      if (!book.year) return;
-      const years = book.year.toString().split(',').map(y => y.trim()).filter(Boolean);
-      years.forEach(year => {
-        if (!yearlyStats[year]) yearlyStats[year] = { read: 0, total: 0, books: [] };
-        yearlyStats[year].total++;
-        const isRead = (book.zrodlo || []).includes("Przeczytane");
-        if (isRead) {
-          yearlyStats[year].read++;
-        }
-        yearlyStats[year].books.push({
-          id: book.id,
-          title: book.plTitle || book.origTitle,
-          author: book.author,
-          read: isRead
-        });
-      });
-    });
 
     return {
-      authorStats: Object.entries(authorStats)
-        .map(([name, stats]) => ({ name, ...stats }))
-        .sort((a, b) => b.read - a.read)
-        .slice(0, 15), // Top 15 authors
-      awardBooksStats,
-      ownedUnread: ownedUnread
-        .sort((a, b) => {
-          const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
-          const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
-          return yearA - yearB;
-        }),
-      awardCoverage: Object.entries(awardCoverage)
-        .map(([name, stats]) => ({ name, ...stats }))
-        .sort((a, b) => b.count - a.count),
-      allAwardsStats,
-      yearlyStats: Object.entries(yearlyStats)
-        .map(([year, stats]) => ({ year, ...stats }))
-        .sort((a, b) => parseInt(a.year) - parseInt(b.year)),
-      availabilityStats,
-      publisherStats,
-      seriesStats,
-      cycleStats,
-      decadeStats,
-      marketStats,
-      // Branches from config (`library.branches`) — adding a 3rd branch in Kalibracja immediately
-      // shows up in stats. `id` = the branch's „Źródło" tag (matched by the marker).
-      libraryStats: branches.map(branch => ({
-        id: branch.sourceTag,
-        name: branch.name,
-        books: books
-          .filter(b => (b.zrodlo || []).includes(branch.sourceTag))
-          .map(b => ({ id: b.id, title: b.plTitle || b.origTitle, author: b.author, year: b.year, read: (b.zrodlo || []).includes("Przeczytane") }))
-          .sort((a, b) => {
-            const yearA = parseInt(a.year?.toString().split(',')[0] || "9999");
-            const yearB = parseInt(b.year?.toString().split(',')[0] || "9999");
-            return yearA - yearB;
-          })
-      }))
+      authorStats: computeAuthorStats(books),
+      awardBooksStats: computeAwardBooksStats(books),
+      ownedUnread: computeOwnedUnread(books),
+      awardCoverage: computeAwardCoverage(books),
+      allAwardsStats: computeAllAwardsStats(books),
+      yearlyStats: computeYearlyStats(books),
+      availabilityStats: computeAvailabilityStats(books, branchTags, hasVintedOffers),
+      publisherStats: computePublisherStats(books),
+      seriesStats: computeSeriesStats(books),
+      cycleStats: computeCycleStats(books),
+      decadeStats: computeDecadeStats(books),
+      marketStats: computeMarketStats(books),
+      libraryStats: computeLibraryStats(books, branches),
     };
   }
 }


### PR DESCRIPTION
Fixes #309

Przegląd architektury — **Tier 3**.

`StatsService.getStats` był ~200-liniową metodą liczącą ~11 niezwiązanych agregacji inline (author, award books, owned-unread, coverage, all-awards, availability, publisher, series, cycle, decade, yearly, library) — tylko `computeMarketStats` był wcześniej wyciągnięty.

Wszystkie 11 przeniesione **verbatim** do czystego `services/statsAggregator.ts` (`books[] → stat`). `StatsService` to teraz fetch → filtr (award + niepusty `plTitle`) → delegacja → złożenie (**209 → 42 linie**).

Zero zmiany zachowania — istniejący `statsService.test` (end-to-end przez `getStats`) zielony bez zmian.

## Test
`npm test` — **474 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_