### PR TITLE
fix(shelf): boho header/frame shadows — "paper shadow" (variant C)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.72.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.72.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.72.2** — **Regał: karetka drag&drop na semantyczny zielony/czerwony + sweep neonów.** Karetka wstawiania
+- **1.72.3** — **Regał (boho): nagłówki/gzyms/plakietki „Cień papieru" (wariant C).** Twarde czarne cienie z
+  drewna 40k (`rgba(0,0,0,.6–.85)`) czytały się na lnie jak brud: halo pod tytułem gzymsu + czarny inset „wchodzący
+  do wnętrza" regału. Przeniesione na zmienne `--sk-*` z FALLBACKIEM = obecna wartość ciemna (40k bez zmian) i
+  NADPISANIEM w jasnej skórze = wariant C: miękkie, CIEPŁE cienie NA ZEWNĄTRZ. Nowe zmienne (`ShelfFrame` +
+  `ShelfDivider`): `--sk-frame-drop` (miękki ciepły cień pod regałem), `--sk-cornice-shadow`/`--sk-well-shadow`
+  (delikatny ciepły inset zamiast czarnego mułu), `--sk-title-shadow: none` (tytuł bez halo), `--sk-plate-drop`
+  (plakietka „siada" ciepłym cieniem) + `--sk-plate-glow: none` + `--sk-plate-text-shadow: none`. Cogi/holo/HUD i
+  tak ukryte w boho (`.dc-40k display:none`), więc ich cienie pominięte. Makieta 4 wariantów pokazana userowi →
+  wybór C. Suite 502 zielone, lint czysty, build OK (zmienne w bundlu). Karetka wstawiania
   (poprawne/niepoprawne miejsce, `ShelfRow`) niosła inline `rgba` (valid=CYAN, invalid=rose) → nie remapowała się
   wcale. Teraz klasy `.drop-caret-valid/invalid`: ciemny = żywe (emerald/rose), boho = ciepła leśna zieleń
   `rgba(107,142,62)` / terakota `rgba(180,74,56)` — widoczne na lnie. Semantyka zielony=OK zamiast cyan.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.72.2",
+  "version": "1.72.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.72.2",
+  "version": "1.72.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.72.2",
+      "version": "1.72.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.72.2",
+  "version": "1.72.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/ShelfDivider.tsx
+++ b/src/components/shelf/ShelfDivider.tsx
@@ -81,8 +81,8 @@ export const ShelfDivider: React.FC<Props> = ({ label, width = 10, height = SHEL
             ...(toLeft ? { right: 0 } : { left: 0 }),
             color: "var(--sk-plate-text)", fontSize: 11, letterSpacing: "0.06em",
             background: "var(--sk-plate-bg)",
-            boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), 0 5px 9px -4px #000, 0 0 12px rgba(var(--noo-glow),.25)",
-            textShadow: "0 0 6px rgba(var(--noo-glow),.45)",
+            boxShadow: "inset 0 0 0 1.5px var(--sk-plate-edge), inset 0 1px 0 rgba(var(--noo-glow),.30), var(--sk-plate-drop, 0 5px 9px -4px #000), var(--sk-plate-glow, 0 0 12px rgba(var(--noo-glow),.25))",
+            textShadow: "var(--sk-plate-text-shadow, 0 0 6px rgba(var(--noo-glow),.45))",
           }}
         >
           <CogSigil className="w-[13px] h-[13px] shrink-0 drop-shadow-[0_0_3px_rgba(var(--noo-glow),.6)]" />

--- a/src/components/shelf/ShelfFrame.tsx
+++ b/src/components/shelf/ShelfFrame.tsx
@@ -43,7 +43,7 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
       className={`relative rounded-[18px] border-2 transition-all duration-200 ${stateRing}`}
       style={{
         background: "var(--sk-cab-bg)",
-        boxShadow: "0 24px 40px -22px rgba(0,0,0,.85), inset 0 1px 0 rgba(var(--noo-glow),.10), var(--sk-frame-glow)",
+        boxShadow: "var(--sk-frame-drop, 0 24px 40px -22px rgba(0,0,0,.85)), inset 0 1px 0 rgba(var(--noo-glow),.10), var(--sk-frame-glow)",
         ...(highlight === "idle" ? { borderColor: "var(--sk-frame-border)" } : {}),
       }}
     >
@@ -54,13 +54,13 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
           className="absolute top-0 inset-x-0 h-[46px] rounded-t-[16px] flex items-center gap-3 px-4 overflow-hidden"
           style={{
             background: "var(--sk-cornice-bg)",
-            boxShadow: "inset 0 -2px 5px rgba(0,0,0,.6), inset 0 1px 0 rgba(var(--noo-glow),.14)",
+            boxShadow: "var(--sk-cornice-shadow, inset 0 -2px 5px rgba(0,0,0,.6)), inset 0 1px 0 rgba(var(--noo-glow),.14)",
           }}
         >
           {/* Cog-wheel sigil */}
           <CogSigil className="w-7 h-7 shrink-0 drop-shadow-[0_1px_2px_rgba(0,0,0,.6)]" />
           <span className={a.text}>{icon}</span>
-          <h3 className="text-sm font-display font-bold uppercase tracking-[0.22em] text-amber-100/90 truncate min-w-0 drop-shadow-[0_1px_2px_rgba(0,0,0,.7)]">
+          <h3 className="text-sm font-display font-bold uppercase tracking-[0.22em] text-amber-100/90 truncate min-w-0" style={{ filter: "var(--sk-title-shadow, drop-shadow(0 1px 2px rgba(0,0,0,.7)))" }}>
             {title}
           </h3>
           <span className={`shrink-0 px-2 py-0.5 rounded-lg text-[10px] font-bold border ${a.chip}`}>{count}</span>
@@ -76,7 +76,7 @@ export const ShelfFrame: React.FC<Props> = ({ title, icon, accent, count, highli
           className="relative rounded-lg p-3 pt-4 overflow-hidden"
           style={{
             background: "var(--sk-well-bg)",
-            boxShadow: "inset 0 3px 12px rgba(0,0,0,.75), inset 0 -2px 6px rgba(0,0,0,.5)",
+            boxShadow: "var(--sk-well-shadow, inset 0 3px 12px rgba(0,0,0,.75), inset 0 -2px 6px rgba(0,0,0,.5))",
           }}
         >
           <HoloField />

--- a/src/index.css
+++ b/src/index.css
@@ -306,6 +306,16 @@ body {
   --sk-cog-ring: #b6905f; --sk-cog-skull: #6a5738; --sk-cog-disc: #efe6d5;
   --sk-frame-accent: 206,155,63;
   --sk-frame-border: rgba(58,52,43,.14); --sk-frame-glow: 0 0 0 rgba(0,0,0,0);
+  /* „Cień papieru" (wariant C): twarde czarne insety z 40k → miękkie, CIEPŁE
+     cienie NA ZEWNĄTRZ. Nic nie „wchodzi do wnętrza", tekst nagłówka bez halo,
+     regał/gzyms/plakietka „siedzą" na lnie. (Ciemny motyw używa fallbacków w JS.) */
+  --sk-frame-drop: 0 18px 34px -20px rgba(58,52,43,.42), 0 3px 8px -5px rgba(58,52,43,.20);
+  --sk-cornice-shadow: inset 0 -1px 3px rgba(58,52,43,.06);
+  --sk-well-shadow: inset 0 6px 14px -10px rgba(58,52,43,.16);
+  --sk-title-shadow: none;
+  --sk-plate-drop: 0 6px 12px -6px rgba(58,52,43,.38);
+  --sk-plate-glow: 0 0 0 rgba(0,0,0,0);
+  --sk-plate-text-shadow: none;
   --sk-plinth: linear-gradient(180deg,#e2d3b8,#d0bd98);
   --sk-foot: linear-gradient(180deg,#d3c09e,#c0aa82);
   --sk-room-bg: linear-gradient(180deg,#efe6d5 0%,#e8dcc4 55%,#e0d1b6 100%), repeating-linear-gradient(90deg, rgba(58,52,43,.03) 0 2px, transparent 2px 130px);


### PR DESCRIPTION
Fixes #337

## Problem
The shelf's cornice title, frame and decade plates carried hard black shadows (`rgba(0,0,0,.6–.85)`) inherited from the 40k dark wood. On the light linen they read as dirt: a dark halo under the cornice title and a black inset **bleeding into** the shelf interior.

## Fix — "paper shadow" (variant C, chosen from a 4-variant mock)
Moved these shadows onto `--sk-*` CSS vars, with the **dark value as the inline fallback** (so the 40k theme is byte-for-byte unchanged) and a **boho override** in the light skin = soft, warm shadows cast *outward* instead of hard black insets.

- **ShelfFrame**: `--sk-frame-drop` (soft warm drop so the shelf sits on the linen), `--sk-cornice-shadow` / `--sk-well-shadow` (faint warm inset, no black mud), `--sk-title-shadow: none` (title loses its halo).
- **ShelfDivider** (decade plate): `--sk-plate-drop` (warm drop), plus `--sk-plate-glow: none` and `--sk-plate-text-shadow: none` (no clay halo behind the label).
- Cogs / holo / HUD are already `.dc-40k display:none` in boho, so their shadows needed no change.

## Verification
`npm run lint` clean, `npm test` **502** green, `npm run build` OK — the new `--sk-*` vars are confirmed in the bundle. Dark theme unchanged (uses the JS fallbacks). Version 1.72.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_