### PR TITLE
fix(shelf): triple candle cluster above each shelf (not a single candle)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.74.2** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.74.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,11 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.74.3** — **Świece nad regałem = potrójny klaster (taki był zamysł).** Pojedyncza `WaxCandle` zamieniona z
+  powrotem na `CandleCluster` (3 świece), przywrócone `VARIANTS`. Cluster skalowany przez wymiary SVG (nie
+  transform) → precyzyjne osadzenie tuż nad gzymsem (`-top-[60px]`, scale 0.42); glow skalowany z rozmiarem.
+  Wariant + pozycja pozioma (`left-1/4…1/2`) z hasha `shelfId` — sąsiednie regały różnią się układem i miejscem,
+  nie kolidują z nagłówkiem. Tło sali dalej czyste, ciemny 40k bez zmian. Suite 502 zielone, lint czysty, build OK.
 - **1.74.2** — **Świece: klastry z tła usunięte, świeca przeniesiona nad górną ramkę regału.** Dwa duże klastry
   narożne w `RoomDecor` (boho) USUNIĘTE (+ martwy `CandleCluster`/`VARIANTS`); ciemny 40k zachowuje kinkiety.
   Per-regał `WaxCandle` skalowana teraz przez wymiary SVG (nie transform) → precyzyjne pozycjonowanie; siedzi tuż

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.74.2",
+  "version": "1.74.3",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.74.2",
+  "version": "1.74.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.74.2",
+      "version": "1.74.3",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.74.2",
+  "version": "1.74.3",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/shelf/RoomDecor.tsx
+++ b/src/components/shelf/RoomDecor.tsx
@@ -92,26 +92,33 @@ const Candle: React.FC<Spec & { baseY?: number; speed?: number }> = ({ x, w, top
   );
 };
 
-/** A single thick wax candle — sits on top of each shelf (above the cornice).
- *  Sized via the SVG width/height (not a CSS transform), so the element's box
- *  equals the drawing and it can be positioned precisely above the frame. */
-export const WaxCandle: React.FC<{ className?: string; tone?: Tone; w?: number; speed?: number; scale?: number }> = ({ className, tone = "iv", w = 22, speed = 1, scale = 0.62 }) => {
-  const vbw = Math.round(w * 2.3 + 8);
-  const vbh = 82;
-  const x = 6;
-  const glow = 62 * scale;
+// Distinct three-candle arrangements — different tone order, heights and WIDTHS
+// (girth), so two placements never read as mirror images of each other.
+const VARIANTS: Spec[][] = [
+  [ { x: 6, w: 22, top: 100, tone: "cl", dur: 3.8, delay: 0.5 }, { x: 36, w: 34, top: 56, tone: "iv", dur: 4.4, delay: 0 }, { x: 80, w: 27, top: 82, tone: "bw", dur: 4.0, delay: 0.9 } ],
+  [ { x: 8, w: 30, top: 66, tone: "bw", dur: 4.2, delay: 0.3 }, { x: 46, w: 20, top: 106, tone: "cl", dur: 3.6, delay: 0.8 }, { x: 74, w: 33, top: 84, tone: "iv", dur: 4.0, delay: 0 } ],
+  [ { x: 6, w: 27, top: 88, tone: "iv", dur: 3.9, delay: 0.2 }, { x: 40, w: 21, top: 68, tone: "cl", dur: 4.1, delay: 0.6 }, { x: 72, w: 34, top: 96, tone: "bw", dur: 3.7, delay: 1.0 } ],
+];
+
+/** A cluster of three thick, wax-dripping candles — sits on top of each shelf
+ *  (above the cornice). Sized via the SVG width/height (not a CSS transform) so
+ *  its box equals the drawing and it can be positioned precisely; `variant` picks
+ *  one of the distinct (non-mirror) arrangements. */
+export const CandleCluster: React.FC<{ className?: string; variant?: number; speed?: number; scale?: number }> = ({ className, variant = 0, speed = 1, scale = 1 }) => {
+  const candles = VARIANTS[((variant % VARIANTS.length) + VARIANTS.length) % VARIANTS.length];
+  const glow = 150 * scale;
   return (
     <div className={`candle-boho absolute pointer-events-none ${className ?? ""}`} aria-hidden>
       <motion.div
         className="absolute left-1/2 -translate-x-1/2 rounded-full"
-        style={{ width: glow, height: glow, top: -glow * 0.35, background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(5px)" }}
-        animate={{ opacity: [0.5, 0.72, 0.48, 0.66, 0.55] }}
-        transition={{ duration: 4.4 / speed, repeat: Infinity, ease: "easeInOut" }}
+        style={{ width: glow, height: glow, top: -glow * 0.3, background: "radial-gradient(closest-side, var(--sk-room-glow), transparent)", filter: "blur(7px)" }}
+        animate={{ opacity: [0.55, 0.8, 0.5, 0.74, 0.6] }}
+        transition={{ duration: 4.6 / speed, repeat: Infinity, ease: "easeInOut" }}
       />
-      <svg viewBox={`0 0 ${vbw} ${vbh}`} width={vbw * scale} height={vbh * scale} style={{ display: "block" }}>
+      <svg viewBox="0 0 118 152" width={118 * scale} height={152 * scale} style={{ display: "block" }}>
         <CandleDefs />
-        <Candle x={x} w={w} top={34} baseY={80} tone={tone} dur={4.1} delay={0} speed={speed} />
-        <ellipse cx={x + w / 2} cy="81" rx={w * 0.85} ry="3.5" fill="#cdbb9a" opacity=".45" />
+        {candles.map((c, i) => <Candle key={i} {...c} speed={speed} />)}
+        <ellipse cx="58" cy="149" rx="54" ry="6" fill="#cdbb9a" opacity=".5" />
       </svg>
     </div>
   );

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -7,7 +7,7 @@ import { buildShelfItems, chunk } from "../../utils/shelfLayout";
 import { canInsertAt } from "../../utils/shelfInsertion";
 import { ShelfRow, EmptyShelfRow, GapBoundary, GapCaret } from "./ShelfRow";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
-import { WaxCandle } from "./RoomDecor";
+import { CandleCluster } from "./RoomDecor";
 import { useEffectiveConfig } from "../../hooks/useAppConfig";
 
 interface Props {
@@ -32,15 +32,14 @@ interface Props {
 /** One shelf: wooden body + PHYSICAL layout of volumes (filled shelves, leaning tilted ones). */
 export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, onDragStart, onDragEnd, onDropBook, onPreciseDrop, draggingBook, preciseEnabled = true, pageSize }) => {
   const dragging = draggingBook !== null;
-  // Boho candle on top of the shelf — thick + wax-dripping, varied per shelf
-  // (tone / girth / offset from the shelf id) so shelves don't look identical.
+  // Boho candle cluster (three thick, wax-dripping candles) on top of the shelf,
+  // varied per shelf (arrangement + spot from the shelf id) so shelves differ.
   const flameSpeed = useEffectiveConfig().ui.flameSpeed / 100;
   const candleH = Array.from(shelfId).reduce((a, c) => a + c.charCodeAt(0), 0);
-  const candleTone = (["iv", "bw", "cl"] as const)[candleH % 3];
-  const candleW = [19, 24, 28][candleH % 3];
+  const candleVariant = candleH % 3;
   // Varied horizontal spot in a safe band (past the header icon, before the pager)
-  // so candles don't collide with the header and neighbouring shelves differ.
-  const candleLeftCls = ["left-1/4", "left-1/3", "left-1/2", "left-2/3"][candleH % 4];
+  // so the cluster doesn't collide with the header and neighbouring shelves differ.
+  const candleLeftCls = ["left-1/4", "left-1/3", "left-1/2"][candleH % 3];
   const [over, setOver] = useState(false);
   const [page, setPage] = useState(0);
   const wellRef = useRef<HTMLDivElement>(null);
@@ -136,7 +135,7 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
         <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 w-[8px] h-[13px] rounded-[50%_50%_45%_45%/60%_60%_40%_40%]"
           style={{ background: "radial-gradient(circle at 50% 72%, #fff3c0, #ffb03a 55%, #ff6a00)", boxShadow: "0 0 14px 5px rgba(255,150,40,.5)" }} />
       </div>
-      <WaxCandle className={`-top-[47px] ${candleLeftCls} z-20`} tone={candleTone} w={candleW} speed={flameSpeed} />
+      <CandleCluster className={`-top-[60px] ${candleLeftCls} z-20`} variant={candleVariant} scale={0.42} speed={flameSpeed} />
 
       <ShelfFrame
         title={title} icon={icon} accent={accent} count={books.length}


### PR DESCRIPTION
The intent was **three** candles on top of each shelf, not one.

- Swapped the single `WaxCandle` back for `CandleCluster` (VARIANTS restored).
- The cluster is sized via the **SVG width/height** (not a CSS transform), so it seats precisely just above the cornice (`-top-[60px]`, `scale 0.42`; the glow scales with size).
- The arrangement `variant` + horizontal spot (`left-1/4…1/2`) come from the shelf id, so neighbouring shelves differ in layout and place and don't collide with the header.
- Room background stays clear; dark 40k unchanged.

`npm run lint` clean, `npm test` **502** green, `npm run build` OK. Version 1.74.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_