### PR TITLE
fix(security): cap scraped response sizes and bound the in-process caches

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.78.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.79.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,19 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.79.0** — **[SEC-PR7] Limity zasobów: rozmiar odpowiedzi + ograniczone cache.** (1) `scrapingClient`
+  eksportuje `MAX_RESPONSE_BYTES` (12 MB) + `responseSizeLimit` (`maxContentLength`/`maxBodyLength`), wpięte we
+  WSZYSTKIE 9 wywołań axiosa (Vinted ×4, ISBN ×4, OPAC ×1). Wcześniej żadne nie miało limitu — axios buforuje całe
+  ciało w pamięci, a `withRetry` (do 6 prób) mnożył to razy sześć na 512 MB instancji. 12 MB jest CELOWO powyżej
+  ~7 MB stron katalogu Vinted (patrz historia OOM) — chodzi o ucięcie przypadku patologicznego, nie normalnego
+  ruchu. (2) Nowy `services/boundedCache.ts` (`BoundedCache`, FIFO z twardym capem) zastępuje nielimitowane
+  `Map` w `cycleLookupService` (500 wpisów; klucz z `?title=`/`?author=`, a każde chybienie to do ~34 żądań do
+  wiki) i `isbnLookupService` (2000; klucz = dowolny ISBN-13 z poprawną sumą kontrolną, trywialny do masowego
+  generowania). FIFO nie LRU — świadomie, prostota nad hit-rate; `null` pozostaje legalną WARTOŚCIĄ (obecność
+  przez `has()`, nie truthiness). +6 testów. Suite 546 zielone, lint czysty, build OK.
+  **ŚWIADOMIE POMINIĘTE**: pinning certu OPAC przez `ca:` zamiast `rejectUnauthorized:false` — wymaga prawdziwego
+  certyfikatu pośredniego, którego nie zweryfikuję z tego sandboxa, a wpisanie go na ślepo (plus wygasanie) grozi
+  zepsuciem skanu bibliotecznego. Zostaje jako świadomy dług z uzasadnieniem.
 - **1.78.0** — **[SEC-PR6] Nagłówki bezpieczeństwa + CSP.** `middleware/securityHeaders.ts` montowany PIERWSZY
   w `app.ts` (więc obejmuje też odpowiedzi 401/403/503 i statyczne SPA) + `app.disable("x-powered-by")`.
   Nagłówki: CSP, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: same-origin`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.78.0",
+      "version": "1.79.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.78.0",
+  "version": "1.79.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/scrapingClient.ts
+++ b/scrapingClient.ts
@@ -49,3 +49,23 @@ export const createScrapingAgent = (opts: ScrapingAgentOptions = {}) => new http
   maxSockets: opts.maxSockets ?? 5,
   rejectUnauthorized: opts.rejectUnauthorized ?? true,
 });
+
+/**
+ * Hard ceiling on a scraped response body. Axios buffers the whole response in memory
+ * before we ever see it, and none of the calls set a limit — so a slow-drip or
+ * oversized response from any scraped host was an uncapped allocation on a 512 MB
+ * instance. `withRetry` multiplies it: a configurable 6 attempts means one book could
+ * pull six full-size bodies.
+ *
+ * 12 MB is deliberately well ABOVE the ~7 MB Vinted catalog pages this scanner is built
+ * for (see the OOM history in backlog.md) — the point is to stop the pathological case,
+ * not to second-guess normal traffic. Exceeding it rejects the request instead of
+ * filling the heap.
+ */
+export const MAX_RESPONSE_BYTES = 12 * 1024 * 1024;
+
+/** Axios options capping the buffered response — spread into every scraping call. */
+export const responseSizeLimit = {
+  maxContentLength: MAX_RESPONSE_BYTES,
+  maxBodyLength: MAX_RESPONSE_BYTES,
+};

--- a/services/__tests__/boundedCache.test.ts
+++ b/services/__tests__/boundedCache.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { BoundedCache } from "../boundedCache";
+
+describe("BoundedCache", () => {
+  it("stores and reads back like a Map", () => {
+    const c = new BoundedCache<number>(10);
+    c.set("a", 1);
+    expect(c.has("a")).toBe(true);
+    expect(c.get("a")).toBe(1);
+    expect(c.size).toBe(1);
+  });
+
+  it("treats null as a real cached VALUE, not a miss", () => {
+    // Both call sites cache „looked it up, there is nothing" as null, so presence must
+    // be tested with has() rather than truthiness — otherwise every negative lookup
+    // would re-hit the upstream API.
+    const c = new BoundedCache<number | null>(10);
+    c.set("nothing", null);
+    expect(c.has("nothing")).toBe(true);
+    expect(c.get("nothing")).toBeNull();
+  });
+
+  it("never grows past the cap, evicting the oldest entry", () => {
+    const c = new BoundedCache<number>(3);
+    c.set("a", 1); c.set("b", 2); c.set("c", 3);
+    expect(c.size).toBe(3);
+
+    c.set("d", 4); // evicts "a"
+    expect(c.size).toBe(3);
+    expect(c.has("a")).toBe(false);
+    expect(c.has("b")).toBe(true);
+    expect(c.has("d")).toBe(true);
+  });
+
+  it("holds the line under a flood of distinct keys (the abuse case)", () => {
+    const c = new BoundedCache<number>(50);
+    for (let i = 0; i < 5000; i++) c.set(`key-${i}`, i);
+    expect(c.size).toBe(50);
+    expect(c.has("key-0")).toBe(false);
+    expect(c.has("key-4999")).toBe(true);
+  });
+
+  it("re-setting an existing key updates it without counting as growth", () => {
+    const c = new BoundedCache<number>(2);
+    c.set("a", 1); c.set("b", 2);
+    c.set("a", 99);
+    expect(c.size).toBe(2);
+    expect(c.get("a")).toBe(99);
+    expect(c.has("b")).toBe(true); // "b" was not evicted by the overwrite
+  });
+
+  it("rejects a nonsensical cap instead of silently misbehaving", () => {
+    expect(() => new BoundedCache<number>(0)).toThrow();
+  });
+});

--- a/services/boundedCache.ts
+++ b/services/boundedCache.ts
@@ -1,0 +1,51 @@
+/**
+ * A `Map` with a hard size limit and FIFO eviction.
+ *
+ * WHY. Two in-process caches (`cycleLookupService`, `isbnLookupService`) were plain
+ * `Map`s with no cap, no TTL and no eviction, keyed by a string that comes straight
+ * from the request (`?title=`, `/api/isbn/:code`). On a 512 MB instance a loop over
+ * distinct keys grew the heap without bound — and each miss on the cycle lookup also
+ * fans out up to ~34 requests to a third-party wiki, so the cache is what stands
+ * between normal use and turning the app into a request amplifier.
+ *
+ * FIFO rather than LRU on purpose: these are lookup caches for a browsing session, and
+ * insertion order is a good enough proxy for staleness. `Map` already iterates in
+ * insertion order, so eviction is one `keys().next()` — no bookkeeping, nothing to get
+ * subtly wrong. Note a HIT does not refresh position, which is exactly the trade being
+ * made here (simplicity over hit-rate).
+ *
+ * `null` is a legitimate cached VALUE ("looked it up, there is nothing"), so presence
+ * is tested with `has()`, never by truthiness of `get()`.
+ */
+export class BoundedCache<V> {
+  private map = new Map<string, V>();
+
+  constructor(private readonly maxEntries: number) {
+    if (maxEntries < 1) throw new Error("BoundedCache: maxEntries must be >= 1");
+  }
+
+  has(key: string): boolean {
+    return this.map.has(key);
+  }
+
+  get(key: string): V | undefined {
+    return this.map.get(key);
+  }
+
+  set(key: string, value: V): void {
+    // Re-setting an existing key must not count as growth.
+    if (!this.map.has(key) && this.map.size >= this.maxEntries) {
+      const oldest = this.map.keys().next();
+      if (!oldest.done) this.map.delete(oldest.value);
+    }
+    this.map.set(key, value);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}

--- a/services/cycleLookupService.ts
+++ b/services/cycleLookupService.ts
@@ -4,6 +4,7 @@ import { WikiParser } from "../wiki.parser";
 import { NotionBook } from "../src/types";
 import { isWikiAuthorMatch } from "./dataNormalizer";
 import { createLogger } from "../logger";
+import { BoundedCache } from "./boundedCache";
 
 const log = createLogger("CycleLookup");
 
@@ -52,7 +53,9 @@ const MAX_HOPS = 15; // safety cap on walking the chain in each direction
  * In-process memory cache (key: title+author) — a repeat click is instant.
  */
 export class CycleLookupService {
-  private cache = new Map<string, CycleView | null>();
+  // Bounded: the key comes from `?title=`/`?author=`, so an unbounded Map would grow
+  // with every distinct request — and each miss costs up to ~34 wiki fetches.
+  private cache = new BoundedCache<CycleView | null>(500);
 
   constructor(private notion: NotionAdapter, private wiki: WikiAdapter) {}
 

--- a/services/isbnLookupService.ts
+++ b/services/isbnLookupService.ts
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { responseSizeLimit } from "../scrapingClient";
+import { BoundedCache } from "./boundedCache";
 import { normalizeIsbn } from "./isbn";
 import { createLogger } from "../logger";
 
@@ -25,14 +27,16 @@ export interface IsbnBook {
 
 // Process-memory cache keyed by canonical ISBN-13. `null` = looked up, not found
 // (cached to avoid re-hitting the API); transient errors are NOT cached.
-const cache = new Map<string, IsbnBook | null>();
+// Bounded: the key is any checksum-valid ISBN-13, which is trivially generatable in
+// bulk, so an unbounded Map was a slow heap leak driven by request input.
+const cache = new BoundedCache<IsbnBook | null>(2000);
 
 export async function lookupIsbn(rawCode: string): Promise<IsbnBook | null> {
   const isbn = normalizeIsbn(rawCode);
   if (!isbn) return null;
   if (cache.has(isbn)) return cache.get(isbn)!;
   try {
-    const res = await axios.get(GOOGLE_BOOKS, { params: { q: `isbn:${isbn}` }, timeout: 10000 });
+    const res = await axios.get(GOOGLE_BOOKS, { params: { q: `isbn:${isbn}` }, timeout: 10000, ...responseSizeLimit });
     const info = res.data?.items?.[0]?.volumeInfo;
     if (!info?.title) {
       cache.set(isbn, null);
@@ -71,7 +75,7 @@ function collectIsbns(items: any[]): string[] {
 
 /** One Google Books query → deduped ISBN-13s. */
 async function queryGoogle(q: string): Promise<string[]> {
-  const res = await axios.get(GOOGLE_BOOKS, { params: { q, maxResults: 20 }, timeout: 10000 });
+  const res = await axios.get(GOOGLE_BOOKS, { params: { q, maxResults: 20 }, timeout: 10000, ...responseSizeLimit });
   return collectIsbns(Array.isArray(res.data?.items) ? res.data.items : []);
 }
 
@@ -101,7 +105,7 @@ async function fromGoogle(title: string, author: string): Promise<string[]> {
 async function queryOpenLibrary(title: string, author: string): Promise<string[]> {
   const params: Record<string, string | number> = { title, limit: 5, fields: "isbn" };
   if (author) params.author = author;
-  const res = await axios.get(OPEN_LIBRARY, { params, timeout: 10000 });
+  const res = await axios.get(OPEN_LIBRARY, { params, timeout: 10000, ...responseSizeLimit });
   const docs: any[] = Array.isArray(res.data?.docs) ? res.data.docs : [];
   const found = new Set<string>();
   for (const doc of docs) {
@@ -116,7 +120,7 @@ async function queryOpenLibrary(title: string, author: string): Promise<string[]
 
 /** One Biblioteka Narodowa query → deduped ISBN-13s (from MARC 020 $a + the isbnIssn field). */
 async function queryBN(params: Record<string, string | number>): Promise<string[]> {
-  const res = await axios.get(BN_API, { params: { ...params, limit: 20 }, timeout: 10000 });
+  const res = await axios.get(BN_API, { params: { ...params, limit: 20 }, timeout: 10000, ...responseSizeLimit });
   const bibs: any[] = Array.isArray(res.data?.bibs) ? res.data.bibs : [];
   const found = new Set<string>();
   for (const bib of bibs) {

--- a/services/libraryCheckService.ts
+++ b/services/libraryCheckService.ts
@@ -4,7 +4,7 @@ import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent } from "../src/types";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
-import { getRandomUserAgent, createScrapingAgent } from "../scrapingClient";
+import { getRandomUserAgent, createScrapingAgent, responseSizeLimit } from "../scrapingClient";
 import { parseOpacResults, findBookMatch } from "./opacParser";
 import { ConfigService } from "./configService";
 
@@ -64,7 +64,7 @@ export class LibraryCheckService {
 
         try {
           const response = await withRetry(
-            () => axios.get(url, { httpsAgent, headers, timeout: REQUEST_TIMEOUT }),
+            () => axios.get(url, { httpsAgent, headers, timeout: REQUEST_TIMEOUT, ...responseSizeLimit }),
             2,
             1500,
           );

--- a/services/vintedSyncService.ts
+++ b/services/vintedSyncService.ts
@@ -3,7 +3,7 @@ import { NotionAdapter } from "../notion.adapter";
 import { SyncEvent } from "../src/types";
 import { withRetry } from "../retry";
 import { createLogger } from "../logger";
-import { createScrapingAgent } from "../scrapingClient";
+import { createScrapingAgent, responseSizeLimit } from "../scrapingClient";
 import { parseVintedItems, vintedDiagnostics, looksBlocked, looksEmpty, extractVintedSeller, VintedItem } from "./vintedParser";
 import { NotionBook } from "../src/types";
 import { offerFromItem, parseVintedData, mergeAndDiff, serializeVintedData, computeChangedAt, toStoredBookView, StoredVintedData, StoredOffer, StoredBookView, OfferDiff, EMPTY_DIFF } from "./vintedStore";
@@ -121,7 +121,7 @@ export class VintedSyncService {
         if (session.cookie) {
           try {
             const probeUrl = buildCatalogUrl(v, `${candidates[0].plTitle} ${candidates[0].author || ""}`.trim());
-            const probe = await axios.get(probeUrl, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs });
+            const probe = await axios.get(probeUrl, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs, ...responseSizeLimit });
             const ph: string = probe.data;
             const d = vintedDiagnostics(ph, 0);
             const usable = looksBlocked(ph) || d.noResultsMarker || d.hasCatalogJson || d.hasFeedGrid || d.itemLinks > 0;
@@ -171,7 +171,7 @@ export class VintedSyncService {
         sendEvent({ type: "search_attempt", result: { id: book.id, title: book.plTitle, author: book.author, url, status: "pending", itemCount: 0 } });
 
         try {
-          const response = await withRetry(async () => axios.get(url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs }), v.retryAttempts, v.retryBackoffMs);
+          const response = await withRetry(async () => axios.get(url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs, ...responseSizeLimit }), v.retryAttempts, v.retryBackoffMs);
 
           const html = response.data;
           log.info(`Odpowiedź Vinted`, { title, chars: html.length, ...memMb() });
@@ -306,7 +306,7 @@ export class VintedSyncService {
         const firstOffer = pending[0]?.offers[0];
         if (session.cookie && firstOffer) {
           try {
-            const probe = await axios.get(firstOffer.url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs });
+            const probe = await axios.get(firstOffer.url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs, ...responseSizeLimit });
             const ph: string = probe.data;
             if (!looksBlocked(ph) && !extractVintedSeller(ph)) {
               session = { userAgent: "", cookie: "" };
@@ -329,7 +329,7 @@ export class VintedSyncService {
           fetched++;
           sendEvent({ type: "progress", message: `Sprzedawca: ${p.book.plTitle} (${fetched}/${target})`, current: fetched, total: target });
           try {
-            const response = await withRetry(async () => axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs }), v.retryAttempts, v.retryBackoffMs);
+            const response = await withRetry(async () => axios.get(offer.url, { httpsAgent, headers: vintedRequestHeaders(cfg.scraping.userAgents, session), timeout: v.requestTimeoutMs, ...responseSizeLimit }), v.retryAttempts, v.retryBackoffMs);
             const html = response.data;
             if (looksBlocked(html)) {
               log.warn("Vinted zablokował stronę oferty (sprzedawca, baza)", { url: offer.url });


### PR DESCRIPTION
Fixes #360 — last fix from the security sweep's hygiene batch.

## 1. Response size
None of the **nine** axios calls set `maxContentLength`, and axios buffers the whole body before we see it — an uncapped allocation on a 512 MB instance, multiplied by `withRetry` (up to 6 attempts pulling full-size bodies for one book).

`scrapingClient` now exports `MAX_RESPONSE_BYTES` (12 MB) + `responseSizeLimit`, applied to Vinted (×4), the ISBN sources (×4) and OPAC (×1).

**12 MB is deliberately well above** the ~7 MB Vinted catalog pages this scanner is built for (see the OOM history in `backlog.md`): the point is to stop the pathological case, not to second-guess normal traffic.

## 2. Bounded caches
`cycleLookupService` and `isbnLookupService` were plain `Map`s with no cap, no TTL and no eviction, keyed straight off request input. New `services/boundedCache.ts` adds a hard size limit with FIFO eviction:

- **cycle lookup → 500 entries.** Each miss costs up to ~34 wiki fetches, so this cache is what stops the app becoming a request amplifier against a third party.
- **ISBN → 2000 entries.** The key is any checksum-valid ISBN-13 — trivially generated in bulk.

**FIFO rather than LRU, on purpose:** insertion order is a good enough proxy for staleness for a browsing-session lookup cache, and `Map` already iterates that way, so eviction is one `keys().next()` with no bookkeeping to get subtly wrong. A hit does not refresh position — that's the trade, and it's documented.

`null` stays a legitimate cached **value** ("looked it up, there is nothing"), so presence is tested with `has()`, never truthiness — otherwise every negative lookup would re-hit the upstream API. There's a test pinning that.

## Deliberately NOT done
Pinning the OPAC intermediate certificate via `ca:` instead of `rejectUnauthorized: false`. That needs the real chain, which I can't verify from this sandbox, and embedding one blind (plus its eventual expiry) risks breaking the library scan outright. Left as documented debt in the backlog with the reasoning, rather than a blind change.

## Verification
`npm run lint` clean, `npm test` **546** green (+6), `npm run build` OK. Version 1.79.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_