### PR TITLE
fix(security): host allow-list for Vinted URLs — closes the SSRF re-fetch

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.74.3** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.75.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.75.0** — **[SEC-PR1] Allow-lista hosta dla URL-i Vinted — zamyka SSRF + 6 sinków `href`.** Nowy
+  `services/vintedUrl.ts`: `isVintedUrl` (host = `vinted.pl`/subdomeny, tylko http(s)) i `isVintedPhotoUrl`
+  (+`vinted.net` dla CDN). Dopasowanie `h===base || h.endsWith("."+base)` — `evilvinted.pl` i
+  `vinted.pl.attacker.com` odpadają. Wpięte: (1) `parseVintedData` waliduje KAŻDĄ ofertę na WYJŚCIU ze storage
+  (`sanitizeStoredOffer`) — zły `url` = drop oferty, zły `photo`/`seller` = drop pola; (2) `offerFromItem` zwraca
+  `null` dla obcego hosta (obrona w głąb na wejściu; caller filtruje); (3) filtr przed re-fetchem w
+  `vintedSyncService` z testu PODCIĄGU `/\/items\//` → `isVintedUrl(url) && url.includes("/items/")`. To był
+  realny wektor: `http://169.254.169.254/items/` przechodził stary filtr i był pobierany z wnętrza Rendera
+  z ciasteczkiem `cf_clearance`. +15 testów (m.in. dokładne cele SSRF, suffix-confusion, `javascript:`).
+  Fixture'y z atrapami URL (`"u"`, `"u1"`) w `vintedStore.test`/`marketStats.test` urealnione — nigdy nie były
+  poprawnymi danymi Vinted. Suite 517 zielone, lint czysty, build OK.
 - **1.74.3** — **Świece nad regałem = potrójny klaster (taki był zamysł).** Pojedyncza `WaxCandle` zamieniona z
   powrotem na `CandleCluster` (3 świece), przywrócone `VARIANTS`. Cluster skalowany przez wymiary SVG (nie
   transform) → precyzyjne osadzenie tuż nad gzymsem (`-top-[60px]`, scale 0.42); glow skalowany z rozmiarem.

--- a/backlog.md
+++ b/backlog.md
@@ -1333,6 +1333,44 @@ Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze 
   (`parseReadDate`/`parseImportCsv`/`buildReadDatePlan`). DO ZROBIENIA kiedyś: opakować to w UI (upload CSV w
   Ustawieniach → podgląd planu: dopasowane/niedopasowane/niejednoznaczne → zatwierdź zapis), reużywając tych
   helperów. Nowe rekordy „na bieżąco" już obsłużone automatycznym stemplowaniem przy oznaczaniu „Przeczytane".
+- **SECURITY SWEEP (2026-08-28) — findingi do naprawy, NIC jeszcze nie zrobione.** Pełny audyt (4 obszary:
+  HTTP/auth, sekrety, scrapery, frontend). **Basic Auth JEST włączony na produkcji (potwierdzone przez usera)** —
+  to przelicza wagi: findingi wymagające dostępu do API schodzą na dalszy plan, a na czoło wychodzą te, których
+  auth NIE zasłania. Raport: `docs/security-sweep.md` (jeśli powstanie) / artifact z sesji.
+  - **[1] SSRF w resolve sprzedawców — NAJWYŻSZY priorytet, auth tego NIE chroni.** `vintedSyncService.ts:271`
+    filtruje `/\/items\//.test(o.url)` = test PODCIĄGU, nie hosta; `parseVintedData` (`vintedStore.ts:113-118`)
+    przepuszcza `offers` hurtem (choć `scannedAt`/`changedAt` typuje); `vintedParser.ts:204` przyjmuje dowolny
+    absolutny `http…` ze scrapowanego JSON-a; nagłówki dokładają `Cookie` bez sprawdzenia hosta. Wektor wchodzi
+    przez SCRAPOWANĄ TREŚĆ (nie przez API), więc autoryzacja nie stanowi bariery. Fix: allow-lista hosta+schematu
+    w `parseVintedData` — zamyka też 6 sinków `href` w UI (ten sam root cause).
+  - **[2] CSRF — dotyczy WYŁĄCZNIE stanu z włączonym auth (czyli naszego).** Poświadczenia Basic są dołączane
+    przez przeglądarkę do żądań cross-site; bezparametrowe rytuały (`/api/sync-purify`, `/api/sync/stop`,
+    `/api/sync/reset`, `syncController.ts:183-197`) da się odpalić formularzem z obcej strony. Endpointy z ciałem
+    JSON są bezpieczne (formularz cross-site nie wyśle `application/json`). Fix: check `Origin`/`Referer`.
+  - **[3] Destrukcyjny zapis schematu (footgun, już nie atak).** Walidacja przepuszcza `newOptions: []`
+    (`syncController.ts:126-131`), a `updateSchema` (`notion.adapter.ts:101-106`) PODMIENIA opcje w całości →
+    `PATCH` z pustą listą na `Źródło` czyści tagi w całej kolekcji, nieodwracalnie. Za authem = ryzyko własnej
+    pomyłki/buga, nie obcego. Fix: odrzuć pustą listę + allow-lista edytowalnych kolumn.
+  - **[4] Auth fail-open jako LATENTNE ryzyko.** `basicAuth.ts:29` `if (!user || !pass) return next()`, a
+    `render.yaml` ma `sync: false` → świeży deploy z blueprintu wstaje OTWARTY. Dziś OK, ale jedna pomyłka przy
+    rotacji zmiennych = cicha ekspozycja. Fix: fail-closed w `NODE_ENV=production`.
+  - **[5] `dist/server.cjs` serwowany publicznie** (`server.ts:30-32` — build wrzuca SPA i bundle serwera do tego
+    samego `dist/`). Za authem to non-issue; sprawdzone: ZERO zaszytych poświadczeń w bundlu. Fix przy okazji:
+    build SPA do `dist/public/`.
+  - **[6] Limity zasobów**: nielimitowane `Map` cache (`cycleLookupService.ts:55`, `isbnLookupService.ts:28`) bez
+    TTL/capa; brak `maxContentLength` na wszystkich axiosach (przy 7 MB stronach Vinted i 512 MB Rendera);
+    `/api/cycle` robi do ~34 żądań wychodzących na chybienie. Za authem = tylko własny footgun/wyciek pamięci.
+  - **[7] TLS wyłączony na OPAC** (`libraryCheckService.ts:45-48`, `rejectUnauthorized:false`) — auth nieistotny,
+    to warstwa sieciowa. Kontrolowane (per-agent, bez poświadczeń), ale odpowiedzi decydują o zapisach do Notion.
+    Węższy fix: dopiąć brakujący cert przez `ca:`.
+  - **[8] Drobne**: brak nagłówków bezpieczeństwa (CSP/X-Frame-Options/nosniff), ciasteczka Vinted spłaszczane bez
+    scope’u hosta (`cookies.ts` + `browserPrime.ts:73` bierze WSZYSTKIE ciasteczka kontekstu), `error.message`
+    z upstreamu zwracany dosłownie (leak ID bazy w komunikacie Notion), `nanoid` w npm audit (build-time only).
+  - **ZWERYFIKOWANE JAKO CZYSTE** (nie powtarzać audytu): zero XSS (brak jakiegokolwiek sinka HTML w `src/`),
+    zero sekretów w drzewie i w 286 commitach historii, klucz Notion nigdy nie logowany/nie zwracany/nie w bundlu,
+    `mergeConfig` wzorowy (neutralizuje też prototype pollution), Basic Auth poprawny (`timingSafeEqual`, montowany
+    przed `express.json()` i statykiem), brak SSRF w warstwie HTTP/path traversal/SQL/shell injection, brak ReDoS,
+    lock zadań bez TOCTOU, keepalive SSE sprzątane, Playwright nie odwiedza niezaufanych URL-i.
 - **Prognoza domknięcia kolekcji (reading velocity, dalszy ciąg)** — DO ZROBIENIA. Na bazie `readingStats`
   (`recentPace`) + liczby brakujących (nieprzeczytanych) award-booków policzyć szacunek „przy obecnym tempie
   domkniesz kolekcję ~za X (lat/mies.), ok. rok YYYY". Miejsce: `computeReadingStats` (dołożyć pole `forecast`)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.74.3",
+  "version": "1.75.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.74.3",
+  "version": "1.75.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.74.3",
+      "version": "1.75.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.74.3",
+  "version": "1.75.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/services/__tests__/marketStats.test.ts
+++ b/services/__tests__/marketStats.test.ts
@@ -12,8 +12,8 @@ const mk = (id: string, over: Partial<NotionBook>): NotionBook => ({
 describe("marketStats.computeMarketStats", () => {
   it("sums the cheapest wanted-book offers into completion cost", () => {
     const books = [
-      mk("1", { vintedData: blob([{ url: "u1", price: 20, currency: "PLN" }, { url: "u2", price: 12, currency: "PLN" }]) }),
-      mk("2", { vintedData: blob([{ url: "u3", price: 30, currency: "PLN" }]) }),
+      mk("1", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 20, currency: "PLN" }, { url: "https://www.vinted.pl/items/2", price: 12, currency: "PLN" }]) }),
+      mk("2", { vintedData: blob([{ url: "https://www.vinted.pl/items/3", price: 30, currency: "PLN" }]) }),
     ];
     const m = computeMarketStats(books);
     expect(m.completionCost).toBe(42); // 12 + 30
@@ -25,9 +25,9 @@ describe("marketStats.computeMarketStats", () => {
 
   it("excludes owned and read books (already have / don't want)", () => {
     const books = [
-      mk("1", { zrodlo: ["Posiadam"], vintedData: blob([{ url: "u", price: 10, currency: "PLN" }]) }),
-      mk("2", { zrodlo: ["Przeczytane"], vintedData: blob([{ url: "u", price: 10, currency: "PLN" }]) }),
-      mk("3", { vintedData: blob([{ url: "u", price: 15, currency: "PLN" }]) }),
+      mk("1", { zrodlo: ["Posiadam"], vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 10, currency: "PLN" }]) }),
+      mk("2", { zrodlo: ["Przeczytane"], vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 10, currency: "PLN" }]) }),
+      mk("3", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 15, currency: "PLN" }]) }),
     ];
     const m = computeMarketStats(books);
     expect(m.booksWithOffers).toBe(1);
@@ -36,9 +36,9 @@ describe("marketStats.computeMarketStats", () => {
 
   it("captures price drops (price < prevPrice), biggest first", () => {
     const books = [
-      mk("1", { vintedData: blob([{ url: "u", price: 18, prevPrice: 25, currency: "PLN" }]) }),
-      mk("2", { vintedData: blob([{ url: "u", price: 40, prevPrice: 100, currency: "PLN" }]) }),
-      mk("3", { vintedData: blob([{ url: "u", price: 10, prevPrice: 8, currency: "PLN" }]) }), // price rise — skipped
+      mk("1", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 18, prevPrice: 25, currency: "PLN" }]) }),
+      mk("2", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 40, prevPrice: 100, currency: "PLN" }]) }),
+      mk("3", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 10, prevPrice: 8, currency: "PLN" }]) }), // price rise — skipped
     ];
     const m = computeMarketStats(books);
     expect(m.priceDrops.map((d) => d.bookId)).toEqual(["2", "1"]);
@@ -48,9 +48,9 @@ describe("marketStats.computeMarketStats", () => {
   it("ranks sellers by distinct wanted books (>=2), summing per-book minimums", () => {
     const seller = (id: string, login: string) => ({ id, login, url: `https://vinted.pl/member/${id}` });
     const books = [
-      mk("1", { vintedData: blob([{ url: "u", price: 20, currency: "PLN", seller: seller("s1", "ala") }]) }),
-      mk("2", { vintedData: blob([{ url: "u", price: 30, currency: "PLN", seller: seller("s1", "ala") }]) }),
-      mk("3", { vintedData: blob([{ url: "u", price: 15, currency: "PLN", seller: seller("s2", "bob") }]) }), // only 1 book
+      mk("1", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 20, currency: "PLN", seller: seller("s1", "ala") }]) }),
+      mk("2", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 30, currency: "PLN", seller: seller("s1", "ala") }]) }),
+      mk("3", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: 15, currency: "PLN", seller: seller("s2", "bob") }]) }), // only 1 book
     ];
     const m = computeMarketStats(books);
     expect(m.topSellers).toHaveLength(1);
@@ -61,7 +61,7 @@ describe("marketStats.computeMarketStats", () => {
     const books = [
       mk("1", {}),                                                   // no blob
       mk("2", { vintedData: blob([]) }),                             // empty
-      mk("3", { vintedData: blob([{ url: "u", price: null, currency: "PLN" }]) }), // no price
+      mk("3", { vintedData: blob([{ url: "https://www.vinted.pl/items/1", price: null, currency: "PLN" }]) }), // no price
     ];
     const m = computeMarketStats(books);
     expect(m).toMatchObject({ completionCost: 0, booksWithOffers: 0, totalOffers: 0 });

--- a/services/__tests__/vintedStore.test.ts
+++ b/services/__tests__/vintedStore.test.ts
@@ -29,19 +29,29 @@ describe("vintedStore", () => {
     expect(view.cyklNr).toBeUndefined();
   });
 
+  // URLs in these fixtures must be real Vinted ones — the store validates them against a
+  // host allow-list (see vintedUrl.ts), so placeholders like "u" are dropped by design.
   it("offerFromItem maps VintedItem fields (priceValue → price)", () => {
     const item: VintedItem = {
-      title: "T", price: "10", priceValue: 10, currency: "zł", url: "u", photo: "p",
-      seller: { id: "1", login: "x", url: "m" },
+      title: "T", price: "10", priceValue: 10, currency: "zł",
+      url: "https://www.vinted.pl/items/1", photo: "https://images1.vinted.net/t/p.jpeg",
+      seller: { id: "1", login: "x", url: "https://www.vinted.pl/member/1" },
     };
     expect(offerFromItem(item)).toEqual({
-      url: "u", title: "T", price: 10, currency: "zł", photo: "p", seller: { id: "1", login: "x", url: "m" },
+      url: "https://www.vinted.pl/items/1", title: "T", price: 10, currency: "zł",
+      photo: "https://images1.vinted.net/t/p.jpeg",
+      seller: { id: "1", login: "x", url: "https://www.vinted.pl/member/1" },
     });
   });
 
   it("serialize + parse round-trips", () => {
-    const data = { scannedAt: "2026-01-01T00:00:00.000Z", offers: [{ url: "u", price: 5, currency: "zł" }] };
-    expect(parseVintedData(serializeVintedData(data))).toEqual(data);
+    const data = {
+      scannedAt: "2026-01-01T00:00:00.000Z",
+      changedAt: undefined,
+      offers: [{ url: "https://www.vinted.pl/items/5", title: undefined, price: 5, currency: "zł",
+                 photo: null, seller: null, prevPrice: undefined, firstSeenAt: undefined }],
+    };
+    expect(parseVintedData(serializeVintedData(data as any))).toEqual(data);
   });
 
   it("parseVintedData returns null for empty / corrupt / missing offers array", () => {

--- a/services/__tests__/vintedUrl.test.ts
+++ b/services/__tests__/vintedUrl.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { isVintedUrl, isVintedPhotoUrl } from "../vintedUrl";
+import { parseVintedData, offerFromItem, sanitizeStoredOffer } from "../vintedStore";
+import { VintedItem } from "../vintedParser";
+
+describe("isVintedUrl", () => {
+  it("accepts the URL shapes the parser actually produces", () => {
+    expect(isVintedUrl("https://www.vinted.pl/items/123-tytul")).toBe(true);
+    expect(isVintedUrl("https://vinted.pl/items/123")).toBe(true);
+    expect(isVintedUrl("https://www.vinted.pl/member/456")).toBe(true); // seller profile
+  });
+
+  it("rejects the SSRF targets that the old substring filter let through", () => {
+    // These all contain „/items/" and so passed `/\/items\//.test(url)`.
+    expect(isVintedUrl("http://169.254.169.254/items/")).toBe(false); // cloud metadata
+    expect(isVintedUrl("http://localhost:10000/items/")).toBe(false);
+    expect(isVintedUrl("http://127.0.0.1/items/admin")).toBe(false);
+  });
+
+  it("rejects look-alike hosts (suffix confusion)", () => {
+    expect(isVintedUrl("https://evilvinted.pl/items/1")).toBe(false);
+    expect(isVintedUrl("https://vinted.pl.attacker.com/items/1")).toBe(false);
+    expect(isVintedUrl("https://notvinted.pl/items/1")).toBe(false);
+  });
+
+  it("rejects non-web schemes", () => {
+    expect(isVintedUrl("javascript:alert(document.domain)")).toBe(false);
+    expect(isVintedUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isVintedUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects junk and non-strings", () => {
+    expect(isVintedUrl("")).toBe(false);
+    expect(isVintedUrl("/items/123")).toBe(false); // relative — not resolvable to a host
+    expect(isVintedUrl(null)).toBe(false);
+    expect(isVintedUrl(undefined)).toBe(false);
+    expect(isVintedUrl(42)).toBe(false);
+    expect(isVintedUrl({ toString: () => "https://www.vinted.pl/items/1" })).toBe(false);
+  });
+
+  it("allows the image CDN only for photos", () => {
+    expect(isVintedPhotoUrl("https://images1.vinted.net/t/abc/photo.jpeg")).toBe(true);
+    expect(isVintedUrl("https://images1.vinted.net/t/abc/photo.jpeg")).toBe(false); // not an offer host
+    expect(isVintedPhotoUrl("https://evil.example/tracker.gif")).toBe(false);
+  });
+});
+
+const offer = (over: Record<string, unknown> = {}) => ({
+  url: "https://www.vinted.pl/items/1",
+  title: "Solaris",
+  price: 20,
+  currency: "PLN",
+  ...over,
+});
+
+describe("parseVintedData — re-validates the blob on the way OUT of Notion", () => {
+  it("drops an offer whose URL points off-site (the SSRF vector)", () => {
+    const raw = JSON.stringify({
+      scannedAt: "2026-01-01T00:00:00Z",
+      offers: [offer(), offer({ url: "http://169.254.169.254/items/" })],
+    });
+    const parsed = parseVintedData(raw);
+    expect(parsed!.offers).toHaveLength(1);
+    expect(parsed!.offers[0].url).toBe("https://www.vinted.pl/items/1");
+  });
+
+  it("drops a javascript: URL that would otherwise become an href", () => {
+    const raw = JSON.stringify({ scannedAt: "", offers: [offer({ url: "javascript:alert(1)" })] });
+    expect(parseVintedData(raw)!.offers).toEqual([]);
+  });
+
+  it("keeps the offer but strips a hostile photo", () => {
+    const raw = JSON.stringify({ scannedAt: "", offers: [offer({ photo: "https://evil.example/track.gif" })] });
+    const parsed = parseVintedData(raw);
+    expect(parsed!.offers).toHaveLength(1);
+    expect(parsed!.offers[0].photo).toBeNull();
+  });
+
+  it("drops a seller whose profile link is off-site, keeping the offer", () => {
+    const raw = JSON.stringify({
+      scannedAt: "",
+      offers: [offer({ seller: { id: "7", login: "x", url: "https://evil.example/member/7" } })],
+    });
+    const parsed = parseVintedData(raw);
+    expect(parsed!.offers).toHaveLength(1);
+    expect(parsed!.offers[0].seller).toBeNull();
+  });
+
+  it("preserves a legitimate blob unchanged in substance", () => {
+    const good = {
+      scannedAt: "2026-01-01T00:00:00Z",
+      changedAt: "2026-01-02T00:00:00Z",
+      offers: [offer({
+        photo: "https://images1.vinted.net/t/a/p.jpeg",
+        seller: { id: "7", login: "kolekcjoner", url: "https://www.vinted.pl/member/7" },
+        prevPrice: 25,
+        firstSeenAt: "2025-12-01T00:00:00Z",
+      })],
+    };
+    const parsed = parseVintedData(JSON.stringify(good));
+    expect(parsed!.scannedAt).toBe(good.scannedAt);
+    expect(parsed!.changedAt).toBe(good.changedAt);
+    expect(parsed!.offers).toHaveLength(1);
+    expect(parsed!.offers[0]).toMatchObject({
+      url: "https://www.vinted.pl/items/1",
+      title: "Solaris",
+      price: 20,
+      currency: "PLN",
+      photo: "https://images1.vinted.net/t/a/p.jpeg",
+      seller: { id: "7", login: "kolekcjoner", url: "https://www.vinted.pl/member/7" },
+      prevPrice: 25,
+      firstSeenAt: "2025-12-01T00:00:00Z",
+    });
+  });
+
+  it("still tolerates a corrupt blob without throwing", () => {
+    expect(parseVintedData("{not json")).toBeNull();
+    expect(parseVintedData(JSON.stringify({ offers: "nope" }))).toBeNull();
+    expect(parseVintedData(JSON.stringify({ offers: [null, 42, "x"] }))!.offers).toEqual([]);
+  });
+});
+
+describe("offerFromItem — defence in depth on the way IN", () => {
+  const item = (over: Partial<VintedItem> = {}): VintedItem => ({
+    id: "1", title: "Solaris", url: "https://www.vinted.pl/items/1",
+    price: "20", priceValue: 20, currency: "PLN", ...over,
+  } as VintedItem);
+
+  it("stores a normal scraped offer", () => {
+    expect(offerFromItem(item())).toMatchObject({ url: "https://www.vinted.pl/items/1", price: 20 });
+  });
+
+  it("refuses to store an off-site URL scraped from a hostile page", () => {
+    expect(offerFromItem(item({ url: "http://169.254.169.254/items/" }))).toBeNull();
+  });
+});
+
+describe("sanitizeStoredOffer", () => {
+  it("normalizes missing/!finite numbers rather than passing them through", () => {
+    const o = sanitizeStoredOffer({ url: "https://vinted.pl/items/9", price: "tanio", currency: 7 });
+    expect(o).toMatchObject({ price: null, currency: "PLN" });
+  });
+});

--- a/services/vintedStore.ts
+++ b/services/vintedStore.ts
@@ -1,5 +1,6 @@
 import { VintedItem, VintedSeller } from "./vintedParser";
 import { NotionBook } from "../src/types";
+import { isVintedUrl, isVintedPhotoUrl } from "./vintedUrl";
 
 /**
  * Persistent storage of Vinted results in Notion (a JSON blob in a book's text field).
@@ -89,15 +90,52 @@ export function toStoredBookView(book: NotionBook, data: StoredVintedData): Stor
   };
 }
 
-/** VintedItem (from the scan) → StoredOffer (for storage). */
-export function offerFromItem(item: VintedItem): StoredOffer {
+/**
+ * Drops a seller whose profile link isn't a Vinted URL. The parser only ever builds
+ * `https://www.vinted.pl/member/{id}`, so a mismatch means the value didn't come from
+ * the parser — dropping it is self-healing (the next resolve pass re-fetches it).
+ */
+function sanitizeSeller(seller: unknown): VintedSeller | null {
+  if (!seller || typeof seller !== "object") return null;
+  const s = seller as Record<string, unknown>;
+  if (typeof s.id !== "string" || typeof s.login !== "string") return null;
+  if (!isVintedUrl(s.url)) return null;
+  return { id: s.id, login: s.login, url: s.url };
+}
+
+/**
+ * Validates ONE stored offer against the host allow-list. Returns null when the offer
+ * must be dropped entirely (a non-Vinted `url` — the offer's identity is untrustworthy
+ * and it is what the seller-resolve pass would re-fetch). A bad `photo` or `seller` only
+ * loses that field, since the offer itself is still usable.
+ */
+export function sanitizeStoredOffer(raw: unknown): StoredOffer | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  if (!isVintedUrl(o.url)) return null;
+  return {
+    url: o.url,
+    title: typeof o.title === "string" ? o.title : undefined,
+    price: typeof o.price === "number" && isFinite(o.price) ? o.price : null,
+    currency: typeof o.currency === "string" ? o.currency : "PLN",
+    photo: isVintedPhotoUrl(o.photo) ? o.photo : null,
+    seller: sanitizeSeller(o.seller),
+    prevPrice: typeof o.prevPrice === "number" && isFinite(o.prevPrice) ? o.prevPrice : undefined,
+    firstSeenAt: typeof o.firstSeenAt === "string" ? o.firstSeenAt : undefined,
+  };
+}
+
+/** VintedItem (from the scan) → StoredOffer (for storage). Returns null for an
+ *  off-site URL — defence in depth, so a hostile scraped link never even gets stored. */
+export function offerFromItem(item: VintedItem): StoredOffer | null {
+  if (!isVintedUrl(item.url)) return null;
   return {
     url: item.url,
     title: item.title,
     price: item.priceValue,
     currency: item.currency,
-    photo: item.photo ?? null,
-    seller: item.seller ?? null,
+    photo: isVintedPhotoUrl(item.photo) ? item.photo : null,
+    seller: sanitizeSeller(item.seller),
   };
 }
 
@@ -114,7 +152,11 @@ export function parseVintedData(raw: string | null | undefined): StoredVintedDat
       return {
         scannedAt: typeof d.scannedAt === "string" ? d.scannedAt : "",
         changedAt: typeof d.changedAt === "string" ? d.changedAt : undefined,
-        offers: d.offers,
+        // Every offer is re-validated on the way OUT of storage, not just on the way in:
+        // the blob lives in Notion, so anything that can write there could otherwise
+        // smuggle an off-site URL past the parser's guarantee (→ SSRF on the re-fetch,
+        // and an unvalidated `href` in the UI). Bad offers are dropped, not repaired.
+        offers: d.offers.map(sanitizeStoredOffer).filter((o: StoredOffer | null): o is StoredOffer => o !== null),
       };
     }
     return null;

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -7,6 +7,7 @@ import { createScrapingAgent } from "../scrapingClient";
 import { parseVintedItems, vintedDiagnostics, looksBlocked, looksEmpty, extractVintedSeller, VintedItem } from "./vintedParser";
 import { NotionBook } from "../src/types";
 import { offerFromItem, parseVintedData, mergeAndDiff, serializeVintedData, computeChangedAt, toStoredBookView, StoredVintedData, StoredOffer, StoredBookView, OfferDiff, EMPTY_DIFF } from "./vintedStore";
+import { isVintedUrl } from "./vintedUrl";
 import { selectAndOrderCandidates } from "./vintedScanPlanner";
 import { vintedRequestHeaders, memMb, throttle, classifyVintedError, VintedSession } from "./vintedHttp";
 import { primeVintedSession, cookieCount } from "./vintedSession";
@@ -52,7 +53,8 @@ export class VintedSyncService {
    */
   private async persistBookOffers(book: NotionBook, items: VintedItem[], scannedAt: string): Promise<OfferDiff> {
     try {
-      const fresh = items.map(offerFromItem);
+      // `offerFromItem` returns null for an off-site URL (host allow-list) — drop those.
+      const fresh = items.map(offerFromItem).filter((o): o is StoredOffer => o !== null);
       const prevData = parseVintedData(book.vintedData);
       const { offers, diff } = mergeAndDiff(fresh, prevData?.offers, scannedAt);
       const changedAt = computeChangedAt(prevData, diff, scannedAt);
@@ -268,7 +270,11 @@ export class VintedSyncService {
       for (const book of allBooks) {
         const data = parseVintedData(book.vintedData);
         if (!data) continue;
-        const nulls = data.offers.filter((o) => o.seller == null && /\/items\//.test(o.url));
+        // Host check, not a substring test: `/\/items\//` alone also matched
+        // e.g. `http://169.254.169.254/items/`, which was then fetched from inside the
+        // host network WITH the session cookie attached. `parseVintedData` already
+        // drops off-site URLs; this is the second gate on the exact value we re-fetch.
+        const nulls = data.offers.filter((o) => o.seller == null && isVintedUrl(o.url) && o.url.includes("/items/"));
         if (nulls.length) { pending.push({ book, data, offers: nulls }); totalPending += nulls.length; }
       }
 

--- a/services/vintedUrl.ts
+++ b/services/vintedUrl.ts
@@ -1,0 +1,57 @@
+/**
+ * Host allow-list for Vinted URLs — the trust boundary for scraped links.
+ *
+ * WHY THIS EXISTS. The scraper's parser guarantees that every offer URL points at
+ * Vinted (it prefixes relative paths with the Vinted origin), but that guarantee was
+ * enforced only on INGEST and silently dropped on RELOAD: `parseVintedData` re-hydrated
+ * the blob from Notion and passed `offers` through untouched. Two consequences:
+ *
+ *  1. SSRF — the seller-resolve pass re-fetches `offer.url` and attaches the warmed
+ *     Cloudflare session cookie. The only filter was `/\/items\//.test(url)`, a
+ *     SUBSTRING test, so `http://169.254.169.254/items/` passed and was fetched from
+ *     inside the host network, with the response parsed and written back.
+ *  2. The same unvalidated strings render as `href`/`src` in the UI.
+ *
+ * So the check belongs on the HOST, not on a path fragment, and it has to run on the
+ * way OUT of storage as well as on the way in. `isValidUrl` (utils.ts) only checks the
+ * protocol, which is not enough here.
+ */
+
+/** Offer and seller-profile links live on the Vinted site itself. */
+const SITE_HOSTS = ["vinted.pl"];
+/** Offer thumbnails are served from the Vinted image CDN (e.g. images1.vinted.net). */
+const PHOTO_HOSTS = ["vinted.pl", "vinted.net"];
+
+/**
+ * Exact-or-subdomain match. `endsWith("." + base)` (rather than a bare `endsWith`)
+ * is what stops `evilvinted.pl` / `vinted.pl.attacker.com` from passing.
+ */
+function hostMatches(hostname: string, bases: string[]): boolean {
+  const h = hostname.toLowerCase();
+  return bases.some((b) => h === b || h.endsWith(`.${b}`));
+}
+
+function hostAllowed(value: unknown, bases: string[]): boolean {
+  if (typeof value !== "string" || value === "") return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false; // relative/garbage/`javascript:alert(1)` without a parseable form
+  }
+  // Reject every non-web scheme (javascript:, data:, file:, gopher:…). A `javascript:`
+  // URL also has an empty hostname, so the host check below would catch it anyway —
+  // this is the explicit belt to that suspenders.
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
+  return hostMatches(parsed.hostname, bases);
+}
+
+/** True only for an http(s) URL on vinted.pl (or a subdomain) — offers and seller profiles. */
+export function isVintedUrl(value: unknown): value is string {
+  return hostAllowed(value, SITE_HOSTS);
+}
+
+/** True only for an http(s) URL on a Vinted host serving images (vinted.net / vinted.pl). */
+export function isVintedPhotoUrl(value: unknown): value is string {
+  return hostAllowed(value, PHOTO_HOSTS);
+}


### PR DESCRIPTION
Fixes #348 — first fix from the security sweep.

## The bug
The parser guarantees offer URLs point at Vinted, but that guarantee was enforced **only on ingest** and silently dropped on reload: `parseVintedData` passed `offers` through wholesale while type-checking its siblings (`scannedAt`, `changedAt`).

The seller-resolve pass then re-fetched `offer.url` **with the session cookie attached**, gated only by `/\/items\//.test(url)` — a *substring* test. `http://169.254.169.254/items/` satisfied it, was fetched from inside the host network, and the response was parsed, written back to Notion and rendered — a **readable** SSRF oracle.

Not covered by Basic Auth: the hostile value enters through **scraped content**, not the API.

## The fix
- **`services/vintedUrl.ts`** (new) — `isVintedUrl` (host `vinted.pl` + subdomains, http(s) only) and `isVintedPhotoUrl` (also `vinted.net` for the image CDN). Matching is `h === base || h.endsWith("." + base)`, so `evilvinted.pl` and `vinted.pl.attacker.com` do **not** pass.
- **`parseVintedData`** validates every offer on the way **out** of storage (`sanitizeStoredOffer`): a bad `url` drops the offer (it's the offer's identity, and what gets re-fetched); a bad `photo` or `seller` drops just that field, keeping the usable offer.
- **`offerFromItem`** returns `null` for an off-site URL — defence in depth so a hostile scraped link is never stored; the caller filters those.
- **The re-fetch filter** is now a host check instead of a substring test.

This one function also closes the six `href`/`src` sinks that render blob URLs, since they all read through `parseVintedData`.

## Tests (+15)
The actual SSRF targets (metadata IP, localhost), suffix confusion, `javascript:`/`data:`/`file:` schemes, offer-drop vs field-drop behaviour, legitimate blob round-trip, and corrupt-blob tolerance.

**Fixture note:** `vintedStore.test` and `marketStats.test` used placeholder URLs (`"u"`, `"u1"`) which the allow-list now rejects. Those were never valid Vinted data, so I made them realistic rather than loosening the check.

## Verification
`npm run lint` clean, `npm test` **517** green, `npm run build` OK. Version 1.75.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_