### PR TITLE
chore(controllers): shared Notion-keys guard + source-tag + structured logs

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.9** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.10** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.10** — **[Tier 4, PR2] Kontroler: wspólny guard kluczy + walidacja tagu + strukturalne logi.**
+  `requireNotionKeys(res)` zastępuje 4× skopiowany guard `NOTION_API_KEY`/`DATABASE_ID` (runSync/checkVinted/
+  resolveVinted/getVintedStored). `resolveSourceTag(tag)` zastępuje 2× zdublowaną walidację `ALLOWED_SOURCE_TAGS`
+  (mark/unmark). 6× `console.error` → strukturalny `log.error` (stats/books/wikiLastUpdate/notionSchema/mark/
+  unmark) — spójne z resztą kontrolera. Zero zmiany zachowania (te same statusy/komunikaty). Suite 473 zielone,
+  lint czysty, build OK.
 - **1.67.9** — **[Tier 4, PR1] Backend higiena: martwy kod + cykl importów + logger + nieużywana zależność.**
   (1) Usunięty martwy `WikiAdapter.fetchPageContentWithSlots` (zero prod-wywołań, łamał kontrakt błędu —
   zwracał `""` zamiast rzucać) + jego test i mock w `server.test`. (2) Cykl `vintedSession ↔ browserPrime`

--- a/controllers/syncController.ts
+++ b/controllers/syncController.ts
@@ -7,12 +7,21 @@ import { normalizeIsbn } from "../services/isbn";
 
 const log = createLogger("SyncController");
 
+/** Guard: the endpoint needs Notion credentials. Sends 400 and returns false when missing. */
+function requireNotionKeys(res: Response): boolean {
+  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+    res.status(400).json({ error: "Brak kluczy API Notion." });
+    return false;
+  }
+  return true;
+}
+
 export const getStats = async (req: Request, res: Response) => {
   try {
     const stats = await syncManager.getStats();
     res.json(stats);
   } catch (error: any) {
-    console.error("Stats Error:", error);
+    log.error("Stats error", { message: error.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania statystyk." });
   }
 };
@@ -27,7 +36,7 @@ export const getBooks = async (req: Request, res: Response) => {
     const books = await syncManager.getBooks(fresh, all);
     res.json(books);
   } catch (error: any) {
-    console.error("Books Error:", error);
+    log.error("Books error", { message: error.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania rekordów." });
   }
 };
@@ -39,7 +48,7 @@ export const getWikiLastUpdate = async (req: Request, res: Response) => {
     const lastUpdate = await syncManager.getWikiLastUpdate(title as string);
     res.json({ lastUpdate });
   } catch (error: any) {
-    console.error("Wiki Last Update Error:", error);
+    log.error("Wiki last-update error", { message: error.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania daty aktualizacji." });
   }
 };
@@ -95,7 +104,7 @@ export const getNotionSchema = async (req: Request, res: Response) => {
     }
     res.json(properties);
   } catch (error: any) {
-    console.error("Notion API Error:", error);
+    log.error("Notion schema error", { message: error.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas pobierania schematu." });
   }
 };
@@ -159,9 +168,7 @@ export const stopIntegrityCheck = makeStopHandler("Zatrzymano skanowanie integra
 export const runSync = async (req: Request, res: Response) => {
   const { awardName, pageTitle, syncAll } = req.body as SyncParams;
 
-  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
-    return res.status(400).json({ error: "Brak kluczy API Notion." });
-  }
+  if (!requireNotionKeys(res)) return;
 
   await executeSyncTask(
     req,
@@ -198,20 +205,25 @@ export const stopSchemaSync = makeStopHandler("Zatrzymano inicjalizację schemat
 // a given branch), it cannot inject arbitrary tags into the Notion base.
 const ALLOWED_SOURCE_TAGS = new Set(["Przeczytane", "Posiadam", "Biblioteka", "Biblioteka 9"]);
 
+/** Validate + default the „Źródło" tag (mark/unmark share this). */
+function resolveSourceTag(tag: unknown): { tag: string } | { error: string } {
+  const sourceTag = (tag as string) ?? "Przeczytane";
+  if (!ALLOWED_SOURCE_TAGS.has(sourceTag)) return { error: `Niedozwolony znacznik: ${sourceTag}.` };
+  return { tag: sourceTag };
+}
+
 export const markAsRead = async (req: Request, res: Response) => {
   try {
     const { pageId, tag } = req.body;
     if (!pageId) return res.status(400).json({ error: "Missing pageId parameter" });
 
-    const sourceTag = tag ?? "Przeczytane";
-    if (!ALLOWED_SOURCE_TAGS.has(sourceTag)) {
-      return res.status(400).json({ error: `Niedozwolony znacznik: ${sourceTag}.` });
-    }
+    const resolved = resolveSourceTag(tag);
+    if ("error" in resolved) return res.status(400).json({ error: resolved.error });
 
-    await syncManager.markAsRead(pageId, sourceTag);
+    await syncManager.markAsRead(pageId, resolved.tag);
     res.json({ success: true });
   } catch (error: any) {
-    console.error("Mark as Read Error:", error);
+    log.error("Mark as read error", { message: error.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas oznaczania pozycji." });
   }
 };
@@ -245,23 +257,19 @@ export const unmarkAsRead = async (req: Request, res: Response) => {
     const { pageId, tag } = req.body;
     if (!pageId) return res.status(400).json({ error: "Missing pageId parameter" });
 
-    const sourceTag = tag ?? "Przeczytane";
-    if (!ALLOWED_SOURCE_TAGS.has(sourceTag)) {
-      return res.status(400).json({ error: `Niedozwolony znacznik: ${sourceTag}.` });
-    }
+    const resolved = resolveSourceTag(tag);
+    if ("error" in resolved) return res.status(400).json({ error: resolved.error });
 
-    await syncManager.unmarkRead(pageId, sourceTag);
+    await syncManager.unmarkRead(pageId, resolved.tag);
     res.json({ success: true });
   } catch (error: any) {
-    console.error("Unmark as Read Error:", error);
+    log.error("Unmark as read error", { message: error.message });
     res.status(500).json({ error: error.message || "Wystąpił błąd podczas usuwania znacznika." });
   }
 };
 
 export const checkVintedAvailability = async (req: Request, res: Response) => {
-  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
-    return res.status(400).json({ error: "Brak kluczy API Notion." });
-  }
+  if (!requireNotionKeys(res)) return;
 
   // Resume: the frontend can ask to skip books scanned within the last N hours.
   const skipRaw = req.body?.skipScannedWithinHours;
@@ -278,9 +286,7 @@ export const checkVintedAvailability = async (req: Request, res: Response) => {
 export const stopVintedCheck = makeStopHandler("Zatrzymywanie skanowania Vinted...");
 
 export const resolveVintedSellers = async (req: Request, res: Response) => {
-  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
-    return res.status(400).json({ error: "Brak kluczy API Notion." });
-  }
+  if (!requireNotionKeys(res)) return;
   // No cap by default — resolution is incremental and resumable, so one pass
   // resolves all the missing ones it can. An optional `cap` from the body limits the pass.
   const capRaw = req.body?.cap;
@@ -297,9 +303,7 @@ export const resolveVintedSellers = async (req: Request, res: Response) => {
 export const stopVintedResolveSellers = makeStopHandler("Zatrzymywanie ustalania sprzedawców...");
 
 export const getVintedStored = async (_req: Request, res: Response) => {
-  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
-    return res.status(400).json({ error: "Brak kluczy API Notion." });
-  }
+  if (!requireNotionKeys(res)) return;
   try {
     res.json(await syncManager.getVintedStored());
   } catch (error: any) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.9",
+  "version": "1.67.10",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.9",
+  "version": "1.67.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.9",
+      "version": "1.67.10",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.9",
+  "version": "1.67.10",
   "type": "module",
   "engines": {
     "node": ">=18 <21"


### PR DESCRIPTION
Przegląd architektury — **Tier 4 (PR2)**, kontroler.

- `requireNotionKeys(res)` zastępuje **4×** skopiowany guard `NOTION_API_KEY`/`DATABASE_ID` (runSync, checkVintedAvailability, resolveVintedSellers, getVintedStored).
- `resolveSourceTag(tag)` zastępuje **2×** zdublowaną walidację `ALLOWED_SOURCE_TAGS` (markAsRead, unmarkAsRead).
- **6×** `console.error` → strukturalny `log.error` (stats, books, wikiLastUpdate, notionSchema, mark, unmark) — spójnie z resztą kontrolera.

Zero zmiany zachowania (te same statusy i komunikaty).

## Test
`npm test` — **473 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_