### PR TITLE
feat(read-date): one-time CSV import of read dates (helpers + script)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.69.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.70.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.70.0** — **[RD-PR2] Jednorazowy import dat przeczytania z CSV (helpery + skrypt).** Czysta,
+  przetestowana logika w `services/readDateImport.ts`: `parseReadDate` (rozpoznaje `dd.mm.yyyy` / `yyyy-mm-dd` /
+  `yyyy-mm` / `mm.yyyy` / `yyyy`; daty częściowe przyklejane do początku okresu — miesiąc `-01`, rok `-01-01`),
+  `parseImportCsv` (średnik + BOM + nagłówek), `buildReadDatePlan` (dwustopniowe dopasowanie: exact `robustBookKey`
+  autor+tytuł, potem fallback po UNIKALNYM tytule — nigdy nie wymyśla wiersza; zwija duplikaty biorąc NAJWCZEŚNIEJSZĄ
+  datę; pomija już-datowane bez `--overwrite`). Skrypt `scripts/importReadDates.ts` (poza appem): DRY-RUN domyślnie,
+  `--apply` zapisuje przez `setReadDate`, `--overwrite` nadpisuje. Wymaga NOTION_* w env. +14 testów. Zweryfikowane
+  na realnym CSV usera (712 wierszy: 473 dzień / 19 miesiąc / 220 rok, zero nierozpoznanych, zakres 1993→2026).
+  UWAGA: właściwy import (queryAllBooks + zapis) user robi u siebie — sandbox nie ma kluczy Notion.
 - **1.69.0** — **[RD-PR1] Struktura kolumny „Data przeczytania" (warstwa 1/N feature „tempo czytania").**
   Pierwsza właściwość typu `date` w bazie — brak istniejącej konwencji, użyto natywnego kształtu SDK
   (`{ date: { start } }` / `{ date: null }`, odczyt `prop.date?.start`). (1) `requiredProps` w
@@ -1244,6 +1253,11 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
   w przód (historii nie cofniemy). **POZOSTAJE (osobne PR-y): STATYSTYKI velocity** czytające `dataPrzeczytania` —
   „przeczytane w tym roku: N", wykresy w czasie (miesiąc/rok), tempo (książki/mies.), prognoza domknięcia
   kolekcji, streaki (w `statsService`/`statsAggregator`); ewentualnie surfacing daty na regale/karcie książki.
+- **Import dat przeczytania z CSV — feature w aplikacji (przyszłość).** Jednorazowy import zrobiony skryptem
+  `scripts/importReadDates.ts` (RD-PR2, 1.70.0) na bazie czystych helperów `services/readDateImport.ts`
+  (`parseReadDate`/`parseImportCsv`/`buildReadDatePlan`). DO ZROBIENIA kiedyś: opakować to w UI (upload CSV w
+  Ustawieniach → podgląd planu: dopasowane/niedopasowane/niejednoznaczne → zatwierdź zapis), reużywając tych
+  helperów. Nowe rekordy „na bieżąco" już obsłużone automatycznym stemplowaniem przy oznaczaniu „Przeczytane".
 - (brak) — pipeline persystencji Vinted (ETAP 1–3) kompletny.
 - **Ewentualnie później**: odświeżanie pojedynczej książki/oferty z bazy (re-check
   świeżości), natywna baza „Vinted Offers" (jeśli blob przestanie wystarczać), proxy

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.69.0",
+      "version": "1.70.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.69.0",
+  "version": "1.70.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/scripts/importReadDates.ts
+++ b/scripts/importReadDates.ts
@@ -1,0 +1,91 @@
+/**
+ * ONE-TIME tool: bulk-import read dates („Data przeczytania") from an exported
+ * CSV into the Notion base. Not wired into the app — run it by hand:
+ *
+ *   npx tsx scripts/importReadDates.ts <plik.csv>            # DRY-RUN (preview, no writes)
+ *   npx tsx scripts/importReadDates.ts <plik.csv> --apply    # write the matched dates
+ *   npx tsx scripts/importReadDates.ts <plik.csv> --apply --overwrite  # also overwrite existing dates
+ *
+ * Needs NOTION_API_KEY + NOTION_DATABASE_ID in the environment (.env is loaded).
+ * SAFETY: matches only books ALREADY in the base — it NEVER creates a row. By
+ * default it also skips books that already carry a date. Dry-run first, read the
+ * report, then re-run with --apply.
+ *
+ * The matching/parsing logic lives in `services/readDateImport.ts` (unit-tested);
+ * this file is only the CSV read + Notion I/O + reporting wrapper.
+ */
+import "dotenv/config";
+import { readFileSync } from "fs";
+import { NotionAdapter } from "../notion.adapter";
+import { parseImportCsv, buildReadDatePlan, MatchableBook } from "../services/readDateImport";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const csvPath = args.find((a) => !a.startsWith("--"));
+  const apply = args.includes("--apply");
+  const overwrite = args.includes("--overwrite");
+
+  if (!csvPath) {
+    console.error("Użycie: npx tsx scripts/importReadDates.ts <plik.csv> [--apply] [--overwrite]");
+    process.exit(1);
+  }
+  if (!process.env.NOTION_API_KEY || !process.env.NOTION_DATABASE_ID) {
+    console.error("Brak NOTION_API_KEY / NOTION_DATABASE_ID w środowisku (.env).");
+    process.exit(1);
+  }
+
+  const rows = parseImportCsv(readFileSync(csvPath, "utf8"));
+  console.log(`CSV: ${rows.length} wierszy z ${csvPath}`);
+
+  const notion = new NotionAdapter(process.env.NOTION_API_KEY, process.env.NOTION_DATABASE_ID);
+  await notion.init();
+  console.log("Pobieram książki z bazy Notion...");
+  const books = (await notion.queryAllBooks((c) => process.stdout.write(`\r  pobrano ${c}...`))) as MatchableBook[];
+  process.stdout.write("\n");
+  console.log(`Baza: ${books.length} książek.`);
+
+  const plan = buildReadDatePlan(rows, books, { overwrite });
+
+  console.log("\n=== PODGLĄD (dry-run) ===");
+  console.log(`  Do zapisu:            ${plan.updates.length}`);
+  console.log(`  Pominięte (mają datę): ${plan.skippedExisting.length}${overwrite ? " (overwrite ON — puste)" : ""}`);
+  console.log(`  Bez dopasowania:       ${plan.unmatched.length} (spoza scope bazy — OK)`);
+  console.log(`  Niejednoznaczne:       ${plan.ambiguous.length}`);
+  console.log(`  Zła data (nieznany fmt): ${plan.unparseableDate.length}`);
+  console.log(`  Zwinięte duplikaty:    ${plan.collapsed} (kilka wierszy → jedna książka, brana najwcześniejsza)`);
+
+  const byUnique = plan.updates.filter((u) => u.matchedBy === "unique-title");
+  if (byUnique.length) {
+    console.log(`\n  ⚠ Dopasowane po samym (unikalnym) tytule — zerknij, czy słusznie (${byUnique.length}):`);
+    for (const u of byUnique.slice(0, 40)) console.log(`     • ${u.csvTitle}  →  ${u.iso} (${u.dateRaw})`);
+    if (byUnique.length > 40) console.log(`     ... i ${byUnique.length - 40} więcej`);
+  }
+  if (plan.ambiguous.length) {
+    console.log(`\n  ⚠ Niejednoznaczne (pominięte):`);
+    for (const a of plan.ambiguous.slice(0, 20)) console.log(`     • ${a.row.tytul} (${a.row.autor}) → ${a.bookIds.length} kandydatów`);
+  }
+  console.log(`\n  Przykłady do zapisu:`);
+  for (const u of plan.updates.slice(0, 12)) console.log(`     • ${u.csvTitle}  →  ${u.iso}`);
+
+  if (!apply) {
+    console.log("\nDRY-RUN — nic nie zapisano. Dodaj --apply, by zapisać powyższe.");
+    return;
+  }
+
+  console.log(`\n=== ZAPIS (${plan.updates.length}) ===`);
+  let done = 0, failed = 0;
+  for (const u of plan.updates) {
+    try {
+      await notion.setReadDate(u.id, u.iso);
+      done++;
+      process.stdout.write(`\r  zapisano ${done}/${plan.updates.length}...`);
+    } catch (e: any) {
+      failed++;
+      console.error(`\n  BŁĄD dla ${u.csvTitle} (${u.id}): ${e?.message || e}`);
+    }
+  }
+  process.stdout.write("\n");
+  console.log(`Gotowe: ${done} zapisanych, ${failed} błędów.`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/services/__tests__/readDateImport.test.ts
+++ b/services/__tests__/readDateImport.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { parseReadDate, parseImportCsv, buildReadDatePlan, MatchableBook } from "../readDateImport";
+
+describe("parseReadDate", () => {
+  it("parses a full dd.mm.yyyy date as day precision", () => {
+    expect(parseReadDate("28.08.2026")).toEqual({ iso: "2026-08-28", precision: "day" });
+    expect(parseReadDate("05.07.2026")).toEqual({ iso: "2026-07-05", precision: "day" });
+  });
+
+  it("snaps a year-only value to Jan 1", () => {
+    expect(parseReadDate("2006")).toEqual({ iso: "2006-01-01", precision: "year" });
+  });
+
+  it("snaps a month value (yyyy-mm and mm.yyyy) to the 1st", () => {
+    expect(parseReadDate("2024-01")).toEqual({ iso: "2024-01-01", precision: "month" });
+    expect(parseReadDate("2020-09")).toEqual({ iso: "2020-09-01", precision: "month" });
+    expect(parseReadDate("03.2019")).toEqual({ iso: "2019-03-01", precision: "month" });
+  });
+
+  it("accepts an ISO full date", () => {
+    expect(parseReadDate("2022-11-30")).toEqual({ iso: "2022-11-30", precision: "day" });
+  });
+
+  it("rejects impossible and unrecognized dates", () => {
+    expect(parseReadDate("32.01.2020")).toBeNull(); // no such day
+    expect(parseReadDate("10.13.2020")).toBeNull(); // no such month
+    expect(parseReadDate("2020-13")).toBeNull();
+    expect(parseReadDate("")).toBeNull();
+    expect(parseReadDate("wczoraj")).toBeNull();
+  });
+});
+
+describe("parseImportCsv", () => {
+  it("strips the BOM + header and reads fixed columns", () => {
+    const csv = "﻿tytul;autor;data_przeczytania;link\n" +
+      "Behemot;Peter Watts;28.08.2026;https://example.com/a\n" +
+      "Nocarz;Magdalena Kozak;2006;https://example.com/b\n";
+    const rows = parseImportCsv(csv);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ tytul: "Behemot", autor: "Peter Watts", dataRaw: "28.08.2026", link: "https://example.com/a" });
+    expect(rows[1].dataRaw).toBe("2006");
+  });
+
+  it("folds a stray delimiter into the link column, not the fixed fields", () => {
+    const csv = "tytul;autor;data_przeczytania;link\n" +
+      "T;A;2020;https://x/a;b\n";
+    const rows = parseImportCsv(csv);
+    expect(rows[0]).toEqual({ tytul: "T", autor: "A", dataRaw: "2020", link: "https://x/a;b" });
+  });
+
+  it("skips blank lines", () => {
+    const csv = "tytul;autor;data_przeczytania;link\n\nT;A;2020;u\n\n";
+    expect(parseImportCsv(csv)).toHaveLength(1);
+  });
+});
+
+const book = (id: string, plTitle: string, author: string, extra: Partial<MatchableBook> = {}): MatchableBook =>
+  ({ id, plTitle, author, ...extra });
+
+describe("buildReadDatePlan", () => {
+  it("matches on author+title and resolves the date", () => {
+    const books = [book("b1", "Behemot", "Peter Watts")];
+    const plan = buildReadDatePlan(
+      [{ tytul: "Behemot", autor: "Peter Watts", dataRaw: "28.08.2026", link: "" }],
+      books,
+    );
+    expect(plan.updates).toEqual([
+      { id: "b1", iso: "2026-08-28", precision: "day", matchedBy: "author+title", csvTitle: "Behemot", dateRaw: "28.08.2026" },
+    ]);
+    expect(plan.unmatched).toHaveLength(0);
+  });
+
+  it("falls back to a UNIQUE title when the author differs, but not when the title is shared", () => {
+    const unique = [book("b1", "Rozgwiazda", "Peter Watts")];
+    const planU = buildReadDatePlan(
+      [{ tytul: "Rozgwiazda", autor: "P. Watts (inne zapisy)", dataRaw: "2025", link: "" }],
+      unique,
+    );
+    expect(planU.updates.map(u => u.id)).toEqual(["b1"]);
+    expect(planU.updates[0].matchedBy).toBe("unique-title");
+
+    const shared = [book("b1", "Wir", "Peter Watts"), book("b2", "Wir", "Ktoś Inny")];
+    const planS = buildReadDatePlan(
+      [{ tytul: "Wir", autor: "Ktoś Zupełnie Trzeci", dataRaw: "2025", link: "" }],
+      shared,
+    );
+    expect(planS.updates).toHaveLength(0);
+    expect(planS.ambiguous).toHaveLength(1);
+    expect(planS.ambiguous[0].bookIds.sort()).toEqual(["b1", "b2"]);
+  });
+
+  it("reports CSV rows with no book in the base as unmatched (never invents a row)", () => {
+    const books = [book("b1", "Behemot", "Peter Watts")];
+    const plan = buildReadDatePlan(
+      [{ tytul: "Zupełnie Inna Książka", autor: "Nieznany", dataRaw: "2010", link: "" }],
+      books,
+    );
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.unmatched).toHaveLength(1);
+  });
+
+  it("collapses several CSV rows for one book, keeping the earliest date", () => {
+    const books = [book("b1", "Wir", "Peter Watts")];
+    const plan = buildReadDatePlan(
+      [
+        { tytul: "Wir", autor: "Peter Watts", dataRaw: "25.07.2026", link: "" },
+        { tytul: "Wir", autor: "Peter Watts", dataRaw: "01.02.2019", link: "" },
+      ],
+      books,
+    );
+    expect(plan.updates).toHaveLength(1);
+    expect(plan.updates[0].iso).toBe("2019-02-01");
+    expect(plan.collapsed).toBe(1);
+  });
+
+  it("skips a book that already has a date unless overwrite is set", () => {
+    const books = [book("b1", "Behemot", "Peter Watts", { dataPrzeczytania: "2020-01-01" })];
+    const rows = [{ tytul: "Behemot", autor: "Peter Watts", dataRaw: "28.08.2026", link: "" }];
+
+    const noOverwrite = buildReadDatePlan(rows, books, { overwrite: false });
+    expect(noOverwrite.updates).toHaveLength(0);
+    expect(noOverwrite.skippedExisting).toHaveLength(1);
+
+    const overwrite = buildReadDatePlan(rows, books, { overwrite: true });
+    expect(overwrite.updates).toHaveLength(1);
+    expect(overwrite.skippedExisting).toHaveLength(0);
+  });
+
+  it("collects rows with an unparseable date separately", () => {
+    const books = [book("b1", "Behemot", "Peter Watts")];
+    const plan = buildReadDatePlan(
+      [{ tytul: "Behemot", autor: "Peter Watts", dataRaw: "kiedyś", link: "" }],
+      books,
+    );
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.unparseableDate).toHaveLength(1);
+  });
+});

--- a/services/readDateImport.ts
+++ b/services/readDateImport.ts
@@ -1,0 +1,232 @@
+import { robustBookKey } from "./bookMatch";
+import { normalizeData } from "./dataNormalizer";
+
+/**
+ * Pure helpers for a one-time bulk import of read dates („Data przeczytania")
+ * from an exported CSV (`tytul;autor;data_przeczytania;link`). No Notion access
+ * here — these are testable pure functions; the runnable wrapper lives in
+ * `scripts/importReadDates.ts`. Also the foundation for the future in-app CSV
+ * import feature (backlog).
+ *
+ * Hard rule: matching is against books ALREADY in the base — the plan never
+ * invents a row. Unmatched CSV entries are reported, not created.
+ */
+
+export type DatePrecision = "day" | "month" | "year";
+export interface ParsedReadDate {
+  /** Notion calendar day („YYYY-MM-DD"). Partial inputs snap to the period start. */
+  iso: string;
+  precision: DatePrecision;
+}
+
+function isValidYmd(y: number, m: number, d: number): boolean {
+  if (m < 1 || m > 12 || d < 1 || d > 31) return false;
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+const p2 = (n: number) => String(n).padStart(2, "0");
+const p4 = (n: number) => String(n).padStart(4, "0");
+
+/**
+ * Recognizes the read-date formats seen in the export and normalizes each to a
+ * Notion calendar day. Full dates keep their day; a month-only value snaps to
+ * the 1st, a year-only value to Jan 1 (day/month granularity is approximate for
+ * those — the velocity stats aggregate by month/year, so the period is what
+ * matters). Returns `null` for anything unrecognized (so the caller can report it).
+ *
+ * Accepted: `dd.mm.yyyy`, `yyyy-mm-dd`, `yyyy-mm`, `mm.yyyy`, `yyyy`.
+ */
+export function parseReadDate(raw: string): ParsedReadDate | null {
+  const s = (raw || "").trim();
+  if (!s) return null;
+  let m: RegExpMatchArray | null;
+
+  if ((m = s.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/))) {
+    const d = +m[1], mo = +m[2], y = +m[3];
+    return isValidYmd(y, mo, d) ? { iso: `${p4(y)}-${p2(mo)}-${p2(d)}`, precision: "day" } : null;
+  }
+  if ((m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/))) {
+    const y = +m[1], mo = +m[2], d = +m[3];
+    return isValidYmd(y, mo, d) ? { iso: `${m[1]}-${m[2]}-${m[3]}`, precision: "day" } : null;
+  }
+  if ((m = s.match(/^(\d{4})-(\d{1,2})$/))) {
+    const y = +m[1], mo = +m[2];
+    return mo >= 1 && mo <= 12 ? { iso: `${p4(y)}-${p2(mo)}-01`, precision: "month" } : null;
+  }
+  if ((m = s.match(/^(\d{1,2})\.(\d{4})$/))) {
+    const mo = +m[1], y = +m[2];
+    return mo >= 1 && mo <= 12 ? { iso: `${p4(y)}-${p2(mo)}-01`, precision: "month" } : null;
+  }
+  if ((m = s.match(/^(\d{4})$/))) {
+    return { iso: `${m[1]}-01-01`, precision: "year" };
+  }
+  return null;
+}
+
+export interface ImportRow {
+  tytul: string;
+  autor: string;
+  dataRaw: string;
+  link: string;
+}
+
+/**
+ * Parses the semicolon-delimited export (`tytul;autor;data_przeczytania;link`),
+ * stripping a UTF-8 BOM and the header row. A field is never split further, so a
+ * stray delimiter in the link column folds back into `link` (title/author/date
+ * keep their fixed positions).
+ */
+export function parseImportCsv(content: string): ImportRow[] {
+  const text = content.replace(/^﻿/, "");
+  const rows: ImportRow[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    const parts = line.split(";");
+    if (i === 0 && /^tytul$/i.test((parts[0] || "").trim())) continue; // header
+    if (parts.length < 3) continue;
+    rows.push({
+      tytul: (parts[0] || "").trim(),
+      autor: (parts[1] || "").trim(),
+      dataRaw: (parts[2] || "").trim(),
+      link: parts.slice(3).join(";").trim(),
+    });
+  }
+  return rows;
+}
+
+/** Title-only normalization key — mirrors the title half of `robustBookKey`,
+ *  used for the safe unique-title fallback match. */
+export function bookTitleKey(title: string): string {
+  return normalizeData(title || "", "title")
+    .toLowerCase()
+    .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+export interface MatchableBook {
+  id: string;
+  plTitle?: string;
+  origTitle?: string;
+  author?: string;
+  /** Existing read date on the base row, if any (don't overwrite unless asked). */
+  dataPrzeczytania?: string;
+}
+
+export interface ReadDateUpdate {
+  id: string;
+  iso: string;
+  precision: DatePrecision;
+  /** How the row was matched — for dry-run transparency. */
+  matchedBy: "author+title" | "unique-title";
+  /** The CSV title (for the report). */
+  csvTitle: string;
+  dateRaw: string;
+}
+
+export interface ImportPlan {
+  /** Rows to write: one per matched base book, earliest read date kept. */
+  updates: ReadDateUpdate[];
+  /** Matched a base row that already has a date — skipped unless `overwrite`. */
+  skippedExisting: ReadDateUpdate[];
+  /** CSV rows with no book in the base (expected: non-award reads). */
+  unmatched: ImportRow[];
+  /** CSV rows whose date string was unrecognized. */
+  unparseableDate: ImportRow[];
+  /** CSV rows whose title matched >1 base book and author didn't disambiguate. */
+  ambiguous: { row: ImportRow; bookIds: string[] }[];
+  /** How many extra CSV rows collapsed onto an already-matched book (kept earliest). */
+  collapsed: number;
+}
+
+function pushUnique(map: Map<string, Set<string>>, key: string, id: string) {
+  if (!key) return;
+  if (!map.has(key)) map.set(key, new Set());
+  map.get(key)!.add(id);
+}
+
+/**
+ * Builds the import plan: matches each CSV row to at most one existing base book
+ * and resolves the read date. Two-tier matching, strictly non-inventive:
+ *   1. exact `robustBookKey` (author + title, on plTitle or origTitle);
+ *   2. fallback on a UNIQUE normalized title (catches author-format drift) —
+ *      only when that title maps to exactly one base book, so it can never
+ *      mis-assign a date across two different books.
+ * When several CSV rows map to one book, the earliest date wins (first read).
+ */
+export function buildReadDatePlan(
+  rows: ImportRow[],
+  books: MatchableBook[],
+  opts: { overwrite: boolean } = { overwrite: false },
+): ImportPlan {
+  // Indexes over the base.
+  const exactIndex = new Map<string, Set<string>>(); // robustBookKey -> bookIds
+  const titleIndex = new Map<string, Set<string>>(); // titleKey     -> bookIds
+  const byId = new Map<string, MatchableBook>();
+  for (const b of books) {
+    byId.set(b.id, b);
+    if (b.plTitle) {
+      pushUnique(exactIndex, robustBookKey(b.author || "", b.plTitle), b.id);
+      pushUnique(titleIndex, bookTitleKey(b.plTitle), b.id);
+    }
+    if (b.origTitle) {
+      pushUnique(exactIndex, robustBookKey(b.author || "", b.origTitle), b.id);
+      pushUnique(titleIndex, bookTitleKey(b.origTitle), b.id);
+    }
+  }
+
+  const unmatched: ImportRow[] = [];
+  const unparseableDate: ImportRow[] = [];
+  const ambiguous: { row: ImportRow; bookIds: string[] }[] = [];
+  // bookId -> best (earliest) candidate so far
+  const best = new Map<string, ReadDateUpdate>();
+  let collapsed = 0;
+
+  for (const row of rows) {
+    const parsed = parseReadDate(row.dataRaw);
+    if (!parsed) { unparseableDate.push(row); continue; }
+
+    let ids: string[] = [];
+    let matchedBy: ReadDateUpdate["matchedBy"] = "author+title";
+
+    const exactKey = robustBookKey(row.autor, row.tytul);
+    const exact = exactKey ? exactIndex.get(exactKey) : undefined;
+    if (exact && exact.size >= 1) {
+      ids = [...exact];
+      matchedBy = "author+title";
+    } else {
+      const tk = bookTitleKey(row.tytul);
+      const byTitle = tk ? titleIndex.get(tk) : undefined;
+      if (byTitle && byTitle.size >= 1) { ids = [...byTitle]; matchedBy = "unique-title"; }
+    }
+
+    if (ids.length === 0) { unmatched.push(row); continue; }
+    if (ids.length > 1) { ambiguous.push({ row, bookIds: ids }); continue; }
+
+    const id = ids[0];
+    const candidate: ReadDateUpdate = {
+      id, iso: parsed.iso, precision: parsed.precision, matchedBy, csvTitle: row.tytul, dateRaw: row.dataRaw,
+    };
+    const prev = best.get(id);
+    if (!prev) {
+      best.set(id, candidate);
+    } else {
+      collapsed++;
+      // Keep the earliest read date (first time read).
+      if (candidate.iso < prev.iso) best.set(id, candidate);
+    }
+  }
+
+  // Split matched books into writable vs. skipped (already dated, no overwrite).
+  const updates: ReadDateUpdate[] = [];
+  const skippedExisting: ReadDateUpdate[] = [];
+  for (const u of best.values()) {
+    const existing = byId.get(u.id)?.dataPrzeczytania;
+    if (existing && !opts.overwrite) skippedExisting.push(u);
+    else updates.push(u);
+  }
+
+  return { updates, skippedExisting, unmatched, unparseableDate, ambiguous, collapsed };
+}


### PR DESCRIPTION
Fixes #327

## What
Backfill `Data przeczytania` from an exported reading log (`tytul;autor;data_przeczytania;link`). New reads are already stamped on mark-as-read (#326); this handles the history — as a **one-time** operation. The full in-app CSV import is a separate future feature (added to the backlog).

## Pure, unit-tested logic — `services/readDateImport.ts`
- **`parseReadDate`** — recognizes `dd.mm.yyyy`, `yyyy-mm-dd`, `yyyy-mm`, `mm.yyyy`, `yyyy`. Partial dates snap to the period start (month → `-01`, year → `-01-01`); the velocity stats aggregate by month/year, so the period is what matters. Rejects impossible/unknown formats.
- **`parseImportCsv`** — semicolon-delimited, BOM- and header-aware; a stray delimiter folds into the `link` column so the fixed fields stay put.
- **`buildReadDatePlan`** — two-tier matching against books **already in the base**:
  1. exact `robustBookKey` (author + title, on plTitle or origTitle);
  2. fallback on a **unique** normalized title (catches author-format drift) — only when the title maps to exactly one base book, so it can never mis-assign a date across two different books.

  It **never invents a row**. Collapses several CSV rows for one book keeping the **earliest** date; skips already-dated rows unless `overwrite`. Reports `unmatched` / `ambiguous` / `unparseableDate` / `collapsed`.

## Runnable tool — `scripts/importReadDates.ts` (not wired into the app)
```
npx tsx scripts/importReadDates.ts <plik.csv>                     # DRY-RUN preview, no writes
npx tsx scripts/importReadDates.ts <plik.csv> --apply             # write matched dates
npx tsx scripts/importReadDates.ts <plik.csv> --apply --overwrite # also replace existing dates
```
Needs `NOTION_API_KEY` + `NOTION_DATABASE_ID` in the env. Dry-run prints the full plan (counts + samples, incl. the unique-title matches to eyeball) so nothing is written blind.

## Verification
- Validated `parseReadDate` / `parseImportCsv` against a **real 712-row export**: 473 day / 19 month / 220 year precision, **zero unrecognized**, range 1993→2026.
- +14 unit tests (date formats incl. rejects, CSV edge cases, matching tiers, unmatched-never-invents, duplicate collapse → earliest, overwrite gating, unparseable).
- `npm run lint` clean, `npm test` **496** green, `npm run build` OK. Version 1.70.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_