### PR TITLE
chore(backend): dead code, import cycle, structured logging, unused dep

### DIFF
--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -30,7 +30,6 @@ vi.mock('../notion.adapter', () => {
 vi.mock('../wiki.adapter', () => {
   const WikiAdapter = vi.fn();
   WikiAdapter.prototype.fetchPageContent = vi.fn().mockResolvedValue('{| class="wikitable"\n|-\n! Rok !! Autor !! Tytuł oryginalny !! Tytuł polski\n|-\n| 1961 || [[Stanisław Lem]] || \'\'Solaris\'\' || Solaris\n|}');
-  WikiAdapter.prototype.fetchPageContentWithSlots = vi.fn().mockResolvedValue('{{Książka|wydawca=Wydawnictwo Literackie|seria=Dzieła}}');
   return { WikiAdapter };
 });
 

--- a/__tests__/wiki.adapter.test.ts
+++ b/__tests__/wiki.adapter.test.ts
@@ -103,28 +103,4 @@ describe('WikiAdapter', () => {
       expect(failedTitles).toEqual(['Solaris', 'Diuna']);
     });
   });
-
-  describe('fetchPageContentWithSlots', () => {
-    it('fetches page content from main slot', async () => {
-      const mockResponse = {
-        data: {
-          query: {
-            pages: {
-              '123': {
-                revisions: [{
-                  slots: {
-                    main: { '*': 'Slot Content' }
-                  }
-                }]
-              }
-            }
-          }
-        }
-      };
-      mockGet.mockResolvedValueOnce(mockResponse);
-      
-      const content = await wikiAdapter.fetchPageContentWithSlots('Test Title');
-      expect(content).toBe('Slot Content');
-    });
-  });
 });

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.8** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.9** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,14 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.9** — **[Tier 4, PR1] Backend higiena: martwy kod + cykl importów + logger + nieużywana zależność.**
+  (1) Usunięty martwy `WikiAdapter.fetchPageContentWithSlots` (zero prod-wywołań, łamał kontrakt błędu —
+  zwracał `""` zamiast rzucać) + jego test i mock w `server.test`. (2) Cykl `vintedSession ↔ browserPrime`
+  zerwany: `parseSetCookie` → nowy `services/cookies.ts` (re-export z `vintedSession` dla kompatybilności;
+  `browserPrime` importuje z `cookies`). (3) `console.*` → strukturalny `createLogger` w `duplicateSyncService`
+  (drop 2 debug, 1 → `log.info`) i `lpSyncService` (`log.error`). (4) `DuplicateSyncService` — usunięta
+  nieużywana zależność `WikiAdapter` (konstruktor + wiring w `syncManager` + test). Suite 473 zielone (−1 =
+  usunięty test martwego kodu), lint czysty, build OK.
 - **1.67.8** — **[Tier 3, A3] `BookshelfSection` — kolejka zapisów/optymistyka → `useShelfMutations`.** Z ciała
   komponentu wyniesione: serializowana kolejka „latest-wins" per książka (`pendingRef`/`runningRef`, guard na
   nieatomowy `mutateMultiSelect`), optymistyczne overrides „przeczytane" + rollback, optymistyczny zapis

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.8",
+  "version": "1.67.9",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.8",
+  "version": "1.67.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.8",
+      "version": "1.67.9",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.8",
+  "version": "1.67.9",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/duplicateSyncService.test.ts
+++ b/services/__tests__/duplicateSyncService.test.ts
@@ -2,13 +2,11 @@ import { fakeConfig } from "./testConfig";
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DuplicateSyncService } from '../duplicateSyncService';
 import { NotionAdapter } from '../../notion.adapter';
-import { WikiAdapter } from '../../wiki.adapter';
 import { NotionBook } from '../../src/types';
 
 describe('DuplicateSyncService', () => {
   let service: DuplicateSyncService;
   let mockNotion: any;
-  let mockWiki: any;
   let mockSendEvent: any;
 
   beforeEach(() => {
@@ -17,11 +15,9 @@ describe('DuplicateSyncService', () => {
       queryAllBooks: vi.fn(),
     };
 
-    mockWiki = {};
-
     mockSendEvent = vi.fn();
 
-    service = new DuplicateSyncService(mockNotion as unknown as NotionAdapter, mockWiki as unknown as WikiAdapter, fakeConfig);
+    service = new DuplicateSyncService(mockNotion as unknown as NotionAdapter, fakeConfig);
   });
 
   it('detects duplicates with identical titles', async () => {

--- a/services/browserPrime.ts
+++ b/services/browserPrime.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { VintedSession } from "./vintedHttp";
-import { parseSetCookie } from "./vintedSession";
+import { parseSetCookie } from "./cookies";
 
 const VINTED_HOME = "https://www.vinted.pl/";
 

--- a/services/cookies.ts
+++ b/services/cookies.ts
@@ -1,0 +1,22 @@
+/**
+ * Assembles the `Cookie` header from a response's `Set-Cookie` array (axios
+ * `res.headers["set-cookie"]`). Takes only the `name=value` pair (before the
+ * first `;`), skips attributes (Path/Expires/…) and empty/malformed entries.
+ * Pure function — lives in its own module so `vintedSession` and `browserPrime`
+ * both depend on it without forming an import cycle.
+ */
+export function parseSetCookie(setCookie: string[] | undefined | null): string {
+  if (!Array.isArray(setCookie)) return "";
+  const pairs: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of setCookie) {
+    if (typeof raw !== "string") continue;
+    const pair = raw.split(";")[0]?.trim();
+    if (!pair || !pair.includes("=")) continue;
+    const name = pair.slice(0, pair.indexOf("=")).trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    pairs.push(pair);
+  }
+  return pairs.join("; ");
+}

--- a/services/duplicateSyncService.ts
+++ b/services/duplicateSyncService.ts
@@ -1,28 +1,28 @@
 import { NotionAdapter } from "../notion.adapter";
-import { WikiAdapter } from "../wiki.adapter";
 import { NotionBook, SyncEvent } from "../src/types";
 import { scoreDuplicatePair } from "./bookMatch";
 import { ConfigService } from "./configService";
 import { isAwardBook } from "./bookCategory";
+import { createLogger } from "../logger";
+
+const log = createLogger("DuplicateSync");
 
 export class DuplicateSyncService {
-  constructor(private notion: NotionAdapter, private wiki: WikiAdapter, private config: ConfigService) {}
+  constructor(private notion: NotionAdapter, private config: ConfigService) {}
 
   async runDuplicateCheck(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
-    console.log("DuplicateSyncService runDuplicateCheck started");
     try {
       // Similarity thresholds from config (knobs `sync.dup*Threshold`).
       const { dupAuthorThreshold, dupTitleThreshold } = (await this.config.getConfig()).sync;
       sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
       await this.notion.init();
-      console.log("Notion initialized");
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });
       const fetched: NotionBook[] = await this.notion.queryAllBooks((count) => sendEvent({ type: "status", message: `Pobrano ${count} książek z Notion...` }), checkCancellation);
       // Duplicate detection concerns award entries — side cycle volumes are
       // legitimately distinct books, not duplicates (excluded from comparisons).
       const allBooks: NotionBook[] = fetched.filter(isAwardBook);
-      console.log(`Fetched ${fetched.length} books (${allBooks.length} award after category filter)`);
-      
+      log.info(`Pobrano ${fetched.length} książek (${allBooks.length} nagrodowych po filtrze kategorii)`, { fetched: fetched.length, award: allBooks.length });
+
       const duplicates: { bookA: string; bookB: string; reason: string }[] = [];
       for (let i = 0; i < allBooks.length; i++) {
         if (checkCancellation()) { sendEvent({ type: "status", message: "Przerwano sprawdzanie duplikatów." }); break; }

--- a/services/lpSyncService.ts
+++ b/services/lpSyncService.ts
@@ -2,6 +2,9 @@ import { NotionAdapter } from "../notion.adapter";
 import pLimit from "p-limit";
 import { NotionBook, SyncEvent } from "../src/types";
 import { isAwardBook } from "./bookCategory";
+import { createLogger } from "../logger";
+
+const log = createLogger("LpSync");
 
 export class LpSyncService {
   constructor(private notion: NotionAdapter) {}
@@ -35,7 +38,7 @@ export class LpSyncService {
             await this.notion.updateLp(book.id, expectedLp);
             updatedCount++;
             syncSummary.updated.push(`${book.plTitle || book.origTitle} (Zaktualizowano: Lp -> ${expectedLp})`);
-          } catch (err: any) { console.error(`Błąd Lp dla ${book.plTitle}:`, err.message); }
+          } catch (err: any) { log.error(`Błąd Lp dla ${book.plTitle}`, { title: book.plTitle, error: err.message }); }
         }
         processedCount++;
         if (processedCount % 10 === 0 || processedCount === allBooks.length) {

--- a/services/vintedSession.ts
+++ b/services/vintedSession.ts
@@ -3,29 +3,13 @@ import https from "https";
 import { getRandomUserAgent } from "../scrapingClient";
 import { vintedRequestHeaders, VintedSession } from "./vintedHttp";
 import { primeWithBrowser } from "./browserPrime";
+import { parseSetCookie } from "./cookies";
+
+// Re-exported for existing importers/tests; the implementation lives in `cookies.ts`
+// so `browserPrime` can use it without a `vintedSession ↔ browserPrime` cycle.
+export { parseSetCookie };
 
 const VINTED_HOME = "https://www.vinted.pl/";
-
-/**
- * Assembles the `Cookie` header from a response's `Set-Cookie` array (axios `res.headers["set-cookie"]`).
- * Takes only the `name=value` pair (the part before the first `;`), skips attributes (Path/Expires/…)
- * and empty/malformed entries. Pure function — easy to test.
- */
-export function parseSetCookie(setCookie: string[] | undefined | null): string {
-  if (!Array.isArray(setCookie)) return "";
-  const pairs: string[] = [];
-  const seen = new Set<string>();
-  for (const raw of setCookie) {
-    if (typeof raw !== "string") continue;
-    const pair = raw.split(";")[0]?.trim();
-    if (!pair || !pair.includes("=")) continue;
-    const name = pair.slice(0, pair.indexOf("=")).trim();
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    pairs.push(pair);
-  }
-  return pairs.join("; ");
-}
 
 /**
  * „Warming up" a Vinted session: one GET of the home page with a real browser signature,

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -38,7 +38,7 @@ const notionAdapter = new NotionAdapter(process.env.NOTION_API_KEY!, process.env
 const wikiAdapter = new WikiAdapter();
 /** App configuration (knobs) — defaults + overrides from Notion; injected into the services. */
 export const configService = new ConfigService(notionAdapter);
-const duplicateSyncService = new DuplicateSyncService(notionAdapter, wikiAdapter, configService);
+const duplicateSyncService = new DuplicateSyncService(notionAdapter, configService);
 const bookSyncService = new BookSyncService(notionAdapter, wikiAdapter, configService);
 const publisherSyncService = new PublisherSyncService(notionAdapter, wikiAdapter);
 const seriesSyncService = new SeriesSyncService(notionAdapter, wikiAdapter);

--- a/wiki.adapter.ts
+++ b/wiki.adapter.ts
@@ -88,35 +88,6 @@ export class WikiAdapter {
     }
   }
 
-  async fetchPageContentWithSlots(title: string): Promise<string> {
-    try {
-      const response = await withRetry(() => wikiAxios.get(this.baseUrl, {
-        params: {
-          action: "query",
-          prop: "revisions",
-          rvprop: "content",
-          rvslots: "main",
-          titles: title,
-          redirects: 1,
-          format: "json"
-        }
-      }), 3, 2000);
-
-      const pages = response.data.query.pages;
-      const pageId = Object.keys(pages)[0];
-
-      if (pageId === "-1") {
-        console.warn(`Nie znaleziono strony "${title}" w encyklopedii.`);
-        return "";
-      }
-
-      const rev = pages[pageId].revisions[0];
-      return rev.slots?.main?.["*"] || rev["*"] || rev.content || "";
-    } catch (error: any) {
-      console.warn(`Błąd pobierania strony "${title}": ${error.message} (zablokowane IP?)`);
-      return "";
-    }
-  }
 
   /**
    * Fetches the content of multiple pages. Returns a content map plus a list of titles


### PR DESCRIPTION
Przegląd architektury — **Tier 4 (PR1)**, backend higiena.

- **Martwy kod:** usunięty `WikiAdapter.fetchPageContentWithSlots` (zero wywołań w prod; łamał kontrakt błędu — zwracał `""` zamiast rzucać) + jego test i mock w `server.test`.
- **Cykl importów:** `vintedSession ↔ browserPrime` zerwany — `parseSetCookie` przeniesiony do nowego `services/cookies.ts` (re-export z `vintedSession` dla kompatybilności; `browserPrime` importuje z `cookies`).
- **Logowanie:** `console.*` → strukturalny `createLogger` w `duplicateSyncService` (drop 2 debug, 1 → `log.info`) i `lpSyncService` (`log.error`).
- **Nieużywana zależność:** `DuplicateSyncService` bez wstrzykiwanego `WikiAdapter` (konstruktor + wiring w `syncManager` + test).

## Test
`npm test` — **473 zielone** (−1 = usunięty test martwego kodu), lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_