### PR TITLE
feat(theme): theme-aware favicon (boho for light, 40k for dark)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.67.13** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.68.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.68.0** — **Favicon zależny od motywu (boho/40k).** Favicon podąża za jawnym przełącznikiem `data-theme`
+  (NIE za `prefers-color-scheme` — apka rozłącza motyw od OS, więc trik `<link media>` byłby niespójny).
+  Dwie ikony (ten sam emblemat-kompas dla rozpoznawalności karty, różna paleta): **light/boho** = kremowe tło
+  `#FBF6EC`, atrament `#3A342B`, glinka `#C07A56` w rdzeniu; **dark/40k** = dotychczasowa (slate `#020617`, cyan
+  `#22d3ee`, fiolet `#a855f7`). Obie ikony + wiring DOM to JEDNO źródło prawdy w inline-skrypcie `index.html`
+  (`window.__setFavicon`) — ustawiane przed mountem Reacta ⇒ zero mignięcia (spójne z ustawianiem motywu tam);
+  statyczny `<link id="favicon">` domyślnie boho (fallback bez JS). `src/utils/favicon.ts` (`applyFavicon`) tylko
+  przekazuje aktywny motyw z efektu `useTheme` przy każdym toggle. +2 testy (`favicon.test.ts`). Suite 475
+  zielone, lint czysty, build OK.
 - **1.67.13** — **[Tier 4, PR5] Adapter schema-methods bez wyciekającego id (warstwowanie).**
   `notion.adapter.ts`: `retrieveDataSource()`/`updateDatabaseProperty(name,type)`/`renameProperty(old,new)` gubią
   vestigialny parametr `databaseId`/`dataSourceId` i celują wewnętrznie w `this.actualDataSourceId!`; usunięto

--- a/index.html
+++ b/index.html
@@ -6,18 +6,45 @@
     <title>Librem — Twoja kolekcja nagradzanej fantastyki</title>
     <meta name="description" content="Librem — osobista kolekcja nagradzanej fantastyki (Hugo, Nebula, Locus) z Encyklopedii Fantastyki, synchronizowana z Notion." />
     <meta name="theme-color" content="#F3ECDF" />
+    <!-- Default (light/boho) favicon — the inline script below swaps it for the
+         40k one under the dark theme. Kept as a static link so a no-JS load still
+         gets a sensible boho icon. -->
     <link
+      id="favicon"
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2064%2064'%3E%3Crect%20width='64'%20height='64'%20rx='14'%20fill='%23020617'/%3E%3Cg%20fill='none'%20stroke='%2322d3ee'%20stroke-width='3.5'%20stroke-linejoin='round'%3E%3Cpath%20d='M32%206v8M32%2050v8M6%2032h8M50%2032h8M13.5%2013.5l5.7%205.7M44.8%2044.8l5.7%205.7M50.5%2013.5l-5.7%205.7M19.2%2044.8l-5.7%205.7'/%3E%3Ccircle%20cx='32'%20cy='32'%20r='16'/%3E%3C/g%3E%3Ccircle%20cx='32'%20cy='32'%20r='6.5'%20fill='%23a855f7'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2064%2064%22%3E%3Crect%20width%3D%2264%22%20height%3D%2264%22%20rx%3D%2214%22%20fill%3D%22%23FBF6EC%22%2F%3E%3Cg%20fill%3D%22none%22%20stroke%3D%22%233A342B%22%20stroke-width%3D%223.5%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M32%206v8M32%2050v8M6%2032h8M50%2032h8M13.5%2013.5l5.7%205.7M44.8%2044.8l5.7%205.7M50.5%2013.5l-5.7%205.7M19.2%2044.8l-5.7%205.7%22%2F%3E%3Ccircle%20cx%3D%2232%22%20cy%3D%2232%22%20r%3D%2216%22%2F%3E%3C%2Fg%3E%3Ccircle%20cx%3D%2232%22%20cy%3D%2232%22%20r%3D%226.5%22%20fill%3D%22%23C07A56%22%2F%3E%3C%2Fsvg%3E"
     />
     <script>
-      // Set the theme before React mounts so there's no flash. Default: light (Librem).
+      // Set the theme AND the matching favicon before React mounts, so neither
+      // flashes. Default: light (Librem/boho). The two icons + the DOM wiring live
+      // here as the single source of truth; `src/utils/favicon.ts` just forwards
+      // the current theme to window.__setFavicon on every toggle.
       (function () {
-        try {
-          var t = localStorage.getItem('librem-theme');
-          document.documentElement.dataset.theme = (t === 'dark' || t === 'light') ? t : 'light';
-        } catch (e) { document.documentElement.dataset.theme = 'light'; }
+        var t;
+        try { t = localStorage.getItem('librem-theme'); } catch (e) {}
+        t = (t === 'dark' || t === 'light') ? t : 'light';
+        document.documentElement.dataset.theme = t;
+
+        var ICONS = {
+          // 40k: dark slate plate, cyan compass, purple core.
+          dark: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='14' fill='#020617'/><g fill='none' stroke='#22d3ee' stroke-width='3.5' stroke-linejoin='round'><path d='M32 6v8M32 50v8M6 32h8M50 32h8M13.5 13.5l5.7 5.7M44.8 44.8l5.7 5.7M50.5 13.5l-5.7 5.7M19.2 44.8l-5.7 5.7'/><circle cx='32' cy='32' r='16'/></g><circle cx='32' cy='32' r='6.5' fill='#a855f7'/></svg>",
+          // Boho: warm paper plate, ink compass, clay core.
+          light: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='14' fill='#FBF6EC'/><g fill='none' stroke='#3A342B' stroke-width='3.5' stroke-linejoin='round'><path d='M32 6v8M32 50v8M6 32h8M50 32h8M13.5 13.5l5.7 5.7M44.8 44.8l5.7 5.7M50.5 13.5l-5.7 5.7M19.2 44.8l-5.7 5.7'/><circle cx='32' cy='32' r='16'/></g><circle cx='32' cy='32' r='6.5' fill='#C07A56'/></svg>"
+        };
+        window.__setFavicon = function (theme) {
+          var svg = ICONS[theme] || ICONS.light;
+          var link = document.getElementById('favicon');
+          if (!link) {
+            link = document.createElement('link');
+            link.id = 'favicon';
+            link.rel = 'icon';
+            link.type = 'image/svg+xml';
+            document.head.appendChild(link);
+          }
+          link.href = 'data:image/svg+xml,' + encodeURIComponent(svg);
+        };
+        window.__setFavicon(t);
       })();
     </script>
   </head>

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.67.13",
+  "version": "1.68.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.67.13",
+  "version": "1.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.67.13",
+      "version": "1.68.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.67.13",
+  "version": "1.68.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { applyFavicon } from "../utils/favicon";
 
 /**
  * App theme: „light" = Librem (jasny boho), „dark" = Warhammer (dotychczasowy).
@@ -27,6 +28,7 @@ export function useTheme() {
   useEffect(() => {
     if (typeof document !== "undefined") document.documentElement.dataset.theme = theme;
     try { localStorage.setItem(KEY, theme); } catch { /* ignore */ }
+    applyFavicon(theme);
   }, [theme]);
 
   const toggle = useCallback(() => setTheme((t) => (t === "light" ? "dark" : "light")), []);

--- a/src/utils/__tests__/favicon.test.ts
+++ b/src/utils/__tests__/favicon.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { applyFavicon } from "../favicon";
+
+afterEach(() => {
+  delete (window as any).__setFavicon;
+});
+
+describe("applyFavicon", () => {
+  it("forwards the active theme to the inline-script hook", () => {
+    const spy = vi.fn();
+    window.__setFavicon = spy;
+
+    applyFavicon("dark");
+    applyFavicon("light");
+
+    expect(spy).toHaveBeenNthCalledWith(1, "dark");
+    expect(spy).toHaveBeenNthCalledWith(2, "light");
+  });
+
+  it("is a no-op when the inline script hasn't registered the hook", () => {
+    expect(() => applyFavicon("light")).not.toThrow();
+  });
+});

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -1,0 +1,16 @@
+/**
+ * Theme-aware favicon. The two icons (boho for light, 40k for dark) and the DOM
+ * wiring are defined once in the pre-mount inline script in `index.html` — that
+ * placement is what lets the correct icon paint before React mounts (no flash),
+ * mirroring how the theme itself is set there. This helper just forwards the
+ * active theme to that script on every toggle.
+ */
+declare global {
+  interface Window {
+    __setFavicon?: (theme: "light" | "dark") => void;
+  }
+}
+
+export function applyFavicon(theme: "light" | "dark"): void {
+  if (typeof window !== "undefined") window.__setFavicon?.(theme);
+}


### PR DESCRIPTION
Fixes #321

## What
The favicon was permanently the 40k emblem (dark slate + cyan compass + purple core) — great under the dark theme, out of place under the default light/boho theme. Now it follows the active theme.

## Why not `<link media="(prefers-color-scheme)">`
The app decouples its theme from the OS (`data-theme`, default light regardless of `prefers-color-scheme`). A media-query icon swap would follow the OS, not the app's toggle — a dark-OS/light-app user would get the wrong icon. So the favicon is driven by the **same signal** as the rest of the theme.

## Changes
- **`index.html`**: both icons + the DOM wiring defined once in the pre-mount inline script (`window.__setFavicon`), and the correct one is set **before React mounts** → no flash, mirroring how the theme itself is set there. The static `<link id="favicon">` defaults to the boho icon so a no-JS load still gets a sensible on-brand icon.
- **Boho icon**: same compass emblem (preserves tab recognition), recolored to the Librem palette — warm paper `#FBF6EC` plate, ink `#3A342B` compass, clay `#C07A56` core.
- **Dark icon**: unchanged (`#020617` / `#22d3ee` / `#a855f7`).
- **`src/utils/favicon.ts`** (`applyFavicon`): forwards the active theme to the inline hook; `useTheme` calls it on every toggle. +2 unit tests.

## Verification
`npm run lint` clean, `npm test` **475** green (2 new), `npm run build` OK — confirmed the favicon logic is present in built `dist/index.html`. Version bumped to 1.68.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_