### PR TITLE
refactor(hooks): type useSyncManager + relocate stats domain types

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.11** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.12** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.12** — **[Tier 4, PR4] Typowanie `useSyncManager` + relokacja typów domenowych stats.** (1) `sync: any`/
+  `FULL_SYNC_STEPS[].sync: any`/`clearOthers(any)`/`handleSyncAction(any)` → `type SyncInstance =
+  ReturnType<typeof useSync>` (kontrakt rytuału już nie wymazany). Payloady wyników zostają `any[]` (heterogen).
+  (2) ~85 linii interfejsów domenowych przeniesione z `useStats.ts` do nowego `src/types/stats.ts`; `useStats`
+  re-eksportuje je (back-compat), a dwa hooki sięgające po TYP do sąsiedniego hooka (`useLibraryCheck`,
+  `useMarkAsRead` — `IdentifiedBooks`) importują teraz z `../types/stats`. Zero zmiany zachowania. Suite 473
+  zielone, lint czysty, build OK.
 - **1.67.11** — **[Tier 4, PR3] Wspólne prymitywy request w hookach.** `src/utils/http.ts`: `markReadRequest`
   (jeden transport mark/unmark — dotąd 3 kopie: `useMarkRead`, `useMarkAsRead`, `useCyclesHarvest`; każdy hook
   nakłada swój optimistic/lock/error) + `postStop` (fire-and-forget POST `/stop` — dotąd 3 kopie w

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.11",
+  "version": "1.67.12",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.11",
+  "version": "1.67.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.11",
+      "version": "1.67.12",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.11",
+  "version": "1.67.12",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/hooks/useLibraryCheck.ts
+++ b/src/hooks/useLibraryCheck.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from "react";
-import { IdentifiedBooks } from "./useStats";
+import { IdentifiedBooks } from "../types/stats";
 import { useSSEStream } from "./useSSEStream";
 import { postStop } from "../utils/http";
 

--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import type { IdentifiedBooks } from "./useStats";
+import type { IdentifiedBooks } from "../types/stats";
 import { markReadRequest } from "../utils/http";
 
 type BookRef = { id: string; title: string; author: string; year?: number | null };

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,91 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 
-export interface AuthorStat {
-  name: string;
-  read: number;
-  total: number;
-  books: { id: string; title: string; year?: number | null; read: boolean }[];
-}
-
-export interface AwardCoverageStat {
-  name: string;
-  count: number;
-  total: number;
-}
-
-export interface YearlyStat {
-  year: string;
-  read: number;
-  total: number;
-  books: { id: string; title: string; author: string; read: boolean }[];
-}
-
-export interface LibraryStat {
-  id: string;
-  name: string;
-  books: { id: string; title: string; author: string; year?: number | null; read: boolean }[];
-}
-
-export interface IdentifiedBook {
-  id: string;
-  title: string;
-  author: string;
-  year?: number | null;
-  // Filled by the library scan (OPAC) — title/author read from the catalog
-  extractedTitle?: string | null;
-  extractedAuthor?: string | null;
-}
-
-/** Aggregated availability of unread items — priority partition (each book once). */
-export interface AvailabilityStats {
-  totalUnread: number;
-  /** Owned but unread. */
-  owned: number;
-  /** Available to borrow from the library (branch tag), not owned. */
-  library: number;
-  /** Available on Vinted (≥1 stored offer), not owned and not in the library. */
-  vinted: number;
-  /** No trace — not owned, no library, no offers. */
-  none: number;
-}
-
-export interface PublisherStat { name: string; count: number; read: number }
-export interface SeriesStat { name: string; count: number; owned: number; read: number }
-export interface CycleStats { partOfCycle: number; standalone: number; total: number }
-export interface DecadeStat { decade: number; total: number; read: number; owned: number }
-
-export interface CheapOffer { bookId: string; bookTitle: string; price: number; currency: string; url: string }
-export interface PriceDrop extends CheapOffer { prevPrice: number }
-export interface TopSeller { id: string; login: string; url: string; books: number; total: number }
-export interface MarketStats {
-  currency: string;
-  completionCost: number;
-  booksWithOffers: number;
-  totalOffers: number;
-  cheapest: CheapOffer[];
-  priceDrops: PriceDrop[];
-  topSellers: TopSeller[];
-}
-
-export interface Stats {
-  authorStats: AuthorStat[];
-  awardBooksStats: { read: number; total: number };
-  ownedUnread: { id: string; title: string; author: string; year?: number | null }[];
-  awardCoverage: AwardCoverageStat[];
-  allAwardsStats: { read: number; total: number };
-  yearlyStats: YearlyStat[];
-  availabilityStats: AvailabilityStats;
-  publisherStats: PublisherStat[];
-  seriesStats: SeriesStat[];
-  cycleStats: CycleStats;
-  decadeStats: DecadeStat[];
-  marketStats: MarketStats;
-  libraryStats: LibraryStat[];
-}
-
-export interface IdentifiedBooks {
-  [libraryId: string]: IdentifiedBook[];
-}
+export type {
+  AuthorStat, AwardCoverageStat, YearlyStat, LibraryStat, IdentifiedBook, AvailabilityStats,
+  PublisherStat, SeriesStat, CycleStats, DecadeStat, CheapOffer, PriceDrop, TopSeller, MarketStats,
+  Stats, IdentifiedBooks,
+} from "../types/stats";
+import type { Stats } from "../types/stats";
 
 export function useStats() {
   const [stats, setStats] = useState<Stats | null>(null);

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -3,6 +3,9 @@ import { useSync } from "./useSync";
 import { PREDEFINED_AWARDS, SYNC_ALL_AWARD } from "../constants";
 import { useEffectiveConfig } from "./useAppConfig";
 
+/** One ritual's `useSync` instance — the contract shared by every sync in the manager. */
+type SyncInstance = ReturnType<typeof useSync>;
+
 /**
  * Front-end orchestration of all synchronization rituals.
  *
@@ -39,7 +42,7 @@ export function useSyncManager() {
   const anyError = syncs.find(s => s.state.error);
   const isAnySyncLoading = syncs.some(s => s.state.loading);
 
-  const clearOthers = (currentSync: any) => {
+  const clearOthers = (currentSync: SyncInstance) => {
     syncs.forEach(s => {
       if (s !== currentSync) {
         s.reset();
@@ -47,7 +50,7 @@ export function useSyncManager() {
     });
   };
 
-  const handleSyncAction = async (syncService: any, params: any = {}, statusMessage: string | null = null) => {
+  const handleSyncAction = async (syncService: SyncInstance, params: Record<string, any> = {}, statusMessage: string | null = null) => {
     setFullSyncResults(null);
     clearOthers(syncService);
     return await syncService.startSync(params, undefined, statusMessage);
@@ -86,7 +89,7 @@ export function useSyncManager() {
   // „Wielki Rytuał" — a data-described step sequence (not 7× copy-paste).
   // `abortOnFail` steps abort the whole thing on error and drop results; the last one
   // (Lp) only appends its result if present, and always closes the summary.
-  const FULL_SYNC_STEPS: { sync: any; name: string; color: string; label: string; params?: any; abortOnFail: boolean }[] = [
+  const FULL_SYNC_STEPS: { sync: SyncInstance; name: string; color: string; label: string; params?: Record<string, any>; abortOnFail: boolean }[] = [
     { sync: schemaSync, name: "Schemat", color: "emerald", label: "Krok 1/7: Inicjacja schematu...", abortOnFail: true },
     { sync: purifySync, name: "Porządkowanie", color: "amber", label: "Krok 2/7: Porządkowanie tytułów...", abortOnFail: true },
     { sync, name: "Nagrody", color: "cyan", label: "Krok 3/7: Synchronizacja nagród...", params: { awardName: "Wszystkie Nagrody", syncAll: true }, abortOnFail: true },

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -1,0 +1,92 @@
+/**
+ * Domain types for the stats/library feature. Extracted from `useStats` so hooks
+ * and components import them from here instead of reaching into the stats-hook
+ * module (which had become a de-facto types barrel).
+ */
+
+export interface AuthorStat {
+  name: string;
+  read: number;
+  total: number;
+  books: { id: string; title: string; year?: number | null; read: boolean }[];
+}
+
+export interface AwardCoverageStat {
+  name: string;
+  count: number;
+  total: number;
+}
+
+export interface YearlyStat {
+  year: string;
+  read: number;
+  total: number;
+  books: { id: string; title: string; author: string; read: boolean }[];
+}
+
+export interface LibraryStat {
+  id: string;
+  name: string;
+  books: { id: string; title: string; author: string; year?: number | null; read: boolean }[];
+}
+
+export interface IdentifiedBook {
+  id: string;
+  title: string;
+  author: string;
+  year?: number | null;
+  // Filled by the library scan (OPAC) — title/author read from the catalog
+  extractedTitle?: string | null;
+  extractedAuthor?: string | null;
+}
+
+/** Aggregated availability of unread items — priority partition (each book once). */
+export interface AvailabilityStats {
+  totalUnread: number;
+  /** Owned but unread. */
+  owned: number;
+  /** Available to borrow from the library (branch tag), not owned. */
+  library: number;
+  /** Available on Vinted (≥1 stored offer), not owned and not in the library. */
+  vinted: number;
+  /** No trace — not owned, no library, no offers. */
+  none: number;
+}
+
+export interface PublisherStat { name: string; count: number; read: number }
+export interface SeriesStat { name: string; count: number; owned: number; read: number }
+export interface CycleStats { partOfCycle: number; standalone: number; total: number }
+export interface DecadeStat { decade: number; total: number; read: number; owned: number }
+
+export interface CheapOffer { bookId: string; bookTitle: string; price: number; currency: string; url: string }
+export interface PriceDrop extends CheapOffer { prevPrice: number }
+export interface TopSeller { id: string; login: string; url: string; books: number; total: number }
+export interface MarketStats {
+  currency: string;
+  completionCost: number;
+  booksWithOffers: number;
+  totalOffers: number;
+  cheapest: CheapOffer[];
+  priceDrops: PriceDrop[];
+  topSellers: TopSeller[];
+}
+
+export interface Stats {
+  authorStats: AuthorStat[];
+  awardBooksStats: { read: number; total: number };
+  ownedUnread: { id: string; title: string; author: string; year?: number | null }[];
+  awardCoverage: AwardCoverageStat[];
+  allAwardsStats: { read: number; total: number };
+  yearlyStats: YearlyStat[];
+  availabilityStats: AvailabilityStats;
+  publisherStats: PublisherStat[];
+  seriesStats: SeriesStat[];
+  cycleStats: CycleStats;
+  decadeStats: DecadeStat[];
+  marketStats: MarketStats;
+  libraryStats: LibraryStat[];
+}
+
+export interface IdentifiedBooks {
+  [libraryId: string]: IdentifiedBook[];
+}


### PR DESCRIPTION
Przegląd architektury — **Tier 4 (PR4)**.

- **Typowanie `useSyncManager`:** `sync`/`params`/`FULL_SYNC_STEPS[].sync` były `any`; teraz `type SyncInstance = ReturnType<typeof useSync>` przywraca kontrakt `useSync` w korzeniu kompozycji. Heterogeniczne payloady wyników zostają `any[]`.
- **Relokacja typów:** ~85 linii interfejsów domenowych przeniesione z `useStats.ts` do nowego `src/types/stats.ts`. `useStats` re-eksportuje je (back-compat), a dwa hooki sięgające po TYP do sąsiedniego hooka (`useLibraryCheck`, `useMarkAsRead` → `IdentifiedBooks`) importują teraz z `../types/stats`.

Zero zmiany zachowania. `npm test` — **473 zielone**, lint czysto, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_