### PR TITLE
fix(security): stop serving the backend bundle as a static file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Cogitator Omnissiah — a full-stack app that syncs sci-fi book awards (Hugo, Ne
 
 ```bash
 npm run dev      # Start dev server (tsx server.ts — serves API + Vite frontend)
-npm run build    # vite build + esbuild bundle of server.ts → dist/server.cjs
+npm run build    # vite build → dist/public/ (SPA) + esbuild bundle of server.ts → dist/server.cjs (served static root = dist/public only)
 npm run lint     # tsc --noEmit (strict mode; no separate linter configured)
 npm test         # vitest run (full suite)
 npx vitest run <path>   # Run a single test file

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ flowchart TB
 - **Serwisy** (`/services/`) — po jednym na koncern; orkiestratory (np. `bookSyncService`, `integrityService`) delegują logikę do czystych helperów.
 - **Czyste helpery** — `wiki.parser` (`parseAwardTable`), `bookDiff` (`buildBookUpdates`/`buildAuthorTags`/`buildNewBookProperties`), `vintedParser`, `vintedStore` (merge/diff/`computeChangedAt`), `vintedScanPlanner` (`selectAndOrderCandidates`), `vintedHttp` (nagłówki/throttle/klasyfikacja błędu), `bookSearchIndex`, `dataNormalizer`, `diffEngine`: bez I/O, w pełni testowalne.
 - **Adaptery** — `NotionAdapter`, `WikiAdapter`: czyste wrappery API bez logiki biznesowej. Mapowanie strona Notion → domena wyniesione do `notionMapper`; skanery HTML (biblioteka/Vinted) dzielą `scrapingClient` (rotacja User-Agent + keep-alive). Adaptery rozróżniają „brak danych" od „awarii infrastruktury" (patrz [Obserwowalność](#obserwowalność-i-diagnostyka)).
-- **Frontend** — React 19 SPA (Tailwind CSS, `motion/react`, `lucide-react`), 5 zakładek: Statystyki, **Regał** (wizualizacja półek + drag&drop), **Skryptorium** (wyszukiwarka), Liturgie (rytuały), Vinted. Cała orkiestracja rytuałów w `useSyncManager`. Transport SSE (fetch → `res.ok` → `consumeSSE` + stall watchdog + komunikat błędu) żyje raz w **`useSSEStream`**; hooki strumieniowe (`useSync`, `useVintedCheck`, `useLibraryCheck`) budują na nim i różnią się tylko routingiem zdarzeń. Duży komponent skanera Vinted rozbity na `components/stats/vinted/*`. W dev serwowany przez Vite (middleware), w produkcji jako statyczny build z `dist/`.
+- **Frontend** — React 19 SPA (Tailwind CSS, `motion/react`, `lucide-react`), 5 zakładek: Statystyki, **Regał** (wizualizacja półek + drag&drop), **Skryptorium** (wyszukiwarka), Liturgie (rytuały), Vinted. Cała orkiestracja rytuałów w `useSyncManager`. Transport SSE (fetch → `res.ok` → `consumeSSE` + stall watchdog + komunikat błędu) żyje raz w **`useSSEStream`**; hooki strumieniowe (`useSync`, `useVintedCheck`, `useLibraryCheck`) budują na nim i różnią się tylko routingiem zdarzeń. Duży komponent skanera Vinted rozbity na `components/stats/vinted/*`. W dev serwowany przez Vite (middleware), w produkcji jako statyczny build z `dist/public/` (bundle backendu leży obok, w `dist/`, i **nie** jest serwowany).
 
 Szczegóły zasad architektonicznych: **[`COGITATOR_GUIDELINES.md`](./COGITATOR_GUIDELINES.md)**.
 
@@ -248,7 +248,7 @@ npm run dev      # serwer dev (tsx server.ts) — API + frontend Vite na http://
 Pozostałe komendy:
 
 ```bash
-npm run build    # vite build + esbuild bundle server.ts → dist/server.cjs
+npm run build    # vite build → dist/public/ (SPA) + esbuild bundle server.ts → dist/server.cjs
 npm start        # uruchom produkcyjny build (node dist/server.cjs)
 npm run lint     # tsc --noEmit (tryb strict; brak osobnego lintera)
 npm test         # vitest run (pełny pakiet)

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.77.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.77.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,12 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.77.1** — **[SEC-PR5] Bundle backendu przestaje być serwowany publicznie.** Build wrzucał SPA **i**
+  `server.cjs` do tego samego `dist/`, a `express.static(dist)` serwował katalog w całości → `GET /server.cjs`
+  zwracał 1,7 MB kodu backendu (bez poświadczeń — sprawdzone — ale z pełną mapą tras i logiką walidacji).
+  Teraz `vite build` → `dist/public/` (`build.outDir` + `emptyOutDir`), a statyczny root serwera to `dist/public`;
+  `server.cjs` zostaje w `dist/`, poza zasięgiem. Zweryfikowane po rebuildzie: `dist/public/` zawiera tylko
+  `index.html` + `assets/`. Docs zaktualizowane (README ×2, CLAUDE.md). Suite 535 zielone, lint czysty.
 - **1.77.0** — **[SEC-PR4] Auth fail-closed w produkcji (koniec z cichym otwarciem).** `basicAuth` przestaje
   bezwarunkowo przepuszczać przy braku poświadczeń: dev/test = dalej no-op (wygoda lokalna), **produkcja bez
   `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` = 503 na wszystko poza `/api/health`**. Powód: `render.yaml` deklaruje

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.77.0",
+  "version": "1.77.1",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.77.0",
+  "version": "1.77.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.77.0",
+      "version": "1.77.1",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.77.0",
+  "version": "1.77.1",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/server.ts
+++ b/server.ts
@@ -28,7 +28,11 @@ export async function startServer() {
     });
     app.use(vite.middlewares);
   } else if (process.env.NODE_ENV === "production") {
-    const distPath = path.join(process.cwd(), "dist");
+    // Only the built SPA — NOT `dist/`, which also contains the bundled backend
+    // (`server.cjs`). Serving `dist/` wholesale published the entire backend at
+    // `GET /server.cjs`: no credentials in it, but a complete route map and the
+    // validation logic. The static root now holds exactly what is meant to be public.
+    const distPath = path.join(process.cwd(), "dist", "public");
     app.use(express.static(distPath));
     app.get("*", (req, res) => {
       res.sendFile(path.join(distPath, "index.html"));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,14 @@ export default defineConfig(() => {
     define: {
       __APP_VERSION__: JSON.stringify(version),
     },
+    // The SPA builds into `dist/public/`, NOT `dist/`. `dist/` also holds the bundled
+    // backend (`server.cjs`), and the server serves its static root wholesale — so a
+    // shared directory published the whole backend at `GET /server.cjs`. Keeping the
+    // two apart means the static root contains only what is meant to be public.
+    build: {
+      outDir: 'dist/public',
+      emptyOutDir: true,
+    },
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {


### PR DESCRIPTION
Fixes #356 — fifth fix from the security sweep.

## The bug
The SPA and the bundled backend both landed in `dist/`, and the server served that directory wholesale — so `GET /server.cjs` returned 1.7 MB of backend code.

I checked the bundle: **no hardcoded credentials** (the Notion key is only ever read via `process.env`), so this is source disclosure, not secret disclosure. But it publishes the full route map and validation logic — exactly what shouldn't be reachable if auth ever lapses.

## The fix
- `vite.config.ts`: `build.outDir = 'dist/public'` (+ `emptyOutDir`).
- `server.ts`: the static root is now `dist/public`, so it contains exactly what is meant to be public. `server.cjs` stays in `dist/`, outside the served tree.

`npm start` (`node dist/server.cjs`) is unchanged, and so is the Render start command.

## Verification
Clean rebuild confirms the split: `dist/public/` holds only `index.html` + `assets/`, and `dist/public/server.cjs` does not exist. `npm run lint` clean, `npm test` **535** green.

Docs updated (README build/deploy notes, `CLAUDE.md` command reference) so the layout change is discoverable. Version 1.77.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_