### PR TITLE
fix(security): same-origin (CSRF) guard on state-changing requests

### DIFF
--- a/__tests__/sameOrigin.test.ts
+++ b/__tests__/sameOrigin.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import { sameOrigin } from "../middleware/sameOrigin";
+
+/** Minimal app with the middleware in the same position as in `app.ts`. */
+const makeApp = () => {
+  const app = express();
+  app.use(sameOrigin());
+  app.use(express.json());
+  app.post("/api/sync-purify", (_req, res) => res.json({ ran: true }));
+  app.get("/api/books", (_req, res) => res.json({ ok: true }));
+  return app;
+};
+
+describe("sameOrigin (CSRF)", () => {
+  it("allows a same-origin POST from the SPA", async () => {
+    const res = await request(makeApp())
+      .post("/api/sync-purify")
+      .set("Host", "librem.example")
+      .set("Origin", "https://librem.example");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ran: true });
+  });
+
+  it("rejects the cross-site form POST — the actual attack", async () => {
+    const res = await request(makeApp())
+      .post("/api/sync-purify")
+      .set("Host", "librem.example")
+      .set("Origin", "https://evil.example");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/CSRF/);
+  });
+
+  it("rejects a look-alike origin", async () => {
+    const res = await request(makeApp())
+      .post("/api/sync-purify")
+      .set("Host", "librem.example")
+      .set("Origin", "https://librem.example.evil.com");
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects an opaque origin (sandboxed iframe / redirect)", async () => {
+    const res = await request(makeApp())
+      .post("/api/sync-purify")
+      .set("Host", "librem.example")
+      .set("Origin", "null");
+    expect(res.status).toBe(403);
+  });
+
+  it("falls back to Referer when Origin is absent", async () => {
+    const app = makeApp();
+    const ok = await request(app).post("/api/sync-purify")
+      .set("Host", "librem.example").set("Referer", "https://librem.example/regal");
+    expect(ok.status).toBe(200);
+
+    const bad = await request(app).post("/api/sync-purify")
+      .set("Host", "librem.example").set("Referer", "https://evil.example/page");
+    expect(bad.status).toBe(403);
+  });
+
+  it("allows a non-browser client that sends neither header (curl, import script)", async () => {
+    const res = await request(makeApp()).post("/api/sync-purify").set("Host", "librem.example");
+    expect(res.status).toBe(200);
+  });
+
+  it("ignores GETs entirely — they change no state", async () => {
+    const res = await request(makeApp())
+      .get("/api/books")
+      .set("Host", "librem.example")
+      .set("Origin", "https://evil.example");
+    expect(res.status).toBe(200);
+  });
+
+  it("matches on host only, so TLS termination at the proxy doesn't false-reject", async () => {
+    // Externally https, internally the proxy may forward as http.
+    const res = await request(makeApp())
+      .post("/api/sync-purify")
+      .set("Host", "librem.example")
+      .set("Origin", "http://librem.example");
+    expect(res.status).toBe(200);
+  });
+
+  it("distinguishes ports (dev servers on the same host)", async () => {
+    const res = await request(makeApp())
+      .post("/api/sync-purify")
+      .set("Host", "localhost:3000")
+      .set("Origin", "http://localhost:5173");
+    expect(res.status).toBe(403);
+  });
+});

--- a/app.ts
+++ b/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import syncRoutes from "./routes/syncRoutes";
 import { basicAuth } from "./middleware/basicAuth";
+import { sameOrigin } from "./middleware/sameOrigin";
 
 /**
  * Express app wiring (no listening). Static/Vite and `listen` live in
@@ -12,5 +13,8 @@ export const app = express();
 // Opt-in Basic Auth (active only when BASIC_AUTH_USER + _PASSWORD are set).
 // Must come first, to protect the SPA and static files too.
 app.use(basicAuth());
+// CSRF: reject state-changing requests that state a foreign origin. Mounted before the
+// routes (and before the body parser — nothing needs parsing to make this decision).
+app.use(sameOrigin());
 app.use(express.json());
 app.use("/api", syncRoutes);

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.75.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.76.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.76.0** — **[SEC-PR2] Ochrona CSRF (same-origin) na żądaniach zmieniających stan.** Nowy
+  `middleware/sameOrigin.ts`, montowany w `app.ts` po `basicAuth`, przed `express.json()`. Dla
+  POST/PUT/PATCH/DELETE: podany `Origin` musi mieć ten sam HOST co nasz `Host` (fallback na `Referer`);
+  `Origin: null` i niepoprawne wartości = odrzucone (403). **Brak obu nagłówków = przepuszczamy** — świadomie:
+  przeglądarka ZAWSZE wysyła `Origin` przy cross-origin POST (też z formularza), więc jego brak oznacza klienta
+  nie-przeglądarkowego (curl, `scripts/importReadDates.ts`); blokowanie łamałoby legalny CLI nie zamykając
+  żadnego ataku. Porównanie po HOŚCIE (nie pełnym origin), żeby terminacja TLS na proxy Rendera (https na
+  zewnątrz, http wewnątrz) nie dawała false-reject; port jest częścią hosta, więc dev na innym porcie odpada.
+  **Ten finding istniał WYŁĄCZNIE dzięki włączonemu Basic Auth** — poświadczenia Basic, inaczej niż ciasteczka
+  `SameSite`, przeglądarka dokleja też do żądań cross-site, a rytuały bez ciała (`/api/sync-purify`,
+  `/api/sync/stop`, `/api/sync/reset`) dało się odpalić auto-submitowanym formularzem. +9 testów. Suite 526
+  zielone, lint czysty, build OK.
 - **1.75.0** — **[SEC-PR1] Allow-lista hosta dla URL-i Vinted — zamyka SSRF + 6 sinków `href`.** Nowy
   `services/vintedUrl.ts`: `isVintedUrl` (host = `vinted.pl`/subdomeny, tylko http(s)) i `isVintedPhotoUrl`
   (+`vinted.net` dla CDN). Dopasowanie `h===base || h.endsWith("."+base)` — `evilvinted.pl` i

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/middleware/sameOrigin.ts
+++ b/middleware/sameOrigin.ts
@@ -1,0 +1,59 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * CSRF defence for state-changing requests.
+ *
+ * WHY THIS IS NEEDED PRECISELY BECAUSE BASIC AUTH IS ON. Unlike a `SameSite` cookie,
+ * HTTP Basic credentials are attached by the browser to CROSS-SITE requests to our
+ * origin too. Several rituals take no body at all (`/api/sync-purify`, `/api/sync/stop`,
+ * `/api/sync/reset`, …), so a page on any other site could auto-submit
+ * `<form action="https://…/api/sync-purify" method="POST">` and the request would fire
+ * with the owner's cached credentials. The response is unreadable cross-origin (we send
+ * no CORS headers), but the SIDE EFFECT — a Notion-mutating run — still lands.
+ *
+ * THE POLICY. For POST/PUT/PATCH/DELETE:
+ *   - `Origin` present  → its host must equal our own `Host`. Otherwise 403.
+ *   - no `Origin`, `Referer` present → same check against the referer's host.
+ *   - neither header    → allowed.
+ *
+ * That last branch is deliberate, not an oversight: browsers always send `Origin` on a
+ * cross-origin POST (including form submissions), so its ABSENCE means the caller isn't
+ * a browser — curl, the import script, a health probe. Rejecting those would break
+ * legitimate CLI use without closing any browser-driven attack.
+ *
+ * Hosts are compared rather than full origins so that TLS termination at the hosting
+ * proxy (http internally, https externally) doesn't produce false rejections.
+ */
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/** Host (with port, when present) of an absolute URL; null when unparseable. */
+function hostOf(value: string | undefined): string | null {
+  if (!value || value === "null") return null; // `Origin: null` = opaque origin → not ours
+  try {
+    return new URL(value).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function sameOrigin() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!MUTATING.has(req.method)) return next();
+
+    const self = (req.headers.host || "").toLowerCase();
+    const origin = req.headers.origin;
+    const referer = req.headers.referer;
+
+    // A stated origin must match ours. `Origin: null` and unparseable values are
+    // treated as "stated but not ours" → rejected, rather than falling through.
+    if (origin !== undefined) {
+      if (hostOf(origin) === self && self !== "") return next();
+    } else if (referer !== undefined) {
+      if (hostOf(referer) === self && self !== "") return next();
+    } else {
+      return next(); // no browser context — see the policy note above
+    }
+
+    return res.status(403).json({ error: "Żądanie odrzucone: niezgodne źródło (ochrona CSRF)." });
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.75.0",
+      "version": "1.76.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.75.0",
+  "version": "1.76.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"


### PR DESCRIPTION
Fixes #350 — second fix from the security sweep.

## The bug
HTTP Basic credentials, unlike `SameSite` cookies, are attached by the browser to **cross-site** requests to our origin. The parameterless rituals need no body, so any page could auto-submit a cross-site form and the run would fire with the owner's cached credentials. The response is unreadable (no CORS headers) but the **side effect lands**.

This one exists *precisely because* auth is enabled — with auth off it was moot.

## The fix
`middleware/sameOrigin.ts`, mounted after `basicAuth` and before the body parser (nothing needs parsing to make this decision).

For `POST`/`PUT`/`PATCH`/`DELETE`:
- **`Origin` present** → its **host** must equal our `Host`, else `403`.
- **no `Origin`, `Referer` present** → same check against the referer.
- **`Origin: null`** (opaque origin) and unparseable values → rejected, not passed through.
- **neither header** → **allowed**.

That last branch is deliberate and worth calling out: browsers *always* send `Origin` on a cross-origin POST, form submissions included, so its absence means the caller isn't a browser — curl, `scripts/importReadDates.ts`, a probe. Rejecting those would break legitimate CLI use without closing any browser-driven attack.

Hosts are compared rather than full origins so TLS termination at Render (https outside, http inside) doesn't false-reject. The port is part of the host, so a dev server on another port is still rejected.

## Tests (+9)
The actual cross-site form POST, look-alike origin (`librem.example.evil.com`), opaque `Origin: null`, `Referer` fallback both ways, CLI passthrough, GET exemption, proxy scheme mismatch, dev port mismatch.

## Verification
`npm run lint` clean, `npm test` **526** green, `npm run build` OK. Version 1.76.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_