### PR TITLE
refactor(stats): lift masonry + DnD reorder out of StatsSection

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.6** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.7** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.7** — **[Tier 3, A2b] Masonry + drag&drop `StatsSection` → `StatsMasonry` + `useCardReorder`.** Silnik
+  układu (kolumny wg breakpointu, round-robin, segmenty span2, `renderCard` z DnD) i stan reorderu (arranging/
+  drag/hover + `persistStatsOrder`/`moveId`/reset) wyniesione z komponentu-sekcji. `StatsSection` = sama
+  kompozycja (372→**148 linii** łącznie z A2a). Zero zmiany zachowania. Suite 474 zielone, lint czysty, build
+  OK. (Zamyka A2 — StatsSection zdekomponowany.)
 - **1.67.6** — **[Tier 3, A2a] Ekstrakcja 6 inline kart `StatsSection` do komponentów `stats/`.** Karty
   authors/awards/yearly/ownedUnread/library/identified były pisane ręcznie inline (powielony nagłówek), gdy
   reszta to komponenty. Wyciągnięte VERBATIM: `AuthorsCard`, `AwardsProgressCard`, `YearlyCard`,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.6",
+  "version": "1.67.7",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.6",
+  "version": "1.67.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.6",
+      "version": "1.67.7",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.6",
+  "version": "1.67.7",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { motion } from "motion/react";
 import { BarChart3, RefreshCw, GripVertical, LayoutGrid, RotateCcw, Check } from "lucide-react";
 import { useStats } from "../hooks/useStats";
@@ -16,15 +16,9 @@ import { YearlyCard } from "./stats/YearlyCard";
 import { OwnedUnreadCard } from "./stats/OwnedUnreadCard";
 import { LibraryProgressCard } from "./stats/LibraryProgressCard";
 import { IdentifiedLibraryCard } from "./stats/IdentifiedLibraryCard";
-import { useEffectiveConfig, persistStatsOrder } from "../hooks/useAppConfig";
-import { orderByIds, moveId, distributeColumns } from "../utils/statsLayout";
-
-interface StatCard {
-  id: string;
-  /** Full-width grid card (md:col-span-2). */
-  span2?: boolean;
-  node: React.ReactNode;
-}
+import { StatsMasonry, StatCard } from "./stats/StatsMasonry";
+import { useCardReorder } from "../hooks/useCardReorder";
+import { useEffectiveConfig } from "../hooks/useAppConfig";
 
 export const StatsSection: React.FC = () => {
   // Library branches from config (fallback: defaults until fetched).
@@ -39,21 +33,8 @@ export const StatsSection: React.FC = () => {
   const [refreshTick, setRefreshTick] = useState(0);
   const refreshAll = () => { fetchStats(); setRefreshTick((t) => t + 1); };
 
-  // Card arranging mode (drag&drop) + current drag state.
-  const [arranging, setArranging] = useState(false);
-  const [dragId, setDragId] = useState<string | null>(null);
-  const [overId, setOverId] = useState<string | null>(null);
-
-  // Masonry column count depends on the md breakpoint (768px) — round-robin keeps
-  // reading „row by row", so the columns must match what's visible.
-  const [cols, setCols] = useState(2);
-  useEffect(() => {
-    const mq = window.matchMedia("(min-width: 768px)");
-    const apply = () => setCols(mq.matches ? 2 : 1);
-    apply();
-    mq.addEventListener("change", apply);
-    return () => mq.removeEventListener("change", apply);
-  }, []);
+  // Card arranging (drag&drop reorder) state + persistence.
+  const reorder = useCardReorder();
 
   if (loading && !stats) {
     return (
@@ -102,65 +83,6 @@ export const StatsSection: React.FC = () => {
     { id: "identified", node: <IdentifiedLibraryCard branches={branches} identifiedBooks={identifiedBooks} onCheck={checkLibrary} onCheckAll={() => checkAllLibraries(branches)} onStop={stopLibraryCheck} checkingLibrary={checkingLibrary} checkProgress={checkProgress} libraryError={libraryError} onMarkAsRead={markAsRead} markingId={markingId} markedIds={markedIds} /> },
   ];
 
-  // Effective order (user's save + new cards at the end) and lookup by id.
-  const order = orderByIds(cards.map((c) => c.id), cfg.ui.statsOrder);
-  const byId = new Map(cards.map((c) => [c.id, c]));
-  const ordered = order.map((id) => byId.get(id)).filter((c): c is StatCard => Boolean(c));
-
-  const commitReorder = (target: string) => {
-    if (!dragId || dragId === target) return;
-    persistStatsOrder(moveId(order, dragId, target));
-  };
-  const exitArrange = () => { setArranging(false); setDragId(null); setOverId(null); };
-
-  // A single card with the DnD wrapper + arranging-mode overlays (reusable in round-robin
-  // blocks and in full-width cards).
-  const renderCard = (card: StatCard) => {
-    const dragging = dragId === card.id;
-    const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
-    return (
-      <div
-        key={card.id}
-        className={`relative ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
-        draggable={arranging}
-        onDragStart={(e) => {
-          if (!arranging) return;
-          setDragId(card.id);
-          e.dataTransfer.effectAllowed = "move";
-          try { e.dataTransfer.setData("text/plain", card.id); } catch { /* Safari */ }
-        }}
-        onDragEnter={() => { if (arranging) setOverId(card.id); }}
-        onDragOver={(e) => { if (arranging) e.preventDefault(); }}
-        onDrop={(e) => { if (arranging) { e.preventDefault(); commitReorder(card.id); } }}
-        onDragEnd={() => { setDragId(null); setOverId(null); }}
-      >
-        <div className={arranging ? "pointer-events-none" : ""}>{card.node}</div>
-        {arranging && (
-          <div className={`absolute inset-0 rounded-3xl border-2 border-dashed pointer-events-none transition-colors ${isOver ? "border-cyan-400/70 bg-cyan-500/5" : "border-amber-500/40"}`} />
-        )}
-        {arranging && !dragging && (
-          <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 rounded-lg bg-slate-950/85 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-widest pointer-events-none">
-            <GripVertical className="w-3 h-3" /> przeciągnij
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  // Segmentation: full-width cards (span2) break the round-robin block and render
-  // at full width; the rest go into columns (i % cols) with independent packing.
-  type Segment = { kind: "full"; card: StatCard } | { kind: "block"; cards: StatCard[] };
-  const segments: Segment[] = [];
-  let run: StatCard[] = [];
-  for (const c of ordered) {
-    if (c.span2) {
-      if (run.length) { segments.push({ kind: "block", cards: run }); run = []; }
-      segments.push({ kind: "full", card: c });
-    } else {
-      run.push(c);
-    }
-  }
-  if (run.length) segments.push({ kind: "block", cards: run });
 
   return (
     <div className="space-y-8">
@@ -174,9 +96,9 @@ export const StatsSection: React.FC = () => {
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
 
-        {arranging && (
+        {reorder.arranging && (
           <button
-            onClick={() => persistStatsOrder([])}
+            onClick={reorder.reset}
             className="p-2 rounded-lg text-slate-500 hover:text-amber-300 hover:bg-slate-900 transition-colors"
             title="Przywróć domyślną kolejność kart"
             aria-label="Przywróć domyślną kolejność kart"
@@ -185,12 +107,12 @@ export const StatsSection: React.FC = () => {
           </button>
         )}
         <button
-          onClick={() => (arranging ? exitArrange() : setArranging(true))}
-          className={`p-2 rounded-lg transition-colors border ${arranging ? "bg-amber-500/15 text-amber-300 border-amber-500/40" : "border-transparent text-slate-500 hover:text-cyan-400 hover:bg-slate-900"}`}
-          title={arranging ? "Zakończ układanie kart" : "Ułóż karty (przeciągnij i upuść)"}
+          onClick={reorder.toggle}
+          className={`p-2 rounded-lg transition-colors border ${reorder.arranging ? "bg-amber-500/15 text-amber-300 border-amber-500/40" : "border-transparent text-slate-500 hover:text-cyan-400 hover:bg-slate-900"}`}
+          title={reorder.arranging ? "Zakończ układanie kart" : "Ułóż karty (przeciągnij i upuść)"}
           aria-label="Przełącz tryb układania kart"
         >
-          {arranging ? <Check className="w-5 h-5" /> : <LayoutGrid className="w-5 h-5" />}
+          {reorder.arranging ? <Check className="w-5 h-5" /> : <LayoutGrid className="w-5 h-5" />}
         </button>
 
         <button
@@ -213,32 +135,14 @@ export const StatsSection: React.FC = () => {
       {/* „Twoja kolekcja" — stały rząd KPI (nad kartami; nie wchodzi w masonry). */}
       <KpiRow stats={stats} />
 
-      {arranging && (
+      {reorder.arranging && (
         <div className="flex items-center justify-center gap-2 text-[11px] text-amber-300/80 uppercase tracking-widest font-bold">
           <GripVertical className="w-3.5 h-3.5" />
           Przeciągnij karty, aby ustalić kolejność — zapis jest automatyczny
         </div>
       )}
 
-      {/* Masonry „row by row": cards laid out round-robin (i % cols) across separate
-          columns, each packing independently (no height coupling = no gaps),
-          while reading left→right/top→bottom stays 0,1,2,3,... A full-width card
-          (the decade histogram) breaks the block and takes the whole width. */}
-      <div className="space-y-8">
-        {segments.map((seg, si) =>
-          seg.kind === "full" ? (
-            <div key={`full-${si}`}>{renderCard(seg.card)}</div>
-          ) : (
-            <div key={`block-${si}`} className="flex gap-8">
-              {distributeColumns(seg.cards, cols).map((col, ci) => (
-                <div key={ci} className="flex-1 min-w-0 flex flex-col gap-8">
-                  {col.map((card) => renderCard(card))}
-                </div>
-              ))}
-            </div>
-          )
-        )}
-      </div>
+      <StatsMasonry cards={cards} savedOrder={cfg.ui.statsOrder} reorder={reorder} />
     </div>
   );
 };

--- a/src/components/stats/StatsMasonry.tsx
+++ b/src/components/stats/StatsMasonry.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from "react";
+import { GripVertical } from "lucide-react";
+import { orderByIds, distributeColumns } from "../../utils/statsLayout";
+import { CardReorder } from "../../hooks/useCardReorder";
+
+export interface StatCard {
+  id: string;
+  /** Full-width card (breaks the round-robin block, takes the whole width). */
+  span2?: boolean;
+  node: React.ReactNode;
+}
+
+type Segment = { kind: "full"; card: StatCard } | { kind: "block"; cards: StatCard[] };
+
+/**
+ * The stats card masonry: lays cards out "row by row" (round-robin across
+ * `cols` columns that each pack independently, so no height coupling → no gaps),
+ * with full-width (`span2`) cards breaking the block. Also renders the
+ * drag-and-drop affordances in arranging mode. All DnD state comes from the
+ * `reorder` hook — this component is layout only.
+ */
+export const StatsMasonry: React.FC<{ cards: StatCard[]; savedOrder: string[]; reorder: CardReorder }> = ({ cards, savedOrder, reorder }) => {
+  // Column count follows the md breakpoint (768px) — round-robin reads "row by
+  // row", so the columns must match what's visible.
+  const [cols, setCols] = useState(2);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const apply = () => setCols(mq.matches ? 2 : 1);
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, []);
+
+  // Effective order (user's save + new cards at the end) and lookup by id.
+  const order = orderByIds(cards.map((c) => c.id), savedOrder);
+  const byId = new Map(cards.map((c) => [c.id, c]));
+  const ordered = order.map((id) => byId.get(id)).filter((c): c is StatCard => Boolean(c));
+
+  const { arranging, dragId, overId } = reorder;
+
+  const renderCard = (card: StatCard) => {
+    const dragging = dragId === card.id;
+    const isOver = arranging && overId === card.id && !!dragId && dragId !== card.id;
+    return (
+      <div
+        key={card.id}
+        className={`relative ${arranging ? "cursor-move select-none" : ""} ${dragging ? "opacity-40" : ""}`}
+        draggable={arranging}
+        onDragStart={(e) => {
+          if (!arranging) return;
+          reorder.startDrag(card.id);
+          e.dataTransfer.effectAllowed = "move";
+          try { e.dataTransfer.setData("text/plain", card.id); } catch { /* Safari */ }
+        }}
+        onDragEnter={() => { if (arranging) reorder.hover(card.id); }}
+        onDragOver={(e) => { if (arranging) e.preventDefault(); }}
+        onDrop={(e) => { if (arranging) { e.preventDefault(); reorder.commitReorder(order, card.id); } }}
+        onDragEnd={reorder.endDrag}
+      >
+        <div className={arranging ? "pointer-events-none" : ""}>{card.node}</div>
+        {arranging && (
+          <div className={`absolute inset-0 rounded-3xl border-2 border-dashed pointer-events-none transition-colors ${isOver ? "border-cyan-400/70 bg-cyan-500/5" : "border-amber-500/40"}`} />
+        )}
+        {arranging && !dragging && (
+          <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 rounded-lg bg-slate-950/85 border border-amber-500/30 text-amber-300 text-[9px] font-bold uppercase tracking-widest pointer-events-none">
+            <GripVertical className="w-3 h-3" /> przeciągnij
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Full-width cards break the round-robin block and render at full width; the
+  // rest go into columns (i % cols) with independent packing.
+  const segments: Segment[] = [];
+  let run: StatCard[] = [];
+  for (const c of ordered) {
+    if (c.span2) {
+      if (run.length) { segments.push({ kind: "block", cards: run }); run = []; }
+      segments.push({ kind: "full", card: c });
+    } else {
+      run.push(c);
+    }
+  }
+  if (run.length) segments.push({ kind: "block", cards: run });
+
+  return (
+    <div className="space-y-8">
+      {segments.map((seg, si) =>
+        seg.kind === "full" ? (
+          <div key={`full-${si}`}>{renderCard(seg.card)}</div>
+        ) : (
+          <div key={`block-${si}`} className="flex gap-8">
+            {distributeColumns(seg.cards, cols).map((col, ci) => (
+              <div key={ci} className="flex-1 min-w-0 flex flex-col gap-8">
+                {col.map((card) => renderCard(card))}
+              </div>
+            ))}
+          </div>
+        )
+      )}
+    </div>
+  );
+};

--- a/src/hooks/useCardReorder.ts
+++ b/src/hooks/useCardReorder.ts
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { moveId } from "../utils/statsLayout";
+import { persistStatsOrder } from "./useAppConfig";
+
+/**
+ * Drag-and-drop reorder state for the stats card masonry: the "arranging" toggle,
+ * the current drag/hover ids, and persistence of the new order. Kept out of
+ * StatsSection so the section is composition only and StatsMasonry stays a pure
+ * layout component driven by this state.
+ */
+export function useCardReorder() {
+  const [arranging, setArranging] = useState(false);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+
+  const endDrag = () => { setDragId(null); setOverId(null); };
+  const exit = () => { setArranging(false); endDrag(); };
+
+  /** Persist the new order when `dragId` is dropped onto `target` (within `order`). */
+  const commitReorder = (order: string[], target: string) => {
+    if (!dragId || dragId === target) return;
+    persistStatsOrder(moveId(order, dragId, target));
+  };
+
+  return {
+    arranging,
+    dragId,
+    overId,
+    startDrag: (id: string) => setDragId(id),
+    hover: (id: string) => setOverId(id),
+    endDrag,
+    commitReorder,
+    toggle: () => (arranging ? exit() : setArranging(true)),
+    reset: () => persistStatsOrder([]),
+  };
+}
+
+export type CardReorder = ReturnType<typeof useCardReorder>;


### PR DESCRIPTION
Przegląd architektury — **Tier 3 (A2b)**, domyka dekompozycję `StatsSection`.

Silnik układu kart (kolumny wg breakpointu, round-robin, segmenty `span2`, `renderCard` z drag&drop) przeniesiony do komponentu `StatsMasonry`; stan interakcji reorderu (arranging / drag / hover + `persistStatsOrder` / `moveId` / reset) do hooka `useCardReorder`. `StatsSection` to teraz sama kompozycja (**372 → 148 linii** łącznie z A2a). Zero zmiany zachowania.

## Test
`npm test` — **474 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_