### PR TITLE
feat(stats): „Tempo czytania" card — reading pace on the stats tab

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.71.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.72.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,16 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.71.0** — **[RD-PR3] Agregacja „tempa czytania" (backend, warstwa 1/2).** `computeReadingStats` w
+- **1.72.0** — **[RD-PR4] Karta „Tempo czytania" (frontend).** `ReadingPaceCard` na zakładce statystyk (span2,
+  obok „Osi czasu"), konsumuje `stats.readingStats`. 3 kafle KPI: „W tym roku" (+ delta vs ubiegły, ↑emerald/
+  ↓slate), „Książek/rok" (recentPace), „Z datą łącznie" (totalDated); histogram roczny (słupek = przeczytane w
+  danym roku, bieżący rok + rekord podświetlone), stopka „X/Y przeczytanych ma datę" gdy niepełne pokrycie. Puste
+  → zachęta do oznaczania. Paleta jak `DecadeHistogram` (amber nagłówek/rekord, cyan słupki, slate track) → auto-
+  adaptacja w obu skórach przez remap zmiennych. `ReadingStats`/`ReadingYearCount` dodane do re-eksportu w
+  `useStats`; karta wpięta do rejestru w `StatsSection` (nowe id „readingPace" dopina się na końcu zapisanego
+  układu — istniejący userzy je zobaczą). Suite 502 zielone, lint czysty, build OK. **Feature „tempo czytania"
+  domknięty w podstawie**; opcjonalnie później: prognoza domknięcia kolekcji (recentPace + brakujące award-booki),
+  streaki, surfacing daty na karcie książki. `computeReadingStats` w
   `statsAggregator` liczy przeczytane **award-booki wg ROKU** z `dataPrzeczytania` (granularność roczna
   ŚWIADOMA: daty rok-only to `YYYY-01-01`, więc rozbicie miesięczne wymyśliłoby szpic w styczniu — liczymy tylko
   rok). Zwraca: `perYear` (rosnąco), `totalRead` vs `totalDated` (ile historii ma datę), `thisYear`/`lastYear`,
@@ -1256,12 +1265,12 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
   REKOMENDACJA: pkt 1 ZROBIONY (1.47.0) → obserwować, czy blok ustępuje; jeśli nie, pkt 2 lekki
   (Playwright tylko do cookie — realny challenge-solve, nie tylko puste GET).
 
-- **Data przeczytania + „Tempo czytania" (velocity)** — WARSTWA STRUKTURALNA ZREALIZOWANA (RD-PR1, 1.69.0):
-  kolumna `Data przeczytania` (date) w schemacie, mapper → `NotionBook.dataPrzeczytania`, adapter `setReadDate`,
-  ścieżka zapisu `markAsRead`/`unmarkRead` stempluje/czyści (gate na tag „Przeczytane"). Dane łapane OD TERAZ
-  w przód (historii nie cofniemy). **POZOSTAJE (osobne PR-y): STATYSTYKI velocity** czytające `dataPrzeczytania` —
-  „przeczytane w tym roku: N", wykresy w czasie (miesiąc/rok), tempo (książki/mies.), prognoza domknięcia
-  kolekcji, streaki (w `statsService`/`statsAggregator`); ewentualnie surfacing daty na regale/karcie książki.
+- **Data przeczytania + „Tempo czytania" (velocity)** — ZREALIZOWANE (RD-PR1..4, 1.69.0–1.72.0): kolumna +
+  mapper + ścieżka zapisu (stempel na „Przeczytane"), jednorazowy import historii z CSV (skrypt), agregacja
+  `computeReadingStats` (przeczytane award-booki wg ROKU) i karta „Tempo czytania" na statystykach (KPI w tym roku
+  + delta, tempo książek/rok, histogram roczny). Granularność ROCZNA (daty rok-only = 1 stycznia, więc bez
+  rozbicia miesięcznego). **OPCJONALNIE później**: prognoza domknięcia kolekcji (recentPace + brakujące
+  award-booki), streaki, surfacing daty przeczytania na karcie książki/regale.
 - **Import dat przeczytania z CSV — feature w aplikacji (przyszłość).** Jednorazowy import zrobiony skryptem
   `scripts/importReadDates.ts` (RD-PR2, 1.70.0) na bazie czystych helperów `services/readDateImport.ts`
   (`parseReadDate`/`parseImportCsv`/`buildReadDatePlan`). DO ZROBIENIA kiedyś: opakować to w UI (upload CSV w

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.71.0",
+      "version": "1.72.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.71.0",
+  "version": "1.72.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -7,6 +7,7 @@ import { useMarkAsRead } from "../hooks/useMarkAsRead";
 import { AvailabilityCard } from "./stats/AvailabilityCard";
 import { PublishingCard } from "./stats/PublishingCard";
 import { DecadeHistogram } from "./stats/DecadeHistogram";
+import { ReadingPaceCard } from "./stats/ReadingPaceCard";
 import { MarketCard } from "./stats/MarketCard";
 import { CyclesHarvestCard } from "./stats/CyclesHarvestCard";
 import { KpiRow } from "./stats/KpiRow";
@@ -77,6 +78,7 @@ export const StatsSection: React.FC = () => {
     { id: "publishing", node: <PublishingCard publishers={stats.publisherStats} series={stats.seriesStats} cycles={stats.cycleStats} /> },
     { id: "cyclesHarvest", node: <CyclesHarvestCard refreshSignal={refreshTick} /> },
     { id: "decades", span2: true, node: <DecadeHistogram decades={stats.decadeStats} /> },
+    { id: "readingPace", span2: true, node: <ReadingPaceCard reading={stats.readingStats} /> },
     { id: "yearly", node: <YearlyCard years={stats.yearlyStats} /> },
     { id: "ownedUnread", node: <OwnedUnreadCard books={stats.ownedUnread} markingId={markingId} onMarkAsRead={markAsRead} /> },
     { id: "library", node: <LibraryProgressCard libraries={stats.libraryStats} onMarkAsRead={markAsRead} markingId={markingId} /> },

--- a/src/components/stats/ReadingPaceCard.tsx
+++ b/src/components/stats/ReadingPaceCard.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { motion } from "motion/react";
+import { Gauge, Crown, ArrowUp, ArrowDown, Minus } from "lucide-react";
+import { ReadingStats } from "../../hooks/useStats";
+
+/**
+ * „Tempo czytania" — reading pace over award books by the YEAR each was marked
+ * read („Data przeczytania"). Year-granular by design: historical dates are often
+ * year-only (see `computeReadingStats`), so we never pretend to month precision.
+ * KPI tiles (this year + delta, recent pace, record year) over a yearly histogram;
+ * bar height = books read that year, current year and record year highlighted.
+ */
+export const ReadingPaceCard: React.FC<{ reading: ReadingStats }> = ({ reading }) => {
+  const { perYear, thisYear, lastYear, bestYear, recentPace, totalRead, totalDated } = reading;
+  const max = Math.max(1, ...perYear.map((y) => y.count));
+  const currentYear = new Date().getFullYear();
+  const delta = thisYear - lastYear;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.24 }}
+      className="glass-card p-6 rounded-3xl border-amber-500/10 space-y-6"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-bold font-display uppercase tracking-widest text-amber-400 flex items-center gap-2">
+          <Gauge className="w-4 h-4" />
+          Tempo czytania
+        </h3>
+        {bestYear && (
+          <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-amber-300/80">
+            <Crown className="w-3.5 h-3.5" /> Rekord: {bestYear.count} w {bestYear.year}
+          </span>
+        )}
+      </div>
+
+      {totalDated === 0 ? (
+        <p className="text-slate-400 text-sm italic text-center py-8">
+          Brak dat przeczytania. Oznaczaj książki jako „Przeczytane", by zbierać tempo.
+        </p>
+      ) : (
+        <>
+          {/* KPI tiles */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded-2xl bg-slate-900/40 border border-slate-700/40 p-3 text-center">
+              <div className="text-2xl font-bold font-display text-cyan-300 tabular-nums flex items-center justify-center gap-1.5">
+                {thisYear}
+                {delta !== 0 && (
+                  <span className={`text-xs flex items-center ${delta > 0 ? "text-emerald-400" : "text-slate-500"}`}>
+                    {delta > 0 ? <ArrowUp className="w-3.5 h-3.5" /> : <ArrowDown className="w-3.5 h-3.5" />}
+                    {Math.abs(delta)}
+                  </span>
+                )}
+                {delta === 0 && lastYear > 0 && <Minus className="w-3.5 h-3.5 text-slate-600" />}
+              </div>
+              <div className="text-[9px] uppercase tracking-widest text-slate-500 font-bold mt-1">W tym roku</div>
+            </div>
+            <div className="rounded-2xl bg-slate-900/40 border border-slate-700/40 p-3 text-center">
+              <div className="text-2xl font-bold font-display text-amber-300 tabular-nums">{recentPace}</div>
+              <div className="text-[9px] uppercase tracking-widest text-slate-500 font-bold mt-1">Książek / rok</div>
+            </div>
+            <div className="rounded-2xl bg-slate-900/40 border border-slate-700/40 p-3 text-center">
+              <div className="text-2xl font-bold font-display text-slate-200 tabular-nums">{totalDated}</div>
+              <div className="text-[9px] uppercase tracking-widest text-slate-500 font-bold mt-1">Z datą łącznie</div>
+            </div>
+          </div>
+
+          {/* Yearly histogram — bar = books read that year */}
+          <div className="flex items-end gap-1 h-[140px] pt-2">
+            {perYear.map((y) => {
+              const h = (y.count / max) * 100;
+              const isCurrent = y.year === currentYear;
+              const isBest = bestYear?.year === y.year;
+              return (
+                <div key={y.year} className="flex-1 h-full flex flex-col items-center gap-1.5 min-w-0 group">
+                  <span className="text-[9px] text-slate-500 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity">{y.count}</span>
+                  <div className="w-full flex-1 flex items-end" style={{ minHeight: 1 }}>
+                    <div
+                      className={`w-full rounded-t-[3px] ${
+                        isBest ? "bg-gradient-to-t from-amber-500 to-amber-400"
+                          : isCurrent ? "bg-gradient-to-t from-cyan-500 to-cyan-300"
+                          : "bg-gradient-to-t from-cyan-600/70 to-cyan-500/70"
+                      }`}
+                      style={{ height: `${Math.max(h, 3)}%` }}
+                      title={`${y.year}: przeczytane ${y.count}`}
+                    />
+                  </div>
+                  <span className="text-[9px] text-slate-500 tabular-nums whitespace-nowrap">{`'${String(y.year % 100).padStart(2, "0")}`}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Footer note — honesty about dated coverage */}
+          <div className="flex items-center justify-center gap-4 text-[10px] text-slate-500 uppercase tracking-widest font-bold">
+            <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-cyan-500/70" /> Przeczytane / rok</span>
+            {totalDated < totalRead && (
+              <span className="text-slate-400 tabular-nums normal-case tracking-normal">{totalDated}/{totalRead} przeczytanych ma datę</span>
+            )}
+          </div>
+        </>
+      )}
+    </motion.div>
+  );
+};

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -2,7 +2,8 @@ import { useState, useEffect, useCallback } from "react";
 
 export type {
   AuthorStat, AwardCoverageStat, YearlyStat, LibraryStat, IdentifiedBook, AvailabilityStats,
-  PublisherStat, SeriesStat, CycleStats, DecadeStat, CheapOffer, PriceDrop, TopSeller, MarketStats,
+  PublisherStat, SeriesStat, CycleStats, DecadeStat, ReadingYearCount, ReadingStats,
+  CheapOffer, PriceDrop, TopSeller, MarketStats,
   Stats, IdentifiedBooks,
 } from "../types/stats";
 import type { Stats } from "../types/stats";


### PR DESCRIPTION
Fixes #331

## What
The visible payoff of the read-date work — a stats card rendering the per-year reading aggregation (#330). Completes the reading-velocity feature in its base form.

## The card — `ReadingPaceCard` (span2, next to „Oś czasu")
- **Three KPI tiles**: „W tym roku" (with a ↑/↓ delta vs last year), „Książek / rok" (recent pace), „Z datą łącznie".
- **Yearly histogram**: bar = books read that year; the current year and the record year are highlighted.
- **Honest about coverage**: footer shows „X/Y przeczytanych ma datę" when not every read book is dated; empty state nudges the user to start marking reads.
- **Year granularity throughout** — no monthly breakdown — so the year-only historical dates (the `1 stycznia` placeholders) read as "that year", never as a January spike.

## Wiring
- Palette mirrors `DecadeHistogram` (amber header/record, cyan bars, slate track) → recolors correctly under both the boho and 40k themes via the palette-var remap.
- `ReadingStats` / `ReadingYearCount` added to the `useStats` re-export.
- Registered in `StatsSection` with a new id `readingPace`; `orderByIds` appends new ids to a saved layout, so existing users see it too.

## Verification
`npm run lint` clean, `npm test` **502** green, `npm run build` OK. Version 1.72.0.

## Optional follow-ups (not in this PR)
Collection-completion forecast (recent pace + remaining unread award books), reading streaks, surfacing the read date on the book card / shelf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_