### PR TITLE
feat(shelf): swipe to change shelf segment on mobile

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -14,7 +14,7 @@
 
 ## Stan bieżący
 
-- Wersja aplikacji: **1.79.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
+- Wersja aplikacji: **1.80.0** (źródło prawdy: `metadata.json`; mirror w `package.json` + `package-lock.json`).
 - Branch roboczy: `claude/book-aggregator-setup-t6kfvd`. Deploy leci z `main` — zmiany
   muszą trafić na `main` (PR + merge), inaczej redeploy serwuje stary kod.
 - **Konwencja PR/issue**: jedna logiczna zmiana = jeden granularny PR (nie batchujemy).
@@ -69,6 +69,17 @@
 
 Wersja ze źródła prawdy `metadata.json` (mirror w `package.json`). Najnowsze na górze.
 
+- **1.80.0** — **Swipe do przełączania segmentów regału (mobile).** Nowy `src/hooks/useHorizontalSwipe.ts`
+  (zwraca handlery touch do rozlania na element). Sedno nie w wykrywaniu gestu, tylko w NIE kradzeniu cudzych:
+  (1) swipe liczy się tylko gdy poziomy dystans DOMINUJE nad pionowym (`|dx| > |dy| * 1.4`), więc zwykłe
+  przewijanie strony nigdy nie przerzuci półki; (2) **nigdy nie wołamy `preventDefault` na `touchmove`** — to
+  właśnie ono blokowałoby scroll (i omija problem pasywnych listenerów); (3) drugi palec = anulowanie (pinch-zoom
+  zostaje przeglądarce); (4) próg 50 px i cap 800 ms, żeby wolne przeciąganie nie uchodziło za flick.
+  `Shelf.tsx`: nawigacja stron wyciągnięta do `goPrev`/`goNext` — swipe i strzałki dzielą JEDNĄ implementację;
+  gest wyłączony przy `pageCount === 1` i w trakcie drag&drop książki. Podpowiedź w `BookshelfSection`
+  rozdzielona per breakpoint (mobile: „Przesuń palcem w bok…", desktop: dotychczasowa o strzałkach) — swipe jest
+  nieodkrywalny bez napisania o nim. +9 testów (głównie przypadki, w których swipe NIE ma zadziałać). Suite 555
+  zielone, lint czysty, build OK.
 - **1.79.0** — **[SEC-PR7] Limity zasobów: rozmiar odpowiedzi + ograniczone cache.** (1) `scrapingClient`
   eksportuje `MAX_RESPONSE_BYTES` (12 MB) + `responseSizeLimit` (`maxContentLength`/`maxBodyLength`), wpięte we
   WSZYSTKIE 9 wywołań axiosa (Vinted ×4, ISBN ×4, OPAC ×1). Wcześniej żadne nie miało limitu — axios buforuje całe

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Cogitator Omnissiah",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "description": "A full-stack application that syncs book awards from Encyklopedia Fantastyki (MediaWiki API) to a Notion database.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-example",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-example",
-      "version": "1.79.0",
+      "version": "1.80.0",
       "dependencies": {
         "@notionhq/client": "^5.15.0",
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "1.79.0",
+  "version": "1.80.0",
   "type": "module",
   "engines": {
     "node": ">=18 <21"

--- a/src/components/BookshelfSection.tsx
+++ b/src/components/BookshelfSection.tsx
@@ -78,8 +78,11 @@ export const BookshelfSection: React.FC = () => {
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent" />
       </div>
+      {/* Hint differs by input: a swipe is undiscoverable without saying so, and the
+          chevrons are the mouse affordance. Shown per breakpoint, not per device. */}
       <p className="text-center text-[11px] text-slate-500 uppercase tracking-widest font-bold -mt-4">
-        Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał N"
+        <span className="hidden sm:inline">Przeciągnij wolumin między regałami · strzałkami przełączasz segmenty „Regał N"</span>
+        <span className="sm:hidden">Przesuń palcem w bok, aby zmienić segment „Regał N"</span>
       </p>
 
       {/* „Regał" skin switch (Holo+ / Klasyczny) — choice persists in localStorage.

--- a/src/components/shelf/Shelf.tsx
+++ b/src/components/shelf/Shelf.tsx
@@ -9,6 +9,7 @@ import { ShelfRow, EmptyShelfRow, GapBoundary, GapCaret } from "./ShelfRow";
 import { ShelfFrame, ShelfAccent } from "./ShelfFrame";
 import { CandleCluster } from "./RoomDecor";
 import { useEffectiveConfig } from "../../hooks/useAppConfig";
+import { useHorizontalSwipe } from "../../hooks/useHorizontalSwipe";
 
 interface Props {
   shelfId: ShelfId;
@@ -91,12 +92,6 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
     return () => ro.disconnect();
   }, []);
 
-  const rootProps: React.HTMLAttributes<HTMLDivElement> = {
-    onDragOver: (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true); },
-    onDragLeave: (e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setOver(false); },
-    onDrop: (e) => { e.preventDefault(); setOver(false); onDropBook(shelfId); },
-  };
-
   const { items, slotByKey } = buildShelfItems(books);
   const rows = width > 0 ? packAndLayout(items, { rowWidth: width }) : [];
 
@@ -107,17 +102,36 @@ export const Shelf: React.FC<Props> = ({ shelfId, title, icon, accent, books, on
   const shown = segments[cur] ?? [];
   const pad = pageSize ? Math.max(0, pageSize - shown.length) : 0;
 
+  // One implementation of paging, shared by the chevrons and the touch swipe.
+  const goPrev = () => setPage(Math.max(0, cur - 1));
+  const goNext = () => setPage(Math.min(pageCount - 1, cur + 1));
+
+  // Swipe left = next segment (content moves the way the finger does). Disabled while
+  // dragging a book, so a touch-drag can never be read as a page flip.
+  const swipe = useHorizontalSwipe({
+    onSwipeLeft: goNext,
+    onSwipeRight: goPrev,
+    enabled: pageCount > 1 && !dragging,
+  });
+
+  const rootProps: React.HTMLAttributes<HTMLDivElement> = {
+    onDragOver: (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true); },
+    onDragLeave: (e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setOver(false); },
+    onDrop: (e) => { e.preventDefault(); setOver(false); onDropBook(shelfId); },
+    ...swipe,
+  };
+
   const headerExtra = (
     <div className="flex items-center gap-2">
       {dragging && <span className="text-[10px] uppercase tracking-widest text-amber-200/70 font-bold">upuść tutaj</span>}
       {pageSize && pageCount > 1 && (
         <div className="flex items-center gap-1.5">
-          <button onClick={() => setPage((p) => Math.max(0, Math.min(p, pageCount - 1) - 1))} disabled={cur === 0}
+          <button onClick={goPrev} disabled={cur === 0}
             className="p-1 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Poprzedni regał">
             <ChevronLeft className="w-4 h-4" />
           </button>
           <span className="text-[10px] font-display font-bold uppercase tracking-widest text-amber-200/80">Regał {cur + 1}<span className="text-amber-200/60"> / {pageCount}</span></span>
-          <button onClick={() => setPage((p) => Math.min(pageCount - 1, Math.min(p, pageCount - 1) + 1))} disabled={cur >= pageCount - 1}
+          <button onClick={goNext} disabled={cur >= pageCount - 1}
             className="p-1 rounded-md text-amber-200/70 hover:text-amber-100 disabled:opacity-30" aria-label="Następny regał">
             <ChevronRight className="w-4 h-4" />
           </button>

--- a/src/hooks/__tests__/useHorizontalSwipe.test.tsx
+++ b/src/hooks/__tests__/useHorizontalSwipe.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useHorizontalSwipe } from "../useHorizontalSwipe";
+
+const left = vi.fn();
+const right = vi.fn();
+
+const Probe: React.FC<{ enabled?: boolean }> = ({ enabled = true }) => {
+  const handlers = useHorizontalSwipe({ onSwipeLeft: left, onSwipeRight: right, enabled });
+  return <div data-testid="area" {...handlers} style={{ width: 300, height: 200 }} />;
+};
+
+/** One-finger gesture: start at (x0,y0), lift at (x1,y1). */
+function swipe(x0: number, y0: number, x1: number, y1: number) {
+  const area = screen.getByTestId("area");
+  fireEvent.touchStart(area, { touches: [{ clientX: x0, clientY: y0 }] });
+  fireEvent.touchMove(area, { touches: [{ clientX: x1, clientY: y1 }] });
+  fireEvent.touchEnd(area, { changedTouches: [{ clientX: x1, clientY: y1 }] });
+}
+
+beforeEach(() => { left.mockClear(); right.mockClear(); });
+
+describe("useHorizontalSwipe", () => {
+  it("fires left on a right-to-left flick", () => {
+    render(<Probe />);
+    swipe(250, 100, 120, 108);
+    expect(left).toHaveBeenCalledOnce();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("fires right on a left-to-right flick", () => {
+    render(<Probe />);
+    swipe(80, 100, 220, 95);
+    expect(right).toHaveBeenCalledOnce();
+    expect(left).not.toHaveBeenCalled();
+  });
+
+  it("ignores a vertical scroll — the page keeps its gesture", () => {
+    render(<Probe />);
+    swipe(150, 40, 165, 260); // big dy, small dx
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("ignores a diagonal drag where vertical dominates", () => {
+    render(<Probe />);
+    swipe(200, 60, 120, 200); // dx -80, dy +140 → vertical wins
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("ignores a tap or a nudge below the distance threshold", () => {
+    render(<Probe />);
+    swipe(150, 100, 150, 100); // tap
+    swipe(150, 100, 178, 100); // 28px nudge
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("cancels when a second finger joins (pinch-zoom)", () => {
+    render(<Probe />);
+    const area = screen.getByTestId("area");
+    fireEvent.touchStart(area, { touches: [{ clientX: 250, clientY: 100 }] });
+    fireEvent.touchMove(area, { touches: [{ clientX: 200, clientY: 100 }, { clientX: 90, clientY: 140 }] });
+    fireEvent.touchEnd(area, { changedTouches: [{ clientX: 120, clientY: 100 }] });
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all when disabled (single page / drag in progress)", () => {
+    render(<Probe enabled={false} />);
+    swipe(250, 100, 120, 100);
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("ignores a touchend with no preceding touchstart", () => {
+    render(<Probe />);
+    fireEvent.touchEnd(screen.getByTestId("area"), { changedTouches: [{ clientX: 10, clientY: 100 }] });
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  it("is reset by touchcancel (interrupting call, system gesture)", () => {
+    render(<Probe />);
+    const area = screen.getByTestId("area");
+    fireEvent.touchStart(area, { touches: [{ clientX: 250, clientY: 100 }] });
+    fireEvent.touchCancel(area, {});
+    fireEvent.touchEnd(area, { changedTouches: [{ clientX: 100, clientY: 100 }] });
+    expect(left).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useHorizontalSwipe.ts
+++ b/src/hooks/useHorizontalSwipe.ts
@@ -1,0 +1,64 @@
+import { useRef, TouchEvent } from "react";
+
+/**
+ * Horizontal swipe gesture for touch devices — returns handlers to spread onto an element.
+ *
+ * The whole difficulty here is NOT detecting a swipe; it's not stealing gestures that
+ * belong to the page:
+ *
+ *  - **Vertical scrolling wins.** A swipe counts only when the horizontal distance
+ *    dominates the vertical one (`|dx| > |dy| * RATIO`), so an ordinary flick down the
+ *    page never flips a shelf. We deliberately never call `preventDefault` on
+ *    `touchmove` — that is what would actually block scrolling.
+ *  - **Pinch-zoom is left alone.** A second finger cancels the gesture outright.
+ *  - **A slow drag isn't a swipe.** Past `MAX_DURATION_MS` we assume the finger was
+ *    resting or dragging, not flicking.
+ *
+ * Mouse drag&drop is untouched: this only listens to touch events, and HTML5 DnD is
+ * mouse-driven anyway.
+ */
+const MIN_DISTANCE_PX = 50;
+const DOMINANCE_RATIO = 1.4; // horizontal must beat vertical by this much
+const MAX_DURATION_MS = 800;
+
+interface Options {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  /** When false the handlers are inert (e.g. only one page, or a drag in progress). */
+  enabled?: boolean;
+}
+
+export function useHorizontalSwipe({ onSwipeLeft, onSwipeRight, enabled = true }: Options) {
+  const start = useRef<{ x: number; y: number; t: number } | null>(null);
+
+  const reset = () => { start.current = null; };
+
+  return {
+    onTouchStart: (e: TouchEvent) => {
+      if (!enabled || e.touches.length !== 1) { reset(); return; }
+      const t = e.touches[0];
+      start.current = { x: t.clientX, y: t.clientY, t: Date.now() };
+    },
+    onTouchMove: (e: TouchEvent) => {
+      // A second finger means pinch/zoom — hand the gesture back to the browser.
+      if (e.touches.length > 1) reset();
+    },
+    onTouchEnd: (e: TouchEvent) => {
+      const s = start.current;
+      reset();
+      if (!enabled || !s) return;
+
+      const t = e.changedTouches[0];
+      if (!t) return;
+      const dx = t.clientX - s.x;
+      const dy = t.clientY - s.y;
+
+      if (Date.now() - s.t > MAX_DURATION_MS) return;
+      if (Math.abs(dx) < MIN_DISTANCE_PX) return;
+      if (Math.abs(dx) < Math.abs(dy) * DOMINANCE_RATIO) return; // vertical scroll wins
+
+      if (dx < 0) onSwipeLeft(); else onSwipeRight();
+    },
+    onTouchCancel: reset,
+  };
+}


### PR DESCRIPTION
Fixes #362

## What
Swipe left/right on a shelf to move between „Regał N" segments. Swipe left = next (the content moves the way the finger does).

## The interesting part isn't detecting the swipe — it's not stealing gestures
`src/hooks/useHorizontalSwipe.ts` returns touch handlers to spread onto an element:

- **Vertical scrolling wins.** A swipe counts only when the horizontal distance *dominates* the vertical one (`|dx| > |dy| * 1.4`), so an ordinary flick down the page never flips a shelf.
- **`preventDefault` is never called on `touchmove`.** That's what would actually block scrolling — and avoiding it also sidesteps the passive-listener problem entirely.
- **A second finger cancels the gesture**, leaving pinch-zoom to the browser.
- **50 px minimum distance, 800 ms cap** — a slow drag or a resting finger isn't a flick.

## Wiring
`Shelf.tsx`: paging extracted into `goPrev`/`goNext`, so the swipe and the chevrons share **one** implementation rather than two copies of the clamping logic. The gesture is disabled when there's a single page and while a book is being dragged.

`BookshelfSection`: the hint now splits by breakpoint — a swipe is undiscoverable unless you say so, while the chevrons remain the mouse affordance.

## Tests (+9)
Mostly the cases where the swipe **must not** fire: vertical scroll, vertical-dominant diagonal, tap, sub-threshold nudge, pinch (second finger), disabled state, a stray `touchend` with no `touchstart`, and `touchcancel`.

## Note on verification
The logic is unit-tested in jsdom; I did not drive a real device. Two real-browser risks were designed out rather than tested around: passive listeners are moot because nothing calls `preventDefault`, and there's no competing horizontal scroll container (the shelf interior is `overflow-hidden`). If the 50 px / 1.4 thresholds feel off on your phone, they're two constants at the top of the hook.

`npm run lint` clean, `npm test` **555** green, `npm run build` OK. Version 1.80.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsGKHWoTDMUywnidjwgqMT)_