### PR TITLE
feat(ui): theme toggle as a discreet moon/sun icon button

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.68.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.68.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.68.1** — **Przełącznik motywu: pigułka z tekstem → dyskretna ikona księżyc/słońce.** W nagłówku (prawy górny
+  róg) zamiast „pigułki" `ikona + Ciemny/Jasny` jest teraz okrągły przycisk 40×40 tylko z ikoną: księżyc w jasnym
+  (→ ciemny), słońce (amber) w ciemnym (→ jasny), z delikatną animacją obrotu przy zmianie (`AnimatePresence`,
+  rotate ±90°). Styl dopasowany do obu motywów (boho: `#fbf6ec`/`#e4d9c4`/glinka hover; 40k: slate/cyan). Etykiety
+  `title`/`aria-label` zachowane (dostępność ikony-przycisku). Tylko `src/App.tsx`. Suite 475 zielone, lint czysty.
 - **1.68.0** — **Favicon zależny od motywu (boho/40k).** Favicon podąża za jawnym przełącznikiem `data-theme`
   (NIE za `prefers-color-scheme` — apka rozłącza motyw od OS, więc trik `<link media>` byłby niespójny).
   Dwie ikony (ten sam emblemat-kompas dla rozpoznawalności karty, różna paleta): **light/boho** = kremowe tło

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.68.0",
+      "version": "1.68.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.68.0",
+  "version": "1.68.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,18 +81,33 @@ export default function App() {
             </p>
           </div>
 
-          {/* Theme toggle — jasny „Librem" / ciemny „Warhammer" */}
+          {/* Theme toggle — dyskretna ikona księżyc/słońce (jasny „Librem" / ciemny „Warhammer") */}
           <motion.button
-            whileHover={{ scale: 1.04 }}
-            whileTap={{ scale: 0.96 }}
+            whileHover={{ scale: 1.08 }}
+            whileTap={{ scale: 0.92 }}
             onClick={toggleTheme}
-            className="flex items-center gap-2 px-4 py-2.5 rounded-full bg-slate-900/80 border border-cyan-500/30 text-slate-300 backdrop-blur-md shadow-lg transition-colors hover:border-cyan-400/50"
+            className={`shrink-0 grid place-items-center w-10 h-10 rounded-full border backdrop-blur-md shadow-sm transition-colors ${
+              theme === 'light'
+                ? 'border-[#e4d9c4] bg-[#fbf6ec]/70 text-[#8c8069] hover:text-[#c07a56] hover:border-[#c07a56]/50'
+                : 'border-cyan-500/30 bg-slate-900/70 text-slate-300 hover:text-cyan-300 hover:border-cyan-400/50'
+            }`}
             title={theme === 'light' ? 'Przełącz na motyw ciemny' : 'Przełącz na motyw jasny'}
             aria-label={theme === 'light' ? 'Przełącz na motyw ciemny' : 'Przełącz na motyw jasny'}
           >
-            {theme === 'light'
-              ? <><Moon className="w-4 h-4" /><span className="text-xs font-bold uppercase tracking-widest">Ciemny</span></>
-              : <><Sun className="w-4 h-4 text-amber-400" /><span className="text-xs font-bold uppercase tracking-widest">Jasny</span></>}
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.span
+                key={theme}
+                initial={{ rotate: -90, opacity: 0, scale: 0.6 }}
+                animate={{ rotate: 0, opacity: 1, scale: 1 }}
+                exit={{ rotate: 90, opacity: 0, scale: 0.6 }}
+                transition={{ duration: 0.2 }}
+                className="grid place-items-center"
+              >
+                {theme === 'light'
+                  ? <Moon className="w-[18px] h-[18px]" />
+                  : <Sun className="w-[18px] h-[18px] text-amber-400" />}
+              </motion.span>
+            </AnimatePresence>
           </motion.button>
         </motion.header>
 


### PR DESCRIPTION
Fixes #323

## What
Replaces the labeled pill (icon + "Ciemny"/"Jasny") in the header with a compact **40×40 icon-only** round toggle:
- **Light theme** → moon (click switches to dark)
- **Dark theme** → amber sun (click switches to light)
- Small rotate/fade transition on swap (`AnimatePresence`, ±90°)

## Details
- Styling adapts per theme: boho (`#fbf6ec` fill, `#e4d9c4` border, clay hover) for light; slate/cyan for dark.
- `title` / `aria-label` retained so the icon-only control stays accessible.
- `src/App.tsx` only — no logic change to `useTheme`.

## Verification
`npm run lint` clean, `npm test` **475** green, `npm run build` OK. Version bumped to 1.68.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_