### PR TITLE
feat(read-date): capture „Data przeczytania" — schema, mapper, write path

### DIFF
--- a/__tests__/notion.adapter.test.ts
+++ b/__tests__/notion.adapter.test.ts
@@ -187,4 +187,41 @@ describe('NotionAdapter', () => {
       });
     });
   });
+
+  describe('setReadDate', () => {
+    it('stamps a calendar-day date on the page', async () => {
+      mockClient.pages.update.mockResolvedValue({});
+
+      await adapter.setReadDate('page-1', '2024-01-15');
+
+      expect(mockClient.pages.update).toHaveBeenCalledWith({
+        page_id: 'page-1',
+        properties: { 'Data przeczytania': { date: { start: '2024-01-15' } } },
+      });
+    });
+
+    it('clears the date when passed null', async () => {
+      mockClient.pages.update.mockResolvedValue({});
+
+      await adapter.setReadDate('page-1', null);
+
+      expect(mockClient.pages.update).toHaveBeenCalledWith({
+        page_id: 'page-1',
+        properties: { 'Data przeczytania': { date: null } },
+      });
+    });
+
+    it('invalidates the books cache after the write', async () => {
+      const page1 = { id: '1', properties: { 'Tytuł polski': { type: 'title', title: [{ plain_text: 'T-1' }] } } };
+      mockClient.dataSources.retrieve.mockResolvedValue({ id: 'test-db-id' });
+      mockClient.dataSources.query.mockResolvedValue({ results: [page1], has_more: false });
+      mockClient.pages.update.mockResolvedValue({});
+
+      await adapter.getBooksForStats(undefined, undefined, { cache: true }); // primes cache
+      await adapter.setReadDate('page-1', '2024-01-15');                     // invalidates
+      await adapter.getBooksForStats(undefined, undefined, { cache: true }); // must refetch
+
+      expect(mockClient.dataSources.query).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/__tests__/notionMapper.test.ts
+++ b/__tests__/notionMapper.test.ts
@@ -19,6 +19,7 @@ describe("mapPageToBook", () => {
         "Lp": { type: "title", title: rt("1") },
         "Nagroda": { type: "multi_select", multi_select: [{ name: "Nagroda Hugo" }, { name: "Nagroda Locus" }] },
         "Źródło": { type: "multi_select", multi_select: [{ name: "Przeczytane" }] },
+        "Data przeczytania": { type: "date", date: { start: "2024-01-15" } },
       },
     };
 
@@ -35,6 +36,7 @@ describe("mapPageToBook", () => {
       lp: "1",
       awards: ["Nagroda Hugo", "Nagroda Locus"],
       zrodlo: ["Przeczytane"],
+      dataPrzeczytania: "2024-01-15",
     });
   });
 
@@ -51,6 +53,7 @@ describe("mapPageToBook", () => {
     expect(book.awards).toEqual([]);
     expect(book.currentCzesccyklu).toBe(false);
     expect(book.year).toBeUndefined();
+    expect(book.dataPrzeczytania).toBeUndefined();
   });
 
   it("reads a single select award as a one-element list", () => {

--- a/__tests__/syncManager.test.ts
+++ b/__tests__/syncManager.test.ts
@@ -15,6 +15,9 @@ vi.mock("../notion.adapter", () => {
   const NotionAdapter = vi.fn();
   NotionAdapter.prototype.init = vi.fn().mockResolvedValue(undefined);
   NotionAdapter.prototype.getSchema = vi.fn().mockResolvedValue({});
+  NotionAdapter.prototype.addTagToMultiSelect = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.removeTagFromMultiSelect = vi.fn().mockResolvedValue(undefined);
+  NotionAdapter.prototype.setReadDate = vi.fn().mockResolvedValue(undefined);
   return { NotionAdapter };
 });
 
@@ -230,6 +233,45 @@ describe("POST /api/mark-as-read", () => {
   });
 
   afterAll(() => closeServer());
+});
+
+describe("SyncManager.markAsRead / unmarkRead — Data przeczytania stamping", () => {
+  const notion = (syncManager as any).notion;
+
+  beforeEach(() => {
+    vi.restoreAllMocks(); // undo the markAsRead spy from the HTTP describe above
+    notion.addTagToMultiSelect.mockReset().mockResolvedValue(undefined);
+    notion.removeTagFromMultiSelect.mockReset().mockResolvedValue(undefined);
+    notion.setReadDate.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("stamps today's read date only when the tag is 'Przeczytane'", async () => {
+    await syncManager.markAsRead("page-1", "Przeczytane");
+
+    expect(notion.addTagToMultiSelect).toHaveBeenCalledWith("page-1", "Źródło", "Przeczytane");
+    expect(notion.setReadDate).toHaveBeenCalledTimes(1);
+    expect(notion.setReadDate.mock.calls[0][0]).toBe("page-1");
+    expect(notion.setReadDate.mock.calls[0][1]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("does NOT stamp the date for branch/owned tags", async () => {
+    await syncManager.markAsRead("page-2", "Biblioteka");
+    await syncManager.markAsRead("page-3", "Posiadam");
+
+    expect(notion.setReadDate).not.toHaveBeenCalled();
+  });
+
+  it("clears the date when unmarking 'Przeczytane'", async () => {
+    await syncManager.unmarkRead("page-1", "Przeczytane");
+
+    expect(notion.setReadDate).toHaveBeenCalledWith("page-1", null);
+  });
+
+  it("does NOT touch the date when unmarking a branch/owned tag", async () => {
+    await syncManager.unmarkRead("page-2", "Biblioteka");
+
+    expect(notion.setReadDate).not.toHaveBeenCalled();
+  });
 });
 
 describe("SSE event stream (POST /api/sync)", () => {

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.68.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.69.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,20 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.69.0** — **[RD-PR1] Struktura kolumny „Data przeczytania" (warstwa 1/N feature „tempo czytania").**
+  Pierwsza właściwość typu `date` w bazie — brak istniejącej konwencji, użyto natywnego kształtu SDK
+  (`{ date: { start } }` / `{ date: null }`, odczyt `prop.date?.start`). (1) `requiredProps` w
+  `schemaValidationService` +`{ name:"Data przeczytania", type:"date" }` (po `Źródło`); `updateDatabaseProperty`
+  obsługuje `date` bez zmian. (2) `NotionProperty.date` + `NotionBook.dataPrzeczytania?` (src/types.ts);
+  `notionMapper` czyta `dataPrzeczytania` (undefined gdy brak). (3) Adapter `setReadDate(pageId, date|null)` (wzór
+  `updateLp` + `invalidateBooksCache`). (4) Ścieżka zapisu: `syncManager.markAsRead` stempluje `todayIso()` (UTC,
+  dzień), `unmarkRead` czyści — **tylko** gdy `tag==="Przeczytane"` (tagi `Biblioteka*`/`Posiadam` nie ruszają
+  daty). Łapane od teraz w przód (historii nie da się cofnąć). Edge: re-mark już-przeczytanej re-stempluje dziś —
+  UI oznacza tylko na przejściu unread→read, więc w praktyce nie zachodzi. (5) `docs/schema-validation.md` lista
+  required-props doprowadzona do zgodności z kodem (brakowało Źródło/Kategoria/Cykl/CyklNr/VintedData/ShelfOrder/
+  ISBN). +7 testów (adapter setReadDate ×3, mapper ×2, schema ×1, syncManager gating ×4 — netto). Suite 482
+  zielone, lint czysty, build OK. **NASTĘPNE (osobne PR)**: statystyki velocity (przeczytane/rok, tempo, prognoza,
+  streaki) czytające `dataPrzeczytania` w `statsService`/`statsAggregator`; ew. surfacing daty na regale/karcie.
 - **1.68.1** — **Przełącznik motywu: pigułka z tekstem → dyskretna ikona księżyc/słońce.** W nagłówku (prawy górny
   róg) zamiast „pigułki" `ikona + Ciemny/Jasny` jest teraz okrągły przycisk 40×40 tylko z ikoną: księżyc w jasnym
   (→ ciemny), słońce (amber) w ciemnym (→ jasny), z delikatną animacją obrotu przy zmianie (`AnimatePresence`,
@@ -1224,14 +1238,12 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
   REKOMENDACJA: pkt 1 ZROBIONY (1.47.0) → obserwować, czy blok ustępuje; jeśli nie, pkt 2 lekki
   (Playwright tylko do cookie — realny challenge-solve, nie tylko puste GET).
 
-- **Data przeczytania + „Tempo czytania" (velocity)** — ODŁOŻONE (wymaga NOWEGO ZAPISU, nie tylko
-  odczytu). Dziś nie mamy kiedy książka została przeczytana — brak pola. Plan: kolumna „Data
-  przeczytania" (date) stemplowana przy oznaczaniu „Przeczytane" (`markAsRead`/`setRead`), czyszczona
-  przy odznaczeniu; mapper czyta ją do `NotionBook`. Odblokowuje: „przeczytane w tym roku: N",
-  serie/wykresy w czasie (miesiąc/rok), tempo (książki/mies.), prognozę domknięcia kolekcji, streaki.
-  Koszt: zmiana ścieżki zapisu (drag&drop regału + przyciski „oznacz przeczytane" w statystykach/
-  bibliotece) + retro-uzupełnienie historycznych dat niemożliwe (od teraz w przód). Rozważyć po
-  zestawie STAT-PR1..4.
+- **Data przeczytania + „Tempo czytania" (velocity)** — WARSTWA STRUKTURALNA ZREALIZOWANA (RD-PR1, 1.69.0):
+  kolumna `Data przeczytania` (date) w schemacie, mapper → `NotionBook.dataPrzeczytania`, adapter `setReadDate`,
+  ścieżka zapisu `markAsRead`/`unmarkRead` stempluje/czyści (gate na tag „Przeczytane"). Dane łapane OD TERAZ
+  w przód (historii nie cofniemy). **POZOSTAJE (osobne PR-y): STATYSTYKI velocity** czytające `dataPrzeczytania` —
+  „przeczytane w tym roku: N", wykresy w czasie (miesiąc/rok), tempo (książki/mies.), prognoza domknięcia
+  kolekcji, streaki (w `statsService`/`statsAggregator`); ewentualnie surfacing daty na regale/karcie książki.
 - (brak) — pipeline persystencji Vinted (ETAP 1–3) kompletny.
 - **Ewentualnie później**: odświeżanie pojedynczej książki/oferty z bazy (re-check
   świeżości), natywna baza „Vinted Offers" (jeśli blob przestanie wystarczać), proxy

--- a/docs/schema-validation.md
+++ b/docs/schema-validation.md
@@ -5,7 +5,7 @@ Ensures the Notion database has the correct structure (columns and types) requir
 
 ## 2. Validation Logic (`runSchemaValidation`)
 - **Source**: Notion database metadata.
-- **Required Properties**:
+- **Required Properties** (source of truth: `requiredProps` in `services/schemaValidationService.ts`):
   - `Lp`: `title` (Primary column)
   - `Autor`: `multi_select`
   - `Rok`: `multi_select`
@@ -14,7 +14,14 @@ Ensures the Notion database has the correct structure (columns and types) requir
   - `Wydawnictwo`: `multi_select`
   - `Seria`: `multi_select`
   - `Nagroda`: `multi_select`
+  - `Źródło`: `multi_select` (read/ownership/library tags)
+  - `Data przeczytania`: `date` (stamped on „Przeczytane", cleared on unmark; feeds reading-velocity stats)
   - `Część cyklu`: `checkbox`
+  - `Kategoria`: `select` (row category: „Tom cyklu" vs award)
+  - `Cykl`: `rich_text` · `CyklNr`: `number` (cycle grouping)
+  - `VintedData`: `rich_text` (stored Vinted results blob)
+  - `ShelfOrder`: `number` (manual shelf ordering)
+  - `ISBN`: `rich_text` (canonical ISBN-13s from the enrichment ritual)
 
 ## 3. Initialization Steps
 - **Primary Column Renaming**:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.68.1",
+  "version": "1.69.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/notion.adapter.ts
+++ b/notion.adapter.ts
@@ -244,6 +244,22 @@ export class NotionAdapter {
   }
 
   /**
+   * Stamp or clear the „Data przeczytania" date on a book's page: a calendar-day
+   * ISO string („YYYY-MM-DD") to set, `null` to clear. Written as a raw Notion
+   * date property — the first (and so far only) date column in the base, which the
+   * schema ritual provisions. A page update by id needs no data-source resolution.
+   */
+  async setReadDate(pageId: string, date: string | null): Promise<void> {
+    await withRetry(() => this.notion.pages.update({
+      page_id: pageId,
+      properties: {
+        "Data przeczytania": { date: date ? { start: date } : null }
+      }
+    }));
+    this.invalidateBooksCache();
+  }
+
+  /**
    * Shared core for mutating a multi_select field: fetches the current tags, passes them
    * through `transform` and writes the result. `transform` returns a new tag list or
    * `null` = no change (skip the write and cache invalidation). Add/remove are thin

--- a/notionMapper.ts
+++ b/notionMapper.ts
@@ -73,6 +73,12 @@ export function mapPageToBook(page: NotionPage): NotionBook {
   const awards = multiSelectNames(getProp(props, "Nagroda"));
   const zrodlo = multiSelectNames(getProp(props, "Źródło"));
 
+  // Read date („Data przeczytania", date) — stamped when the book is marked
+  // „Przeczytane", cleared on unmark. A calendar day („YYYY-MM-DD", no time);
+  // undefined when never read or the column is absent.
+  const readDateProp = getProp(props, "Data przeczytania");
+  const dataPrzeczytania = readDateProp?.type === "date" ? (readDateProp.date?.start || undefined) : undefined;
+
   // Stored Vinted results blob (rich_text; multiple segments are joined in getPlainText).
   const vintedData = getPlainText(getProp(props, "VintedData")) || undefined;
 
@@ -113,6 +119,7 @@ export function mapPageToBook(page: NotionPage): NotionBook {
     lp,
     awards,
     zrodlo,
+    dataPrzeczytania,
     plTitleRichText,
     origTitleRichText,
     vintedData,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.68.1",
+  "version": "1.69.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.68.1",
+      "version": "1.69.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.68.1",
+  "version": "1.69.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/schemaValidationService.test.ts
+++ b/services/__tests__/schemaValidationService.test.ts
@@ -53,6 +53,7 @@ describe('SchemaValidationService', () => {
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Cykl', 'rich_text');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('CyklNr', 'number');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Źródło', 'multi_select');
+    expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('Data przeczytania', 'date');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('VintedData', 'rich_text');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('ShelfOrder', 'number');
     expect(mockNotion.updateDatabaseProperty).toHaveBeenCalledWith('ISBN', 'rich_text');

--- a/services/schemaValidationService.ts
+++ b/services/schemaValidationService.ts
@@ -27,6 +27,8 @@ export class SchemaValidationService {
         { name: "Seria", type: "multi_select" },
         { name: "Nagroda", type: "multi_select" },
         { name: "Źródło", type: "multi_select" },
+        // Read date — stamped on „Przeczytane", cleared on unmark; feeds reading-velocity stats.
+        { name: "Data przeczytania", type: "date" },
         { name: "Część cyklu", type: "checkbox" },
         // Cycle columns (volumes as rows) — until now created lazily by the Rytuał Żniw.
         { name: "Kategoria", type: "select" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface NotionProperty {
   multi_select?: { name: string; color?: string }[];
   checkbox?: boolean;
   url?: string | null;
+  date?: { start: string; end?: string | null } | null;
   name?: string;
 }
 
@@ -50,6 +51,9 @@ export interface NotionBook {
   kategoria?: string;
   lp?: string;
   zrodlo?: string[];
+  /** Calendar day the book was marked „Przeczytane" (column „Data przeczytania", date; „YYYY-MM-DD").
+   *  Stamped on mark-as-read, cleared on unmark. Undefined = never read / not yet captured. */
+  dataPrzeczytania?: string;
   plTitleRichText?: NotionRichTextItem[];
   origTitleRichText?: NotionRichTextItem[];
   /** JSON blob of stored Vinted results (field „VintedData") — parsed by vintedStore. */

--- a/syncManager.ts
+++ b/syncManager.ts
@@ -34,6 +34,13 @@ import { SyncEvent } from "./src/types";
 
 const log = createLogger("SyncManager");
 
+/** Today as a Notion calendar day („YYYY-MM-DD", UTC). Day-granular on purpose —
+ *  reading-velocity stats aggregate by month/year, so intra-day precision (and the
+ *  server↔user timezone skew near midnight) doesn't matter. */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 const notionAdapter = new NotionAdapter(process.env.NOTION_API_KEY!, process.env.NOTION_DATABASE_ID!);
 const wikiAdapter = new WikiAdapter();
 /** App configuration (knobs) — defaults + overrides from Notion; injected into the services. */
@@ -199,12 +206,21 @@ class SyncManager {
   // passes a branch tag („Biblioteka" = Felin, „Biblioteka 9" =
   // Bronowice), to mark which branch the item is available in.
   async markAsRead(pageId: string, tag: string = "Przeczytane") {
-    return await this.notion.addTagToMultiSelect(pageId, "Źródło", tag);
+    const res = await this.notion.addTagToMultiSelect(pageId, "Źródło", tag);
+    // Only the „Przeczytane" tag stamps the read date — branch tags („Biblioteka…")
+    // and „Posiadam" mark availability/ownership, not a completed read. Captured
+    // from now forward (historical dates can't be backfilled). Edge: re-marking an
+    // already-read book re-stamps today; the UI marks only on the unread→read
+    // transition, so this doesn't happen in practice.
+    if (tag === "Przeczytane") await this.notion.setReadDate(pageId, todayIso());
+    return res;
   }
 
   /** Removes a „Źródło" tag (inverse of `markAsRead`) — drag&drop on the shelf. */
   async unmarkRead(pageId: string, tag: string = "Przeczytane") {
-    return await this.notion.removeTagFromMultiSelect(pageId, "Źródło", tag);
+    const res = await this.notion.removeTagFromMultiSelect(pageId, "Źródło", tag);
+    if (tag === "Przeczytane") await this.notion.setReadDate(pageId, null);
+    return res;
   }
 
   /** Writes manual shelf ordering keys (precise drag&drop). */


### PR DESCRIPTION
Fixes #325

## What
The structural layer for the reading-velocity feature: a new Notion `date` column, `Data przeczytania`, stamped when a book is marked read and cleared on unmark. The stats that consume it are a **separate later PR** — this PR just makes the data start flowing (historical dates can't be backfilled, so capturing early matters).

This is the **first `date` property** in the base — there was no existing convention, so it uses the native Notion SDK shape: `{ date: { start } }` to set, `{ date: null }` to clear, `prop.date?.start` to read.

## Changes
- **Schema** — `services/schemaValidationService.ts`: `{ name: "Data przeczytania", type: "date" }` added to `requiredProps` (next to `Źródło`). `updateDatabaseProperty` handles `date` with no change.
- **Types / mapper** — `src/types.ts`: `NotionProperty.date` + `NotionBook.dataPrzeczytania?`; `notionMapper.ts` reads it (`undefined` when the column is absent).
- **Adapter** — `notion.adapter.ts`: `setReadDate(pageId, date | null)`, mirroring `updateLp` + `invalidateBooksCache` (a page update by id needs no data-source resolution).
- **Write path** — `syncManager.ts`: `markAsRead` stamps today (UTC calendar day via `todayIso()`), `unmarkRead` clears — **only when `tag === "Przeczytane"`**, so branch tags (`Biblioteka`, `Biblioteka 9`) and `Posiadam` never touch the read date.
  - *Known edge*: re-marking an already-read book re-stamps today. The UI marks only on the unread→read transition, so this doesn't happen in practice; documented in code.
- **Docs** — `docs/schema-validation.md` required-props list reconciled with the code (it had drifted — was missing `Źródło`, `Kategoria`, `Cykl`, `CyklNr`, `VintedData`, `ShelfOrder`, `ISBN`).

## Tests (+7)
- Adapter `setReadDate`: stamp payload, clear payload, cache invalidation.
- Mapper: reads the date; `undefined` when absent.
- Schema: asserts the `Data przeczytania` / `date` column is provisioned.
- SyncManager: date stamped only for `Przeczytane` on mark, cleared only for `Przeczytane` on unmark, untouched for branch/owned tags (both directions).

## Verification
`npm run lint` clean, `npm test` **482** green, `npm run build` OK. Version bumped to 1.69.0.

## Follow-ups (separate PRs)
Consume `dataPrzeczytania` in `statsService` / `statsAggregator`: read-this-year count, monthly/yearly charts, books/month pace, collection-completion forecast, streaks; optionally surface the date on the shelf / book card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_