### PR TITLE
fix(security): fail closed in production when Basic Auth is unconfigured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,15 @@ NOTION_DATABASE_ID="YOUR_DATABASE_ID"
 # PORT: opcjonalny port serwera (domyślnie 3000)
 # PORT="3000"
 
-# --- Opcjonalna ochrona hasłem (HTTP Basic Auth) ---
-# Ustaw OBIE wartości, aby wymusić logowanie na publicznym URL.
-# Puste = brak autoryzacji (zachowanie domyślne).
+# --- Ochrona hasłem (HTTP Basic Auth) ---
+# Ustaw OBIE wartości, aby wymusić logowanie na całym serwisie (SPA + API).
+# W developmencie puste = brak autoryzacji (wygoda lokalna).
+# W PRODUKCJI (NODE_ENV=production) brak tych zmiennych = serwis odpowiada 503
+# na wszystko poza /api/health — fail-closed, żeby literówka albo pominięcie
+# przy konfiguracji nie wystawiło bazy Notion publicznie po cichu.
 # BASIC_AUTH_USER=""
 # BASIC_AUTH_PASSWORD=""
+
+# ALLOW_PUBLIC_ACCESS: świadome wystawienie produkcji BEZ hasła.
+# Wymagane dokładnie "true". Ustawiaj tylko, jeśli naprawdę tego chcesz.
+# ALLOW_PUBLIC_ACCESS="true"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ Skopiuj `.env.example` do `.env` i uzupełnij:
 | `NOTION_API_KEY` | ✅ | Token integracji Notion. |
 | `NOTION_DATABASE_ID` | ✅ | ID docelowej bazy Notion. |
 | `PORT` | ➖ | Port serwera (domyślnie `3000`). |
-| `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` | ➖ | Ustaw **obie**, aby włączyć ochronę hasłem (HTTP Basic Auth) na publicznym URL. Puste = brak autoryzacji. |
+| `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` | ⚠️ w produkcji | Ustaw **obie**, aby włączyć ochronę hasłem (HTTP Basic Auth). W dev puste = brak autoryzacji; w produkcji brak = **503 na wszystko poza `/api/health`** (fail-closed). |
+| `ALLOW_PUBLIC_ACCESS` | ➖ | Dokładnie `true` = świadoma zgoda na produkcję bez hasła (wyłącza fail-closed). |
 
 ---
 
@@ -278,7 +279,7 @@ SSE za proxy Rendera jest zahartowane po stronie serwera (padding wymuszający f
 
 To narzędzie osobiste bez wieloużytkownikowej autoryzacji, ale na publicznym URL warto je chronić:
 
-- **Ochrona hasłem (opt-in):** ustaw `BASIC_AUTH_USER` + `BASIC_AUTH_PASSWORD`, aby wymusić HTTP Basic Auth na całym serwisie (SPA + API). Bez tych zmiennych autoryzacja jest wyłączona (brak lockoutu). `/api/health` pozostaje otwarte dla health checku.
+- **Ochrona hasłem (fail-closed w produkcji):** ustaw `BASIC_AUTH_USER` + `BASIC_AUTH_PASSWORD`, aby wymusić HTTP Basic Auth na całym serwisie (SPA + API). W developmencie brak tych zmiennych oznacza brak autoryzacji (wygoda lokalna), ale **w produkcji brak = 503 na wszystko poza `/api/health`** — żeby pominięcie konfiguracji nie wystawiło bazy Notion publicznie po cichu. Świadome wystawienie bez hasła wymaga `ALLOW_PUBLIC_ACCESS=true`. `/api/health` pozostaje otwarte dla health checku.
 - **Walidacja mutacji schematu:** `PATCH /api/notion/schema` przyjmuje wyłącznie typy `select`/`multi_select` i poprawną listę opcji `{ name }` — reszta jest odrzucana (400).
 
 ---

--- a/__tests__/basicAuth.test.ts
+++ b/__tests__/basicAuth.test.ts
@@ -17,10 +17,53 @@ const creds = () => ({ BASIC_AUTH_USER: "u", BASIC_AUTH_PASSWORD: "p" } as any);
 const basic = (u: string, p: string) => "Basic " + Buffer.from(`${u}:${p}`).toString("base64");
 
 describe("basicAuth", () => {
-  it("is a no-op when credentials are not configured (opt-in)", () => {
+  it("is a no-op when credentials are not configured (opt-in in dev)", () => {
     const next = vi.fn();
     basicAuth(() => ({} as any))(mkReq(), mkRes(), next);
     expect(next).toHaveBeenCalledOnce();
+  });
+
+  describe("fail-closed in production", () => {
+    it("refuses to serve when credentials are missing (503, nothing passes through)", () => {
+      const next = vi.fn();
+      const res = mkRes();
+      basicAuth(() => ({ NODE_ENV: "production" } as any))(mkReq({}, "/api/stats"), res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(503);
+      expect(res.body).toMatch(/BASIC_AUTH_USER/);
+    });
+
+    it("keeps the health probe answering, so the host doesn't flap the service", () => {
+      const next = vi.fn();
+      basicAuth(() => ({ NODE_ENV: "production" } as any))(mkReq({}, "/api/health"), mkRes(), next);
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it("allows a deliberately public deployment via an explicit opt-out", () => {
+      const next = vi.fn();
+      basicAuth(() => ({ NODE_ENV: "production", ALLOW_PUBLIC_ACCESS: "true" } as any))(mkReq({}, "/api/stats"), mkRes(), next);
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it("does not accept a sloppy opt-out value", () => {
+      const next = vi.fn();
+      const res = mkRes();
+      basicAuth(() => ({ NODE_ENV: "production", ALLOW_PUBLIC_ACCESS: "1" } as any))(mkReq({}, "/api/stats"), res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(503);
+    });
+
+    it("enforces normally once credentials ARE set in production", () => {
+      const next = vi.fn();
+      const res = mkRes();
+      const env = () => ({ ...creds(), NODE_ENV: "production" } as any);
+      basicAuth(env)(mkReq({}, "/api/stats"), res, next);
+      expect(res.statusCode).toBe(401); // not 503 — configured, just unauthenticated
+
+      const ok = vi.fn();
+      basicAuth(env)(mkReq({ authorization: basic("u", "p") }, "/api/stats"), mkRes(), ok);
+      expect(ok).toHaveBeenCalledOnce();
+    });
   });
 
   it("always allows /api/health even when enabled", () => {

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.76.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.77.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,15 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.77.0** — **[SEC-PR4] Auth fail-closed w produkcji (koniec z cichym otwarciem).** `basicAuth` przestaje
+  bezwarunkowo przepuszczać przy braku poświadczeń: dev/test = dalej no-op (wygoda lokalna), **produkcja bez
+  `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` = 503 na wszystko poza `/api/health`**. Powód: `render.yaml` deklaruje
+  obie zmienne z `sync: false`, więc blueprint ich NIE dostarcza — świeży deploy wstawał otwarty i nic tego nie
+  sygnalizowało. Świadome wystawienie publiczne nadal możliwe, ale wymaga jawnego `ALLOW_PUBLIC_ACCESS=true`
+  (dokładnie „true"; „1" nie wystarcza) — zamiast pominięcia, którego nikt nie zauważa. Odmowa jest głośna, ale
+  odwracalna (nie boot-failure): health probe dalej odpowiada, więc hosting nie flapuje usługi, a ustawienie
+  zmiennych naprawia stan bez redeployu kodu. Zaktualizowane `.env.example`, `README.md` (tabela zmiennych +
+  sekcja wdrożenia) i komentarz w `render.yaml`. +5 testów. Suite 535 zielone, lint czysty, build OK.
 - **1.76.1** — **[SEC-PR3] Guard na destrukcyjny zapis schematu Notion.** `PATCH /api/notion/schema` PODMIENIA
   listę opcji w całości, więc usunięcie opcji czyści wartość we WSZYSTKICH wierszach; allow-lista typu nic o tym
   nie mówiła. Walidacja teraz przeciwko ŻYWEMU schematowi (`getNotionSchema()`), nie zaszytej liście kolumn

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.76.1",
+  "version": "1.77.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/middleware/basicAuth.ts
+++ b/middleware/basicAuth.ts
@@ -9,12 +9,24 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 /**
- * Opt-in HTTP Basic Auth.
+ * HTTP Basic Auth — opt-in in development, FAIL-CLOSED in production.
  *
- * Active only when BOTH BASIC_AUTH_USER and BASIC_AUTH_PASSWORD are set —
- * otherwise the middleware lets everything through
- * (default behavior, no lockout of an existing deployment).
+ * Active whenever BOTH BASIC_AUTH_USER and BASIC_AUTH_PASSWORD are set.
  * `/api/health` is always open (hosting health check).
+ *
+ * WHAT HAPPENS WITHOUT CREDENTIALS. This used to `next()` unconditionally, which made
+ * "no protection" the default state — and `render.yaml` declares both variables with
+ * `sync: false`, i.e. the blueprint does NOT provision them. A fresh deploy therefore
+ * came up serving every Notion-mutating endpoint to the internet, silently. Now:
+ *
+ *   - development / tests → still a no-op, so local work needs no setup;
+ *   - production          → 503 on everything but the health probe.
+ *
+ * The refusal is deliberately loud-but-recoverable rather than a boot failure: the
+ * health probe keeps answering (so the host doesn't flap the service) while nothing
+ * else is served, and setting the two variables fixes it without a redeploy of code.
+ * A genuinely public deployment is still possible — but it now takes an explicit,
+ * auditable `ALLOW_PUBLIC_ACCESS=true` instead of an omission nobody notices.
  *
  * Protects the whole service (SPA + API): the browser shows the native prompt, and
  * same-origin `fetch` from the SPA automatically attaches credentials after login.
@@ -25,11 +37,20 @@ export function basicAuth(getEnv: () => NodeJS.ProcessEnv = () => process.env) {
     const user = env.BASIC_AUTH_USER;
     const pass = env.BASIC_AUTH_PASSWORD;
 
-    // Opt-in: without configured credentials we don't enforce authorization.
-    if (!user || !pass) return next();
-
-    // The health check must be reachable without logging in (hosting monitoring).
+    // The health check must be reachable without logging in (hosting monitoring),
+    // in every branch below — including the fail-closed one.
     if (req.path === "/api/health") return next();
+
+    if (!user || !pass) {
+      const openOnPurpose = env.ALLOW_PUBLIC_ACCESS === "true";
+      if (env.NODE_ENV === "production" && !openOnPurpose) {
+        return res.status(503).send(
+          "Serwis nie jest skonfigurowany: brak BASIC_AUTH_USER / BASIC_AUTH_PASSWORD. " +
+          "Ustaw je, albo świadomie wystaw publicznie przez ALLOW_PUBLIC_ACCESS=true."
+        );
+      }
+      return next(); // dev/test, or an explicit opt-out
+    }
 
     const header = req.headers.authorization || "";
     const [scheme, encoded] = header.split(" ");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.76.1",
+  "version": "1.77.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.76.1",
+      "version": "1.77.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.76.1",
+  "version": "1.77.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/render.yaml
+++ b/render.yaml
@@ -15,7 +15,9 @@ services:
         sync: false
       - key: NOTION_DATABASE_ID
         sync: false
-      # Opcjonalna ochrona hasłem (ustaw obie, aby wymusić Basic Auth):
+      # WYMAGANE w produkcji: bez obu wartości serwis odpowiada 503 na wszystko
+      # poza /api/health (fail-closed — patrz middleware/basicAuth.ts). Wpisz je
+      # w dashboardzie; `sync: false` oznacza, że blueprint ich NIE dostarcza.
       - key: BASIC_AUTH_USER
         sync: false
       - key: BASIC_AUTH_PASSWORD


### PR DESCRIPTION
Fixes #354 — fourth fix from the security sweep.

## The bug
`basicAuth` returned `next()` unconditionally when the credentials were absent, making "no protection" the default. Combined with `render.yaml` declaring both variables `sync: false` (the blueprint does **not** provision them), a fresh deploy came up serving every Notion-mutating endpoint publicly, with nothing signalling it.

## The fix
- **development / tests** → still a no-op, so local work needs no setup;
- **production without credentials** → `503` on everything except `/api/health`.

A genuinely public deployment remains possible, but now takes an explicit **`ALLOW_PUBLIC_ACCESS=true`** (exactly `"true"` — `"1"` is rejected, tested) instead of an omission nobody notices.

### Why 503-and-keep-the-probe rather than refusing to boot
The refusal is deliberately loud but *recoverable*: the health probe keeps answering, so the host doesn't flap the service into a restart loop, and setting the two variables fixes it **without redeploying code**. A boot failure would be strictly worse to recover from at 2am.

## Docs
`.env.example`, `README.md` (variables table + deployment section) and a `render.yaml` comment now describe the fail-closed behaviour — so the next deploy isn't surprised by a 503.

## Tests (+5)
503 when unconfigured in production; health probe still open; explicit opt-out honoured; sloppy opt-out value (`"1"`) rejected; normal 401/allow behaviour once configured (i.e. 401, not 503, when credentials exist but aren't supplied).

## Verification
`npm run lint` clean, `npm test` **535** green, `npm run build` OK. Version 1.77.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_