### PR TITLE
refactor(stats): extract the 6 inline StatsSection cards into components

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.5** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.6** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.6** — **[Tier 3, A2a] Ekstrakcja 6 inline kart `StatsSection` do komponentów `stats/`.** Karty
+  authors/awards/yearly/ownedUnread/library/identified były pisane ręcznie inline (powielony nagłówek), gdy
+  reszta to komponenty. Wyciągnięte VERBATIM: `AuthorsCard`, `AwardsProgressCard`, `YearlyCard`,
+  `OwnedUnreadCard`, `LibraryProgressCard`, `IdentifiedLibraryCard` (typy propsów przez `React.ComponentProps`
+  z item-komponentów → bezpieczne). `StatsSection` 372→244 linie; wszystkie karty jednorodne. Zero zmiany
+  zachowania. Suite 474 zielone, lint czysty, build OK. (A2b — wyniesienie masonry+DnD do hooka — osobno.)
 - **1.67.5** — **[Tier 3, A4] Wspólny selektor `IntegrityCheckResult`→display (`src/utils/integrityDiff.ts`).**
   Derywacja diffów była zduplikowana w `IntegrityCheckCard` i `SanctityDebugger` (oba czytają ten sam
   `result`). Wyciągnięte VERBATIM: `hasInconsistencies`, `toDiffPanels` (strukturalne panele dla debuggera),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.5",
+  "version": "1.67.6",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.5",
+  "version": "1.67.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.5",
+      "version": "1.67.6",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.5",
+  "version": "1.67.6",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,22 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { motion } from "motion/react";
-import { Book, BarChart3, Award, User, Calendar, Package, RefreshCw, Library, Search, GripVertical, LayoutGrid, RotateCcw, Check } from "lucide-react";
+import { BarChart3, RefreshCw, GripVertical, LayoutGrid, RotateCcw, Check } from "lucide-react";
 import { useStats } from "../hooks/useStats";
 import { useLibraryCheck } from "../hooks/useLibraryCheck";
 import { useMarkAsRead } from "../hooks/useMarkAsRead";
-import { ProgressBar } from "./stats/ProgressBar";
-import { YearlyProgressItem } from "./stats/YearlyProgressItem";
-import { LibraryProgressItem } from "./stats/LibraryProgressItem";
-import { AuthorProgressItem } from "./stats/AuthorProgressItem";
-import { IdentifiedLibraryItem } from "./stats/IdentifiedLibraryItem";
-import { OwnedUnreadItem } from "./stats/OwnedUnreadItem";
-import { AwardCoverageGrid } from "./stats/AwardCoverageGrid";
 import { AvailabilityCard } from "./stats/AvailabilityCard";
 import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
 import { MarketCard } from "./stats/MarketCard";
 import { CyclesHarvestCard } from "./stats/CyclesHarvestCard";
 import { KpiRow } from "./stats/KpiRow";
+import { AuthorsCard } from "./stats/AuthorsCard";
+import { AwardsProgressCard } from "./stats/AwardsProgressCard";
+import { YearlyCard } from "./stats/YearlyCard";
+import { OwnedUnreadCard } from "./stats/OwnedUnreadCard";
+import { LibraryProgressCard } from "./stats/LibraryProgressCard";
+import { IdentifiedLibraryCard } from "./stats/IdentifiedLibraryCard";
 import { useEffectiveConfig, persistStatsOrder } from "../hooks/useAppConfig";
 import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
 
@@ -90,143 +89,17 @@ export const StatsSection: React.FC = () => {
   // Card definitions in code order (= default). Each has a stable `id`, by which
   // we remember the user's layout (ui.statsOrder). Reordering doesn't change card content.
   const cards: StatCard[] = [
-    {
-      id: "authors",
-      node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6">
-          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-cyan-500 flex items-center gap-2 mb-4">
-            <User className="w-4 h-4" />
-            Indeks Autorów
-          </h3>
-          <div className="space-y-4 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.authorStats.map((author) => (
-              <AuthorProgressItem key={author.name} author={author} />
-            ))}
-          </div>
-        </motion.div>
-      ),
-    },
-    {
-      id: "awards",
-      node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6">
-          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-purple-500 flex items-center gap-2 mb-4">
-            <Award className="w-4 h-4" />
-            Postęp kolekcji
-          </h3>
-          <div className="space-y-6">
-            <ProgressBar current={stats.awardBooksStats.read} total={stats.awardBooksStats.total} label="Polskie wydania z listy nagród" icon={Book} color="purple" />
-            <ProgressBar current={stats.allAwardsStats.read} total={stats.allAwardsStats.total} label="Książki mające Wszystkie Nagrody" icon={Award} color="emerald" />
-            <AwardCoverageGrid coverage={stats.awardCoverage} />
-          </div>
-        </motion.div>
-      ),
-    },
+    { id: "authors", node: <AuthorsCard authors={stats.authorStats} /> },
+    { id: "awards", node: <AwardsProgressCard awardBooks={stats.awardBooksStats} allAwards={stats.allAwardsStats} coverage={stats.awardCoverage} /> },
     { id: "availability", node: <AvailabilityCard stats={stats.availabilityStats} /> },
     { id: "market", node: <MarketCard market={stats.marketStats} /> },
     { id: "publishing", node: <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} /> },
     { id: "cyclesHarvest", node: <CyclesHarvestCard refreshSignal={refreshTick} /> },
     { id: "decades", span2: true, node: <DecadeHistogram decades={stats.decadeStats} /> },
-    {
-      id: "yearly",
-      node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6">
-          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-orange-500 flex items-center gap-2 mb-4">
-            <Calendar className="w-4 h-4" />
-            Chronologia Przeczytanych
-          </h3>
-          <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.yearlyStats.map((year) => (
-              <YearlyProgressItem key={year.year} year={year} />
-            ))}
-          </div>
-        </motion.div>
-      ),
-    },
-    {
-      id: "ownedUnread",
-      node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }} className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6">
-          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-emerald-500 flex items-center gap-2 mb-4">
-            <Package className="w-4 h-4" />
-            Zasoby Oczekujące (Posiadane)
-          </h3>
-          <div className="space-y-3 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.ownedUnread.length === 0 ? (
-              <p className="text-slate-400 text-sm italic text-center py-8">Wszystkie posiadane zasoby zostały przyswojone.</p>
-            ) : (
-              stats.ownedUnread.map((book, idx) => (
-                <OwnedUnreadItem key={idx} book={book} marking={markingId === book.id} disabled={markingId !== null} onMarkAsRead={markAsRead} />
-              ))
-            )}
-          </div>
-        </motion.div>
-      ),
-    },
-    {
-      id: "library",
-      node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6">
-          <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-500 flex items-center gap-2 mb-4">
-            <Library className="w-4 h-4" />
-            Książki dostępne w bibliotekach
-          </h3>
-          <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
-            {stats.libraryStats.map((library) => (
-              <LibraryProgressItem key={library.id} library={library} onMarkAsRead={markAsRead} markingId={markingId} />
-            ))}
-          </div>
-        </motion.div>
-      ),
-    },
-    {
-      id: "identified",
-      node: (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-400 flex items-center gap-2">
-              <Search className="w-4 h-4" />
-              Zidentyfikowane w bibliotekach
-            </h3>
-            <button
-              onClick={() => checkAllLibraries(branches)}
-              disabled={checkingLibrary !== null}
-              className="px-4 py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-xl border border-blue-500/30 text-xs font-bold uppercase tracking-widest transition-all disabled:opacity-50 flex items-center gap-2"
-            >
-              {checkingLibrary ? (
-                <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 1, ease: "linear" }}>
-                  <RefreshCw className="w-3 h-3" />
-                </motion.div>
-              ) : (
-                <Search className="w-3 h-3" />
-              )}
-              Skanuj Wszystkie
-            </button>
-          </div>
-          {libraryError && (
-            <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-xs text-red-400 font-bold mb-4">
-              Błąd skanowania: {libraryError}
-            </div>
-          )}
-          <div className="space-y-6 max-h-[500px] overflow-y-auto pr-2 custom-scrollbar">
-            {branches.map((library) => (
-              <IdentifiedLibraryItem
-                key={library.id}
-                library={library}
-                books={identifiedBooks[library.id] || []}
-                onCheck={() => checkLibrary(library.id, library.code)}
-                onStop={stopLibraryCheck}
-                onMarkAsRead={markAsRead}
-                markingId={markingId}
-                markedIds={markedIds}
-                isChecking={checkingLibrary === library.id}
-                progress={checkingLibrary === library.id ? checkProgress : null}
-              />
-            ))}
-          </div>
-        </motion.div>
-      ),
-    },
+    { id: "yearly", node: <YearlyCard years={stats.yearlyStats} /> },
+    { id: "ownedUnread", node: <OwnedUnreadCard books={stats.ownedUnread} markingId={markingId} onMarkAsRead={markAsRead} /> },
+    { id: "library", node: <LibraryProgressCard libraries={stats.libraryStats} onMarkAsRead={markAsRead} markingId={markingId} /> },
+    { id: "identified", node: <IdentifiedLibraryCard branches={branches} identifiedBooks={identifiedBooks} onCheck={checkLibrary} onCheckAll={() => checkAllLibraries(branches)} onStop={stopLibraryCheck} checkingLibrary={checkingLibrary} checkProgress={checkProgress} libraryError={libraryError} onMarkAsRead={markAsRead} markingId={markingId} markedIds={markedIds} /> },
   ];
 
   // Effective order (user's save + new cards at the end) and lookup by id.

--- a/src/components/stats/AuthorsCard.tsx
+++ b/src/components/stats/AuthorsCard.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { motion } from "motion/react";
+import { User } from "lucide-react";
+import { AuthorStat } from "../../hooks/useStats";
+import { AuthorProgressItem } from "./AuthorProgressItem";
+
+export const AuthorsCard: React.FC<{ authors: AuthorStat[] }> = ({ authors }) => (
+  <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card p-6 rounded-3xl border-cyan-500/10 space-y-6">
+    <h3 className="text-sm font-bold font-display uppercase tracking-widest text-cyan-500 flex items-center gap-2 mb-4">
+      <User className="w-4 h-4" />
+      Indeks Autorów
+    </h3>
+    <div className="space-y-4 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
+      {authors.map((author) => (
+        <AuthorProgressItem key={author.name} author={author} />
+      ))}
+    </div>
+  </motion.div>
+);

--- a/src/components/stats/AwardsProgressCard.tsx
+++ b/src/components/stats/AwardsProgressCard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Award, Book } from "lucide-react";
+import { AwardCoverageStat } from "../../hooks/useStats";
+import { ProgressBar } from "./ProgressBar";
+import { AwardCoverageGrid } from "./AwardCoverageGrid";
+
+interface Props {
+  awardBooks: { read: number; total: number };
+  allAwards: { read: number; total: number };
+  coverage: AwardCoverageStat[];
+}
+
+export const AwardsProgressCard: React.FC<Props> = ({ awardBooks, allAwards, coverage }) => (
+  <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="glass-card p-6 rounded-3xl border-purple-500/10 space-y-6">
+    <h3 className="text-sm font-bold font-display uppercase tracking-widest text-purple-500 flex items-center gap-2 mb-4">
+      <Award className="w-4 h-4" />
+      Postęp kolekcji
+    </h3>
+    <div className="space-y-6">
+      <ProgressBar current={awardBooks.read} total={awardBooks.total} label="Polskie wydania z listy nagród" icon={Book} color="purple" />
+      <ProgressBar current={allAwards.read} total={allAwards.total} label="Książki mające Wszystkie Nagrody" icon={Award} color="emerald" />
+      <AwardCoverageGrid coverage={coverage} />
+    </div>
+  </motion.div>
+);

--- a/src/components/stats/IdentifiedLibraryCard.tsx
+++ b/src/components/stats/IdentifiedLibraryCard.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Search, RefreshCw } from "lucide-react";
+import { IdentifiedBooks } from "../../hooks/useStats";
+import { IdentifiedLibraryItem } from "./IdentifiedLibraryItem";
+
+type Branch = React.ComponentProps<typeof IdentifiedLibraryItem>["library"];
+type Progress = React.ComponentProps<typeof IdentifiedLibraryItem>["progress"];
+type OnMark = React.ComponentProps<typeof IdentifiedLibraryItem>["onMarkAsRead"];
+type MarkedIds = React.ComponentProps<typeof IdentifiedLibraryItem>["markedIds"];
+
+interface Props {
+  branches: Branch[];
+  identifiedBooks: IdentifiedBooks;
+  onCheck: (id: string, code: string) => void;
+  onCheckAll: () => void;
+  onStop: () => void;
+  checkingLibrary: string | null;
+  checkProgress: Progress;
+  libraryError: string | null;
+  onMarkAsRead: OnMark;
+  markingId: string | null;
+  markedIds: MarkedIds;
+}
+
+export const IdentifiedLibraryCard: React.FC<Props> = ({
+  branches, identifiedBooks, onCheck, onCheckAll, onStop, checkingLibrary, checkProgress, libraryError, onMarkAsRead, markingId, markedIds,
+}) => (
+  <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6">
+    <div className="flex items-center justify-between mb-4">
+      <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-400 flex items-center gap-2">
+        <Search className="w-4 h-4" />
+        Zidentyfikowane w bibliotekach
+      </h3>
+      <button
+        onClick={onCheckAll}
+        disabled={checkingLibrary !== null}
+        className="px-4 py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-xl border border-blue-500/30 text-xs font-bold uppercase tracking-widest transition-all disabled:opacity-50 flex items-center gap-2"
+      >
+        {checkingLibrary ? (
+          <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 1, ease: "linear" }}>
+            <RefreshCw className="w-3 h-3" />
+          </motion.div>
+        ) : (
+          <Search className="w-3 h-3" />
+        )}
+        Skanuj Wszystkie
+      </button>
+    </div>
+    {libraryError && (
+      <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-xs text-red-400 font-bold mb-4">
+        Błąd skanowania: {libraryError}
+      </div>
+    )}
+    <div className="space-y-6 max-h-[500px] overflow-y-auto pr-2 custom-scrollbar">
+      {branches.map((library) => (
+        <IdentifiedLibraryItem
+          key={library.id}
+          library={library}
+          books={identifiedBooks[library.id] || []}
+          onCheck={() => onCheck(library.id, library.code)}
+          onStop={onStop}
+          onMarkAsRead={onMarkAsRead}
+          markingId={markingId}
+          markedIds={markedIds}
+          isChecking={checkingLibrary === library.id}
+          progress={checkingLibrary === library.id ? checkProgress : null}
+        />
+      ))}
+    </div>
+  </motion.div>
+);

--- a/src/components/stats/LibraryProgressCard.tsx
+++ b/src/components/stats/LibraryProgressCard.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Library } from "lucide-react";
+import { LibraryProgressItem } from "./LibraryProgressItem";
+
+type Lib = React.ComponentProps<typeof LibraryProgressItem>["library"];
+type OnMark = React.ComponentProps<typeof LibraryProgressItem>["onMarkAsRead"];
+
+export const LibraryProgressCard: React.FC<{ libraries: Lib[]; onMarkAsRead: OnMark; markingId: string | null }> = ({ libraries, onMarkAsRead, markingId }) => (
+  <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }} className="glass-card p-6 rounded-3xl border-blue-500/10 space-y-6">
+    <h3 className="text-sm font-bold font-display uppercase tracking-widest text-blue-500 flex items-center gap-2 mb-4">
+      <Library className="w-4 h-4" />
+      Książki dostępne w bibliotekach
+    </h3>
+    <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
+      {libraries.map((library) => (
+        <LibraryProgressItem key={library.id} library={library} onMarkAsRead={onMarkAsRead} markingId={markingId} />
+      ))}
+    </div>
+  </motion.div>
+);

--- a/src/components/stats/OwnedUnreadCard.tsx
+++ b/src/components/stats/OwnedUnreadCard.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Package } from "lucide-react";
+import { OwnedUnreadItem } from "./OwnedUnreadItem";
+
+type Book = React.ComponentProps<typeof OwnedUnreadItem>["book"];
+type OnMark = React.ComponentProps<typeof OwnedUnreadItem>["onMarkAsRead"];
+
+export const OwnedUnreadCard: React.FC<{ books: Book[]; markingId: string | null; onMarkAsRead: OnMark }> = ({ books, markingId, onMarkAsRead }) => (
+  <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }} className="glass-card p-6 rounded-3xl border-emerald-500/10 space-y-6">
+    <h3 className="text-sm font-bold font-display uppercase tracking-widest text-emerald-500 flex items-center gap-2 mb-4">
+      <Package className="w-4 h-4" />
+      Zasoby Oczekujące (Posiadane)
+    </h3>
+    <div className="space-y-3 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
+      {books.length === 0 ? (
+        <p className="text-slate-400 text-sm italic text-center py-8">Wszystkie posiadane zasoby zostały przyswojone.</p>
+      ) : (
+        books.map((book, idx) => (
+          <OwnedUnreadItem key={idx} book={book} marking={markingId === book.id} disabled={markingId !== null} onMarkAsRead={onMarkAsRead} />
+        ))
+      )}
+    </div>
+  </motion.div>
+);

--- a/src/components/stats/YearlyCard.tsx
+++ b/src/components/stats/YearlyCard.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Calendar } from "lucide-react";
+import { YearlyStat } from "../../hooks/useStats";
+import { YearlyProgressItem } from "./YearlyProgressItem";
+
+export const YearlyCard: React.FC<{ years: YearlyStat[] }> = ({ years }) => (
+  <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="glass-card p-6 rounded-3xl border-orange-500/10 space-y-6">
+    <h3 className="text-sm font-bold font-display uppercase tracking-widest text-orange-500 flex items-center gap-2 mb-4">
+      <Calendar className="w-4 h-4" />
+      Chronologia Przeczytanych
+    </h3>
+    <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2 custom-scrollbar">
+      {years.map((year) => (
+        <YearlyProgressItem key={year.year} year={year} />
+      ))}
+    </div>
+  </motion.div>
+);


### PR DESCRIPTION
Przegląd architektury — **Tier 3 (A2a)**.

6 z ~11 kart statystyk było pisanych ręcznie inline w `StatsSection` (powielony nagłówek), gdy reszta to już komponenty. Wyciągnięte **verbatim**: `AuthorsCard`, `AwardsProgressCard`, `YearlyCard`, `OwnedUnreadCard`, `LibraryProgressCard`, `IdentifiedLibraryCard`. Typy propsów pochodzą z `React.ComponentProps` item-komponentów → pozostają zsynchronizowane.

`StatsSection` **372 → 244 linie**; wszystkie karty jednorodne. Zero zmiany zachowania.

## Test
`npm test` — **474 zielone** (m.in. App.test nawigujący po zakładce stats/identified), lint czysto, build OK.

Następny PR: A2b — wyniesienie masonry + drag&drop do hooka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_