### PR TITLE
feat(security): baseline security headers + CSP

### DIFF
--- a/__tests__/securityHeaders.test.ts
+++ b/__tests__/securityHeaders.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import { securityHeaders } from "../middleware/securityHeaders";
+
+const makeApp = () => {
+  const app = express();
+  app.disable("x-powered-by");
+  app.use(securityHeaders());
+  app.get("/", (_req, res) => res.send("ok"));
+  app.get("/boom", (_req, res) => res.status(500).json({ error: "x" }));
+  return app;
+};
+
+describe("securityHeaders", () => {
+  it("sets the frame/sniff/referrer headers", async () => {
+    const res = await request(makeApp()).get("/");
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["referrer-policy"]).toBe("same-origin");
+  });
+
+  it("does not advertise Express", async () => {
+    const res = await request(makeApp()).get("/");
+    expect(res.headers["x-powered-by"]).toBeUndefined();
+  });
+
+  it("sets a CSP that pins the directives this app actually relies on", async () => {
+    const csp = (await request(makeApp()).get("/")).headers["content-security-policy"];
+    expect(csp).toContain("frame-ancestors 'none'");   // clickjacking
+    expect(csp).toContain("form-action 'self'");       // second line under the CSRF guard
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("connect-src 'self'");
+  });
+
+  it("allows exactly the external resources the app loads", async () => {
+    const csp = (await request(makeApp()).get("/")).headers["content-security-policy"];
+    expect(csp).toContain("https://fonts.googleapis.com"); // @import in index.css
+    expect(csp).toContain("https://fonts.gstatic.com");    // the font files themselves
+    expect(csp).toContain("https://*.vinted.net");         // offer thumbnails
+    expect(csp).toContain("data:");                        // inline SVG favicon
+  });
+
+  it("applies to error responses too, not just successful ones", async () => {
+    const res = await request(makeApp()).get("/boom");
+    expect(res.status).toBe(500);
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+    expect(res.headers["content-security-policy"]).toBeTruthy();
+  });
+});

--- a/app.ts
+++ b/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import syncRoutes from "./routes/syncRoutes";
 import { basicAuth } from "./middleware/basicAuth";
 import { sameOrigin } from "./middleware/sameOrigin";
+import { securityHeaders } from "./middleware/securityHeaders";
 
 /**
  * Express app wiring (no listening). Static/Vite and `listen` live in
@@ -10,8 +11,15 @@ import { sameOrigin } from "./middleware/sameOrigin";
  */
 export const app = express();
 
-// Opt-in Basic Auth (active only when BASIC_AUTH_USER + _PASSWORD are set).
-// Must come first, to protect the SPA and static files too.
+// Don't advertise the stack.
+app.disable("x-powered-by");
+
+// Security response headers (CSP, nosniff, frame/referrer policy) — first, so they
+// apply to every response including 401/403/503 and the static SPA.
+app.use(securityHeaders());
+
+// Basic Auth: opt-in in dev, fail-closed in production (see middleware/basicAuth.ts).
+// Must come early, to protect the SPA and static files too.
 app.use(basicAuth());
 // CSRF: reject state-changing requests that state a foreign origin. Mounted before the
 // routes (and before the body parser — nothing needs parsing to make this decision).

--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.77.1** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.78.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,18 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.78.0** — **[SEC-PR6] Nagłówki bezpieczeństwa + CSP.** `middleware/securityHeaders.ts` montowany PIERWSZY
+  w `app.ts` (więc obejmuje też odpowiedzi 401/403/503 i statyczne SPA) + `app.disable("x-powered-by")`.
+  Nagłówki: CSP, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: same-origin`
+  (celowo NIE `no-referrer` — middleware CSRF używa `Referer` jako fallbacku). **Uczciwie o zakresie**: `script-src`
+  zachowuje `'unsafe-inline'`, bo `index.html` niesie inline-bootstrap motywu/favicony (to on daje brak mignięcia),
+  więc ta CSP **nie chroni realnie przed XSS** — i nie musi: audyt nie znalazł ŻADNEGO sinka HTML w `src/`.
+  Realną wartość dają pozostałe dyrektywy: `frame-ancestors 'none'` (clickjacking — istotne właśnie przy włączonym
+  Basic Auth), `form-action 'self'` (druga linia pod CSRF), `base-uri 'self'`, `object-src 'none'`,
+  `connect-src 'self'`. Allow-listy odbijają to, co apka faktycznie ładuje: Google Fonts (`@import` w index.css)
+  + miniatury Vinted (`*.vinted.net`) + `data:` (favicon SVG). **Zweryfikowane prawdziwą przeglądarką**
+  (Chromium/Playwright na produkcyjnym buildzie): 0 naruszeń CSP, React montuje się, bootstrap motywu działa.
+  +5 testów. Suite 540 zielone, lint czysty, build OK.
 - **1.77.1** — **[SEC-PR5] Bundle backendu przestaje być serwowany publicznie.** Build wrzucał SPA **i**
   `server.cjs` do tego samego `dist/`, a `express.static(dist)` serwował katalog w całości → `GET /server.cjs`
   zwracał 1,7 MB kodu backendu (bez poświadczeń — sprawdzone — ale z pełną mapą tras i logiką walidacji).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.77.1",
+  "version": "1.78.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/middleware/securityHeaders.ts
+++ b/middleware/securityHeaders.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Baseline security response headers.
+ *
+ * HONEST SCOPE. The `script-src` below keeps `'unsafe-inline'`, because `index.html`
+ * carries the pre-mount theme/favicon bootstrap (an inline script is what makes the
+ * no-flash behaviour possible). So this CSP does NOT meaningfully mitigate XSS — and
+ * it doesn't need to: the audit found no HTML-injection sink anywhere in `src/`
+ * (no `dangerouslySetInnerHTML`, no `innerHTML`, no `eval`). What it DOES buy is the
+ * rest of the policy, which is what actually applies to this app:
+ *
+ *   - `frame-ancestors 'none'` (+ X-Frame-Options) — clickjacking. Relevant precisely
+ *     because Basic Auth is on: an authenticated session could otherwise be framed and
+ *     the sync buttons clicked through an overlay.
+ *   - `form-action 'self'` — a second line under the CSRF middleware: even a form
+ *     injected into our own page cannot post the session anywhere else.
+ *   - `base-uri 'self'` — stops a `<base>` tag from re-pointing every relative URL.
+ *   - `object-src 'none'` — no plugin content, ever.
+ *   - `connect-src 'self'` — the SPA only ever fetches same-origin; this pins that.
+ *
+ * The allow-lists mirror what the app genuinely loads, nothing more: Google Fonts
+ * (imported at the top of index.css) and Vinted offer thumbnails (images1.vinted.net).
+ */
+const CSP = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  // Inline bootstrap script in index.html — see the note above.
+  "script-src 'self' 'unsafe-inline'",
+  // Tailwind + motion/react set element styles; fonts come from Google Fonts.
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  // data: covers the inline SVG favicon; the Vinted hosts serve offer thumbnails.
+  "img-src 'self' data: https://*.vinted.net https://*.vinted.pl",
+  "connect-src 'self'",
+].join("; ");
+
+export function securityHeaders() {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    res.setHeader("Content-Security-Policy", CSP);
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    // `same-origin` rather than `no-referrer`: it keeps referrers off third parties
+    // while still sending them within our own origin, which the CSRF middleware uses
+    // as its fallback when `Origin` is absent.
+    res.setHeader("Referrer-Policy", "same-origin");
+    next();
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.77.1",
+  "version": "1.78.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.77.1",
+      "version": "1.78.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.77.1",
+  "version": "1.78.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"


### PR DESCRIPTION
Fixes #358 — sixth fix from the security sweep.

## What
`middleware/securityHeaders.ts`, mounted **first** in `app.ts` so it covers every response — including `401`/`403`/`503` and the static SPA — plus `app.disable("x-powered-by")`.

Headers: `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: same-origin`.

`same-origin` rather than `no-referrer` is deliberate: the CSRF middleware uses `Referer` as its fallback when `Origin` is absent, so stripping referrers entirely would undercut the previous fix.

## Honest about what this CSP does and doesn't do
`script-src` keeps `'unsafe-inline'`, because `index.html` carries the pre-mount theme/favicon bootstrap (that inline script is what makes the no-flash behaviour possible). **So this CSP does not meaningfully mitigate XSS** — and it doesn't need to: the audit found no HTML-injection sink anywhere in `src/`.

The value is in the rest of the policy, which does apply here:
- `frame-ancestors 'none'` — clickjacking, relevant precisely *because* Basic Auth is on;
- `form-action 'self'` — a second line under the CSRF guard;
- `base-uri 'self'`, `object-src 'none'`, `connect-src 'self'`.

Allow-lists mirror what the app genuinely loads — Google Fonts (the `@import` in `index.css`), Vinted thumbnails (`*.vinted.net`), `data:` for the inline SVG favicon — and nothing else.

## Verification
Beyond the unit tests, I checked this in a **real browser** (Chromium via Playwright, against the production build), because a CSP is exactly the kind of change that silently breaks a page:
- **0 CSP violations**
- React mounts (`#root` populated), the inline theme bootstrap runs (`data-theme` and the favicon are set)
- the only console errors were Google Fonts blocked by the sandbox proxy and a 500 from the API on dummy Notion credentials — both expected, neither CSP-related

Also confirmed while I had the server up: `GET /server.cjs` now returns the 3.6 KB SPA fallback rather than the 1.7 MB backend bundle (previous PR), verified by content rather than status code.

`npm run lint` clean, `npm test` **540** green, `npm run build` OK. Version 1.78.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_