### PR TITLE
refactor(shelf): move optimistic save-queue into useShelfMutations

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.7** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.8** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.8** — **[Tier 3, A3] `BookshelfSection` — kolejka zapisów/optymistyka → `useShelfMutations`.** Z ciała
+  komponentu wyniesione: serializowana kolejka „latest-wins" per książka (`pendingRef`/`runningRef`, guard na
+  nieatomowy `mutateMultiSelect`), optymistyczne overrides „przeczytane" + rollback, optymistyczny zapis
+  kolejności (`applyOrderPlan` + `saveOrders` + rollback) i wspólny `moveError`. Komponent renderuje i wiąże
+  callbacki; czyste helpery (`planInsertion`/`splitShelves`/`featuredReads`) były już wyciągnięte. 236→177
+  linii. Zero zmiany zachowania. Suite 474 zielone, lint czysty, build OK. **Tier 3 zamknięty** (statsAggregator
+  + A4 + A2a/A2b + A3).
 - **1.67.7** — **[Tier 3, A2b] Masonry + drag&drop `StatsSection` → `StatsMasonry` + `useCardReorder`.** Silnik
   układu (kolumny wg breakpointu, round-robin, segmenty span2, `renderCard` z DnD) i stan reorderu (arranging/
   drag/hover + `persistStatsOrder`/`moveId`/reset) wyniesione z komponentu-sekcji. `StatsSection` = sama

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.7",
+  "version": "1.67.8",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.7",
+  "version": "1.67.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.7",
+      "version": "1.67.8",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.7",
+  "version": "1.67.8",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useMemo, useCallback, useRef, useEffect } from "react";
+import React, { useState, useMemo, useCallback, useEffect } from "react";
 import { Library, BookOpen, CheckCircle2, Sparkles, Loader2, AlertCircle, X } from "lucide-react";
 import { BookIndexEntry } from "../types";
 import { useBooks } from "../hooks/useBooks";
-import { useMarkRead } from "../hooks/useMarkRead";
-import { useShelfOrder } from "../hooks/useShelfOrder";
-import { ShelfId, ReadOverrides, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
+import { useShelfMutations } from "../hooks/useShelfMutations";
+import { ShelfId, isRead, splitShelves, featuredReads } from "../utils/bookshelf";
 import { planInsertion } from "../utils/shelfInsertion";
 import { ShelfSkin, SHELF_SKINS, skinClass, loadSkin, saveSkin } from "../utils/shelfSkin";
 import { useEffectiveConfig } from "../hooks/useAppConfig";
@@ -16,12 +15,9 @@ import { RoomDecor } from "./shelf/RoomDecor";
 
 export const BookshelfSection: React.FC = () => {
   const { books, loading, error, fetchBooks } = useBooks();
-  const { setRead } = useMarkRead();
-  const { saveOrders } = useShelfOrder();
+  const { overrides, orderOverrides, moveError, setMoveError, applyReadChange, applyOrderPlan } = useShelfMutations();
 
-  const [overrides, setOverrides] = useState<ReadOverrides>({});
   const [dragging, setDragging] = useState<BookIndexEntry | null>(null);
-  const [moveError, setMoveError] = useState<string | null>(null);
   const [skin, setSkin] = useState<ShelfSkin>(loadSkin);
   const { theme } = useTheme();
   // Jasny motyw „Librem" = jeden regał jak z makiety: wymuszamy matową skórę
@@ -31,16 +27,7 @@ export const BookshelfSection: React.FC = () => {
   // UI knobs: number of „Regał" rows per page + precise drop.
   const uiCfg = useEffectiveConfig().ui;
   const rowsPerPage = uiCfg.shelfRowsPerPage;
-  // Optimistic overrides of manual order keys (precise drop) until refetch.
-  const [orderOverrides, setOrderOverrides] = useState<Record<string, number>>({});
   useEffect(() => { saveSkin(skin); }, [skin]);
-
-  // Saving the „przeczytane" state is SERIALIZED per book (latest-wins). The backend
-  // `mutateMultiSelect` is a non-atomic retrieve→modify→update, so two overlapping
-  // writes of the same book could read the same state and drift Notion from the UI.
-  // `pendingRef` holds the freshest requested state, `runningRef` — books with an active runner.
-  const pendingRef = useRef<Record<string, boolean>>({});
-  const runningRef = useRef<Set<string>>(new Set());
 
   // Book collection with overridden order keys (optimistically, until refetch).
   const all = useMemo(() => {
@@ -49,33 +36,6 @@ export const BookshelfSection: React.FC = () => {
   }, [books, orderOverrides]);
   const { read, toRead } = useMemo(() => splitShelves(all, overrides), [all, overrides]);
   const featured = useMemo(() => featuredReads(all, overrides), [all, overrides]);
-
-  /** Optimistic „przeczytane" change + serialized save (latest-wins per book). */
-  const applyReadChange = useCallback((book: BookIndexEntry, targetRead: boolean) => {
-    setOverrides((prev) => ({ ...prev, [book.id]: targetRead }));
-    setMoveError(null);
-
-    // Store the freshest requested state; if this book's runner is already running, it will pick it up itself.
-    pendingRef.current[book.id] = targetRead;
-    if (runningRef.current.has(book.id)) return;
-    runningRef.current.add(book.id);
-    void (async () => {
-      try {
-        while (book.id in pendingRef.current) {
-          const desired = pendingRef.current[book.id];
-          delete pendingRef.current[book.id];
-          await setRead(book.id, desired);
-        }
-      } catch (e: any) {
-        // Save didn't go through — revert to the DB state and show the error.
-        delete pendingRef.current[book.id];
-        setOverrides((prev) => { const next = { ...prev }; delete next[book.id]; return next; });
-        setMoveError(`Nie udało się zapisać „${book.plTitle || book.origTitle}": ${e.message}`);
-      } finally {
-        runningRef.current.delete(book.id);
-      }
-    })();
-  }, [setRead]);
 
   const handleDrop = useCallback((target: ShelfId) => {
     const book = dragging;
@@ -103,28 +63,9 @@ export const BookshelfSection: React.FC = () => {
     const seq = (targetRead ? read : toRead).filter((b) => b.id !== book.id);
     const plan = planInsertion(seq, book, insertBeforeId);
 
-    if (plan && plan.orders.length > 0) {
-      setOrderOverrides((prev) => {
-        const next = { ...prev };
-        for (const o of plan.orders) next[o.pageId] = o.order;
-        return next;
-      });
-      void (async () => {
-        try {
-          await saveOrders(plan.orders);
-        } catch (e: any) {
-          setOrderOverrides((prev) => {
-            const next = { ...prev };
-            for (const o of plan.orders) delete next[o.pageId];
-            return next;
-          });
-          setMoveError(`Nie udało się zapisać pozycji „${book.plTitle || book.origTitle}": ${e.message}`);
-        }
-      })();
-    }
-
+    if (plan && plan.orders.length > 0) applyOrderPlan(book, plan.orders);
     if (wasRead !== targetRead) applyReadChange(book, targetRead);
-  }, [dragging, overrides, read, toRead, applyReadChange]);
+  }, [dragging, overrides, read, toRead, applyReadChange, applyOrderPlan]);
 
   return (
     <div className="space-y-8">

--- a/src/hooks/useShelfMutations.ts
+++ b/src/hooks/useShelfMutations.ts
@@ -1,0 +1,84 @@
+import { useState, useRef, useCallback } from "react";
+import { BookIndexEntry } from "../types";
+import { ReadOverrides } from "../utils/bookshelf";
+import { useMarkRead } from "./useMarkRead";
+import { useShelfOrder } from "./useShelfOrder";
+
+/** One row of a precise-drop order plan (from `planInsertion`). */
+export interface OrderChange {
+  pageId: string;
+  order: number;
+}
+
+/**
+ * Optimistic shelf writes with rollback, kept out of BookshelfSection so the
+ * component only renders and wires callbacks. Owns:
+ *  - the „przeczytane" overrides + a SERIALIZED, latest-wins-per-book save queue
+ *    (the backend `mutateMultiSelect` is a non-atomic retrieve→modify→update, so
+ *    overlapping writes of one book could read the same state and drift Notion),
+ *  - the manual-order overrides + optimistic `saveOrders` with rollback,
+ *  - the shared `moveError` surfaced on a failed save.
+ */
+export function useShelfMutations() {
+  const { setRead } = useMarkRead();
+  const { saveOrders } = useShelfOrder();
+
+  const [overrides, setOverrides] = useState<ReadOverrides>({});
+  const [orderOverrides, setOrderOverrides] = useState<Record<string, number>>({});
+  const [moveError, setMoveError] = useState<string | null>(null);
+
+  // pendingRef holds the freshest requested state per book; runningRef — books with an active runner.
+  const pendingRef = useRef<Record<string, boolean>>({});
+  const runningRef = useRef<Set<string>>(new Set());
+
+  /** Optimistic „przeczytane" change + serialized save (latest-wins per book). */
+  const applyReadChange = useCallback((book: BookIndexEntry, targetRead: boolean) => {
+    setOverrides((prev) => ({ ...prev, [book.id]: targetRead }));
+    setMoveError(null);
+
+    // Store the freshest requested state; if this book's runner is already running, it will pick it up itself.
+    pendingRef.current[book.id] = targetRead;
+    if (runningRef.current.has(book.id)) return;
+    runningRef.current.add(book.id);
+    void (async () => {
+      try {
+        while (book.id in pendingRef.current) {
+          const desired = pendingRef.current[book.id];
+          delete pendingRef.current[book.id];
+          await setRead(book.id, desired);
+        }
+      } catch (e: any) {
+        // Save didn't go through — revert to the DB state and show the error.
+        delete pendingRef.current[book.id];
+        setOverrides((prev) => { const next = { ...prev }; delete next[book.id]; return next; });
+        setMoveError(`Nie udało się zapisać „${book.plTitle || book.origTitle}": ${e.message}`);
+      } finally {
+        runningRef.current.delete(book.id);
+      }
+    })();
+  }, [setRead]);
+
+  /** Optimistic manual-order change (precise drop) + `saveOrders` with rollback. */
+  const applyOrderPlan = useCallback((book: BookIndexEntry, orders: OrderChange[]) => {
+    if (orders.length === 0) return;
+    setOrderOverrides((prev) => {
+      const next = { ...prev };
+      for (const o of orders) next[o.pageId] = o.order;
+      return next;
+    });
+    void (async () => {
+      try {
+        await saveOrders(orders);
+      } catch (e: any) {
+        setOrderOverrides((prev) => {
+          const next = { ...prev };
+          for (const o of orders) delete next[o.pageId];
+          return next;
+        });
+        setMoveError(`Nie udało się zapisać pozycji „${book.plTitle || book.origTitle}": ${e.message}`);
+      }
+    })();
+  }, [saveOrders]);
+
+  return { overrides, orderOverrides, moveError, setMoveError, applyReadChange, applyOrderPlan };
+}


### PR DESCRIPTION
Przegląd architektury — **Tier 3 (A3)**, domyka Tier 3.

Z ciała komponentu `BookshelfSection` wyniesione do hooka `useShelfMutations`:
- serializowana kolejka zapisów „latest-wins" per książka (`pendingRef`/`runningRef`, guard na nieatomowy `mutateMultiSelect`),
- optymistyczne overrides „przeczytane" + rollback,
- optymistyczny zapis kolejności (`applyOrderPlan` → `saveOrders` + rollback),
- wspólny `moveError`.

Komponent renderuje i wiąże callbacki; czyste helpery (`planInsertion`/`splitShelves`/`featuredReads`) były już wyciągnięte. **236 → 177 linii**. Zero zmiany zachowania.

## Test
`npm test` — **474 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_