### PR TITLE
feat(shelf): boho room backdrop (putty) + thick wax-dripping candles

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.72.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.73.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.72.3** — **Regał (boho): nagłówki/gzyms/plakietki „Cień papieru" (wariant C).** Twarde czarne cienie z
+- **1.73.0** — **Regał (boho): tło „sali" putty (wariant C) + grube świece ociekające woskiem (Ś3).**
+  Diagnoza: `--sk-room-bg` w boho był JUŻ jasny (len) — ciemne wrażenie robiły twarde czarne cienie/winieta/
+  podłoga w `RoomDecor` (`rgba(0,0,0,.5–.85)`), zwł. dolny pas. (1) Tło → putty/taupe C (`#d9c9ac→#c3ae8b`),
+  ciepła oprawa regału; czarne cienie na zmiennych `--sk-room-topshade/-floorshade/-vignette` (fallback = ciemna
+  wartość 40k, boho = miękkie ciepłe `rgba(58,52,43,.10–.20)`). (2) Świece: nowy `CandleCluster` (Ś3) — 3 grube
+  świece różnej wysokości (kość/glinka/wosk pszczeli) ze spływami wosku, roztopionym rondem i kałużą; płomienie
+  WIĘKSZE i WOLNIEJSZE (motion `transformBox:fill-box`, dur 3.8–4.4 s, glow 4.6 s). Widoczne TYLKO w boho przez
+  nową klasę `.candle-boho` (odwrotność `.dc-40k`); ciemny motyw zachowuje dotychczasowy cienki kinkiet 40k —
+  nietknięty. Makieta 4 tła + 3 świece pokazana userowi → wybór C + Ś3. Suite 502 zielone, lint czysty, build OK. Twarde czarne cienie z
   drewna 40k (`rgba(0,0,0,.6–.85)`) czytały się na lnie jak brud: halo pod tytułem gzymsu + czarny inset „wchodzący
   do wnętrza" regału. Przeniesione na zmienne `--sk-*` z FALLBACKIEM = obecna wartość ciemna (40k bez zmian) i
   NADPISANIEM w jasnej skórze = wariant C: miękkie, CIEPŁE cienie NA ZEWNĄTRZ. Nowe zmienne (`ShelfFrame` +

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.72.3",
+  "version": "1.73.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.72.3",
+  "version": "1.73.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.72.3",
+      "version": "1.73.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.72.3",
+  "version": "1.73.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -38,6 +38,59 @@ const Sconce: React.FC<{ className?: string }> = ({ className }) => (
   </div>
 );
 
+/**
+ * Boho candle cluster (variant Ś3): three thick, wax-dripping candles of varying
+ * height (ivory / clay / beeswax), replacing the thin 40k sconce in the LIGHT skin
+ * only (`.candle-boho` — dark keeps its sconce). Flame is bigger and flickers more
+ * slowly than the sconce, per the design review.
+ */
+const flameAnim = (dur: number, delay = 0) => ({
+  style: { transformOrigin: "50% 100%", transformBox: "fill-box" as const },
+  animate: { scaleY: [1, 1.12, 0.95, 1.07, 1], scaleX: [1, 0.95, 1.05, 0.97, 1], opacity: [0.9, 1, 0.85, 1, 0.92] },
+  transition: { duration: dur, repeat: Infinity, ease: "easeInOut" as const, delay },
+});
+
+const CandleCluster: React.FC<{ className?: string; flip?: boolean }> = ({ className, flip }) => (
+  <div className={`candle-boho absolute pointer-events-none ${className ?? ""}`} aria-hidden style={flip ? { transform: "scaleX(-1)" } : undefined}>
+    {/* warm pooled glow (bigger, slower) */}
+    <motion.div
+      className="absolute -left-[46px] -top-[54px] w-[196px] h-[196px] rounded-full"
+      style={{ background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(8px)" }}
+      animate={{ opacity: [0.55, 0.8, 0.5, 0.74, 0.6] }}
+      transition={{ duration: 4.6, repeat: Infinity, ease: "easeInOut" }}
+    />
+    <svg viewBox="0 0 132 152" width="132" height="152">
+      <defs>
+        <linearGradient id="cc-iv" x1="0" x2="1"><stop offset="0" stopColor="#e6ddc8" /><stop offset=".4" stopColor="#f5efe1" /><stop offset="1" stopColor="#ddd2b8" /></linearGradient>
+        <linearGradient id="cc-bw" x1="0" x2="1"><stop offset="0" stopColor="#c99a3f" /><stop offset=".4" stopColor="#e6bd68" /><stop offset="1" stopColor="#b98a34" /></linearGradient>
+        <linearGradient id="cc-cl" x1="0" x2="1"><stop offset="0" stopColor="#b06a44" /><stop offset=".4" stopColor="#cd8f6e" /><stop offset="1" stopColor="#9a5636" /></linearGradient>
+        <radialGradient id="cc-fl" cx=".5" cy=".7" r=".7"><stop offset="0" stopColor="#fff6cf" /><stop offset=".5" stopColor="#ffc35f" /><stop offset="1" stopColor="#ef7a1e" /></radialGradient>
+      </defs>
+      {/* short clay (left) */}
+      <rect x="8" y="96" width="26" height="52" rx="7" fill="url(#cc-cl)" />
+      <path d="M34 110 q4 16 0 28" stroke="#8a4e33" strokeWidth="3" fill="none" opacity=".55" strokeLinecap="round" />
+      <ellipse cx="21" cy="97" rx="13" ry="4.5" fill="#8a4e33" /><ellipse cx="21" cy="95.5" rx="13" ry="4" fill="#cd8f6e" />
+      <rect x="19.5" y="82" width="3" height="14" rx="1.5" fill="#4d2c1a" />
+      <motion.path d="M21 58 q11 15 0 34 q-11 -19 0 -34" fill="url(#cc-fl)" {...flameAnim(3.8, 0.5)} />
+      {/* tall ivory (center) */}
+      <rect x="44" y="52" width="30" height="96" rx="8" fill="url(#cc-iv)" />
+      <path d="M44 78 q4 22 0 38 M74 88 q-4 20 0 36" stroke="#d7cbaf" strokeWidth="3" fill="none" opacity=".65" strokeLinecap="round" />
+      <ellipse cx="59" cy="53" rx="15" ry="5" fill="#cdbf9f" /><ellipse cx="59" cy="51.5" rx="15" ry="4.5" fill="#efe6cf" />
+      <path d="M49 53 q3 10 -2 15 q-4 -6 2 -15" fill="#e9dec4" />
+      <rect x="57.5" y="36" width="3" height="16" rx="1.5" fill="#5b4a2e" />
+      <motion.path d="M59 8 q13 18 0 40 q-13 -22 0 -40" fill="url(#cc-fl)" {...flameAnim(4.4)} />
+      {/* medium beeswax (right) */}
+      <rect x="84" y="76" width="26" height="72" rx="7" fill="url(#cc-bw)" />
+      <path d="M110 96 q4 18 0 32" stroke="#a87e2e" strokeWidth="3" fill="none" opacity=".55" strokeLinecap="round" />
+      <ellipse cx="97" cy="77" rx="13" ry="4.5" fill="#a87e2e" /><ellipse cx="97" cy="75.5" rx="13" ry="4" fill="#e6c273" />
+      <rect x="95.5" y="60" width="3" height="16" rx="1.5" fill="#4d3c1a" />
+      <motion.path d="M97 34 q12 16 0 36 q-12 -20 0 -36" fill="url(#cc-fl)" {...flameAnim(4.0, 0.9)} />
+      {/* wax pool */}
+      <ellipse cx="60" cy="149" rx="58" ry="6" fill="#cdbb9a" opacity=".55" />
+    </svg>
+  </div>
+);
+
 /** A drifting speck of dust in the light. */
 const Mote: React.FC<{ i: number }> = ({ i }) => {
   const left = (i * 61) % 100;
@@ -63,15 +116,17 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
     className="relative rounded-[20px] overflow-hidden px-4 pt-10 pb-[120px] sm:px-8"
     style={{
       background: "var(--sk-room-bg)",
-      boxShadow: "inset 0 2px 0 var(--sk-room-inset), inset 0 40px 80px -40px rgba(0,0,0,.7)",
+      boxShadow: "inset 0 2px 0 var(--sk-room-inset), var(--sk-room-topshade, inset 0 40px 80px -40px rgba(0,0,0,.7))",
     }}
   >
     {/* Cog-wheel watermark */}
     <CogMark size={320} color="var(--sk-room-cog)" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
 
-    {/* Sconces */}
+    {/* Sconces — dark skin (40k). Boho shows the candle cluster instead. */}
     <Sconce className="left-3 top-16 hidden md:block" />
     <Sconce className="right-3 top-16 hidden md:block" />
+    <CandleCluster className="left-2 top-12 hidden md:block" />
+    <CandleCluster className="right-2 top-12 hidden md:block" flip />
 
     {/* Dust in the air */}
     {Array.from({ length: 16 }).map((_, i) => <Mote key={i} i={i} />)}
@@ -81,9 +136,9 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
 
     {/* Floor */}
     <div className="absolute left-0 right-0 bottom-0 h-[120px] pointer-events-none"
-      style={{ background: "var(--sk-room-floor)", boxShadow: "inset 0 16px 26px -12px rgba(0,0,0,.85)" }} aria-hidden />
+      style={{ background: "var(--sk-room-floor)", boxShadow: "var(--sk-room-floorshade, inset 0 16px 26px -12px rgba(0,0,0,.85))" }} aria-hidden />
 
     {/* Vignette */}
-    <div className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(120% 90% at 50% 40%, rgba(0,0,0,0) 45%, rgba(0,0,0,.5) 100%)" }} aria-hidden />
+    <div className="absolute inset-0 pointer-events-none" style={{ background: "var(--sk-room-vignette, radial-gradient(120% 90% at 50% 40%, rgba(0,0,0,0) 45%, rgba(0,0,0,.5) 100%))" }} aria-hidden />
   </div>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -318,13 +318,19 @@ body {
   --sk-plate-text-shadow: none;
   --sk-plinth: linear-gradient(180deg,#e2d3b8,#d0bd98);
   --sk-foot: linear-gradient(180deg,#d3c09e,#c0aa82);
-  --sk-room-bg: linear-gradient(180deg,#efe6d5 0%,#e8dcc4 55%,#e0d1b6 100%), repeating-linear-gradient(90deg, rgba(58,52,43,.03) 0 2px, transparent 2px 130px);
-  --sk-room-inset: rgba(58,52,43,.06);
-  --sk-room-floor: linear-gradient(180deg,#d8c19a 0,#c9b087 40%,#b89e70 100%);
-  --sk-room-cog: #c1a071;
-  --sk-room-mote: rgba(150,110,60,.32);
-  --sk-room-glow: rgba(206,155,63,.2);
+  /* Tło „sali" poza regałami: wariant C (putty/taupe) — ciepły mid-ton oprawiający
+     jaśniejszy regał, bez schodzenia w ciemność. Czarne cienie/winieta/podłoga (z
+     40k) OCIEPLONE i wygaszone, żeby nic nie robiło ciemnego pasa na lnie. */
+  --sk-room-bg: linear-gradient(180deg,#d9c9ac 0%,#cfbf9d 55%,#c3ae8b 100%), repeating-linear-gradient(90deg, rgba(58,52,43,.035) 0 2px, transparent 2px 130px);
+  --sk-room-inset: rgba(255,255,255,.35);
+  --sk-room-floor: linear-gradient(180deg,#c6b08a 0,#b7a07b 45%,#a8916c 100%);
+  --sk-room-cog: #b79a63;
+  --sk-room-mote: rgba(150,110,60,.30);
+  --sk-room-glow: rgba(206,155,63,.30);
   --sk-room-flame: radial-gradient(circle at 50% 72%, #fff3c0, #eaa53f 55%, #cf7a26);
+  --sk-room-topshade: inset 0 30px 70px -52px rgba(58,52,43,.16);
+  --sk-room-floorshade: inset 0 14px 26px -16px rgba(58,52,43,.20);
+  --sk-room-vignette: radial-gradient(120% 95% at 50% 38%, rgba(58,52,43,0) 58%, rgba(58,52,43,.10) 100%);
 }
 /* Divider (żyła/smużka/sygil) — cieplejszy akcent na jasnym dębie. */
 [data-theme="light"] .skin-holo .shelf-divider,
@@ -343,6 +349,11 @@ body {
    pyłki, żyły danych) → czysty, boho regał. Ciemny motyw = bez zmian. */
 [data-theme="light"] .dc-40k,
 [data-theme="light"] .noo-data { display: none !important; }
+
+/* Odwrotnie: element TYLKO dla jasnej skóry (nowe świece boho). Ciemny motyw
+   zachowuje dotychczasowy cienki kinkiet 40k (`.dc-40k`), boho dostaje klaster. */
+.candle-boho { display: none; }
+[data-theme="light"] .candle-boho { display: block; }
 
 /* Jaśniejsze grzbiety z palety makiety (var `--spine-light`) + jasne okładki. */
 [data-theme="light"] .skin-noospheric .book-spine {


### PR DESCRIPTION
Fixes #339

## Backdrop (variant C — putty/taupe)
The room read as dark in boho — not from the backdrop (already light linen) but from hard black shadows/vignette/floor (`rgba(0,0,0,.5–.85)`) inherited from the 40k dark wood, especially the bottom band.

- `--sk-room-bg` → putty/taupe `#d9c9ac→#c3ae8b`: a warm mid-tone that frames the lighter shelf without going dark.
- The black room shadows move onto `--sk-room-topshade` / `--sk-room-floorshade` / `--sk-room-vignette` vars, with the dark value as the **inline fallback** (40k untouched) and a **soft warm** boho override (`rgba(58,52,43,.10–.20)`).

## Candles (variant Ś3)
New `CandleCluster`: three thick candles of varying height (ivory / clay / beeswax) with wax drips, a melted rim and a pooled base.
- Flames are **bigger and flicker more slowly** (motion, `transformBox: fill-box`, 3.8–4.4s; glow 4.6s) — per the review.
- Shown **only in boho** via a new `.candle-boho` class (the inverse of `.dc-40k`); the dark skin keeps its thin 40k sconce **unchanged**.

Both chosen from a 4-backdrop + 3-candle mock reviewed together.

## Verification
`npm run lint` clean, `npm test` **502** green, `npm run build` OK — the new `--sk-room-*` vars and `.candle-boho` class are confirmed in the bundle. Dark theme unchanged (uses the JS fallbacks + keeps its sconce). Version 1.73.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_