### PR TITLE
fix(shelf): drop background candle clusters, move candle above each shelf frame

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.74.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.74.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,7 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
-- **1.74.1** — **Świece: małe świeczki nad regałami → grube kapiące, zróżnicowane, nie-lustrzane.** Parametryczny
+- **1.74.2** — **Świece: klastry z tła usunięte, świeca przeniesiona nad górną ramkę regału.** Dwa duże klastry
+  narożne w `RoomDecor` (boho) USUNIĘTE (+ martwy `CandleCluster`/`VARIANTS`); ciemny 40k zachowuje kinkiety.
+  Per-regał `WaxCandle` skalowana teraz przez wymiary SVG (nie transform) → precyzyjne pozycjonowanie; siedzi tuż
+  NAD gzymsem (`-top-[47px]`, scale 0.62 ≈ rozmiar z „czerwonych kwadratów"), w zróżnicowanym, BEZPIECZNYM pasie
+  poziomym (`left-1/4…2/3` z hasha `shelfId`) — nie koliduje z ikoną/tytułem/pagerem i sąsiednie regały różnią się
+  miejscem + grubością. Suite 502 zielone, lint czysty, build OK. Parametryczny
   `Candle` (grubość `w`, ton, wysokość; płomień skalowany girth) + `CandleCluster` z 3 wariantami układu (różny
   ton/wysokość/GRUBOŚĆ → dwa miejsca nigdy nie wyglądają jak lustrzane odbicie) i pojedynczy `WaxCandle`. Rogi
   sali: `variant 0` (lewa) vs `variant 1` + inny offset/scale (prawa) — koniec `flip`-mirror. Cienka świeczka nad

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.74.1",
+  "version": "1.74.2",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.74.1",
+  "version": "1.74.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.74.1",
+      "version": "1.74.2",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.74.1",
+  "version": "1.74.2",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -92,48 +92,23 @@ const Candle: React.FC<Spec & { baseY?: number; speed?: number }> = ({ x, w, top
   );
 };
 
-// Distinct three-candle arrangements — different tone order, heights and WIDTHS
-// (girth), so two placements never read as mirror images of each other.
-const VARIANTS: Spec[][] = [
-  [ { x: 6, w: 22, top: 100, tone: "cl", dur: 3.8, delay: 0.5 }, { x: 36, w: 34, top: 56, tone: "iv", dur: 4.4, delay: 0 }, { x: 80, w: 27, top: 82, tone: "bw", dur: 4.0, delay: 0.9 } ],
-  [ { x: 8, w: 30, top: 66, tone: "bw", dur: 4.2, delay: 0.3 }, { x: 46, w: 20, top: 106, tone: "cl", dur: 3.6, delay: 0.8 }, { x: 74, w: 33, top: 84, tone: "iv", dur: 4.0, delay: 0 } ],
-  [ { x: 6, w: 27, top: 88, tone: "iv", dur: 3.9, delay: 0.2 }, { x: 40, w: 21, top: 68, tone: "cl", dur: 4.1, delay: 0.6 }, { x: 72, w: 34, top: 96, tone: "bw", dur: 3.7, delay: 1.0 } ],
-];
-
-export const CandleCluster: React.FC<{ className?: string; variant?: number; scale?: number; speed?: number }> = ({ className, variant = 0, scale = 1, speed = 1 }) => {
-  const candles = VARIANTS[((variant % VARIANTS.length) + VARIANTS.length) % VARIANTS.length];
-  return (
-    <div className={`candle-boho absolute pointer-events-none ${className ?? ""}`} aria-hidden
-      style={scale !== 1 ? { transform: `scale(${scale})`, transformOrigin: "bottom left" } : undefined}>
-      <motion.div
-        className="absolute -left-[46px] -top-[54px] w-[196px] h-[196px] rounded-full"
-        style={{ background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(8px)" }}
-        animate={{ opacity: [0.55, 0.8, 0.5, 0.74, 0.6] }}
-        transition={{ duration: 4.6 / speed, repeat: Infinity, ease: "easeInOut" }}
-      />
-      <svg viewBox="0 0 118 152" width="118" height="152">
-        <CandleDefs />
-        {candles.map((c, i) => <Candle key={i} {...c} speed={speed} />)}
-        <ellipse cx="58" cy="149" rx="54" ry="6" fill="#cdbb9a" opacity=".5" />
-      </svg>
-    </div>
-  );
-};
-
-/** A single thick wax candle — replaces the thin candle on top of each shelf. */
-export const WaxCandle: React.FC<{ className?: string; tone?: Tone; w?: number; speed?: number; scale?: number }> = ({ className, tone = "iv", w = 22, speed = 1, scale = 1 }) => {
+/** A single thick wax candle — sits on top of each shelf (above the cornice).
+ *  Sized via the SVG width/height (not a CSS transform), so the element's box
+ *  equals the drawing and it can be positioned precisely above the frame. */
+export const WaxCandle: React.FC<{ className?: string; tone?: Tone; w?: number; speed?: number; scale?: number }> = ({ className, tone = "iv", w = 22, speed = 1, scale = 0.62 }) => {
   const vbw = Math.round(w * 2.3 + 8);
+  const vbh = 82;
   const x = 6;
+  const glow = 62 * scale;
   return (
-    <div className={`candle-boho absolute pointer-events-none ${className ?? ""}`} aria-hidden
-      style={scale !== 1 ? { transform: `scale(${scale})`, transformOrigin: "bottom center" } : undefined}>
+    <div className={`candle-boho absolute pointer-events-none ${className ?? ""}`} aria-hidden>
       <motion.div
-        className="absolute left-1/2 -translate-x-1/2 -top-[24px] w-[64px] h-[64px] rounded-full"
-        style={{ background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(5px)" }}
+        className="absolute left-1/2 -translate-x-1/2 rounded-full"
+        style={{ width: glow, height: glow, top: -glow * 0.35, background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(5px)" }}
         animate={{ opacity: [0.5, 0.72, 0.48, 0.66, 0.55] }}
         transition={{ duration: 4.4 / speed, repeat: Infinity, ease: "easeInOut" }}
       />
-      <svg viewBox={`0 0 ${vbw} 82`} width={vbw} height="82">
+      <svg viewBox={`0 0 ${vbw} ${vbh}`} width={vbw * scale} height={vbh * scale} style={{ display: "block" }}>
         <CandleDefs />
         <Candle x={x} w={w} top={34} baseY={80} tone={tone} dur={4.1} delay={0} speed={speed} />
         <ellipse cx={x + w / 2} cy="81" rx={w * 0.85} ry="3.5" fill="#cdbb9a" opacity=".45" />
@@ -165,7 +140,6 @@ const Mote: React.FC<{ i: number }> = ({ i }) => {
 export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Appearance knobs (Konfiguracja → ui). Percent → multiplier: 100 % = as designed.
   const ui = useEffectiveConfig().ui;
-  const flameSpeed = ui.flameSpeed / 100;
   return (
   <div
     className="relative rounded-[20px] overflow-hidden px-4 pt-10 pb-[120px] sm:px-8"
@@ -180,12 +154,10 @@ export const RoomDecor: React.FC<{ children: React.ReactNode }> = ({ children })
     {/* Cog-wheel watermark */}
     <CogMark size={320} color="var(--sk-room-cog)" className="absolute left-1/2 -translate-x-1/2 top-6 opacity-[0.05] pointer-events-none" />
 
-    {/* Sconces — dark skin (40k). Boho shows the candle cluster instead. */}
+    {/* Sconces — dark skin (40k) only. In boho the candles live on top of each
+        shelf (see Shelf → WaxCandle), so the room background stays clear. */}
     <Sconce className="left-3 top-16 hidden md:block" />
     <Sconce className="right-3 top-16 hidden md:block" />
-    {/* Two clusters — different arrangements + offsets (not a flipped mirror). */}
-    <CandleCluster className="left-2 top-12 hidden md:block" variant={0} speed={flameSpeed} />
-    <CandleCluster className="right-3 top-[68px] hidden md:block" variant={1} scale={0.9} speed={flameSpeed} />
 
     {/* Dust in the air */}
     {Array.from({ length: 16 }).map((_, i) => <Mote key={i} i={i} />)}

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -38,7 +38,9 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
   const candleH = Array.from(shelfId).reduce((a, c) => a + c.charCodeAt(0), 0);
   const candleTone = (["iv", "bw", "cl"] as const)[candleH % 3];
   const candleW = [19, 24, 28][candleH % 3];
-  const candleLeftCls = ["left-4", "left-8", "left-12"][candleH % 3];
+  // Varied horizontal spot in a safe band (past the header icon, before the pager)
+  // so candles don't collide with the header and neighbouring shelves differ.
+  const candleLeftCls = ["left-1/4", "left-1/3", "left-1/2", "left-2/3"][candleH % 4];
   const [over, setOver] = useState(false);
   const [page, setPage] = useState(0);
   const wellRef = useRef<HTMLDivElement>(null);
@@ -134,7 +136,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
         <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 w-[8px] h-[13px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
           style={{ background: "radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00)", boxShadow: "0 0 14px 5px rgba(255,150,40,.5)" }} />
       </div>
-      <WaxCandle className={`-top-[38px] ${candleLeftCls} z-20`} tone={candleTone} w={candleW} scale={0.6} speed={flameSpeed} />
+      <WaxCandle className={`-top-[47px] ${candleLeftCls} z-20`} tone={candleTone} w={candleW} speed={flameSpeed} />
 
       <ShelfFrame
         title={title} icon={icon} accent={accent} count={books.length}


### PR DESCRIPTION
Fixes #345

## What
Per the annotated screenshot:
- **Removed** the two big candle clusters from the room background in boho (and the now-dead `CandleCluster` / `VARIANTS`). The dark 40k theme keeps its corner sconces.
- The per-shelf `WaxCandle` is now sized via the **SVG width/height** (not a CSS transform), so it can be positioned precisely. It sits just **above the shelf cornice** (`-top-[47px]`, `scale 0.62` ≈ the size marked by the red squares), in a **varied, collision-safe** horizontal band (`left-1/4…2/3`, derived from the shelf id) — clear of the header icon / title / pager, and neighbouring shelves differ in spot and girth.

## Verification
`npm run lint` clean, `npm test` **502** green, `npm run build` OK. Dark theme unchanged. Version 1.74.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_