### PR TITLE
refactor(hooks): shared markReadRequest + postStop request primitives

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.10** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.11** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.11** — **[Tier 4, PR3] Wspólne prymitywy request w hookach.** `src/utils/http.ts`: `markReadRequest`
+  (jeden transport mark/unmark — dotąd 3 kopie: `useMarkRead`, `useMarkAsRead`, `useCyclesHarvest`; każdy hook
+  nakłada swój optimistic/lock/error) + `postStop` (fire-and-forget POST `/stop` — dotąd 3 kopie w
+  `useVintedCheck`/`useLibraryCheck`/`useVintedResolveSellers`). `useSync.stopSync` zostawiony bez zmian —
+  ma dodatkową logikę (czyta `data.success`). Zachowane komunikaty błędów (fallbacki per-caller). Suite 473
+  zielone, lint czysty, build OK.
 - **1.67.10** — **[Tier 4, PR2] Kontroler: wspólny guard kluczy + walidacja tagu + strukturalne logi.**
   `requireNotionKeys(res)` zastępuje 4× skopiowany guard `NOTION_API_KEY`/`DATABASE_ID` (runSync/checkVinted/
   resolveVinted/getVintedStored). `resolveSourceTag(tag)` zastępuje 2× zdublowaną walidację `ALLOWED_SOURCE_TAGS`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.10",
+  "version": "1.67.11",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.10",
+  "version": "1.67.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.10",
+      "version": "1.67.11",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.10",
+  "version": "1.67.11",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/hooks/useCyclesHarvest.ts
+++ b/src/hooks/useCyclesHarvest.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { markReadRequest } from "../utils/http";
 
 export interface VolumeOffer {
   price: number;
@@ -66,13 +67,7 @@ export function useCyclesHarvest() {
     setBusyId(id);
     setError(null);
     try {
-      const url = active ? "/api/mark-as-read" : "/api/unmark-as-read";
-      const res = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pageId: id, tag }),
-      });
-      if (!res.ok) { const j = await res.json().catch(() => null); throw new Error(j?.error || `Błąd serwera: ${res.status}`); }
+      await markReadRequest(id, tag, active, "Nie udało się zmienić statusu tomu.");
       await fetchHarvest(true);
     } catch (e: any) {
       setError(e?.message || "Nie udało się zmienić statusu tomu.");

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from "react";
 import { IdentifiedBooks } from "./useStats";
 import { useSSEStream } from "./useSSEStream";
+import { postStop } from "../utils/http";
 
 export type { IdentifiedBooks };
 
@@ -58,11 +59,7 @@ export function useLibraryCheck() {
   }, [run]);
 
   const stopLibraryCheck = useCallback(async () => {
-    try {
-      await fetch("/api/library-check/stop", { method: "POST" });
-    } catch (err) {
-      console.error("Error stopping library check:", err);
-    }
+    await postStop("/api/library-check/stop");
   }, []);
 
   const checkAllLibraries = useCallback(async (branches: { id: string; code: string }[]) => {

--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import type { IdentifiedBooks } from "./useStats";
+import { markReadRequest } from "../utils/http";
 
 type BookRef = { id: string; title: string; author: string; year?: number | null };
 
@@ -28,12 +29,7 @@ export function useMarkAsRead({ identifiedBooks, addBookToLibrarySection, fetchS
     if (markingId) return;
     setMarkingId(pageId);
     try {
-      const res = await fetch("/api/mark-as-read", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pageId, tag })
-      });
-      if (!res.ok) throw new Error("Błąd podczas oznaczania pozycji");
+      await markReadRequest(pageId, tag, true, "Błąd podczas oznaczania pozycji");
       const sourceTag = tag ?? "Przeczytane";
       setMarkedIds(prev => new Set(prev).add(`${sourceTag}:${pageId}`));
 

--- a/src/hooks/useMarkRead.ts
+++ b/src/hooks/useMarkRead.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { READ_TAG } from "../utils/bookshelf";
+import { markReadRequest } from "../utils/http";
 
 /**
  * Writing the „read" state to Notion: `mark-as-read` adds the „Przeczytane" tag
@@ -7,18 +8,8 @@ import { READ_TAG } from "../utils/bookshelf";
  * (shelf) makes an optimistic move and reverts it if the write fails.
  */
 export function useMarkRead() {
-  const setRead = useCallback(async (pageId: string, read: boolean): Promise<void> => {
-    const url = read ? "/api/mark-as-read" : "/api/unmark-as-read";
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ pageId, tag: READ_TAG }),
-    });
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      throw new Error(body.error || "Zapis do Notion nie powiódł się");
-    }
-  }, []);
+  const setRead = useCallback((pageId: string, read: boolean): Promise<void> =>
+    markReadRequest(pageId, READ_TAG, read), []);
 
   return { setRead };
 }

--- a/src/hooks/useVintedCheck.ts
+++ b/src/hooks/useVintedCheck.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { useSSEStream } from "./useSSEStream";
+import { postStop } from "../utils/http";
 
 export interface VintedResult {
   id: string;
@@ -130,11 +131,7 @@ export function useVintedCheck() {
   }, [run]);
 
   const stopVintedCheck = useCallback(async () => {
-    try {
-      await fetch("/api/vinted-check/stop", { method: "POST" });
-    } catch (err) {
-      console.error("Error stopping Vinted check:", err);
-    }
+    await postStop("/api/vinted-check/stop");
   }, []);
 
   return { 

--- a/src/hooks/useVintedResolveSellers.ts
+++ b/src/hooks/useVintedResolveSellers.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { useSSEStream } from "./useSSEStream";
+import { postStop } from "../utils/http";
 
 /**
  * Stage 2: incrementally fetching sellers for STORED offers (Notion), resumable
@@ -49,11 +50,7 @@ export function useVintedResolveSellers() {
   }, [run]);
 
   const stopResolve = useCallback(async () => {
-    try {
-      await fetch("/api/vinted-resolve-sellers/stop", { method: "POST" });
-    } catch (err) {
-      console.error("Error stopping seller resolution:", err);
-    }
+    await postStop("/api/vinted-resolve-sellers/stop");
   }, []);
 
   return { isResolving, resolveProgress, resolveResult, resolveError, runResolve, stopResolve };

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -12,3 +12,31 @@ export async function fetchWithTimeout(url: string, ms = 12000): Promise<Respons
     clearTimeout(timer);
   }
 }
+
+/**
+ * Add/remove a „Źródło" tag on a Notion row: `active` → `mark-as-read`, else
+ * `unmark-as-read`. The single write transport shared by the shelf, stats and
+ * cycle-harvest hooks; each layers its own optimistic/lock state on top. Throws
+ * on a non-OK response (server error message, or `errorFallback`).
+ */
+export async function markReadRequest(pageId: string, tag: string | undefined, active: boolean, errorFallback = "Zapis do Notion nie powiódł się"): Promise<void> {
+  const url = active ? "/api/mark-as-read" : "/api/unmark-as-read";
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pageId, tag }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || errorFallback);
+  }
+}
+
+/** Fire-and-forget POST to a task's `/stop` endpoint (best-effort; a failure is only logged). */
+export async function postStop(url: string): Promise<void> {
+  try {
+    await fetch(url, { method: "POST" });
+  } catch (err) {
+    console.error("Stop request failed:", err);
+  }
+}


### PR DESCRIPTION
Przegląd architektury — **Tier 4 (PR3)**, wspólne prymitywy request w hookach.

- `markReadRequest(pageId, tag, active, errorFallback)` w `src/utils/http.ts` — jeden transport mark/unmark, zastępuje **3 kopie** (`useMarkRead`, `useMarkAsRead`, `useCyclesHarvest`). Każdy hook nakłada własny optimistic/lock/error; fallbacki per-caller zachowują dotychczasowe komunikaty.
- `postStop(url)` — fire-and-forget POST do `/stop` zadania, zastępuje **3 kopie** (`useVintedCheck`, `useLibraryCheck`, `useVintedResolveSellers`). `useSync.stopSync` zostawiony bez zmian — ma dodatkową logikę (czyta `data.success`).

## Test
`npm test` — **473 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_