### PR TITLE
refactor(integrity): shared IntegrityCheckResult→display selector

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.4** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.5** — **[Tier 3, A4] Wspólny selektor `IntegrityCheckResult`→display (`src/utils/integrityDiff.ts`).**
+  Derywacja diffów była zduplikowana w `IntegrityCheckCard` i `SanctityDebugger` (oba czytają ten sam
+  `result`). Wyciągnięte VERBATIM: `hasInconsistencies`, `toDiffPanels` (strukturalne panele dla debuggera),
+  `yearDiffLines`/`awardDiffLines` (spłaszczone linie dla karty). Oba komponenty konsumują util. Zero zmiany
+  zachowania. Suite 474 zielone, lint czysty, build OK.
 - **1.67.4** — **[Tier 3] `StatsService.getStats` (~200-liniowa god-metoda) → czysty `statsAggregator.ts`.**
   11 agregacji (author/awardBooks/ownedUnread/awardCoverage/allAwards/availability/publisher/series/cycle/
   decade/yearly/library) wyciągnięte VERBATIM jako czyste `books[] → stat` (dołączają do istniejącego

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.4",
+  "version": "1.67.5",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.4",
+  "version": "1.67.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.4",
+      "version": "1.67.5",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.4",
+  "version": "1.67.5",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/IntegrityCheckCard.tsx
+++ b/src/components/IntegrityCheckCard.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import { ShieldAlert, CheckCircle, AlertTriangle, Loader2, Activity, ChevronDown, ChevronUp } from "lucide-react";
 import { useSync } from "../hooks/useSync";
 import { IntegrityCheckResult } from "../types";
+import { yearDiffLines, awardDiffLines } from "../utils/integrityDiff";
 
 interface IntegrityCheckCardProps {
   integritySync: ReturnType<typeof useSync>;
@@ -49,24 +50,13 @@ export const IntegrityCheckCard: React.FC<IntegrityCheckCardProps> = ({
     { id: "lp", label: "Unikalność Lp", status: result?.lpUniqueness.status ?? true, details: result?.lpUniqueness.duplicates || [] },
     { id: "origTitle", label: "Tytuły Oryginalne", status: result?.originalTitleUniqueness.status ?? true, details: result?.originalTitleUniqueness.duplicates || [] },
     { id: "plTitle", label: "Tytuły Polskie", status: result?.polishTitleUniqueness.status ?? true, details: result?.polishTitleUniqueness.duplicates || [] },
-    { 
-      id: "years", 
-      label: "Roczniki (Notion/Wiki)", 
-      status: result?.yearCountMatch.status ?? true, 
-      details: result?.yearCountMatch.diffs.flatMap(d => {
-        const lines = [`Rok ${d.year}: Notion(${d.notion}) vs Wiki(${d.wiki})`];
-        if (d.notionOnly && d.notionOnly.length > 0) {
-          lines.push(`  [TYLKO NOTION]:`);
-          d.notionOnly.forEach(b => lines.push(`    • ${b}`));
-        }
-        if (d.wikiOnly && d.wikiOnly.length > 0) {
-          lines.push(`  [TYLKO WIKI]:`);
-          d.wikiOnly.forEach(b => lines.push(`    • ${b}`));
-        }
-        return lines;
-      }) || [] 
+    {
+      id: "years",
+      label: "Roczniki (Notion/Wiki)",
+      status: result?.yearCountMatch.status ?? true,
+      details: result ? yearDiffLines(result.yearCountMatch.diffs) : [],
     },
-    { id: "awards", label: "Nagrody (Notion/Wiki)", status: result?.awardCountMatch.status ?? true, details: result?.awardCountMatch.diffs.map(d => `${d.award}: Notion(${d.notion}) vs Wiki(${d.wiki})`) || [] }
+    { id: "awards", label: "Nagrody (Notion/Wiki)", status: result?.awardCountMatch.status ?? true, details: result ? awardDiffLines(result.awardCountMatch.diffs) : [] }
   ];
 
   return (

--- a/src/components/SanctityDebugger.tsx
+++ b/src/components/SanctityDebugger.tsx
@@ -2,62 +2,19 @@ import React from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Bug, ChevronRight, AlertCircle, Database, Globe } from "lucide-react";
 import { IntegrityCheckResult } from "../types";
+import { hasInconsistencies, toDiffPanels } from "../utils/integrityDiff";
 
 interface SanctityDebuggerProps {
   result: IntegrityCheckResult | null;
-}
-
-interface DiffEntry {
-  title: string;
-  notion: number;
-  wiki: number;
-  notionOnly?: string[];
-  wikiOnly?: string[];
-  misplaced?: { title: string; otherYear: string }[];
-  collisions?: { title: string; matches: string[] }[];
 }
 
 export const SanctityDebugger: React.FC<SanctityDebuggerProps> = ({ result }) => {
   const [selectedDiff, setSelectedDiff] = React.useState<string | null>(null);
 
   if (!result) return null;
+  if (!hasInconsistencies(result)) return null;
 
-  const hasHeresy = !result.lpUniqueness.status || 
-                    !result.yearCountMatch.status || 
-                    !result.originalTitleUniqueness.status || 
-                    !result.polishTitleUniqueness.status || 
-                    !result.awardCountMatch.status;
-
-  if (!hasHeresy) return null;
-
-  const diffItems: { id: string; label: string; status: boolean; data: DiffEntry[] }[] = [
-    {
-      id: "years",
-      label: "Rozbieżności Roczników",
-      status: result.yearCountMatch.status,
-      data: result.yearCountMatch.diffs.map(d => ({
-        title: `Rok ${d.year}`,
-        notion: d.notion,
-        wiki: d.wiki,
-        notionOnly: d.notionOnly,
-        wikiOnly: d.wikiOnly,
-        misplaced: d.misplaced,
-        collisions: d.collisions
-      }))
-    },
-    {
-      id: "awards",
-      label: "Rozbieżności Nagród",
-      status: result.awardCountMatch.status,
-      data: result.awardCountMatch.diffs.map(d => ({
-        title: d.award,
-        notion: d.notion,
-        wiki: d.wiki,
-        notionOnly: d.notionOnly,
-        wikiOnly: d.wikiOnly
-      }))
-    }
-  ].filter(item => !item.status);
+  const diffItems = toDiffPanels(result);
 
   return (
     <div className="bg-slate-900/60 border border-amber-500/20 rounded-2xl p-6 backdrop-blur-md shadow-2xl shadow-amber-900/10">

--- a/src/utils/integrityDiff.ts
+++ b/src/utils/integrityDiff.ts
@@ -1,0 +1,85 @@
+import { IntegrityCheckResult } from "../types";
+
+/**
+ * Selectors that derive display data from an `IntegrityCheckResult`. Previously
+ * this derivation was duplicated in `IntegrityCheckCard` and `SanctityDebugger`,
+ * both reading the same `result` off `integritySync.state`. Logic is verbatim.
+ */
+
+type YearDiffs = IntegrityCheckResult["yearCountMatch"]["diffs"];
+type AwardDiffs = IntegrityCheckResult["awardCountMatch"]["diffs"];
+
+/** Any check failed → there are inconsistencies to show. */
+export function hasInconsistencies(result: IntegrityCheckResult): boolean {
+  return (
+    !result.lpUniqueness.status ||
+    !result.yearCountMatch.status ||
+    !result.originalTitleUniqueness.status ||
+    !result.polishTitleUniqueness.status ||
+    !result.awardCountMatch.status
+  );
+}
+
+/** Structured diff entry for the SanctityDebugger panels. */
+export interface DiffEntry {
+  title: string;
+  notion: number;
+  wiki: number;
+  notionOnly?: string[];
+  wikiOnly?: string[];
+  misplaced?: { title: string; otherYear: string }[];
+  collisions?: { title: string; matches: string[] }[];
+}
+
+/** The two failing-only diff panels (years / awards) for the debugger view. */
+export function toDiffPanels(result: IntegrityCheckResult): { id: string; label: string; status: boolean; data: DiffEntry[] }[] {
+  return [
+    {
+      id: "years",
+      label: "Rozbieżności Roczników",
+      status: result.yearCountMatch.status,
+      data: result.yearCountMatch.diffs.map((d) => ({
+        title: `Rok ${d.year}`,
+        notion: d.notion,
+        wiki: d.wiki,
+        notionOnly: d.notionOnly,
+        wikiOnly: d.wikiOnly,
+        misplaced: d.misplaced,
+        collisions: d.collisions,
+      })),
+    },
+    {
+      id: "awards",
+      label: "Rozbieżności Nagród",
+      status: result.awardCountMatch.status,
+      data: result.awardCountMatch.diffs.map((d) => ({
+        title: d.award,
+        notion: d.notion,
+        wiki: d.wiki,
+        notionOnly: d.notionOnly,
+        wikiOnly: d.wikiOnly,
+      })),
+    },
+  ].filter((item) => !item.status);
+}
+
+/** Flattened year-diff detail lines (with [TYLKO NOTION]/[TYLKO WIKI] bullets) for the check card. */
+export function yearDiffLines(diffs: YearDiffs): string[] {
+  return diffs.flatMap((d) => {
+    const lines = [`Rok ${d.year}: Notion(${d.notion}) vs Wiki(${d.wiki})`];
+    if (d.notionOnly && d.notionOnly.length > 0) {
+      lines.push(`  [TYLKO NOTION]:`);
+      d.notionOnly.forEach((b) => lines.push(`    • ${b}`));
+    }
+    if (d.wikiOnly && d.wikiOnly.length > 0) {
+      lines.push(`  [TYLKO WIKI]:`);
+      d.wikiOnly.forEach((b) => lines.push(`    • ${b}`));
+    }
+    return lines;
+  });
+}
+
+/** One line per award-count diff for the check card. */
+export function awardDiffLines(diffs: AwardDiffs): string[] {
+  return diffs.map((d) => `${d.award}: Notion(${d.notion}) vs Wiki(${d.wiki})`);
+}


### PR DESCRIPTION
Przegląd architektury — **Tier 3 (A4)**.

Ten sam `IntegrityCheckResult` był mapowany na dane wyświetlane w dwóch miejscach: `IntegrityCheckCard` (spłaszczone linie) i `SanctityDebugger` (strukturalne panele) — oba z `integritySync.state.result`. Derywacja wyciągnięta VERBATIM do `src/utils/integrityDiff.ts`:
- `hasInconsistencies(result)`
- `toDiffPanels(result)` — strukturalne panele (debugger)
- `yearDiffLines` / `awardDiffLines(diffs)` — spłaszczone linie (karta)

Oba komponenty konsumują util. Zero zmiany zachowania. `npm test` — **474 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_