### PR TITLE
feat(config): knobs for the shelf-room look (shade, candle glow, flame speed)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.73.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.74.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,13 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.73.0** — **Regał (boho): tło „sali" putty (wariant C) + grube świece ociekające woskiem (Ś3).**
+- **1.74.0** — **Knoby wyglądu sali regału w Konfiguracji.** Trzy pokrętła (`ui`): `shelfRoomShade` (siła cieni/
+  winiety sali, 0–200%), `candleGlow` (poświata świec, 0–200%), `flameSpeed` (tempo migotania, 50–200%, wyżej=
+  szybciej); default 100. Schema + clamps w `src/configSchema.ts`; edytory (NumberField) w „Kalibracji"
+  (`ConfigSection`). Konsumpcja: alpha cieni/poświaty przez `calc(.X * var(--knob-*, 1))` w `index.css` (jasny
+  skin) — JS ustawia `--knob-room-shade`/`--knob-candle-glow` na `RoomDecor` z wartości % (mnożnik = %/100);
+  `flameSpeed` jako mnożnik dzielący czasy animacji płomieni/glow w `CandleCluster`. Zero migracji (nowe knoby
+  dziedziczą default; storage = tylko diff). Suite 502 zielone, lint czysty, build OK (knoby w bundlu).
   Diagnoza: `--sk-room-bg` w boho był JUŻ jasny (len) — ciemne wrażenie robiły twarde czarne cienie/winieta/
   podłoga w `RoomDecor` (`rgba(0,0,0,.5–.85)`), zwł. dolny pas. (1) Tło → putty/taupe C (`#d9c9ac→#c3ae8b`),
   ciepła oprawa regału; czarne cienie na zmiennych `--sk-room-topshade/-floorshade/-vignette` (fallback = ciemna

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.73.0",
+      "version": "1.74.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.73.0",
+  "version": "1.74.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/ConfigSection.tsx
+++ b/src/components/ConfigSection.tsx
@@ -232,6 +232,9 @@ export const ConfigSection: React.FC = () => {
                   Włączony
                 </label>
               </Field>
+              <NumberField label="Regał: cień sali (%)" hint="Jasna skóra: siła cieni/winiety wokół regału. 0–200; 100 = domyślne, 0 = płasko." value={draft.ui.shelfRoomShade} step={5} onChange={(v) => upd("ui", { shelfRoomShade: v })} />
+              <NumberField label="Regał: poświata świec (%)" hint="Jasna skóra: intensywność blasku świec. 0–200; 100 = domyślne." value={draft.ui.candleGlow} step={5} onChange={(v) => upd("ui", { candleGlow: v })} />
+              <NumberField label="Regał: tempo płomienia (%)" hint="Jasna skóra: szybkość migotania świec. 50–200; wyżej = szybciej." value={draft.ui.flameSpeed} step={5} onChange={(v) => upd("ui", { flameSpeed: v })} />
               <NumberField label="Duplikaty: próg autora" hint="0.5–1; wyżej = mniej czułe." value={draft.sync.dupAuthorThreshold} step={0.01} onChange={(v) => upd("sync", { dupAuthorThreshold: v })} />
               <NumberField label="Duplikaty: próg tytułu" hint="0.5–1; dotyczy tytułu PL i oryginalnego." value={draft.sync.dupTitleThreshold} step={0.01} onChange={(v) => upd("sync", { dupTitleThreshold: v })} />
             </div>

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { motion } from "motion/react";
+import { useEffectiveConfig } from "../../hooks/useAppConfig";
 
 /** Cog-wheel sigil (Mechanicus) — room decoration. Color via `style`, so
  *  the skin variables resolve (`var(--sk-room-cog*)`). */
@@ -50,14 +51,14 @@ const flameAnim = (dur: number, delay = 0) => ({
   transition: { duration: dur, repeat: Infinity, ease: "easeInOut" as const, delay },
 });
 
-const CandleCluster: React.FC<{ className?: string; flip?: boolean }> = ({ className, flip }) => (
+const CandleCluster: React.FC<{ className?: string; flip?: boolean; speed?: number }> = ({ className, flip, speed = 1 }) => (
   <div className={`candle-boho absolute pointer-events-none ${className ?? ""}`} aria-hidden style={flip ? { transform: "scaleX(-1)" } : undefined}>
-    {/* warm pooled glow (bigger, slower) */}
+    {/* warm pooled glow (bigger, slower); `speed` = flame flicker multiplier (from config knob). */}
     <motion.div
       className="absolute -left-[46px] -top-[54px] w-[196px] h-[196px] rounded-full"
       style={{ background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(8px)" }}
       animate={{ opacity: [0.55, 0.8, 0.5, 0.74, 0.6] }}
-      transition={{ duration: 4.6, repeat: Infinity, ease: "easeInOut" }}
+      transition={{ duration: 4.6 / speed, repeat: Infinity, ease: "easeInOut" }}
     />
     <svg viewBox="0 0 132 152" width="132" height="152">
       <defs>
@@ -71,20 +72,20 @@ const CandleCluster: React.FC<{ className?: string; flip?: boolean }> = ({ class
       <path d="M34 110 q4 16 0 28" stroke="#8a4e33" strokeWidth="3" fill="none" opacity=".55" strokeLinecap="round" />
       <ellipse cx="21" cy="97" rx="13" ry="4.5" fill="#8a4e33" /><ellipse cx="21" cy="95.5" rx="13" ry="4" fill="#cd8f6e" />
       <rect x="19.5" y="82" width="3" height="14" rx="1.5" fill="#4d2c1a" />
-      <motion.path d="M21 58 q11 15 0 34 q-11 -19 0 -34" fill="url(#cc-fl)" {...flameAnim(3.8, 0.5)} />
+      <motion.path d="M21 58 q11 15 0 34 q-11 -19 0 -34" fill="url(#cc-fl)" {...flameAnim(3.8 / speed, 0.5)} />
       {/* tall ivory (center) */}
       <rect x="44" y="52" width="30" height="96" rx="8" fill="url(#cc-iv)" />
       <path d="M44 78 q4 22 0 38 M74 88 q-4 20 0 36" stroke="#d7cbaf" strokeWidth="3" fill="none" opacity=".65" strokeLinecap="round" />
       <ellipse cx="59" cy="53" rx="15" ry="5" fill="#cdbf9f" /><ellipse cx="59" cy="51.5" rx="15" ry="4.5" fill="#efe6cf" />
       <path d="M49 53 q3 10 -2 15 q-4 -6 2 -15" fill="#e9dec4" />
       <rect x="57.5" y="36" width="3" height="16" rx="1.5" fill="#5b4a2e" />
-      <motion.path d="M59 8 q13 18 0 40 q-13 -22 0 -40" fill="url(#cc-fl)" {...flameAnim(4.4)} />
+      <motion.path d="M59 8 q13 18 0 40 q-13 -22 0 -40" fill="url(#cc-fl)" {...flameAnim(4.4 / speed)} />
       {/* medium beeswax (right) */}
       <rect x="84" y="76" width="26" height="72" rx="7" fill="url(#cc-bw)" />
       <path d="M110 96 q4 18 0 32" stroke="#a87e2e" strokeWidth="3" fill="none" opacity=".55" strokeLinecap="round" />
       <ellipse cx="97" cy="77" rx="13" ry="4.5" fill="#a87e2e" /><ellipse cx="97" cy="75.5" rx="13" ry="4" fill="#e6c273" />
       <rect x="95.5" y="60" width="3" height="16" rx="1.5" fill="#4d3c1a" />
-      <motion.path d="M97 34 q12 16 0 36 q-12 -20 0 -36" fill="url(#cc-fl)" {...flameAnim(4.0, 0.9)} />
+      <motion.path d="M97 34 q12 16 0 36 q-12 -20 0 -36" fill="url(#cc-fl)" {...flameAnim(4.0 / speed, 0.9)} />
       {/* wax pool */}
       <ellipse cx="60" cy="149" rx="58" ry="6" fill="#cdbb9a" opacity=".55" />
     </svg>
@@ -111,13 +112,20 @@ const Mote: React.FC<{ i: number }> = ({ i }) => {
  * floor, sconces with flickering light, banner, cog-wheel sigil, dust
  * and vignette. Purely decorative (aria-hidden). Does not touch the book physics.
  */
-export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  // Appearance knobs (Konfiguracja → ui). Percent → multiplier: 100 % = as designed.
+  const ui = useEffectiveConfig().ui;
+  const flameSpeed = ui.flameSpeed / 100;
+  return (
   <div
     className="relative rounded-[20px] overflow-hidden px-4 pt-10 pb-[120px] sm:px-8"
     style={{
       background: "var(--sk-room-bg)",
       boxShadow: "inset 0 2px 0 var(--sk-room-inset), var(--sk-room-topshade, inset 0 40px 80px -40px rgba(0,0,0,.7))",
-    }}
+      // The alpha of the room shadows / candle glow scales off these (see index.css).
+      ["--knob-room-shade" as string]: String(ui.shelfRoomShade / 100),
+      ["--knob-candle-glow" as string]: String(ui.candleGlow / 100),
+    } as React.CSSProperties}
   >
     {/* Cog-wheel watermark */}
     <CogMark size={320} color="var(--sk-room-cog)" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
@@ -125,8 +133,8 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
     {/* Sconces — dark skin (40k). Boho shows the candle cluster instead. */}
     <Sconce className="left-3 top-16 hidden md:block" />
     <Sconce className="right-3 top-16 hidden md:block" />
-    <CandleCluster className="left-2 top-12 hidden md:block" />
-    <CandleCluster className="right-2 top-12 hidden md:block" flip />
+    <CandleCluster className="left-2 top-12 hidden md:block" speed={flameSpeed} />
+    <CandleCluster className="right-2 top-12 hidden md:block" flip speed={flameSpeed} />
 
     {/* Dust in the air */}
     {Array.from({ length: 16 }).map((_, i) => <Mote key={i} i={i} />)}
@@ -141,4 +149,5 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
     {/* Vignette */}
     <div className="absolute inset-0 pointer-events-none" style={{ background: "var(--sk-room-vignette, radial-gradient(120% 90% at 50% 40%, rgba(0,0,0,0) 45%, rgba(0,0,0,.5) 100%))" }} aria-hidden />
   </div>
-);
+  );
+};

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -84,6 +84,12 @@ export interface AppConfig {
     preciseShelfDrop: boolean;
     /** Card order in „Analizie Zasobów" (section ids). Empty = default order from code. */
     statsOrder: string[];
+    /** Regał (light skin) — strength of the „room" shadow/vignette, 0–200 % (100 = as designed). */
+    shelfRoomShade: number;
+    /** Regał (light skin) — candle glow intensity, 0–200 % (100 = as designed). */
+    candleGlow: number;
+    /** Regał (light skin) — candle flame flicker speed, 50–200 % (100 = as designed; higher = faster). */
+    flameSpeed: number;
   };
 }
 
@@ -143,6 +149,9 @@ export const DEFAULT_CONFIG: AppConfig = {
     shelfRowsPerPage: 5,
     preciseShelfDrop: true,
     statsOrder: [],
+    shelfRoomShade: 100,
+    candleGlow: 100,
+    flameSpeed: 100,
   },
 };
 
@@ -265,6 +274,9 @@ export function mergeConfig(overrides?: unknown): AppConfig {
       shelfRowsPerPage: clampInt(u.shelfRowsPerPage, 1, 12, d.ui.shelfRowsPerPage),
       preciseShelfDrop: cleanBool(u.preciseShelfDrop, d.ui.preciseShelfDrop),
       statsOrder: cleanIdList(u.statsOrder),
+      shelfRoomShade: clampInt(u.shelfRoomShade, 0, 200, d.ui.shelfRoomShade),
+      candleGlow: clampInt(u.candleGlow, 0, 200, d.ui.candleGlow),
+      flameSpeed: clampInt(u.flameSpeed, 50, 200, d.ui.flameSpeed),
     },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -326,11 +326,14 @@ body {
   --sk-room-floor: linear-gradient(180deg,#c6b08a 0,#b7a07b 45%,#a8916c 100%);
   --sk-room-cog: #b79a63;
   --sk-room-mote: rgba(150,110,60,.30);
-  --sk-room-glow: rgba(206,155,63,.30);
+  /* Knoby (Konfiguracja → ui): `--knob-candle-glow` i `--knob-room-shade` to
+     mnożniki (1 = domyślne), ustawiane w JS na `RoomDecor` z wartości % z configu.
+     calc() na kanale alpha skaluje poświatę świec i siłę cieni sali. */
+  --sk-room-glow: rgba(206,155,63, calc(.30 * var(--knob-candle-glow, 1)));
   --sk-room-flame: radial-gradient(circle at 50% 72%, #fff3c0, #eaa53f 55%, #cf7a26);
-  --sk-room-topshade: inset 0 30px 70px -52px rgba(58,52,43,.16);
-  --sk-room-floorshade: inset 0 14px 26px -16px rgba(58,52,43,.20);
-  --sk-room-vignette: radial-gradient(120% 95% at 50% 38%, rgba(58,52,43,0) 58%, rgba(58,52,43,.10) 100%);
+  --sk-room-topshade: inset 0 30px 70px -52px rgba(58,52,43, calc(.16 * var(--knob-room-shade, 1)));
+  --sk-room-floorshade: inset 0 14px 26px -16px rgba(58,52,43, calc(.20 * var(--knob-room-shade, 1)));
+  --sk-room-vignette: radial-gradient(120% 95% at 50% 38%, rgba(58,52,43,0) 58%, rgba(58,52,43, calc(.10 * var(--knob-room-shade, 1))) 100%);
 }
 /* Divider (żyła/smużka/sygil) — cieplejszy akcent na jasnym dębie. */
 [data-theme="light"] .skin-holo .shelf-divider,


### PR DESCRIPTION
Fixes #341

## What
Three new Konfiguracja knobs (`ui` section) for the boho shelf-room look, defaults = the current design (no behavior change until touched):
- **`shelfRoomShade`** (0–200 %) — strength of the room shadows / vignette.
- **`candleGlow`** (0–200 %) — candle glow intensity.
- **`flameSpeed`** (50–200 %) — candle flame flicker speed (higher = faster).

## How
- **`configSchema.ts`**: fields + defaults + clamps. Diff-only storage means new knobs inherit defaults — no migration.
- **`index.css`**: the alpha of `--sk-room-glow` / `--sk-room-topshade` / `--sk-room-floorshade` / `--sk-room-vignette` now scales via `calc(.X * var(--knob-*, 1))`.
- **`RoomDecor`**: reads `useEffectiveConfig().ui`, sets `--knob-room-shade` / `--knob-candle-glow` on its root (percent → multiplier), and passes `flameSpeed` into `CandleCluster`, which divides the flame/glow animation durations by it.
- **`ConfigSection`**: three `NumberField` editors under „Kalibracja".

Nested `var()` inside the `--sk-room-*` shadow strings resolves against the knob values set on `RoomDecor`, so the whole room + candles react.

## Verification
`npm run lint` clean, `npm test` **502** green, `npm run build` OK — knob vars present in the bundle. Version 1.74.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_