### PR TITLE
feat(stats): reading-velocity aggregation (per-year reading pace)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.70.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.71.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.71.0** — **[RD-PR3] Agregacja „tempa czytania" (backend, warstwa 1/2).** `computeReadingStats` w
+  `statsAggregator` liczy przeczytane **award-booki wg ROKU** z `dataPrzeczytania` (granularność roczna
+  ŚWIADOMA: daty rok-only to `YYYY-01-01`, więc rozbicie miesięczne wymyśliłoby szpic w styczniu — liczymy tylko
+  rok). Zwraca: `perYear` (rosnąco), `totalRead` vs `totalDated` (ile historii ma datę), `thisYear`/`lastYear`,
+  `bestYear` (szczyt), `recentPace` (śr. książek/rok po ukończonych latach od startu, cap 3, bieżący rok wyłączony).
+  `now` wstrzykiwane (testowalność). Typ `ReadingStats` w `src/types/stats.ts` + `Stats.readingStats`; wpięte w
+  `statsService.getStats`. +6 testów. Suite 502 zielone. **NASTĘPNE (RD-PR4, frontend)**: karta „Tempo czytania"
+  na zakładce statystyk (KPI przeczytane w tym roku + delta, recentPace, wykres roczny à la `DecadeHistogram`);
+  potem ew. prognoza domknięcia kolekcji (recentPace + brakujące award-booki) i streaki.
 - **1.70.0** — **[RD-PR2] Jednorazowy import dat przeczytania z CSV (helpery + skrypt).** Czysta,
   przetestowana logika w `services/readDateImport.ts`: `parseReadDate` (rozpoznaje `dd.mm.yyyy` / `yyyy-mm-dd` /
   `yyyy-mm` / `mm.yyyy` / `yyyy`; daty częściowe przyklejane do początku okresu — miesiąc `-01`, rok `-01-01`),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.70.0",
+  "version": "1.71.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.70.0",
+  "version": "1.71.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.70.0",
+      "version": "1.71.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.70.0",
+  "version": "1.71.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/readingStats.test.ts
+++ b/services/__tests__/readingStats.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { computeReadingStats } from "../statsAggregator";
+import { NotionBook } from "../../src/types";
+
+const b = (id: string, read: boolean, dataPrzeczytania?: string): NotionBook => ({
+  id,
+  plTitle: `T-${id}`,
+  origTitle: `T-${id}`,
+  awards: ["Nagroda Hugo"],
+  zrodlo: read ? ["Przeczytane"] : [],
+  dataPrzeczytania,
+});
+
+// Fixed "now" so thisYear / lastYear / recentPace are deterministic.
+const NOW = new Date("2026-08-28T12:00:00Z");
+
+describe("computeReadingStats", () => {
+  it("counts reads per calendar year from the read date", () => {
+    const stats = computeReadingStats([
+      b("1", true, "2026-08-28"),
+      b("2", true, "2026-02-01"),
+      b("3", true, "2025-12-31"),
+      b("4", true, "2024-05-05"),
+    ], NOW);
+
+    expect(stats.perYear).toEqual([
+      { year: 2024, count: 1 },
+      { year: 2025, count: 1 },
+      { year: 2026, count: 2 },
+    ]);
+    expect(stats.thisYear).toBe(2);
+    expect(stats.lastYear).toBe(1);
+  });
+
+  it("treats a year-only (Jan 1) date as a read in that year, not a January event", () => {
+    // Both are stored as YYYY-01-01; the stat only reads the YEAR.
+    const stats = computeReadingStats([
+      b("1", true, "2013-01-01"), // year-only import
+      b("2", true, "2013-01-01"),
+      b("3", true, "2006-01-01"),
+    ], NOW);
+    expect(stats.perYear).toEqual([
+      { year: 2006, count: 1 },
+      { year: 2013, count: 2 },
+    ]);
+    expect(stats.bestYear).toEqual({ year: 2013, count: 2 });
+  });
+
+  it("separates total read from total dated (undated reads don't hit the timeline)", () => {
+    const stats = computeReadingStats([
+      b("1", true, "2025-03-03"),
+      b("2", true), // read but no date
+      b("3", false, "2025-01-01"), // dated but not marked read → ignored
+    ], NOW);
+    expect(stats.totalRead).toBe(2);
+    expect(stats.totalDated).toBe(1);
+    expect(stats.perYear).toEqual([{ year: 2025, count: 1 }]);
+  });
+
+  it("computes recent pace over the last 3 completed years (current year excluded)", () => {
+    const stats = computeReadingStats([
+      // completed years 2023,2024,2025 → (4+6+2)/3 = 4
+      ...Array.from({ length: 4 }, (_, i) => b(`a${i}`, true, "2023-06-01")),
+      ...Array.from({ length: 6 }, (_, i) => b(`c${i}`, true, "2024-06-01")),
+      ...Array.from({ length: 2 }, (_, i) => b(`d${i}`, true, "2025-06-01")),
+      b("now", true, "2026-06-01"), // current year excluded from pace
+    ], NOW);
+    expect(stats.recentPace).toBe(4);
+    expect(stats.thisYear).toBe(1);
+  });
+
+  it("averages pace only over completed years since the first read (no pre-history dilution)", () => {
+    // First dated read is 2025 → window is just [2025], not 2023..2025.
+    const stats = computeReadingStats([
+      ...Array.from({ length: 5 }, (_, i) => b(`x${i}`, true, "2025-06-01")),
+    ], NOW);
+    expect(stats.recentPace).toBe(5);
+  });
+
+  it("returns an empty, safe shape when nothing is dated", () => {
+    const stats = computeReadingStats([b("1", true), b("2", false)], NOW);
+    expect(stats).toEqual({
+      perYear: [], totalRead: 1, totalDated: 0, thisYear: 0, lastYear: 0, bestYear: null, recentPace: 0,
+    });
+  });
+});

--- a/services/statsAggregator.ts
+++ b/services/statsAggregator.ts
@@ -156,6 +156,65 @@ export function computeYearlyStats(books: NotionBook[]) {
     .sort((a, b) => parseInt(a.year) - parseInt(b.year));
 }
 
+/** Calendar year of a stored read date („YYYY-MM-DD"), or null when absent/malformed. */
+const readYearOf = (b: NotionBook): number | null => {
+  const iso = b.dataPrzeczytania;
+  if (!iso) return null;
+  const y = parseInt(iso.slice(0, 4), 10);
+  return Number.isFinite(y) && y > 1000 ? y : null;
+};
+
+/**
+ * Reading pace over AWARD books, by the calendar YEAR each was marked read
+ * („Data przeczytania"). Year granularity is deliberate and load-bearing: much of
+ * the historical data is year-only (imported reads where only the year was known,
+ * stored as Jan 1), so those Jan-1 dates are NOT real January reads — a monthly
+ * breakdown would invent a January spike. We count a book in its read-YEAR and no
+ * finer. Only read books carrying a date land on the timeline; `totalRead` vs
+ * `totalDated` shows how much of the read history is dated. `recentPace` is the
+ * mean books/year over completed years since you started (capped to the last 3;
+ * the current year is excluded because it's still in progress).
+ */
+export function computeReadingStats(books: NotionBook[], now: Date = new Date()) {
+  const currentYear = now.getFullYear();
+  const read = books.filter(isRead);
+
+  const perYearMap: Record<number, number> = {};
+  let totalDated = 0;
+  read.forEach((b) => {
+    const y = readYearOf(b);
+    if (y === null) return;
+    totalDated++;
+    perYearMap[y] = (perYearMap[y] || 0) + 1;
+  });
+
+  const perYear = Object.entries(perYearMap)
+    .map(([year, count]) => ({ year: parseInt(year, 10), count }))
+    .sort((a, b) => a.year - b.year);
+
+  const thisYear = perYearMap[currentYear] || 0;
+  const lastYear = perYearMap[currentYear - 1] || 0;
+
+  // Peak year (earliest on a tie — perYear is ascending, strict `>` keeps the first).
+  const bestYear = perYear.reduce<{ year: number; count: number } | null>(
+    (best, y) => (!best || y.count > best.count ? { year: y.year, count: y.count } : best),
+    null,
+  );
+
+  // Recent pace: mean books/year over completed years since the first dated read,
+  // capped to the last 3 (current year excluded). No completed year → 0.
+  const minYear = perYear.length ? perYear[0].year : currentYear;
+  const windowStart = Math.max(minYear, currentYear - 3);
+  const completedYears: number[] = [];
+  for (let y = windowStart; y <= currentYear - 1; y++) completedYears.push(y);
+  const recentSum = completedYears.reduce((s, y) => s + (perYearMap[y] || 0), 0);
+  const recentPace = completedYears.length
+    ? Math.round((recentSum / completedYears.length) * 10) / 10
+    : 0;
+
+  return { perYear, totalRead: read.length, totalDated, thisYear, lastYear, bestYear, recentPace };
+}
+
 export function computeLibraryStats(books: NotionBook[], branches: { sourceTag: string; name: string }[]) {
   // Branches from config (`library.branches`) — adding a branch in Kalibracja immediately
   // shows up. `id` = the branch's „Źródło" tag (matched by the marker).

--- a/services/statsService.ts
+++ b/services/statsService.ts
@@ -7,6 +7,7 @@ import {
   computeAuthorStats, computeAwardBooksStats, computeOwnedUnread, computeAwardCoverage,
   computeAllAwardsStats, computeAvailabilityStats, computePublisherStats, computeSeriesStats,
   computeCycleStats, computeDecadeStats, computeYearlyStats, computeLibraryStats,
+  computeReadingStats,
 } from "./statsAggregator";
 
 export class StatsService {
@@ -35,6 +36,7 @@ export class StatsService {
       seriesStats: computeSeriesStats(books),
       cycleStats: computeCycleStats(books),
       decadeStats: computeDecadeStats(books),
+      readingStats: computeReadingStats(books),
       marketStats: computeMarketStats(books),
       libraryStats: computeLibraryStats(books, branches),
     };

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -53,6 +53,25 @@ export interface AvailabilityStats {
   none: number;
 }
 
+export interface ReadingYearCount { year: number; count: number }
+/** Reading pace over award books, by the year each was marked read. Year-granular
+ *  on purpose (historical dates are often year-only). */
+export interface ReadingStats {
+  /** Books read per calendar year (ascending; only years with ≥1 read). */
+  perYear: ReadingYearCount[];
+  /** Award books marked read (with or without a date). */
+  totalRead: number;
+  /** Of those, how many carry a „Data przeczytania". */
+  totalDated: number;
+  /** Reads in the current / previous calendar year. */
+  thisYear: number;
+  lastYear: number;
+  /** Peak reading year (earliest on a tie), or null when nothing is dated. */
+  bestYear: ReadingYearCount | null;
+  /** Mean books/year over completed years since you started (last 3, current excluded). */
+  recentPace: number;
+}
+
 export interface PublisherStat { name: string; count: number; read: number }
 export interface SeriesStat { name: string; count: number; owned: number; read: number }
 export interface CycleStats { partOfCycle: number; standalone: number; total: number }
@@ -83,6 +102,7 @@ export interface Stats {
   seriesStats: SeriesStat[];
   cycleStats: CycleStats;
   decadeStats: DecadeStat[];
+  readingStats: ReadingStats;
   marketStats: MarketStats;
   libraryStats: LibraryStat[];
 }


### PR DESCRIPTION
Fixes #329

## What
The backend layer for the reading-velocity feature — consumes the `Data przeczytania` column (structure #326, backfilled via #328). The stats **card** is the next PR.

## Key design decision — year granularity
`computeReadingStats` counts read **award** books by the calendar **year** of their read date. This is deliberate and load-bearing: much of the historical data is year-only (a `1 stycznia` placeholder from before lubimyczytać had finer date formats), stored as `YYYY-01-01`. Those are *not* real January reads, so a monthly breakdown would invent a January spike. We count each read in its year and no finer — which is exactly "treat year-only entries as read in that year".

## Output (`ReadingStats`)
- `perYear` — books read per calendar year (ascending, years with ≥1 read).
- `totalRead` vs `totalDated` — so the UI can be honest about how much read history actually carries a date.
- `thisYear` / `lastYear` — current & previous calendar year counts.
- `bestYear` — peak year (earliest on a tie).
- `recentPace` — mean books/year over completed years since you started (last 3, current year excluded so an in-progress year doesn't drag the average down).

`now` is injectable for deterministic tests.

## Changes
- `services/statsAggregator.ts`: `computeReadingStats(books, now?)`.
- `src/types/stats.ts`: `ReadingStats` + `ReadingYearCount`; `Stats.readingStats`.
- `services/statsService.ts`: wires `computeReadingStats(books)` into `getStats`.

## Tests (+6)
per-year counting; year-only-as-year (two `2013-01-01` → 2013×2, no January meaning); total-read vs total-dated (undated reads excluded from the timeline); recent-pace window over completed years; no pre-history dilution when data starts recently; empty-safe shape when nothing is dated.

## Verification
`npm run lint` clean, `npm test` **502** green, `npm run build` OK. Version 1.71.0.

## Follow-up (next PR)
Frontend „Tempo czytania" card on the stats tab: this-year KPI + delta, recent pace, a yearly bar chart (à la `DecadeHistogram`); then optionally a collection-completion forecast (recentPace + remaining unread award books) and streaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_