### PR TITLE
refactor(adapter): schema methods target resolved data source, drop leaked id

### DIFF
--- a/__tests__/notion.adapter.test.ts
+++ b/__tests__/notion.adapter.test.ts
@@ -174,9 +174,9 @@ describe('NotionAdapter', () => {
   describe('updateDatabaseProperty', () => {
     it('updates a property correctly', async () => {
       mockClient.dataSources.retrieve.mockResolvedValueOnce({ id: 'test-db-id' }); // for init
-      
-      await adapter.updateDatabaseProperty('test-db-id', 'Wydawnictwo', 'rich_text');
-      
+
+      await adapter.updateDatabaseProperty('Wydawnictwo', 'rich_text');
+
       expect(mockClient.dataSources.update).toHaveBeenCalledWith({
         data_source_id: 'test-db-id',
         properties: {

--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -19,7 +19,6 @@ vi.mock('../notion.adapter', () => {
   NotionAdapter.prototype.queryAllBooks = vi.fn().mockResolvedValue([]);
   NotionAdapter.prototype.updatePage = vi.fn().mockResolvedValue(undefined);
   NotionAdapter.prototype.addRow = vi.fn().mockResolvedValue({ id: 'new-page-id' });
-  NotionAdapter.prototype.resolveDataSourceId = vi.fn().mockResolvedValue('test-ds-id');
   NotionAdapter.prototype.retrieveDataSource = vi.fn().mockResolvedValue({ properties: {} });
   NotionAdapter.prototype.updateDatabaseProperty = vi.fn().mockResolvedValue(undefined);
   NotionAdapter.prototype.createColumnIfNeeded = vi.fn().mockResolvedValue(undefined);

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.12** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.67.13** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.67.13** — **[Tier 4, PR5] Adapter schema-methods bez wyciekającego id (warstwowanie).**
+  `notion.adapter.ts`: `retrieveDataSource()`/`updateDatabaseProperty(name,type)`/`renameProperty(old,new)` gubią
+  vestigialny parametr `databaseId`/`dataSourceId` i celują wewnętrznie w `this.actualDataSourceId!`; usunięto
+  `resolveDataSourceId` (był tylko przelotem przez `init()`). Naprawia realny bug: metody brały przekazane id, więc
+  gdyby wywołujący podał surowe `databaseId` w trybie data-source, update poszedłby na złe źródło — teraz nie ma
+  jak. `schemaValidationService` traci odczyt `process.env.NOTION_DATABASE_ID` + `resolveDataSourceId`;
+  `cyclesSyncService` traci martwy `resolveDataSourceId` (wynik nigdy nieużywany). Testy zaktualizowane (bez
+  `'actual-id'`/`'test-ds-id'` jako 1. arg). Zero zmiany zachowania. Suite 473 zielone, lint czysty, build OK.
+  **Tier 4 (i cały przegląd architektury) zamknięty**; kosmetyczne renamy (`useConfig`, `SanctityDebugger`,
+  relokacja `isbn.ts`) świadomie pominięte jako low-value churn.
 - **1.67.12** — **[Tier 4, PR4] Typowanie `useSyncManager` + relokacja typów domenowych stats.** (1) `sync: any`/
   `FULL_SYNC_STEPS[].sync: any`/`clearOthers(any)`/`handleSyncAction(any)` → `type SyncInstance =
   ReturnType<typeof useSync>` (kontrakt rytuału już nie wymazany). Payloady wyników zostają `any[]` (heterogen).

--- a/docs/schema-validation.md
+++ b/docs/schema-validation.md
@@ -27,6 +27,6 @@ Ensures the Notion database has the correct structure (columns and types) requir
 
 ## 4. Implementation Details
 - **Notion API**: Uses `updateDatabaseProperty` and `renameProperty` to modify the database schema.
-- **Database Resolution**: Uses `resolveDataSourceId` to handle potential database ID variations.
+- **Database Resolution**: The adapter resolves the effective data source at `init()` (data-source vs. classic database); the schema-management methods (`retrieveDataSource`/`updateDatabaseProperty`/`renameProperty`) target that resolved source directly — the service no longer passes an id.
 - **Progress Reporting**: Sends SSE events for each schema modification.
 - **Output**: Returns a summary of which columns were added or updated.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.12",
+  "version": "1.67.13",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -287,24 +287,22 @@ export class NotionAdapter {
     });
   }
 
-  async resolveDataSourceId(databaseId: string): Promise<string> {
+  // Schema-management methods all target the base the adapter resolved at init
+  // (`actualDataSourceId`) — callers no longer pass an id, so there is no way to
+  // send an update to the wrong source.
+  async retrieveDataSource(): Promise<any> {
     await this.init();
-    return this.actualDataSourceId!;
+    return this.retrieveSource(this.actualDataSourceId!);
   }
 
-  async retrieveDataSource(dataSourceId: string): Promise<any> {
+  async updateDatabaseProperty(propertyName: string, propertyType: string): Promise<void> {
     await this.init();
-    return this.retrieveSource(dataSourceId);
+    await this.updateSource(this.actualDataSourceId!, { [propertyName]: { [propertyType]: {} } });
   }
 
-  async updateDatabaseProperty(databaseId: string, propertyName: string, propertyType: string): Promise<void> {
+  async renameProperty(oldName: string, newName: string): Promise<void> {
     await this.init();
-    await this.updateSource(databaseId, { [propertyName]: { [propertyType]: {} } });
-  }
-
-  async renameProperty(databaseId: string, oldName: string, newName: string): Promise<void> {
-    await this.init();
-    await this.updateSource(databaseId, { [oldName]: { name: newName } });
+    await this.updateSource(this.actualDataSourceId!, { [oldName]: { name: newName } });
   }
 
   async updatePage(pageId: string, properties: any): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.12",
+  "version": "1.67.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.12",
+      "version": "1.67.13",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.12",
+  "version": "1.67.13",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/cyclesSyncService.test.ts
+++ b/services/__tests__/cyclesSyncService.test.ts
@@ -13,7 +13,6 @@ describe('CyclesSyncService', () => {
 
   beforeEach(() => {
     mockNotion = {
-      resolveDataSourceId: vi.fn().mockResolvedValue('test-id'),
       createColumnIfNeeded: vi.fn(),
       queryAllBooks: vi.fn(),
       updatePage: vi.fn(),

--- a/services/__tests__/schemaValidationService.test.ts
+++ b/services/__tests__/schemaValidationService.test.ts
@@ -8,10 +8,8 @@ describe('SchemaValidationService', () => {
   let mockSendEvent: any;
 
   beforeEach(() => {
-    process.env.NOTION_DATABASE_ID = 'test-db-id';
     mockNotion = {
       init: vi.fn(),
-      resolveDataSourceId: vi.fn().mockResolvedValue('actual-id'),
       retrieveDataSource: vi.fn(),
       renameProperty: vi.fn(),
       updateDatabaseProperty: vi.fn(),
@@ -35,7 +33,7 @@ describe('SchemaValidationService', () => {
 
     await service.runSchemaValidation(mockSendEvent, () => false);
 
-    expect(mockNotion.renameProperty).toHaveBeenCalledWith('actual-id', 'Name', 'Lp');
+    expect(mockNotion.renameProperty).toHaveBeenCalledWith('Name', 'Lp');
   });
 
   it('creates missing properties', async () => {
@@ -48,15 +46,15 @@ describe('SchemaValidationService', () => {
 
     await service.runSchemaValidation(mockSendEvent, () => false);
 
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Autor', 'multi_select');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Tytuł polski', 'rich_text');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Autor', 'multi_select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Tytuł polski', 'rich_text');
     // Cycle columns + closing the old debt are provisioned too.
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Kategoria', 'select');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Cykl', 'rich_text');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'CyklNr', 'number');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'Źródło', 'multi_select');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'VintedData', 'rich_text');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'ShelfOrder', 'number');
-    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('actual-id', 'ISBN', 'rich_text');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Kategoria', 'select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Cykl', 'rich_text');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('CyklNr', 'number');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Źródło', 'multi_select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('VintedData', 'rich_text');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('ShelfOrder', 'number');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('ISBN', 'rich_text');
   });
 });

--- a/services/cyclesSyncService.ts
+++ b/services/cyclesSyncService.ts
@@ -12,8 +12,6 @@ export class CyclesSyncService {
 
   async runCyclesSync(sendEvent: (data: SyncEvent) => void, checkCancellation: () => boolean) {
     try {
-      const databaseId = process.env.NOTION_DATABASE_ID;
-      const actualDataSourceId = await this.notion.resolveDataSourceId(databaseId!);
       sendEvent({ type: "status", message: "Sprawdzanie struktury bazy Notion..." });
       await this.notion.createColumnIfNeeded("Część cyklu", "checkbox");
       sendEvent({ type: "status", message: "Pobieranie listy książek z Notion..." });

--- a/services/schemaValidationService.ts
+++ b/services/schemaValidationService.ts
@@ -9,13 +9,8 @@ export class SchemaValidationService {
       sendEvent({ type: "status", message: "Inicjalizacja bazy Notion..." });
       await this.notion.init();
 
-      const databaseId = process.env.NOTION_DATABASE_ID;
-      if (!databaseId) throw new Error("Brak NOTION_DATABASE_ID w zmiennych środowiskowych.");
-      
-      const actualDataSourceId = await this.notion.resolveDataSourceId(databaseId);
-
       sendEvent({ type: "status", message: "Pobieranie schematu bazy..." });
-      const db = await this.notion.retrieveDataSource(actualDataSourceId) as any;
+      const db = await this.notion.retrieveDataSource() as any;
 
       if (checkCancellation()) {
         sendEvent({ type: "status", message: "Przerwano inicjalizację schematu." });
@@ -48,9 +43,9 @@ export class SchemaValidationService {
       const titleProp = Object.values(db.properties).find((p: any) => p.type === "title") as any;
       if (titleProp && titleProp.name !== "Lp") {
         sendEvent({ type: "status", message: `Zmiana nazwy głównej kolumny z ${titleProp.name} na Lp...` });
-        await this.notion.renameProperty(actualDataSourceId, titleProp.name, "Lp");
+        await this.notion.renameProperty(titleProp.name, "Lp");
         // Refresh db properties after rename
-        const updatedDb = await this.notion.retrieveDataSource(actualDataSourceId) as any;
+        const updatedDb = await this.notion.retrieveDataSource() as any;
         db.properties = updatedDb.properties;
       }
 
@@ -66,12 +61,12 @@ export class SchemaValidationService {
         const existingProp = db.properties[prop.name];
         if (!existingProp) {
           sendEvent({ type: "status", message: `Tworzenie brakującej kolumny: ${prop.name}...` });
-          await this.notion.updateDatabaseProperty(actualDataSourceId, prop.name, prop.type);
+          await this.notion.updateDatabaseProperty(prop.name, prop.type);
           addedCount++;
           summary.added.push(prop.name);
         } else if (existingProp.type !== prop.type) {
           sendEvent({ type: "status", message: `Aktualizacja typu kolumny ${prop.name} z ${existingProp.type} na ${prop.type}...` });
-          await this.notion.updateDatabaseProperty(actualDataSourceId, prop.name, prop.type);
+          await this.notion.updateDatabaseProperty(prop.name, prop.type);
           addedCount++;
           summary.added.push(`${prop.name} (zmiana typu)`);
         }


### PR DESCRIPTION
Fixes #319

## What
The adapter already resolves the effective data source at `init()` (`actualDataSourceId`). Three schema-management methods still accepted a `databaseId`/`dataSourceId` parameter, and `retrieveDataSource`/`updateDatabaseProperty`/`renameProperty` used the **passed** value while the rest of the adapter uses `actualDataSourceId` — a layering leak that let a caller send an update to the wrong source in data-source mode. `resolveDataSourceId` was just a pass-through over `init()`.

## Changes
- **`notion.adapter.ts`**: `retrieveDataSource()` / `updateDatabaseProperty(name, type)` / `renameProperty(old, new)` drop the id param and use `this.actualDataSourceId!`; remove `resolveDataSourceId`.
- **`services/schemaValidationService.ts`**: drop the `process.env.NOTION_DATABASE_ID` read + `resolveDataSourceId` call; call the methods without the id.
- **`services/cyclesSyncService.ts`**: remove the dead `resolveDataSourceId` call (result was never used).
- **Tests**: updated `notion.adapter`, `schemaValidationService`, `cyclesSyncService`, `server` expectations/mocks (no more id first-arg).
- **Docs**: `docs/schema-validation.md` note updated.

## Verification
No behavior change. `npm run lint` clean, `npm test` 473 green, `npm run build` OK. Version bumped to 1.67.13.

This is the final finding of the architecture review — **Tier 4 (and the whole review) is now closed**. The remaining cosmetic renames (`useConfig`, `SanctityDebugger`, `isbn.ts` relocation) were intentionally left as low-value rename churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_